### PR TITLE
ASA-6 fix 'engine-rest' tests

### DIFF
--- a/engine-rest/pom.xml
+++ b/engine-rest/pom.xml
@@ -315,6 +315,76 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <reuseForks>true</reuseForks>
+          <forkCount>1</forkCount>
+          <excludes>
+            <exclude>**/Abstract*</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <configuration>
+              <excludes>
+                <exclude>**/*</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>resteasy-tests</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <phase>test</phase>
+            <configuration>
+              <includes>
+                <include>**/rest/resteasy/**</include>
+              </includes>
+              <excludes>
+                <exclude>**/rest/jersey/**</exclude>
+                <exclude>**/rest/wink/**</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>jersey-tests</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <phase>test</phase>
+            <configuration>
+              <includes>
+                <include>**/rest/jersey/**</include>
+              </includes>
+              <excludes>
+                <exclude>**/rest/resteasy/**</exclude>
+                <exclude>**/rest/wink/**</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>wink-tests</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <phase>test</phase>
+            <configuration>
+              <includes>
+                <include>**/rest/wink/**</include>
+              </includes>
+              <excludes>
+                <exclude>**/rest/resteasy/**</exclude>
+                <exclude>**/rest/jersey/**</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 


### PR DESCRIPTION
This pullrequest should fix the tests in the 'engine-rest' module. For us it seems to be an classloading-issue. If you separate the execution of tests for every framework it worked for us.

Cheers
Jörg
