### PR TITLE
improve(engine): support system property resolution in bpm-platform.xml

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/container/impl/metadata/DeploymentMetadataParse.java
+++ b/engine/src/main/java/org/camunda/bpm/container/impl/metadata/DeploymentMetadataParse.java
@@ -171,13 +171,16 @@ public abstract class DeploymentMetadataParse extends Parse {
    * &lt;/properties&gt;
    * </pre>
    * structure into a properties {@link Map}
+   * 
+   * Supports resolution of Ant-style placeholders against system properties. 
    *
    */
   protected void parseProperties(Element element, Map<String, String> properties) {
 
     for (Element childElement : element.elements()) {
       if(PROPERTY.equals(childElement.getTagName())) {
-        properties.put(childElement.attribute(NAME), childElement.getText());
+        String resolved = PropertyHelper.resolveProperty(System.getProperties(), childElement.getText());
+        properties.put(childElement.attribute(NAME), resolved);
       }
     }
 

--- a/engine/src/test/java/org/camunda/bpm/container/impl/metadata/PropertyHelperTest.java
+++ b/engine/src/test/java/org/camunda/bpm/container/impl/metadata/PropertyHelperTest.java
@@ -2,6 +2,7 @@ package org.camunda.bpm.container.impl.metadata;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 import junit.framework.TestCase;
 
@@ -68,5 +69,40 @@ public class PropertyHelperTest extends TestCase {
     } catch (Exception e) {
       // happy path
     }
+  }
+  
+  public void testResolvePropertyForExistingProperty() {
+    Properties source = new Properties();
+    source.put("camunda.test.someKey", "1234");
+    String result = PropertyHelper.resolveProperty(source, "${camunda.test.someKey}");
+    Assert.assertEquals("1234", result);
+  }
+  
+  public void testResolvePropertyWhitespaceAndMore() {
+    Properties source = new Properties();
+    source.put("camunda.test.someKey", "1234");
+    String result = PropertyHelper.resolveProperty(source, " -${ camunda.test.someKey }- ");
+    Assert.assertEquals(" -1234- ", result);
+  }  
+
+  public void testResolvePropertyForMultiplePropertes() {
+    Properties source = new Properties();
+    source.put("camunda.test.oneKey", "1234");
+    source.put("camunda.test.anotherKey", "5678");
+    String result = PropertyHelper.resolveProperty(source, "-${ camunda.test.oneKey }-${ camunda.test.anotherKey}-");
+    Assert.assertEquals("-1234-5678-", result);
+  }  
+  
+  public void testResolvePropertyForMissingProperty() {
+    Properties source = new Properties();
+    String result = PropertyHelper.resolveProperty(source, "${camunda.test.someKey}");
+    Assert.assertEquals("", result);
+  }
+  
+  public void testResolvePropertyNoTemplate() {
+    Properties source = new Properties();
+    source.put("camunda.test.someKey", "1234");
+    String result = PropertyHelper.resolveProperty(source, "camunda.test.someKey");
+    Assert.assertEquals("camunda.test.someKey", result);
   }
 }


### PR DESCRIPTION
Allows externalization of environment-specific plugin configuration, e.g. for the LdapIdentityProviderPlugin.
Ant-style variable substitution is supported only for the property-element inside the plugin configuration.

Partial solution to CAM-2532
