### PR TITLE
bug(engine): configured JodaTime to use JVM TimeZone (instead of system ...

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/DueDateBusinessCalendar.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/DueDateBusinessCalendar.java
@@ -13,9 +13,12 @@
 package org.camunda.bpm.engine.impl.calendar;
 
 import java.util.Date;
+import java.util.TimeZone;
 
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.ISODateTimeFormat;
 
 
 public class DueDateBusinessCalendar implements BusinessCalendar {
@@ -24,8 +27,9 @@ public class DueDateBusinessCalendar implements BusinessCalendar {
   
   public Date resolveDuedate(String duedate) {
     try {
-      return DateTime.parse(duedate).toDate();
-
+      return DateTime.parse(duedate, 
+          // make sure we use JVM TimeZone (as we do when writing the String with SimpleDateFormat), see https://app.camunda.com/jira/browse/CAM-1170 
+          ISODateTimeFormat.dateTimeParser().withZone(DateTimeZone.forTimeZone(TimeZone.getDefault()))).toDate();
     } catch (Exception e) {
       throw new ProcessEngineException("couldn't resolve duedate: " + e.getMessage(), e);
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/DurationHelper.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/DurationHelper.java
@@ -19,6 +19,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.TimeZone;
 
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.Duration;
@@ -26,6 +27,8 @@ import javax.xml.datatype.Duration;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.ISODateTimeFormat;
 
 /**
  * helper class for parsing ISO8601 duration format (also recurring) and computing next timer date
@@ -116,7 +119,9 @@ public class DurationHelper {
   }
 
   private Date parseDate(String date) throws Exception {
-      return DateTime.parse(date).toDate();
+    return DateTime.parse(date, 
+        // make sure we use JVM TimeZone (as we do when writing the String with SimpleDateFormat), see https://app.camunda.com/jira/browse/CAM-1170 
+        ISODateTimeFormat.dateTimeParser().withZone(DateTimeZone.forTimeZone(TimeZone.getDefault()))).toDate();
   }
 
   private Duration parsePeriod(String period) throws Exception {


### PR DESCRIPTION
...property)

fixes CAM-1170
