### PR TITLE
Tasklist doesn't show group tasks or colleagues when using AD as an LDAP provider

### DIFF
--- a/identity/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
+++ b/identity/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
@@ -163,7 +163,6 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
     try {
       enumeration = initialContext.search(baseDn, groupSearchFilter, ldapConfiguration.getSearchControls());
 
-      List<User> userList = new ArrayList<User>();
       List<String> userDnList = new ArrayList<String>();
 
       // first find group
@@ -173,22 +172,18 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
         NamingEnumeration<?> allMembers = memberAttribute.getAll();
 
         // iterate group members
-        while (allMembers.hasMoreElements() && userList.size() < query.getMaxResults()) {
+        while (allMembers.hasMoreElements() && userDnList.size() < query.getMaxResults()) {
           userDnList.add((String) allMembers.nextElement());
         }
 
       }
 
-      String queriedUserId  = query.getId();
-      String userBaseDn = composeDn(ldapConfiguration.getUserSearchBase(), ldapConfiguration.getBaseDn());
+      List<User> userList = new ArrayList<User>();
       for (String userDn : userDnList) {
-        String userId = userDn.substring(userDn.indexOf("=")+1, userDn.indexOf(","));
-        if(queriedUserId == null) {
-          query.userId(userId);
-        }
-        if(queriedUserId == null || queriedUserId.equals(userId)) {
-          userList.addAll(findUsersWithoutGroupId(query, userBaseDn));
-        }
+          List<User> users = findUsersWithoutGroupId(query, userDn);
+          if (users.size() > 0) {
+            userList.add(users.get(0));
+          }
       }
 
       return userList;
@@ -289,7 +284,7 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
 
     // add additional filters from query
     if(query.getId() != null) {
-      addFilter(ldapConfiguration.getUserIdAttribute(), query.getId(), search);
+      addFilter(ldapConfiguration.getUserIdAttribute(), escapeLDAPSearchFilter(query.getId()), search);
     }
     if(query.getEmail() != null) {
       addFilter(ldapConfiguration.getUserEmailAttribute(), query.getEmail(), search);

--- a/identity/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapGroupQueryTest.java
+++ b/identity/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapGroupQueryTest.java
@@ -25,8 +25,8 @@ public class LdapGroupQueryTest extends LdapIdentityProviderTest {
 
   public void testQueryNoFilter() {
     List<Group> groupList = identityService.createGroupQuery().list();
-
-    assertEquals(4, groupList.size());
+    
+    assertEquals(5, groupList.size());
   }
 
   public void testFilterByGroupId() {

--- a/identity/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapTestEnvironment.java
+++ b/identity/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapTestEnvironment.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.logging.Level;
@@ -83,28 +84,45 @@ public class LdapTestEnvironment {
     }
 
     createGroup("office-berlin");
-    String dnRoman = createUser("roman", "office-berlin", "Roman", "Smirnov", "roman@camunda.org");
-    String dnRobert = createUser("robert", "office-berlin", "Robert", "Gimbel", "robert@camunda.org");
-    String dnDaniel = createUser("daniel", "office-berlin", "Daniel", "Meyer", "daniel@camunda.org");
+    String dnRoman = createUserUid("roman", "office-berlin", "Roman", "Smirnov", "roman@camunda.org");
+    String dnRobert = createUserUid("robert", "office-berlin", "Robert", "Gimbel", "robert@camunda.org");
+    String dnDaniel = createUserUid("daniel", "office-berlin", "Daniel", "Meyer", "daniel@camunda.org");
 
     createGroup("office-london");
-    String dnOscar = createUser("oscar", "office-london", "Oscar", "The Crouch", "oscar@camunda.org");
-    String dnMonster = createUser("monster", "office-london", "Cookie", "Monster", "monster@camunda.org");
+    String dnOscar = createUserUid("oscar", "office-london", "Oscar", "The Crouch", "oscar@camunda.org");
+    String dnMonster = createUserUid("monster", "office-london", "Cookie", "Monster", "monster@camunda.org");
     
     createGroup("office-home");
-    String dnRuecker = createUser("ruecker", "office-home", "Bernd", "Ruecker", "ruecker@camunda.org");
+    String dnRuecker = createUserUid("ruecker", "office-home", "Bernd", "Ruecker", "ruecker@camunda.org");
     // Doesn't work using backslashes, end up with two uid attributes
     // See https://issues.apache.org/jira/browse/DIRSERVER-1442
-    String dnDavid = createUser("david(IT)", "office-home", "David", "Howe\\IT\\", "david@camunda.org");
+    String dnDavid = createUserUid("david(IT)", "office-home", "David", "Howe\\IT\\", "david@camunda.org");
+
+    createGroup("office-external");
+    String dnFozzie = createUserCN("fozzie", "office-external", "Bear", "Fozzie", "fozzie@camunda.org");
     
     createRole("management", dnRuecker, dnRobert, dnDaniel);
     createRole("development", dnRoman, dnDaniel, dnOscar);
     createRole("consulting", dnRuecker);
     createRole("sales", dnRuecker, dnMonster, dnDavid);
+    createRole("external", dnFozzie);
   }
 
-  protected String createUser(String user, String group, String firstname, String lastname, String email) throws Exception {
+  protected String createUserUid(String user, String group, String firstname, String lastname, String email) throws Exception {
     LdapDN dn = new LdapDN("uid="+user+",ou="+group+",o=camunda,c=org");
+    createUser(user, firstname, lastname, email, dn);
+    return dn.toNormName();
+  }
+
+  protected String createUserCN(String user, String group, String firstname, String lastname, String email) throws Exception {
+    LdapDN dn = new LdapDN("cn="+lastname + "\\," + firstname +",ou="+group+",o=camunda,c=org");
+    createUser(user, firstname, lastname, email, dn);
+    return dn.toNormName();
+  }
+
+  private void createUser(String user, String firstname, String lastname,
+      String email, LdapDN dn) throws Exception, NamingException,
+      UnsupportedEncodingException {
     if (!service.getAdminSession().exists(dn)) {
       ServerEntry entry = service.newEntry(dn);
       entry.add("objectClass", "top", "person", "inetOrgPerson"); //, "extensibleObject"); //make extensible to allow for the "memberOf" field
@@ -116,9 +134,8 @@ public class LdapTestEnvironment {
       service.getAdminSession().add(entry);
       System.out.println("created entry: " + dn.toNormName());
     }
-    return dn.toNormName();
   }
-
+  
   protected void createGroup(String name) throws InvalidNameException, Exception, NamingException {
     LdapDN dn = new LdapDN("ou=" + name + ",o=camunda,c=org");
     if (!service.getAdminSession().exists(dn)) {

--- a/identity/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapUserQueryTest.java
+++ b/identity/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapUserQueryTest.java
@@ -24,7 +24,7 @@ public class LdapUserQueryTest extends LdapIdentityProviderTest {
 
   public void testQueryNoFilter() {
     List<User> result = identityService.createUserQuery().list();
-    assertEquals(7, result.size());
+    assertEquals(8, result.size());
   }
 
   public void testFilterByUserId() {
@@ -135,6 +135,14 @@ public class LdapUserQueryTest extends LdapIdentityProviderTest {
         .userEmail("*@camunda.org")
         .list();
     assertEquals(3, result.size());
+  }
+
+  public void testFilterByGroupIdAndIdForDnUsingCn() {
+    List<User> result = identityService.createUserQuery()
+        .memberOfGroup("external")
+        .userId("fozzie")
+        .list();
+    assertEquals(1, result.size());
   }
 
   public void testAuthenticatedUserSeesHimself() {


### PR DESCRIPTION
Fixed LDAP identity provider to include correct escaping for user filtering and correct lookup of group users by distinguished name.  Previous code assumed that the user's DN contained the user id.  In active directory, this is not the case so it is safer to lookup the group user by their distinguished name as it appears in the group membership.

Related to CAM-2478
