### PR TITLE
Add job query for no retries left

### DIFF
--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/runtime/JobQueryDto.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/runtime/JobQueryDto.java
@@ -56,6 +56,7 @@ public class JobQueryDto extends AbstractQueryDto<JobQuery> {
 	private Boolean messages;
 	private Boolean withException;
 	private String exceptionMessage;
+	private Boolean noRetriesLeft;
 
 	private List<ConditionQueryParameterDto> dueDates;
 	
@@ -115,6 +116,11 @@ public class JobQueryDto extends AbstractQueryDto<JobQuery> {
 		this.dueDates = dueDates;
 	}
 
+  @CamundaQueryParam(value="noRetriesLeft", converter = BooleanConverter.class)
+  public void setNoRetriesLeft(Boolean noRetriesLeft) {
+    this.noRetriesLeft = noRetriesLeft;
+  }
+
 	@Override
 	protected boolean isValidSortByValue(String value) {
 		return VALID_SORT_BY_VALUES.contains(value);
@@ -168,6 +174,10 @@ public class JobQueryDto extends AbstractQueryDto<JobQuery> {
 		if (exceptionMessage != null) {
 			query.exceptionMessage(exceptionMessage);
 		}
+
+    if (noRetriesLeft != null && noRetriesLeft) {
+      query.noRetriesLeft();
+    }
 
 		if (dueDates != null) {
 			DateConverter dateConverter = new DateConverter();

--- a/engine-rest/src/test/java/org/camunda/bpm/engine/rest/AbstractJobRestServiceQueryTest.java
+++ b/engine-rest/src/test/java/org/camunda/bpm/engine/rest/AbstractJobRestServiceQueryTest.java
@@ -290,6 +290,7 @@ public abstract class AbstractJobRestServiceQueryTest extends AbstractRestServic
     parameters.put("timers", MockProvider.EXAMPLE_TIMERS);
     parameters.put("withException", MockProvider.EXAMPLE_WITH_EXCEPTION);
     parameters.put("exceptionMessage", MockProvider.EXAMPLE_EXCEPTION_MESSAGE);
+    parameters.put("noRetriesLeft", MockProvider.EXAMPLE_NO_RETRIES_LEFT);
     return parameters;
   }
 	
@@ -317,6 +318,7 @@ public abstract class AbstractJobRestServiceQueryTest extends AbstractRestServic
 		verify(mockQuery).timers();
 		verify(mockQuery).withException();
 		verify(mockQuery).exceptionMessage((String) parameters.get("exceptionMessage"));
+		verify(mockQuery).noRetriesLeft();
 	}
 
 	@Test

--- a/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
+++ b/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
@@ -175,6 +175,7 @@ public abstract class MockProvider {
   public static final Boolean EXAMPLE_TIMERS = true;
   public static final Boolean EXAMPLE_MESSAGES = true;
   public static final Boolean EXAMPLE_WITH_EXCEPTION= true;
+  public static final Boolean EXAMPLE_NO_RETRIES_LEFT = true;
   
   public static final String EXAMPLE_RESOURCE_TYPE_NAME = "exampleResource";
   public static final int EXAMPLE_RESOURCE_TYPE_ID = 12345678;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/JobQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/JobQueryImpl.java
@@ -46,6 +46,7 @@ public class JobQueryImpl extends AbstractQuery<JobQuery, Job> implements JobQue
   protected Date duedateLowerThanOrEqual;
   protected boolean withException;
   protected String exceptionMessage;
+  protected boolean noRetriesLeft;
   
   public JobQueryImpl() {
   }
@@ -160,7 +161,12 @@ public class JobQueryImpl extends AbstractQuery<JobQuery, Job> implements JobQue
     this.exceptionMessage = exceptionMessage;
     return this;
   }
-  
+
+  public JobQuery noRetriesLeft() {
+    noRetriesLeft = true;
+    return this;
+  }
+
   //sorting //////////////////////////////////////////
   
   public JobQuery orderByJobDuedate() {

--- a/engine/src/main/java/org/camunda/bpm/engine/runtime/JobQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/runtime/JobQuery.java
@@ -82,6 +82,9 @@ public interface JobQuery extends Query<JobQuery, Job> {
   /** Only select jobs that failed due to an exception with the given message. */
   JobQuery exceptionMessage(String exceptionMessage);
 
+  /** Only select jobs which have no retries left */
+  JobQuery noRetriesLeft();
+
   //sorting //////////////////////////////////////////
   
   /** Order by job id (needs to be followed by {@link #asc()} or {@link #desc()}). */
@@ -98,4 +101,5 @@ public interface JobQuery extends Query<JobQuery, Job> {
   
   /** Order by execution id (needs to be followed by {@link #asc()} or {@link #desc()}). */
   JobQuery orderByExecutionId();
+
 }

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
@@ -183,6 +183,9 @@
       <if test="exceptionMessage">
       	and RES.EXCEPTION_MSG_ = #{exceptionMessage}
       </if>
+      <if test="noRetriesLeft">
+        and RES.RETRIES_ = 0
+      </if>
     </where>
   </sql>
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/JobQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/JobQueryTest.java
@@ -325,6 +325,15 @@ public class JobQueryTest extends PluggableProcessEngineTestCase {
     
   }
 
+  public void testQueryByNoRetriesLeft() {
+    JobQuery query = managementService.createJobQuery().noRetriesLeft();
+    verifyQueryResults(query, 0);
+
+    setRetries(processInstanceIdOne, 0);
+    // Re-running the query should give only one jobs now, since three job has retries>0
+    verifyQueryResults(query, 1);
+  }
+
   //sorting //////////////////////////////////////////
   
   public void testQuerySorting() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/cmd/FoxJobRetryCmdTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/cmd/FoxJobRetryCmdTest.java
@@ -120,6 +120,7 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTestCase {
     assertEquals(0, job.getRetries());
     assertEquals(1, managementService.createJobQuery().withException().count());
     assertEquals(0, managementService.createJobQuery().withRetriesLeft().count());
+    assertEquals(1, managementService.createJobQuery().noRetriesLeft().count());
     
     execution = refreshExecutionEntity(execution.getId());
     assertEquals("failingServiceTask", execution.getActivityId());
@@ -180,6 +181,7 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTestCase {
     assertEquals(0, job.getRetries());
     assertEquals(1, managementService.createJobQuery().withException().count());
     assertEquals(0, managementService.createJobQuery().withRetriesLeft().count());
+    assertEquals(1, managementService.createJobQuery().noRetriesLeft().count());
     
     execution = refreshExecutionEntity(execution.getId());
     assertEquals("failingUserTask", execution.getActivityId());
@@ -240,6 +242,7 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTestCase {
     assertEquals(0, job.getRetries());
     assertEquals(1, managementService.createJobQuery().withException().count());
     assertEquals(0, managementService.createJobQuery().withRetriesLeft().count());
+    assertEquals(1, managementService.createJobQuery().noRetriesLeft().count());
 
     execution = refreshExecutionEntity(execution.getId());
     assertEquals("failingBusinessRuleTask", execution.getActivityId());
@@ -300,6 +303,7 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTestCase {
     assertEquals(0, job.getRetries());
     assertEquals(1, managementService.createJobQuery().withException().count());
     assertEquals(0, managementService.createJobQuery().withRetriesLeft().count());
+    assertEquals(1, managementService.createJobQuery().noRetriesLeft().count());
     
     execution = refreshExecutionEntity(execution.getId());
     assertEquals("failingCallActivity", execution.getActivityId());
@@ -360,6 +364,7 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTestCase {
     assertEquals(0, job.getRetries());
     assertEquals(1, managementService.createJobQuery().withException().count());
     assertEquals(0, managementService.createJobQuery().withRetriesLeft().count());
+    assertEquals(1, managementService.createJobQuery().noRetriesLeft().count());
     
     execution = refreshExecutionEntity(execution.getId());
     assertEquals("failingScriptTask", execution.getActivityId());
@@ -420,6 +425,7 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTestCase {
     assertEquals(0, job.getRetries());
     assertEquals(1, managementService.createJobQuery().withException().count());
     assertEquals(0, managementService.createJobQuery().withRetriesLeft().count());
+    assertEquals(1, managementService.createJobQuery().noRetriesLeft().count());
     
     execution = refreshExecutionEntity(execution.getId());
     assertEquals("failingSendTask", execution.getActivityId());
@@ -480,6 +486,7 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTestCase {
     assertEquals(0, job.getRetries());
     assertEquals(1, managementService.createJobQuery().withException().count());
     assertEquals(0, managementService.createJobQuery().withRetriesLeft().count());
+    assertEquals(1, managementService.createJobQuery().noRetriesLeft().count());
     
     execution = refreshExecutionEntity(execution.getId());
     assertEquals("failingSubProcess", execution.getActivityId());
@@ -540,6 +547,7 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTestCase {
     assertEquals(0, job.getRetries());
     assertEquals(1, managementService.createJobQuery().withException().count());
     assertEquals(0, managementService.createJobQuery().withRetriesLeft().count());
+    assertEquals(1, managementService.createJobQuery().noRetriesLeft().count());
     
     execution = refreshExecutionEntity(execution.getId());
     assertEquals("failingTask", execution.getActivityId());
@@ -600,6 +608,7 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTestCase {
     assertEquals(0, job.getRetries());
     assertEquals(1, managementService.createJobQuery().withException().count());
     assertEquals(0, managementService.createJobQuery().withRetriesLeft().count());
+    assertEquals(1, managementService.createJobQuery().noRetriesLeft().count());
     
     execution = refreshExecutionEntity(execution.getId());
     assertEquals("failingTransaction", execution.getActivityId());
@@ -660,6 +669,7 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTestCase {
     assertEquals(0, job.getRetries());
     assertEquals(1, managementService.createJobQuery().withException().count());
     assertEquals(0, managementService.createJobQuery().withRetriesLeft().count());
+    assertEquals(1, managementService.createJobQuery().noRetriesLeft().count());
     
     execution = refreshExecutionEntity(execution.getId());
     assertEquals("failingReceiveTask", execution.getActivityId());
@@ -713,6 +723,7 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTestCase {
     assertEquals(0, job.getRetries());
     assertEquals(1, managementService.createJobQuery().withException().count());
     assertEquals(0, managementService.createJobQuery().withRetriesLeft().count());
+    assertEquals(1, managementService.createJobQuery().noRetriesLeft().count());
   }
   
   @Deployment(resources = { "org/camunda/bpm/engine/test/cmd/FoxJobRetryCmdTest.testFailedBoundaryTimerEvent.bpmn20.xml" })
@@ -769,6 +780,7 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTestCase {
     assertEquals(pi.getProcessInstanceId(), job.getProcessInstanceId());
     
     assertEquals(0, job.getRetries());
+    assertEquals(1, managementService.createJobQuery().noRetriesLeft().count());
 
   }
   
@@ -826,6 +838,7 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTestCase {
     assertEquals(pi.getProcessInstanceId(), job.getProcessInstanceId());
     
     assertEquals(0, job.getRetries());
+    assertEquals(1, managementService.createJobQuery().noRetriesLeft().count());
 
   }
   
@@ -840,6 +853,7 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTestCase {
     waitForExecutedJobWithRetriesLeft(0);
     job = refreshJob(job.getId());
     assertEquals(0, job.getRetries());
+    assertEquals(1, managementService.createJobQuery().noRetriesLeft().count());
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/jobexecutor/FailedJobCommandTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/jobexecutor/FailedJobCommandTest.java
@@ -32,6 +32,7 @@ public class FailedJobCommandTest extends AbstractFoxPlatformIntegrationTest {
     // now the retries = 0
     
     Assert.assertEquals(0, managementService.createJobQuery().withRetriesLeft().count());
+    Assert.assertEquals(1, managementService.createJobQuery().noRetriesLeft().count());
     
   }
   
@@ -49,6 +50,7 @@ public class FailedJobCommandTest extends AbstractFoxPlatformIntegrationTest {
     // now the retries = 0
     
     Assert.assertEquals(0, managementService.createJobQuery().withRetriesLeft().count());
+    Assert.assertEquals(51, managementService.createJobQuery().noRetriesLeft().count());
     
   }
 


### PR DESCRIPTION
This pull request adds the job query for no retries left (retry=0) to the management service API and rest API. It is related to CAM-358.
