### PR TITLE
This feature adds bulk commands for process instance: activate, suspend and delete

### DIFF
--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/BulkCommandRestService.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/BulkCommandRestService.java
@@ -1,0 +1,13 @@
+package org.camunda.bpm.engine.rest;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path(BulkCommandRestService.PATH)
+@Produces(MediaType.APPLICATION_JSON)
+public interface BulkCommandRestService {
+
+	  public static final String PATH = "/command";
+	
+}

--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/ProcessInstanceRestService.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/ProcessInstanceRestService.java
@@ -29,6 +29,7 @@ import org.camunda.bpm.engine.rest.dto.CountResultDto;
 import org.camunda.bpm.engine.rest.dto.runtime.ProcessInstanceDto;
 import org.camunda.bpm.engine.rest.dto.runtime.ProcessInstanceQueryDto;
 import org.camunda.bpm.engine.rest.sub.runtime.ProcessInstanceResource;
+import org.camunda.bpm.engine.rest.sub.runtime.ProcessInstancesBulkCmdResource;
 import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
 
 @Path(ProcessInstanceRestService.PATH)
@@ -82,4 +83,7 @@ public interface ProcessInstanceRestService {
   @Produces(MediaType.APPLICATION_JSON)
   CountResultDto queryProcessInstancesCount(ProcessInstanceQueryDto query);
   
+  @Path("/bulk-command")
+  ProcessInstancesBulkCmdResource getBulkCommandResource();  
+
 }

--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/BulkCommandDto.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/BulkCommandDto.java
@@ -1,0 +1,33 @@
+package org.camunda.bpm.engine.rest.dto;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BulkCommandDto {
+
+	private List<String> ids;
+	private Map<String, Object> variables = new HashMap<String,Object>();
+
+	public List<String> getIds() {
+		return ids;
+	}
+	
+	public Map<String, Object> getVariables() {
+		return variables;
+	}	
+	
+	public Object getVariableValue(String variableName){
+		if(variables.containsKey(variableName)){
+			return variables.get(variableName);
+		}
+       return null;		
+	}
+	
+	public static BulkCommandDto fromCommandDetails(List<String> ids,Map<String, Object> variables){
+		BulkCommandDto dto = new BulkCommandDto();
+		dto.ids = ids;
+		dto.variables = variables;
+		return dto; 
+	}
+}

--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/BulkCommandExceptionDto.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/BulkCommandExceptionDto.java
@@ -1,0 +1,23 @@
+package org.camunda.bpm.engine.rest.dto;
+
+public class BulkCommandExceptionDto {
+
+	protected String id;
+	protected String exceptionMessage;
+	
+	public String getId() {
+		return id;
+	}
+
+	public String getExceptionMessage() {
+		return exceptionMessage;
+	}
+		
+	public static BulkCommandExceptionDto fromExceptionDetails(String id, String message) {
+		BulkCommandExceptionDto dto = new BulkCommandExceptionDto();
+		dto.id = id;
+		dto.exceptionMessage = message;
+		return dto;
+	}
+	
+}

--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/impl/ProcessInstanceRestServiceImpl.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/impl/ProcessInstanceRestServiceImpl.java
@@ -23,6 +23,8 @@ import org.camunda.bpm.engine.rest.dto.CountResultDto;
 import org.camunda.bpm.engine.rest.dto.runtime.ProcessInstanceDto;
 import org.camunda.bpm.engine.rest.dto.runtime.ProcessInstanceQueryDto;
 import org.camunda.bpm.engine.rest.sub.runtime.ProcessInstanceResource;
+import org.camunda.bpm.engine.rest.sub.runtime.ProcessInstancesBulkCmdResource;
+import org.camunda.bpm.engine.rest.sub.runtime.impl.ProcessInstancesBulkCmdResourceImpl;
 import org.camunda.bpm.engine.rest.sub.runtime.impl.ProcessInstanceResourceImpl;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
@@ -98,6 +100,11 @@ public class ProcessInstanceRestServiceImpl extends AbstractRestProcessEngineAwa
   @Override
   public ProcessInstanceResource getProcessInstance(String processInstanceId) {
     return new ProcessInstanceResourceImpl(getProcessEngine(), processInstanceId);
+  }
+
+  @Override
+  public ProcessInstancesBulkCmdResource getBulkCommandResource() {	
+	  return new ProcessInstancesBulkCmdResourceImpl(getProcessEngine());	  
   }
 
 }

