### PR TITLE
CAM-436: Add throwing message event

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
@@ -1291,6 +1291,7 @@ public class BpmnParse extends Parse {
     Element signalEventDefinitionElement = intermediateEventElement.element("signalEventDefinition");
     Element compensateEventDefinitionElement = intermediateEventElement.element("compensateEventDefinition");
     Element linkEventDefinitionElement = intermediateEventElement.element("linkEventDefinition");
+    Element messageEventDefinitionElement = intermediateEventElement.element("messageEventDefinition");
     
     // the link event gets a special treatment as a throwing link event (event source) 
     // will not create any activity instance but serves as a "redirection" to the catching link
@@ -1306,8 +1307,7 @@ public class BpmnParse extends Parse {
     } 
 
     boolean otherUnsupportedThrowingIntermediateEvent = 
-      (intermediateEventElement.element("escalationEventDefinition") != null) || //
-      (intermediateEventElement.element("messageEventDefinition") != null); //
+      (intermediateEventElement.element("escalationEventDefinition") != null); //
     // All other event definition types cannot be intermediate throwing (cancelEventDefinition, conditionalEventDefinition, errorEventDefinition, terminateEventDefinition, timerEventDefinition
         
     ActivityImpl nestedActivityImpl = createActivityOnScope(intermediateEventElement, scopeElement);
@@ -1321,7 +1321,9 @@ public class BpmnParse extends Parse {
     } else if(compensateEventDefinitionElement != null) {
       CompensateEventDefinition compensateEventDefinition = parseCompensateEventDefinition(compensateEventDefinitionElement, scopeElement);
       activityBehavior = new IntermediateThrowCompensationEventActivityBehavior(compensateEventDefinition);
-      
+    } else if (messageEventDefinitionElement != null) {
+      // CAM-436 same behaviour as service task
+      activityBehavior = parseServiceTask(messageEventDefinitionElement, scopeElement).getActivityBehavior();
     } else if (otherUnsupportedThrowingIntermediateEvent) {
       addError("Unsupported intermediate throw event type", intermediateEventElement);
     } else { // None intermediate event

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/message/DummyServiceTask.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/message/DummyServiceTask.java
@@ -1,0 +1,31 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.engine.test.bpmn.event.message;
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+
+
+/**
+ * @author Bernd Ruecker
+ */
+public class DummyServiceTask implements JavaDelegate {
+  
+  public static boolean wasExecuted = false;
+  
+  public void execute(DelegateExecution execution) throws Exception {
+    wasExecuted = true;
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/message/MessageIntermediateThrowEventTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/message/MessageIntermediateThrowEventTest.java
@@ -1,0 +1,36 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.engine.test.bpmn.event.message;
+
+import org.camunda.bpm.engine.impl.test.PluggableProcessEngineTestCase;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.test.Deployment;
+
+/**
+ * @author Kristin Polenz
+ */
+public class MessageIntermediateThrowEventTest extends PluggableProcessEngineTestCase {
+  
+  
+  @Deployment
+  public void testSingleIntermediateThrowMessageEvent() {
+    
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
+    
+    assertProcessEnded(processInstance.getId());
+    assertTrue(DummyServiceTask.wasExecuted);
+    
+  }
+
+}

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/event/message/MessageIntermediateThrowEventTest.testSingleIntermediateThrowMessageEvent.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/event/message/MessageIntermediateThrowEventTest.testSingleIntermediateThrowMessageEvent.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples"
+  xmlns:tns="Examples">
+  
+  <process id="process">
+  
+    <startEvent id="theStart" />
+    
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="messageThrow" />
+  
+  	<intermediateThrowEvent id="messageThrow">
+  		<messageEventDefinition activiti:class="org.camunda.bpm.engine.test.bpmn.event.message.DummyServiceTask" />
+  	</intermediateThrowEvent>
+  	
+  	<sequenceFlow id="flow2" sourceRef="messageThrow" targetRef="theEnd" />
+  
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>


### PR DESCRIPTION
This pull request add the intermediate throwing message event with the same behaviour as for service task. It is related to CAM-436.
