### PR TITLE
Process instance ended

### DIFF
--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/runtime/ProcessInstanceDto.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/runtime/ProcessInstanceDto.java
@@ -20,7 +20,6 @@ public class ProcessInstanceDto extends LinkableDto {
   private String id;  
   private String definitionId;
   private String businessKey;
-  private boolean ended;
   private boolean suspended;
 
   public String getId() {
@@ -35,10 +34,6 @@ public class ProcessInstanceDto extends LinkableDto {
     return businessKey;
   }
   
-  public boolean isEnded() {
-    return ended;
-  }
-  
   public boolean isSuspended() {
     return suspended;
   }
@@ -48,7 +43,6 @@ public class ProcessInstanceDto extends LinkableDto {
     result.id = instance.getId();
     result.definitionId = instance.getProcessDefinitionId();
     result.businessKey = instance.getBusinessKey();
-    result.ended = instance.isEnded();
     result.suspended = instance.isSuspended();
     return result;
   }

--- a/engine-rest/src/test/java/org/camunda/bpm/engine/rest/AbstractProcessDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/src/test/java/org/camunda/bpm/engine/rest/AbstractProcessDefinitionRestServiceInteractionTest.java
@@ -323,7 +323,6 @@ public abstract class AbstractProcessDefinitionRestServiceInteractionTest extend
       .body("id", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
       .body("definitionId", equalTo(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))
       .body("businessKey", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY))
-      .body("ended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_ENDED))
       .body("suspended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED))
     .when().post(SUBMIT_FORM_URL);
 
@@ -347,7 +346,6 @@ public abstract class AbstractProcessDefinitionRestServiceInteractionTest extend
         .body("id", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
         .body("definitionId", equalTo(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))
         .body("businessKey", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY))
-        .body("ended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_ENDED))
         .body("suspended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED))
       .when().post(SUBMIT_FORM_URL);
 
@@ -371,7 +369,6 @@ public abstract class AbstractProcessDefinitionRestServiceInteractionTest extend
         .body("id", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
         .body("definitionId", equalTo(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))
         .body("businessKey", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY))
-        .body("ended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_ENDED))
         .body("suspended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED))
       .when().post(SUBMIT_FORM_URL);
 
@@ -397,7 +394,6 @@ public abstract class AbstractProcessDefinitionRestServiceInteractionTest extend
         .body("id", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
         .body("definitionId", equalTo(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))
         .body("businessKey", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY))
-        .body("ended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_ENDED))
         .body("suspended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED))
       .when().post(SUBMIT_FORM_URL);
 
@@ -1538,7 +1534,6 @@ public abstract class AbstractProcessDefinitionRestServiceInteractionTest extend
       .body("id", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
       .body("definitionId", equalTo(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))
       .body("businessKey", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY))
-      .body("ended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_ENDED))
       .body("suspended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED))
     .when().post(SUBMIT_FORM_BY_KEY_URL);
 
@@ -1562,7 +1557,6 @@ public abstract class AbstractProcessDefinitionRestServiceInteractionTest extend
         .body("id", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
         .body("definitionId", equalTo(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))
         .body("businessKey", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY))
-        .body("ended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_ENDED))
         .body("suspended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED))
       .when().post(SUBMIT_FORM_BY_KEY_URL);
 
@@ -1586,7 +1580,6 @@ public abstract class AbstractProcessDefinitionRestServiceInteractionTest extend
         .body("id", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
         .body("definitionId", equalTo(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))
         .body("businessKey", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY))
-        .body("ended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_ENDED))
         .body("suspended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED))
       .when().post(SUBMIT_FORM_BY_KEY_URL);
 
@@ -1612,7 +1605,6 @@ public abstract class AbstractProcessDefinitionRestServiceInteractionTest extend
         .body("id", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
         .body("definitionId", equalTo(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))
         .body("businessKey", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY))
-        .body("ended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_ENDED))
         .body("suspended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED))
       .when().post(SUBMIT_FORM_BY_KEY_URL);
 

--- a/engine-rest/src/test/java/org/camunda/bpm/engine/rest/AbstractProcessInstanceRestServiceInteractionTest.java
+++ b/engine-rest/src/test/java/org/camunda/bpm/engine/rest/AbstractProcessInstanceRestServiceInteractionTest.java
@@ -200,7 +200,6 @@ public abstract class AbstractProcessInstanceRestServiceInteractionTest extends
     given().pathParam("id", MockProvider.EXAMPLE_PROCESS_INSTANCE_ID)
       .then().expect().statusCode(Status.OK.getStatusCode())
       .body("id", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
-      .body("ended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_ENDED))
       .body("definitionId", equalTo(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))
       .body("businessKey", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY))
       .body("suspended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED))

--- a/engine-rest/src/test/java/org/camunda/bpm/engine/rest/AbstractProcessInstanceRestServiceQueryTest.java
+++ b/engine-rest/src/test/java/org/camunda/bpm/engine/rest/AbstractProcessInstanceRestServiceQueryTest.java
@@ -136,13 +136,11 @@ public abstract class AbstractProcessInstanceRestServiceQueryTest extends
     Assert.assertNotNull("There should be one process definition returned", instances.get(0));
 
     String returnedInstanceId = from(content).getString("[0].id");
-    Boolean returnedIsEnded = from(content).getBoolean("[0].ended");
     String returnedDefinitionId = from(content).getString("[0].definitionId");
     String returnedBusinessKey = from(content).getString("[0].businessKey");
     Boolean returnedIsSuspended = from(content).getBoolean("[0].suspended");
 
     Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID, returnedInstanceId);
-    Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_ENDED, returnedIsEnded);
     Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, returnedDefinitionId);
     Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY, returnedBusinessKey);
     Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED, returnedIsSuspended);

--- a/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
+++ b/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
@@ -117,7 +117,6 @@ public abstract class MockProvider {
   public static final String EXAMPLE_PROCESS_INSTANCE_ID = "aProcInstId";
   public static final String ANOTHER_EXAMPLE_PROCESS_INSTANCE_ID = "anotherId";
   public static final boolean EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED = false;
-  public static final boolean EXAMPLE_PROCESS_INSTANCE_IS_ENDED = false;
   public static final String EXAMPLE_PROCESS_INSTANCE_ID_LIST = EXAMPLE_PROCESS_INSTANCE_ID + "," + ANOTHER_EXAMPLE_PROCESS_INSTANCE_ID;
   public static final String EXAMPLE_PROCESS_INSTANCE_ID_LIST_WITH_DUP = EXAMPLE_PROCESS_INSTANCE_ID + "," + ANOTHER_EXAMPLE_PROCESS_INSTANCE_ID + "," + EXAMPLE_PROCESS_INSTANCE_ID;
   public static final String EXAMPLE_NON_EXISTENT_PROCESS_INSTANCE_ID = "aNonExistentProcInstId";
@@ -468,7 +467,6 @@ public abstract class MockProvider {
     when(mock.getProcessDefinitionId()).thenReturn(EXAMPLE_PROCESS_DEFINITION_ID);
     when(mock.getProcessInstanceId()).thenReturn(EXAMPLE_PROCESS_INSTANCE_ID);
     when(mock.isSuspended()).thenReturn(EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED);
-    when(mock.isEnded()).thenReturn(EXAMPLE_PROCESS_INSTANCE_IS_ENDED);
 
     return mock;
   }
@@ -918,7 +916,6 @@ public abstract class MockProvider {
     when(mock.getProcessDefinitionId()).thenReturn(EXAMPLE_PROCESS_DEFINITION_ID);
     when(mock.getProcessInstanceId()).thenReturn(ANOTHER_EXAMPLE_PROCESS_INSTANCE_ID);
     when(mock.isSuspended()).thenReturn(EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED);
-    when(mock.isEnded()).thenReturn(EXAMPLE_PROCESS_INSTANCE_IS_ENDED);
 
     return mock;
   }


### PR DESCRIPTION
fix (rest): remove "isEnded" attribute from Process Instance because a ProcessInstance in runtime is NEVER ended. Confusing.
Fixes CAM-1994
