### PR TITLE
Add escaping of group filter when querying group membership by user id

### DIFF
--- a/identity/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
+++ b/identity/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
@@ -408,7 +408,7 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
       } else {
         userDn = getDnForUser(query.getUserId());
       }
-      addFilter(ldapConfiguration.getGroupMemberAttribute(), userDn, search);
+      addFilter(ldapConfiguration.getGroupMemberAttribute(), escapeLDAPSearchFilter(userDn), search);
     }
     search.write(")");
 
@@ -546,4 +546,31 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
       .isAuthorized(permission, resource, resourceId);
   }
 
+  // Based on https://www.owasp.org/index.php/Preventing_LDAP_Injection_in_Java
+  protected final String escapeLDAPSearchFilter(String filter) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < filter.length(); i++) {
+      char curChar = filter.charAt(i);
+        switch (curChar) {
+          case '\\':
+            sb.append("\\5c");
+            break;
+          case '*':
+            sb.append("\\2a");
+            break;
+          case '(':
+            sb.append("\\28");
+            break;
+          case ')':
+            sb.append("\\29");
+            break;
+          case '\u0000': 
+            sb.append("\\00"); 
+            break;
+          default:
+            sb.append(curChar);
+        }
+    }
+    return sb.toString();
+  }
 }

--- a/identity/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapGroupQueryTest.java
+++ b/identity/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapGroupQueryTest.java
@@ -76,6 +76,11 @@ public class LdapGroupQueryTest extends LdapIdentityProviderTest {
     assertEquals(0, list.size());
   }
 
+  public void testFilterByGroupMemberSpecialCharacter() {
+    List<Group> list = identityService.createGroupQuery().groupMember("david(IT)").list();
+    assertEquals(1, list.size());
+  }
+
   public void testFilterByGroupMemberPosix() {
 
     // by default the configuration does not use posix groups

--- a/identity/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapTestEnvironment.java
+++ b/identity/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapTestEnvironment.java
@@ -93,11 +93,14 @@ public class LdapTestEnvironment {
     
     createGroup("office-home");
     String dnRuecker = createUser("ruecker", "office-home", "Bernd", "Ruecker", "ruecker@camunda.org");
-
+    // Doesn't work using backslashes, end up with two uid attributes
+    // See https://issues.apache.org/jira/browse/DIRSERVER-1442
+    String dnDavid = createUser("david(IT)", "office-home", "David", "Howe\\IT\\", "david@camunda.org");
+    
     createRole("management", dnRuecker, dnRobert, dnDaniel);
     createRole("development", dnRoman, dnDaniel, dnOscar);
     createRole("consulting", dnRuecker);
-    createRole("sales", dnRuecker, dnMonster);
+    createRole("sales", dnRuecker, dnMonster, dnDavid);
   }
 
   protected String createUser(String user, String group, String firstname, String lastname, String email) throws Exception {

--- a/identity/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapUserQueryTest.java
+++ b/identity/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapUserQueryTest.java
@@ -24,7 +24,7 @@ public class LdapUserQueryTest extends LdapIdentityProviderTest {
 
   public void testQueryNoFilter() {
     List<User> result = identityService.createUserQuery().list();
-    assertEquals(6, result.size());
+    assertEquals(7, result.size());
   }
 
   public void testFilterByUserId() {


### PR DESCRIPTION
This fixes the problem of the group membership query not
returning any results if the user DN contains any LDAP special
characters (refer
https://www.owasp.org/index.php/Preventing_LDAP_Injection_in_Java).

This fixes issue CAM-2309.
