### PR TITLE
CAM-1027: Show process definition key in 'start-process-instance' dropdown

### DIFF
--- a/webapps/tasklist/tasklist/src/main/runtime/develop/resources/processes/process-without-processname.bpmn
+++ b/webapps/tasklist/tasklist/src/main/runtime/develop/resources/processes/process-without-processname.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_Mf2wYPLoEeK5LrNo9nbTsw" targetNamespace="http://activiti.org/bpmn">
+  <bpmn2:process id="Process_without_name" isExecutable="true">
+    <bpmn2:endEvent id="EndEvent_1" name="End">
+      <bpmn2:incoming>SequenceFlow_7</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:userTask id="UserTask_2" activiti:candidateGroups="management" name="Nothing to do">
+      <bpmn2:incoming>SequenceFlow_6</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_7</bpmn2:outgoing>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_7" name="" sourceRef="UserTask_2" targetRef="EndEvent_1"/>
+    <bpmn2:startEvent id="StartEvent_1" name="Start">
+      <bpmn2:outgoing>SequenceFlow_6</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_6" name="" sourceRef="StartEvent_1" targetRef="UserTask_2"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_without_name">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_34" bpmnElement="StartEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="245.0" y="232.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="22.0" width="70.0" x="228.0" y="273.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_EndEvent_59" bpmnElement="EndEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="481.0" y="232.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_UserTask_19" bpmnElement="UserTask_2">
+        <dc:Bounds height="80.0" width="100.0" x="336.0" y="210.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_6" bpmnElement="SequenceFlow_6" sourceElement="_BPMNShape_StartEvent_34" targetElement="_BPMNShape_UserTask_19">
+        <di:waypoint xsi:type="dc:Point" x="281.0" y="250.0"/>
+        <di:waypoint xsi:type="dc:Point" x="336.0" y="250.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="6.0" width="6.0" x="307.0" y="250.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_7" bpmnElement="SequenceFlow_7" sourceElement="_BPMNShape_UserTask_19" targetElement="_BPMNShape_EndEvent_59">
+        <di:waypoint xsi:type="dc:Point" x="436.0" y="250.0"/>
+        <di:waypoint xsi:type="dc:Point" x="481.0" y="250.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="6.0" width="6.0" x="457.0" y="250.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/webapps/tasklist/tasklist/src/main/webapp/app/common/header.html
+++ b/webapps/tasklist/tasklist/src/main/webapp/app/common/header.html
@@ -33,7 +33,8 @@
 
           <ul class="dropdown-menu">
             <li ng-repeat="definition in processDefinitions">
-              <a href="#/process-definition/{{definition.id}}">{{ definition.name }}</a>
+              <a ng-show="definition.name" href="#/process-definition/{{definition.id}}">{{ definition.name }}</a>
+              <a ng-show="!definition.name" href="#/process-definition/{{definition.id}}">{{ definition.key }}</a>
             </li>
           </ul>
         </div>

--- a/webapps/tasklist/tasklist/src/main/webapp/app/pages/start.js
+++ b/webapps/tasklist/tasklist/src/main/webapp/app/pages/start.js
@@ -58,7 +58,11 @@ define(["angular"], function(angular) {
     EngineApi.getProcessDefinitions().get({ id: processDefinitionId }).$then(function(response) {
       var processDefinition = response.resource;
 
-      Notifications.addMessage({ status: "Completed", message: "Instance of <a>" + processDefinition.name + "</a> has been started", duration: 5000 });
+      if (processDefinition.name) {
+        Notifications.addMessage({ status: "Completed", message: "Instance of <a>" + processDefinition.name + "</a> has been started", duration: 5000 });
+      } else {
+        Notifications.addMessage({ status: "Completed", message: "Instance of <a>" + processDefinition.key + "</a> has been started", duration: 5000 });
+      }
       $location.url("/overview");
     });
   };


### PR DESCRIPTION
This pull request add a change for the tasklist. The process definition key is shown in the 'start-process-instance' dropdown and in the notification message for process instance has been started when the process definition name is null. It is related to CAM-1027.
