### PR TITLE
fix(webapp): url matcher for authorized engine harded

### DIFF
--- a/webapps/camunda-webapp/webapp/src/main/webapp/app/common/services/engineRequestHeaderProvider.js
+++ b/webapps/camunda-webapp/webapp/src/main/webapp/app/common/services/engineRequestHeaderProvider.js
@@ -5,7 +5,7 @@ ngDefine('camunda.common.services', function(module) {
       var window = $windowProvider.$get();
       var uri = window.location.href;
 
-      var match = uri.match(/app\/(\w+)\/(\w+)\//);
+      var match = uri.match(/\/app\/(\w+)\/(\w+)\//);
       if (match) {
         $httpProvider.defaults.headers.get = {'X-Authorized-Engine' : match[2] };
       } else {


### PR DESCRIPTION
can now handle wars with app in archive name (my-camunda-webapp.war)
