### PR TITLE
fix(webapp/core): Javadoc completed

### DIFF
--- a/webapps/camunda-webapp/core/src/main/java/org/camunda/bpm/cockpit/plugin/PluginRegistry.java
+++ b/webapps/camunda-webapp/core/src/main/java/org/camunda/bpm/cockpit/plugin/PluginRegistry.java
@@ -18,8 +18,8 @@ import org.camunda.bpm.cockpit.plugin.spi.CockpitPlugin;
 /**
  * The holder of registered cockpit plugins.
  *
- * This class is deprecated, use
- *
+ * This class is deprecated, use {@link AppPluginRegistry}
+ * 
  * @author nico.rehwaldt
  */
 @Deprecated


### PR DESCRIPTION
What to use instead of deprecated PluginRegistry
