### PR TITLE
fix(engine): Properly end pruned execution after parallel gateway join

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExecutionEntity.java
@@ -531,7 +531,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
         // Others are already ended (end activities)
         if (!prunedExecution.isEnded()) {
           log.fine("pruning execution " + prunedExecution);
-          prunedExecution.remove();
+          prunedExecution.end();
         }
       }
 
@@ -1275,6 +1275,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
   public void deleteCascade(String deleteReason) {
     this.deleteReason = deleteReason;
     this.deleteRoot = true;
+    this.isEnded = true;
     performOperation(AtomicOperation.DELETE_CASCADE);
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/gateway/ParallelGatewayTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/gateway/ParallelGatewayTest.java
@@ -138,4 +138,23 @@ public class ParallelGatewayTest extends PluggableProcessEngineTestCase {
     //assertEquals(1, historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).finished().count());    
   }
   
+  /**
+   * https://app.camunda.com/jira/browse/CAM-1537
+   */
+  @Deployment
+  public void testGatewayEndTimes() {
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("gatewayEndTimes");
+
+    TaskQuery query = taskService.createTaskQuery().orderByTaskName().asc();
+    List<Task> tasks = query.list();
+    taskService.complete(tasks.get(0).getId());
+    taskService.complete(tasks.get(1).getId());
+
+    // process instance should have finished
+    assertNotNull(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult().getEndTime());
+    // gateways should have end timestamps
+    assertNotNull(historyService.createHistoricActivityInstanceQuery().activityId("Gateway_0").singleResult().getEndTime());
+    assertNotNull(historyService.createHistoricActivityInstanceQuery().activityId("Gateway_1").list().get(0).getEndTime());
+  }
+
 }

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/gateway/ParallelGatewayTest.testGatewayEndTimes.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/gateway/ParallelGatewayTest.testGatewayEndTimes.bpmn20.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:activiti="http://activiti.org/bpmn"
+    xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+
+  <!-- CAM-1537 -->
+
+  <process id="gatewayEndTimes" name="gatewayEndTimes">
+
+    <startEvent id="Start" name="Start"></startEvent>
+
+    <parallelGateway id="Gateway_0" name="Gateway 0"></parallelGateway>
+
+    <userTask id="Task_0" name="Task 0"></userTask>
+
+    <userTask id="Task_1" name="Task 1"></userTask>
+
+    <parallelGateway id="Gateway_1" name="Gateway 1"></parallelGateway>
+
+    <endEvent id="End" name="End"></endEvent>
+
+    <sequenceFlow id="Flow_0" name="" sourceRef="Start" targetRef="Gateway_0"></sequenceFlow>
+
+    <sequenceFlow id="Flow_1" name="" sourceRef="Gateway_0" targetRef="Task_0"></sequenceFlow>
+
+    <sequenceFlow id="Flow_2" name="" sourceRef="Gateway_0" targetRef="Task_1"></sequenceFlow>
+
+    <sequenceFlow id="Flow_3" name="" sourceRef="Task_1" targetRef="Gateway_1"></sequenceFlow>
+
+    <sequenceFlow id="Flow_4" name="" sourceRef="Task_0" targetRef="Gateway_1"></sequenceFlow>
+
+    <sequenceFlow id="Flow_5" name="" sourceRef="Gateway_1" targetRef="End"></sequenceFlow>
+
+  </process>
+
+</definitions>


### PR DESCRIPTION
- use the ExecutionEntity end() instead of remove() function to clean pruned
  executions
- the end() function will correctly call the AtomicOperation ACTIVITY_END,
  which will trigger a database update for the endtime
- add test case and process from  https://app.camunda.com/jira/browse/CAM-1537
- set isEnded flag in ExectuinEntity deleteCascade() function to
  prevent an additional deletion attempt

Closes #CAM-1537
