### PR TITLE
fix: generation of MANIFEST

### DIFF
--- a/engine-osgi/pom.xml
+++ b/engine-osgi/pom.xml
@@ -25,31 +25,6 @@
 	  <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
-        <configuration>
-          <excludeDependencies>${camunda.osgi.exclude.dependencies}</excludeDependencies>
-          <instructions>
-            <Bundle-Name>${project.name}</Bundle-Name>
-            <Bundle-SymbolicName>${camunda.osgi.symbolic.name}</Bundle-SymbolicName>
-            <Bundle-Activator>${camunda.osgi.activator}</Bundle-Activator>
-            <Export-Package>${camunda.osgi.export}</Export-Package>
-            <Import-Package>org.camunda.bpm.engine.osgi*;resolution:=optional, ${camunda.osgi.import}</Import-Package>
-            <DynamicImport-Package>${camunda.osgi.dynamic}</DynamicImport-Package>
-            <Private-Package>${camunda.osgi.private.pkg}</Private-Package>
-            <Implementation-Title>camunda</Implementation-Title>
-            <Implementation-Version>${project.version}</Implementation-Version>
-            <Include-Resource>${camunda.osgi.include.resource}</Include-Resource>
-            <_versionpolicy>${camunda.osgi.import.default.version}</_versionpolicy>
-            <_removeheaders>${camunda.osgi.remove.headers}</_removeheaders>
-            <_failok>${camunda.osgi.failok}</_failok>
-            <Export-Service>${camunda.osgi.export.service}</Export-Service>
-            <Import-Service>${camunda.osgi.import.service}</Import-Service>
-            <Embed-Dependency>${camunda.osgi.embed}</Embed-Dependency>
-          </instructions>
-          <versions>
-            <camunda.osgi.version.clean>${project.version}</camunda.osgi.version.clean>
-          </versions>
-        </configuration>
       </plugin>
 	</plugins>
   </build>

--- a/engine-spring/pom.xml
+++ b/engine-spring/pom.xml
@@ -9,7 +9,11 @@
     <artifactId>camunda-root</artifactId>
     <version>7.1.0-SNAPSHOT</version>
   </parent>
-
+  <properties>
+  	      <camunda.artifact>
+        org.camunda.bpm.engine.spring
+      </camunda.artifact>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.camunda.bpm</groupId>
@@ -103,6 +107,33 @@
 
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+  	  <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>cleanVersions</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -161,14 +161,17 @@
       <mail.server.port>5025</mail.server.port>
   
       <camunda.artifact>
-        org.camunda.bpm.engine.db.mapping.entity,
-        org.camunda.bpm.engine
+        org.camunda.bpm
       </camunda.artifact>
       <camunda.osgi.import.additional>
           junit*;resolution:=optional,
           org.junit*;resolution:=optional,
           com.sun*;resolution:=optional,
           javax.persistence*;resolution:=optional,
+          javax.servlet*;resolution:=optional,
+          javax.transaction*;resolution:=optional,
+          javax.ejb*;resolution:=optional,
+          javax.xml*;resolution:=optional,
           org.apache.commons.mail;resolution:=optional,
           org.apache.tools.ant*;resolution:=optional,
           org.apache.xerces*;resolution:=optional,
@@ -176,6 +179,7 @@
           org.springframework*;resolution:=optional,
           org.drools*;resolution:=optional,
           com.fasterxml*;resolution:=optional,
+          org.jboss.vfs*;resolution:=optional,
       </camunda.osgi.import.additional>
   </properties>
 
@@ -218,15 +222,15 @@
           </archive>
         </configuration>
       </plugin>
-      <plugin>
+  	  <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <executions>
           <execution>
             <phase>generate-sources</phase>
-              <goals>
-                <goal>cleanVersions</goal>
-              </goals>
+            <goals>
+              <goal>cleanVersions</goal>
+            </goals>
           </execution>
           <execution>
             <id>bundle-manifest</id>

--- a/pom.xml
+++ b/pom.xml
@@ -730,11 +730,35 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>1.7</version>
-        </plugin>
-        <plugin>
+        </plugin><plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
           <version>2.3.7</version>
+          <extensions>true</extensions>
+          <configuration>
+           <excludeDependencies>${camunda.osgi.exclude.dependencies}</excludeDependencies>
+           <instructions>
+             <Bundle-Name>${project.name}</Bundle-Name>
+             <Bundle-SymbolicName>${camunda.osgi.symbolic.name}</Bundle-SymbolicName>
+             <Bundle-Activator>${camunda.osgi.activator}</Bundle-Activator>
+             <Export-Package>${camunda.osgi.export}</Export-Package>
+             <Import-Package>org.camunda.bpm.engine.osgi*;resolution:=optional, ${camunda.osgi.import}</Import-Package>
+             <DynamicImport-Package>${camunda.osgi.dynamic}</DynamicImport-Package>
+             <Private-Package>${camunda.osgi.private.pkg}</Private-Package>
+             <Implementation-Title>camunda</Implementation-Title>
+             <Implementation-Version>${project.version}</Implementation-Version>
+             <Include-Resource>${camunda.osgi.include.resource}</Include-Resource>
+             <_versionpolicy>${camunda.osgi.import.default.version}</_versionpolicy>
+             <_removeheaders>${camunda.osgi.remove.headers}</_removeheaders>
+             <_failok>${camunda.osgi.failok}</_failok>
+             <Export-Service>${camunda.osgi.export.service}</Export-Service>
+             <Import-Service>${camunda.osgi.import.service}</Import-Service>
+             <Embed-Dependency>${camunda.osgi.embed}</Embed-Dependency>
+            </instructions>
+           <versions>
+            <camunda.osgi.version.clean>${project.version}</camunda.osgi.version.clean>
+           </versions>
+          </configuration>
         </plugin>
         <plugin>                    
           <groupId>org.codehaus.cargo</groupId>


### PR DESCRIPTION
move configuration for maven-bundle-plugin from engine-osgi to root POM
change property "camunda.artifact" to "org.camunda.bpm" for engine POM
because it has classes in that package that need to be exported
declare org.jboss.vfs and the javax-packages servlet, transaction, ejb,
and xml as optional imports for engine
set camunda.artifact property for engine-spring
add maven-bundle-plugin and maven-jar-plugin to engine-spring module

Closes #1551
