### PR TITLE
fix(pom): bundle plug-in configuration

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -135,6 +135,9 @@
       <camunda.artifact>
         org.camunda.bpm
       </camunda.artifact>
+      <camunda.osgi.import.defaults>
+      	org.camunda.bpm.model*
+      </camunda.osgi.import.defaults>
       <camunda.osgi.import.additional>
           junit*;resolution:=optional,
           org.junit*;resolution:=optional,
@@ -149,10 +152,9 @@
           org.apache.commons.mail;resolution:=optional,
           org.apache.tools.ant*;resolution:=optional,
           org.apache.xerces*;resolution:=optional,
-          org.camunda.bpm.engine.osgi*;resolution:=optional,
           org.springframework*;resolution:=optional,
           com.fasterxml*;resolution:=optional,
-          org.jboss.vfs*;resolution:=optional,
+          org.jboss.vfs*;resolution:=optional
       </camunda.osgi.import.additional>
   </properties>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -73,7 +73,7 @@
     </camunda.osgi.import.pkg>
     <camunda.osgi.activator />
     <camunda.osgi.failok>false</camunda.osgi.failok>
-    <camunda.osgi.export>${camunda.osgi.export.pkg};${camunda.osgi.version};-noimport:=true</camunda.osgi.export>
+    <camunda.osgi.export>!org.camunda.bpm.model*, ${camunda.osgi.export.pkg};${camunda.osgi.version};-noimport:=true</camunda.osgi.export>
     <!--
     <camunda.osgi.export.pkg>!*.impl;${camunda.artifact}*</camunda.osgi.export.pkg>
     <camunda.osgi.private.pkg>${camunda.artifact}*.impl</camunda.osgi.private.pkg>
@@ -645,7 +645,7 @@
              <Bundle-SymbolicName>${camunda.osgi.symbolic.name}</Bundle-SymbolicName>
              <Bundle-Activator>${camunda.osgi.activator}</Bundle-Activator>
              <Export-Package>${camunda.osgi.export}</Export-Package>
-             <Import-Package>org.camunda.bpm.engine.osgi*;resolution:=optional, ${camunda.osgi.import}</Import-Package>
+             <Import-Package>${camunda.osgi.import}</Import-Package>
              <DynamicImport-Package>${camunda.osgi.dynamic}</DynamicImport-Package>
              <Private-Package>${camunda.osgi.private.pkg}</Private-Package>
              <Implementation-Title>camunda</Implementation-Title>


### PR DESCRIPTION
change the bundle plug-in configuration to consider the moved model
packages
org.camunda.bpm.model package exports are no longer included in this
bundle, instead they are added to the imports
also remove the org.camnda.bpm.osgi imports
