### PR TITLE
refactor(distro): use default linux browser if configured

### DIFF
--- a/distro/gf31/assembly/src/start-camunda.sh
+++ b/distro/gf31/assembly/src/start-camunda.sh
@@ -1,16 +1,20 @@
-#! /bin/sh
+#!/bin/sh
+
+BROWSERS="gnome-www-browser x-www-browser firefox chromium chromium-browser google-chrome"
+
 echo "starting camunda BPM platform on Glassfish Application Server ${version.glassfish}";
 
-if [ "`which firefox`" = "/usr/bin/firefox" ]; then
-  BROWSER="/usr/bin/firefox";
-elif [ "`which chromium-browser`" = "/usr/bin/chromium-browser" ]; then
-  BROWSER="/usr/bin/chromium-browser";
-else
-  BROWSER="empty";
+if [ -z "$BROWSER" ]; then
+  for executable in $BROWSERS; do
+    BROWSER=`which $executable 2> /dev/null`
+    if [ -n "$BROWSER" ]; then
+      break;
+    fi
+  done
 fi
 
-if [ "$BROWSER" = "empty" ]; then
-( sleep 25;  echo "We are sorry... We tried all we could do but we couldn't locate your default browser... \nIf you want to see our default website please open your browser and insert this URL:\nhttp://localhost:8080/camunda-welcome/index.html";) &
+if [ -z "$BROWSER" ]; then
+  (sleep 25; echo -e "We are sorry... We tried all we could do but we couldn't locate your default browser... \nIf you want to see our default website please open your browser and insert this URL:\nhttp://localhost:8080/camunda-welcome/index.html";) &
 else
   (sleep 5; $BROWSER "http://localhost:8080/camunda-welcome/index.html";) &
 fi

--- a/distro/jbossas7/assembly/src/start-camunda.sh
+++ b/distro/jbossas7/assembly/src/start-camunda.sh
@@ -1,16 +1,20 @@
-#! /bin/sh
+#!/bin/sh
+
+BROWSERS="gnome-www-browser x-www-browser firefox chromium chromium-browser google-chrome"
+
 echo "starting camunda BPM ${project.version}  on JBoss Application Server ${version.jboss.as}";
 
-if [ "`which firefox`" = "/usr/bin/firefox" ]; then
-  BROWSER="/usr/bin/firefox";
-elif [ "`which chromium-browser`" = "/usr/bin/chromium-browser" ]; then
-  BROWSER="/usr/bin/chromium-browser";
-else
-  BROWSER="empty";
+if [ -z "$BROWSER" ]; then
+  for executable in $BROWSERS; do
+    BROWSER=`which $executable 2> /dev/null`
+    if [ -n "$BROWSER" ]; then
+      break;
+    fi
+  done
 fi
 
-if [ "$BROWSER" = "empty" ]; then
-( sleep 15;  echo "We are sorry... We tried all we could do but we couldn't locate your default browser... \nIf you want to see our default website please open your browser and insert this URL:\nhttp://localhost:8080/camunda-welcome/index.html";) &
+if [ -z "$BROWSER" ]; then
+  (sleep 15; echo -e "We are sorry... We tried all we could do but we couldn't locate your default browser... \nIf you want to see our default website please open your browser and insert this URL:\nhttp://localhost:8080/camunda-welcome/index.html";) &
 else
   (sleep 15; $BROWSER "http://localhost:8080/camunda-welcome/index.html";) &
 fi

--- a/distro/tomcat/assembly/src/start-camunda.sh
+++ b/distro/tomcat/assembly/src/start-camunda.sh
@@ -1,18 +1,20 @@
-#! /bin/sh
+#!/bin/sh
+
+BROWSERS="gnome-www-browser x-www-browser firefox chromium chromium-browser google-chrome"
+
 echo "starting camunda BPM platform on Tomcat Application Server";
 
-if [ "`which firefox`" = "/usr/bin/firefox" ]; then
-  BROWSER="/usr/bin/firefox";
-elif [ "`which chromium-browser`" = "/usr/bin/chromium-browser" ]; then
-  BROWSER="/usr/bin/chromium-browser";
-elif [ "`which google-chrome`" = "/usr/bin/google-chrome" ]; then
-  BROWSER="/usr/bin/google-chrome";
-else
-  BROWSER="empty";
+if [ -z "$BROWSER" ]; then
+  for executable in $BROWSERS; do
+    BROWSER=`which $executable 2> /dev/null`
+    if [ -n "$BROWSER" ]; then
+      break;
+    fi
+  done
 fi
 
-if [ "$BROWSER" = "empty" ]; then
-( sleep 15;  echo "We are sorry... We tried all we could do but we couldn't locate your default browser... \nIf you want to see our default website please open your browser and insert this URL:\nhttp://localhost:8080/camunda-welcome/index.html";) &
+if [ -z "$BROWSER" ]; then
+  (sleep 15; echo -e "We are sorry... We tried all we could do but we couldn't locate your default browser... \nIf you want to see our default website please open your browser and insert this URL:\nhttp://localhost:8080/camunda-welcome/index.html";) &
 else
   (sleep 5; $BROWSER "http://localhost:8080/camunda-welcome/index.html";) &
 fi


### PR DESCRIPTION
- use environment variable BROWSER if already set
- use gnome or X default browser if configured
- refactor browser executable search to be more extensible
- use echo -e option to enable interpretation of backslash escapes
  (most distributions disable this by default)
- remove redundant spaces
