### PR TITLE
CAM-436 Add message end event

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
@@ -2396,6 +2396,7 @@ public class BpmnParse extends Parse {
       Element errorEventDefinition = endEventElement.element("errorEventDefinition");
       Element cancelEventDefinition = endEventElement.element("cancelEventDefinition");
       Element terminateEventDefinition = endEventElement.element("terminateEventDefinition");
+      Element messageEventDefinitionElement = endEventElement.element("messageEventDefinition");
       if (errorEventDefinition != null) { // error end event
         String errorRef = errorEventDefinition.attribute("errorRef");
         if (errorRef == null || "".equals(errorRef)) {
@@ -2417,6 +2418,9 @@ public class BpmnParse extends Parse {
         }
       } else if (terminateEventDefinition != null) {
         activity.setActivityBehavior(new TerminateEndEventActivityBehavior());
+      } else if (messageEventDefinitionElement != null) {
+        // CAM-436 same behaviour as service task
+        activity.setActivityBehavior(parseServiceTask(messageEventDefinitionElement, scope).getActivityBehavior());
       } else { // default: none end event
         activity.setActivityBehavior(new NoneEndEventActivityBehavior());
       }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/end/DummyServiceTask.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/end/DummyServiceTask.java
@@ -1,0 +1,39 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.engine.test.bpmn.event.end;
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+
+
+/**
+ * @author Kristin Polenz
+ */
+public class DummyServiceTask implements JavaDelegate {
+  
+  public static boolean wasExecuted = false;
+  public static boolean expressionWasExecuted = false;
+  public static boolean delegateExpressionWasExecuted = false;
+  
+  public void execute(DelegateExecution execution) throws Exception {
+    boolean expressionWasExecuted = (Boolean )execution.getVariable("expressionWasExecuted");
+    boolean delegateExpressionWasExecuted = (Boolean )execution.getVariable("delegateExpressionWasExecuted");
+    boolean wasExecuted = (Boolean )execution.getVariable("wasExecuted");
+    
+    this.expressionWasExecuted = expressionWasExecuted;
+    this.delegateExpressionWasExecuted = delegateExpressionWasExecuted;
+    this.wasExecuted = wasExecuted;
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/end/EndEventBean.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/end/EndEventBean.java
@@ -1,0 +1,31 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.engine.test.bpmn.event.end;
+
+import java.io.Serializable;
+
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+
+/**
+ * @author Kristin Polenz
+ */
+public class EndEventBean implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  public JavaDelegate getJavaDelegate() {
+    return new DummyServiceTask();
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/end/MessageEndEventTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/end/MessageEndEventTest.java
@@ -1,0 +1,66 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.bpmn.event.end;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.camunda.bpm.engine.impl.test.PluggableProcessEngineTestCase;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.test.Deployment;
+
+/**
+ * @author Kristin Polenz
+ */
+public class MessageEndEventTest extends PluggableProcessEngineTestCase {
+
+  @Deployment
+  public void testMessageEndEvent() throws Exception {
+    Map<String, Object> variables = new HashMap<String, Object>();
+    
+    // class
+    variables.put("wasExecuted", true);
+    variables.put("expressionWasExecuted", false);
+    variables.put("delegateExpressionWasExecuted", false);
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process", variables);
+    assertNotNull(processInstance);
+    
+    assertProcessEnded(processInstance.getId());
+    assertTrue(DummyServiceTask.wasExecuted);
+    
+    // expression
+    variables = new HashMap<String, Object>();
+    variables.put("wasExecuted", false);
+    variables.put("expressionWasExecuted", true);
+    variables.put("delegateExpressionWasExecuted", false);
+    variables.put("endEventBean", new EndEventBean());
+    processInstance = runtimeService.startProcessInstanceByKey("process", variables);
+    assertNotNull(processInstance);
+    
+    assertProcessEnded(processInstance.getId());
+    assertTrue(DummyServiceTask.expressionWasExecuted);
+    
+    // delegate expression
+    variables = new HashMap<String, Object>();
+    variables.put("wasExecuted", false);
+    variables.put("expressionWasExecuted", false);
+    variables.put("delegateExpressionWasExecuted", true);
+    variables.put("endEventBean", new EndEventBean());
+    processInstance = runtimeService.startProcessInstanceByKey("process", variables);
+    assertNotNull(processInstance);
+    
+    assertProcessEnded(processInstance.getId());
+    assertTrue(DummyServiceTask.delegateExpressionWasExecuted);
+  }
+
+}

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/event/end/MessageEndEventTest.testMessageEndEvent.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/event/end/MessageEndEventTest.testMessageEndEvent.bpmn20.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples"
+  xmlns:tns="Examples">
+  
+  <process id="process">
+  
+    <startEvent id="theStart" />
+    
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="exclusiveGateway" />
+    
+    <exclusiveGateway id="exclusiveGateway" />
+     
+     <sequenceFlow id="flow2" sourceRef="exclusiveGateway" targetRef="expressionEnd">
+      <conditionExpression xsi:type="tFormalExpression">${expressionWasExecuted}</conditionExpression>
+     </sequenceFlow>
+     
+     <sequenceFlow id="flow3" sourceRef="exclusiveGateway" targetRef="delegateExpressionEnd">
+      <conditionExpression xsi:type="tFormalExpression">${delegateExpressionWasExecuted}</conditionExpression>
+     </sequenceFlow>
+     
+     <sequenceFlow id="flow4" sourceRef="exclusiveGateway" targetRef="classEnd">
+      <conditionExpression xsi:type="tFormalExpression">${wasExecuted}</conditionExpression>
+     </sequenceFlow>
+     
+     <endEvent id="expressionEnd">
+       <messageEventDefinition activiti:expression="#{endEventBean.getJavaDelegate().execute(execution)}" />
+     </endEvent>
+
+     <endEvent id="delegateExpressionEnd">
+       <messageEventDefinition activiti:delegateExpression="#{endEventBean.getJavaDelegate()}" />
+     </endEvent>
+  
+     <endEvent id="classEnd">
+       <messageEventDefinition activiti:class="org.camunda.bpm.engine.test.bpmn.event.end.DummyServiceTask" />
+     </endEvent>
+    
+  </process>
+
+</definitions>


### PR DESCRIPTION
This pull request adds the new bpmn element message end event with the same behaviour as for service task. It is related to CAM-436.
