### PR TITLE
fix(engine): Disallow deployment of process archives with no processes

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/container/impl/jmx/deployment/DeployProcessArchivesStep.java
+++ b/engine/src/main/java/org/camunda/bpm/container/impl/jmx/deployment/DeployProcessArchivesStep.java
@@ -42,12 +42,13 @@ public class DeployProcessArchivesStep extends MBeanDeploymentOperationStep {
 
     for (Entry<URL, ProcessesXml> processesXml : processesXmls.entrySet()) {
       for (ProcessArchiveXml processArchive : processesXml.getValue().getProcessArchives()) {
-
-        // for each process archive add an individual operation step
-        operationContext.addStep(new DeployProcessArchiveStep(processArchive, processesXml.getKey()));
+        if(processArchive.getProcessResourceNames().size() > 0) {
+          // for each process archive add an individual operation step
+          operationContext.addStep(new DeployProcessArchiveStep(processArchive, processesXml.getKey()));
+        } else {
+          LOGGER.warning("Ignoring deployment for " + processArchive.getName() + " because it does not have any defined processes.");
+        }
       }
     }
-
   }
-
 }

--- a/engine/src/test/java/org/camunda/bpm/application/impl/embedded/EmbeddedProcessApplicationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/application/impl/embedded/EmbeddedProcessApplicationTest.java
@@ -34,7 +34,7 @@ public class EmbeddedProcessApplicationTest extends PluggableProcessEngineTestCa
     
   }
 
-  public void FAILING_testDeployAppWithoutProcesses() {
+  public void testDeployAppWithoutProcesses() {
 
     // register existing process engine with BPM platform
     RuntimeContainerDelegate runtimeContainerDelegate = RuntimeContainerDelegate.INSTANCE.get();
@@ -45,12 +45,12 @@ public class EmbeddedProcessApplicationTest extends PluggableProcessEngineTestCa
 
     ProcessEngine processEngine = BpmPlatform.getProcessEngineService().getDefaultProcessEngine();
     long deployments = processEngine.getRepositoryService().createDeploymentQuery().count();
-    assertEquals(0, deployments);
 
     processApplication.undeploy();
 
     // unregister process engine
     runtimeContainerDelegate.unregisterProcessEngine(processEngine);
+    assertEquals(0, deployments);
 
   }
 


### PR DESCRIPTION
Disallow PA deployment when no processes are defined so that no entry
is created in ACT_RE_DEPLOYMENT

Closes CAM-1536
