### PR TITLE
Rename to camunda

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/StandaloneInMemProcessEngineConfiguration.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/StandaloneInMemProcessEngineConfiguration.java
@@ -21,6 +21,6 @@ public class StandaloneInMemProcessEngineConfiguration extends StandaloneProcess
 
   public StandaloneInMemProcessEngineConfiguration() {
     this.databaseSchemaUpdate = DB_SCHEMA_UPDATE_CREATE_DROP;
-    this.jdbcUrl = "jdbc:h2:mem:activiti";
+    this.jdbcUrl = "jdbc:h2:mem:camunda";
   }
 }


### PR DESCRIPTION
renamed default in-memory-database from activiti to camunda (as written in docs)
