### PR TITLE
fix(engine): Disallow message events with empty message names

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
@@ -1111,6 +1111,9 @@ public class BpmnParse extends Parse {
         }
       }
     }
+    if(subscription.getEventType().equals("message") && (subscription.getEventName() == null || "".equalsIgnoreCase(subscription.getEventName().trim()))) {
+      addError("Cannot have a message event subscription with an empty or missing name", element);
+    }
     eventDefinitions.add(subscription);
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/message/MessageStartEventTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/message/MessageStartEventTest.java
@@ -66,16 +66,17 @@ public class MessageStartEventTest extends PluggableProcessEngineTestCase {
   }
 
   // SEE: https://app.camunda.com/jira/browse/CAM-1448
-  public void FAILING_testEmptyMessageNameFails() {
+  public void testEmptyMessageNameFails() {
     try {
       repositoryService
         .createDeployment()
-        .addClasspathResource("org/camunda/bpm/engine/test/bpmn/event/message/MessageStartEventTest.testSingleMessageStartEvent.bpmn20.xml")
+        .addClasspathResource("org/camunda/bpm/engine/test/bpmn/event/message/MessageStartEventTest.testEmptyMessageNameFails.bpmn20.xml")
         .deploy();
       fail("exception expected");
     }catch (ProcessEngineException e) {
       // TODO: exception message
-      assertTrue(e.getMessage().contains("TO BE DETERMINED"));
+      //assertTrue(e.getMessage().contains("TO BE DETERMINED"));
+      assertTrue(e.getMessage().contains("Cannot have a message event subscription with an empty or missing name"));
     }
   }
 

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/event/message/MessageStartEventTest.testEmptyMessageNameFails.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/event/message/MessageStartEventTest.testEmptyMessageNameFails.bpmn20.xml
@@ -5,7 +5,7 @@
   targetNamespace="Examples"
   xmlns:tns="Examples">
   
-  <message id="newInvoice" />
+  <message id="newInvoice"/>
   
   <process id="singleMessageStartEvent">
   


### PR DESCRIPTION
fix(engine): Disallow message events with empty message names

Disallow empty - null or blank - message names

Closes CAM-1448