--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/runtime/ProcessInstancesBulkCmdResource.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/runtime/ProcessInstancesBulkCmdResource.java
@@ -1,0 +1,28 @@
+package org.camunda.bpm.engine.rest.sub.runtime;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.camunda.bpm.engine.rest.dto.BulkCommandDto;
+import org.camunda.bpm.engine.rest.dto.BulkCommandExceptionDto;
+
+public interface ProcessInstancesBulkCmdResource {
+
+	  @PUT
+	  @Path("/suspended")
+	  @Consumes(MediaType.APPLICATION_JSON)
+	  @Produces(MediaType.APPLICATION_JSON)
+	  List<BulkCommandExceptionDto> updateSuspensionStates(BulkCommandDto commandDto);
+	  
+	  @DELETE
+	  @Path("/delete")
+	  @Consumes(MediaType.APPLICATION_JSON)
+	  @Produces(MediaType.APPLICATION_JSON)
+	  List<BulkCommandExceptionDto> deleteProcessInstances(BulkCommandDto commandDto);	
+}

--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/runtime/impl/ProcessInstancesBulkCmdResourceImpl.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/runtime/impl/ProcessInstancesBulkCmdResourceImpl.java
@@ -1,0 +1,74 @@
+package org.camunda.bpm.engine.rest.sub.runtime.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.core.Response.Status;
+
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.rest.dto.BulkCommandDto;
+import org.camunda.bpm.engine.rest.dto.BulkCommandExceptionDto;
+import org.camunda.bpm.engine.rest.exception.InvalidRequestException;
+import org.camunda.bpm.engine.rest.sub.runtime.ProcessInstancesBulkCmdResource;
+
+public class ProcessInstancesBulkCmdResourceImpl implements
+		ProcessInstancesBulkCmdResource {
+	
+	private ProcessEngine engine;
+	  
+	public ProcessInstancesBulkCmdResourceImpl(ProcessEngine engine) {
+	    this.engine = engine;	  
+	}
+	
+	@Override
+	public  List<BulkCommandExceptionDto> updateSuspensionStates(BulkCommandDto commandDto) {
+		RuntimeService runtimeService = engine.getRuntimeService();
+		 List<BulkCommandExceptionDto> bulkCommandExceptions  = new ArrayList<BulkCommandExceptionDto>();
+		 boolean suspensionState = false;
+		 String variableName = "suspended";
+		 
+		 if(!commandDto.getVariables().containsKey(variableName)){		
+			 throw new InvalidRequestException(Status.NOT_FOUND,"No variable 'suspended' found for update suspension state operation");
+		 }	
+		 
+		 try {		 
+		 suspensionState = (Boolean)commandDto.getVariables().get(variableName);
+		 } catch(ClassCastException ce) {
+			 throw new InvalidRequestException(Status.BAD_REQUEST,"The value for the variable '" + variableName + "' is not the correct type");
+		 }
+		 
+		 for(String id : commandDto.getIds()){
+			try {
+				if(suspensionState){
+					runtimeService.suspendProcessInstanceById(id);	
+				} else {
+					runtimeService.activateProcessInstanceById(id);
+				}			  
+			} catch(RuntimeException e) {
+				bulkCommandExceptions.add(BulkCommandExceptionDto.fromExceptionDetails(id, e.getMessage()));
+			}
+		}		
+		return bulkCommandExceptions;
+	}	
+
+	@Override
+	public  List<BulkCommandExceptionDto> deleteProcessInstances(BulkCommandDto commandDto) {
+		RuntimeService runtimeService = engine.getRuntimeService();
+		List<BulkCommandExceptionDto> bulkCommandExceptions  = new ArrayList<BulkCommandExceptionDto>();
+		 String deleteReason = null;
+		
+		 if(commandDto.getVariables().containsKey("deleteReason")){
+			deleteReason = (String)commandDto.getVariables().get("deleteReason");
+		 }	 
+		
+		for(String id : commandDto.getIds()){			
+			try {
+			  runtimeService.deleteProcessInstance(id,deleteReason);
+			} catch(RuntimeException e) {
+				bulkCommandExceptions.add(BulkCommandExceptionDto.fromExceptionDetails(id, e.getMessage()));
+			}
+		}				
+		return bulkCommandExceptions;
+	}
+}

--- a/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
+++ b/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
@@ -95,6 +95,10 @@ public abstract class MockProvider {
   public static final String ANOTHER_EXAMPLE_PROCESS_INSTANCE_ID = "anotherId";
   public static final boolean EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED = false;
   public static final boolean EXAMPLE_PROCESS_INSTANCE_IS_ENDED = false;
+
+  public static final String EXAMPLE_NON_EXISTENT_PROCESS_INSTANCE_ID = "aNonExistentProcInstId";
+  public static final String EXAMPLE_ANOTHER_NON_EXISTENT_PROCESS_INSTANCE_ID = "aAnotherNonExistentProcInstId";
+  public static final String EXAMPLE_HIST_PROCESS_DELETE_REASON = "aDeleteReason";
   
   // variable instance
   public static final String EXAMPLE_VARIABLE_INSTANCE_NAME = "aVariableInstanceName";


### PR DESCRIPTION
Conflicts:
    engine-rest/src/main/java/org/camunda/bpm/engine/rest/ProcessInstanceRestService.java
    engine-rest/src/main/java/org/camunda/bpm/engine/rest/impl/ProcessInstanceRestServiceImpl.java
    engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
