### PR TITLE
Clear cached activity during SetProcessDefinitionVersionCmd

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SetProcessDefinitionVersionCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SetProcessDefinitionVersionCmd.java
@@ -28,6 +28,7 @@ import org.camunda.bpm.engine.impl.persistence.entity.HistoricProcessInstanceEnt
 import org.camunda.bpm.engine.impl.persistence.entity.HistoricProcessInstanceManager;
 import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
+import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
 import org.camunda.bpm.engine.impl.pvm.process.ProcessDefinitionImpl;
 import org.camunda.bpm.engine.impl.util.EnsureUtil;
 import org.camunda.bpm.engine.runtime.ProcessInstance;


### PR DESCRIPTION
The execution seems to cache its activity, including outgoing transitions. Refresh the activity from the new process definition so that newly added activities directly following the migration point are executed.
