### PR TITLE
engine-rest - exposed the underlying ability to query by process instance ids list

### DIFF
--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/converter/StringSetConverter.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/converter/StringSetConverter.java
@@ -1,0 +1,14 @@
+package org.camunda.bpm.engine.rest.dto.converter;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class StringSetConverter implements StringToTypeConverter<Set<String>> {
+
+	@Override
+	public Set<String> convertQueryParameterToType(String value) {
+		return new HashSet<String>(Arrays.asList(value.split(",")));
+	}
+
+}

--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/runtime/ProcessInstanceQueryDto.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/runtime/ProcessInstanceQueryDto.java
@@ -14,6 +14,7 @@ package org.camunda.bpm.engine.rest.dto.runtime;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response.Status;
@@ -26,6 +27,7 @@ import org.camunda.bpm.engine.rest.dto.converter.BooleanConverter;
 import org.camunda.bpm.engine.rest.dto.converter.VariableListConverter;
 import org.camunda.bpm.engine.rest.exception.InvalidRequestException;
 import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
+import org.camunda.bpm.engine.rest.dto.converter.StringSetConverter;
 
 public class ProcessInstanceQueryDto extends AbstractQueryDto<ProcessInstanceQuery> {
 
@@ -48,6 +50,7 @@ public class ProcessInstanceQueryDto extends AbstractQueryDto<ProcessInstanceQue
   private String subProcessInstance;
   private Boolean active;
   private Boolean suspended;
+  private Set<String> processInstanceIds;
   
   private List<VariableQueryParameterDto> variables;
   
@@ -61,6 +64,11 @@ public class ProcessInstanceQueryDto extends AbstractQueryDto<ProcessInstanceQue
 
   public String getProcessDefinitionKey() {
     return processDefinitionKey;
+  }
+  
+  @CamundaQueryParam(value = "processInstanceIds", converter = StringSetConverter.class)
+  public void setProcessInstanceIds(Set<String> processInstanceIds) {
+		this.processInstanceIds = processInstanceIds;
   }
 
   @CamundaQueryParam("processDefinitionKey")
@@ -115,6 +123,10 @@ public class ProcessInstanceQueryDto extends AbstractQueryDto<ProcessInstanceQue
 
   @Override
   protected void applyFilters(ProcessInstanceQuery query) {
+	  
+    if (processInstanceIds != null) {
+      query.processInstanceIds(processInstanceIds);
+    }
     if (processDefinitionKey != null) {
       query.processDefinitionKey(processDefinitionKey);
     }

--- a/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
+++ b/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
@@ -18,7 +18,9 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.camunda.bpm.engine.authorization.Authorization;
 import org.camunda.bpm.engine.form.FormProperty;
@@ -37,6 +39,7 @@ import org.camunda.bpm.engine.runtime.EventSubscription;
 import org.camunda.bpm.engine.runtime.Execution;
 import org.camunda.bpm.engine.runtime.Job;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
 import org.camunda.bpm.engine.runtime.VariableInstance;
 import org.camunda.bpm.engine.task.DelegationState;
 import org.camunda.bpm.engine.task.Task;
@@ -89,6 +92,10 @@ public abstract class MockProvider {
   public static final String ANOTHER_EXAMPLE_PROCESS_INSTANCE_ID = "anotherId";
   public static final boolean EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED = false;
   public static final boolean EXAMPLE_PROCESS_INSTANCE_IS_ENDED = false;
+  public static final String EXAMPLE_PROCESS_INSTANCE_ID_LIST = EXAMPLE_PROCESS_INSTANCE_ID + "," + ANOTHER_EXAMPLE_PROCESS_INSTANCE_ID;
+  public static final String EXAMPLE_PROCESS_INSTANCE_ID_LIST_WITH_DUP = EXAMPLE_PROCESS_INSTANCE_ID + "," + ANOTHER_EXAMPLE_PROCESS_INSTANCE_ID + "," + EXAMPLE_PROCESS_INSTANCE_ID;
+  public static final String EXAMPLE_NON_EXISTENT_PROCESS_INSTANCE_ID = "aNonExistentProcInstId";
+  public static final String EXAMPLE_PROCESS_INSTANCE_ID_LIST_WITH_NONEXISTENT_ID = EXAMPLE_PROCESS_INSTANCE_ID + "," + EXAMPLE_NON_EXISTENT_PROCESS_INSTANCE_ID;
   
   // variable instance
   public static final String EXAMPLE_VARIABLE_INSTANCE_NAME = "aVariableInstanceName";
@@ -534,4 +541,28 @@ public abstract class MockProvider {
     });
   }
  
+  public static List<ProcessInstance> createAnotherMockProcessInstanceList() {
+	List<ProcessInstance> mockProcessInstanceList = new ArrayList<ProcessInstance>();
+	mockProcessInstanceList.add(createMockInstance());
+	mockProcessInstanceList.add(createAnotherMockInstance());	
+	return mockProcessInstanceList;
+  }
+
+  public static ProcessInstance createAnotherMockInstance() {
+	ProcessInstance mock = mock(ProcessInstance.class);
+	  
+	when(mock.getId()).thenReturn(ANOTHER_EXAMPLE_PROCESS_INSTANCE_ID);
+	when(mock.getBusinessKey()).thenReturn(EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY);
+	when(mock.getProcessDefinitionId()).thenReturn(EXAMPLE_PROCESS_DEFINITION_ID);
+	when(mock.getProcessInstanceId()).thenReturn(ANOTHER_EXAMPLE_PROCESS_INSTANCE_ID);
+	when(mock.isSuspended()).thenReturn(EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED);
+	when(mock.isEnded()).thenReturn(EXAMPLE_PROCESS_INSTANCE_IS_ENDED);
+		    
+	return mock;
+  }	
+  
+  public static Set<String> createMockSetFromList(String list){
+	  return new HashSet<String>(Arrays.asList(list.split(",")));
+  }
+  
 }


### PR DESCRIPTION
engine-rest - exposed the underlying ability to query by process instance ids list
