### PR TITLE
fix(start-camunda.sh): improve standalone JBoss startup

### DIFF
--- a/distro/jbossas71/assembly/src/start-camunda.sh
+++ b/distro/jbossas71/assembly/src/start-camunda.sh
@@ -15,4 +15,4 @@ else
   (sleep 15; $BROWSER "http://localhost:8080/camunda-welcome/index.html";) &
 fi
 
-/bin/sh "$(dirname "$0")/server/jboss-as-7.1.3.Final/bin/standalone.sh"
+/bin/sh "$(dirname "$0")/server/jboss-as-${version.jboss.as}/bin/standalone.sh"


### PR DESCRIPTION
start-camunda.sh does not start jboss standalone correctly if run from a directory different from the script's location.
