### PR TITLE
feat(engine): 1st lvl cache reuse with exclusive jobs

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -408,6 +408,11 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    */
   protected boolean isDeploymentLockUsed = true;
 
+  /** Allows setting whether the process engine should try reusing the first level entity cache.
+   * Default setting is false, enabling it improves performance of asynchronous continuations.
+   */
+  protected boolean isDbEntityCacheReuseEnabled = false;
+
   protected Connectors connectors;
 
   protected List<SerializationVariableTypeResolver> serializationTypeResolvers = new ArrayList<SerializationVariableTypeResolver>();
@@ -2375,4 +2380,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     this.serializationTypeResolvers = serializationTypeResolvers;
     return this;
   }
+
+  public boolean isDbEntityCacheReuseEnabled() {
+    return isDbEntityCacheReuseEnabled;
+  }
+
+  public ProcessEngineConfigurationImpl setDbEntityCacheReuseEnabled(boolean isDbEntityCacheReuseEnabled) {
+    this.isDbEntityCacheReuseEnabled = isDbEntityCacheReuseEnabled;
+    return this;
+  }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/ExecuteJobsCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/ExecuteJobsCmd.java
@@ -50,9 +50,7 @@ public class ExecuteJobsCmd implements Command<Object>, Serializable {
     if (log.isLoggable(Level.FINE)) {
       log.fine("Executing job " + jobId);
     }
-    JobEntity job = commandContext
-      .getJobManager()
-      .findJobById(jobId);
+    JobEntity job = commandContext.getDbEntityManger().selectById(JobEntity.class, jobId);
 
     final CommandExecutor commandExecutor = Context.getProcessEngineConfiguration().getCommandExecutorTxRequiresNew();
     final JobExecutorContext jobExecutorContext = Context.getJobExecutorContext();

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmmn/entity/runtime/CaseExecutionEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmmn/entity/runtime/CaseExecutionEntity.java
@@ -84,8 +84,6 @@ public class CaseExecutionEntity extends CmmnExecution implements CaseExecution,
   protected String parentId;
   protected String superCaseExecutionId;
 
-  protected boolean forcedUpdate;
-
   // case definition ///////////////////////////////////////////////////////////
 
   public String getCaseDefinitionId() {
@@ -432,7 +430,9 @@ public class CaseExecutionEntity extends CmmnExecution implements CaseExecution,
   }
 
   public void forceUpdate() {
-    this.forcedUpdate = true;
+    Context.getCommandContext()
+      .getDbEntityManger()
+      .forceUpdate(this);
   }
 
   public boolean hasReferenceTo(DbEntity entity) {
@@ -464,11 +464,6 @@ public class CaseExecutionEntity extends CmmnExecution implements CaseExecution,
     persistentState.put("parentId", parentId);
     persistentState.put("currentState", currentState);
     persistentState.put("previousState", previousState);
-
-    if (forcedUpdate) {
-      persistentState.put("forcedUpdate", Boolean.TRUE);
-    }
-
     return persistentState;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/entitymanager/cache/CachedDbEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/entitymanager/cache/CachedDbEntity.java
@@ -48,8 +48,17 @@ public class CachedDbEntity implements Recyclable {
       && !dbEntity.getPersistentState().equals(copy);
   }
 
+  public void forceSetDirty() {
+    // set the value of the copy to some value which will always be different from the new entity state.
+    this.copy = -1;
+  }
+
   public void makeCopy() {
     copy = dbEntity.getPersistentState();
+  }
+
+  public String toString() {
+    return entityState + " " + dbEntity.getClass().getSimpleName() + "["+dbEntity.getId()+"]";
   }
 
   // getters / setters ////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/entitymanager/operation/DbOperationManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/entitymanager/operation/DbOperationManager.java
@@ -41,11 +41,11 @@ public class DbOperationManager {
 
   // comparators ////////////////
 
-  public Comparator<Class<?>> INSERT_TYPE_COMPARATOR = new EntityTypeComparatorForInserts();
-  public Comparator<Class<?>> MODIFICATION_TYPE_COMPARATOR = new EntityTypeComparatorForModifications();
-  public Comparator<DbEntityOperation> INSERT_OPERATION_COMPARATOR = new DbEntityOperationComparator();
-  public Comparator<DbEntityOperation> MODIFICATION_OPERATION_COMPARATOR  = new DbEntityOperationComparator();
-  public Comparator<DbBulkOperation> BULK_OPERATION_COMPARATOR = new DbBulkOperationComparator();
+  public static Comparator<Class<?>> INSERT_TYPE_COMPARATOR = new EntityTypeComparatorForInserts();
+  public static Comparator<Class<?>> MODIFICATION_TYPE_COMPARATOR = new EntityTypeComparatorForModifications();
+  public static Comparator<DbEntityOperation> INSERT_OPERATION_COMPARATOR = new DbEntityOperationComparator();
+  public static Comparator<DbEntityOperation> MODIFICATION_OPERATION_COMPARATOR  = new DbEntityOperationComparator();
+  public static Comparator<DbBulkOperation> BULK_OPERATION_COMPARATOR = new DbBulkOperationComparator();
 
   // pre-sorted operation maps //////////////
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSession.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSession.java
@@ -130,10 +130,10 @@ public class DbSqlSession extends AbstractPersistenceSession {
     }
     sqlSession.insert(insertStatement, parameter);
 
-    // increment revision of our copy
+    // set revision of our copy to 1
     if (parameter instanceof HasDbRevision) {
       HasDbRevision versionedObject = (HasDbRevision) parameter;
-      versionedObject.setRevision(versionedObject.getRevisionNext());
+      versionedObject.setRevision(1);
     }
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/JobExecutorContext.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/JobExecutorContext.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,7 @@ package org.camunda.bpm.engine.impl.jobexecutor;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.camunda.bpm.engine.impl.db.entitymanager.cache.DbEntityCache;
 import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
 
 /**
@@ -23,8 +24,13 @@ import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
 public class JobExecutorContext {
 
   protected List<String> currentProcessorJobQueue = new LinkedList<String>();
+
+  /** the currently executed job */
   protected JobEntity currentJob;
-        
+
+  /** reusable cache */
+  protected DbEntityCache entityCache;
+
   public List<String> getCurrentProcessorJobQueue() {
     return currentProcessorJobQueue;
   }
@@ -32,12 +38,21 @@ public class JobExecutorContext {
   public boolean isExecutingExclusiveJob() {
     return currentJob == null ? false : currentJob.isExclusive();
   }
-     
+
   public void setCurrentJob(JobEntity currentJob) {
     this.currentJob = currentJob;
   }
-    
+
   public JobEntity getCurrentJob() {
     return currentJob;
   }
+
+  public DbEntityCache getEntityCache() {
+    return entityCache;
+  }
+
+  public void setEntityCache(DbEntityCache entityCache) {
+    this.entityCache = entityCache;
+  }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExecutionEntity.java
@@ -196,8 +196,6 @@ public class ExecutionEntity extends PvmExecutionImpl implements
    */
   protected String superCaseExecutionId;
 
-  protected boolean forcedUpdate;
-
   public ExecutionEntity() {
 
   }
@@ -1054,9 +1052,6 @@ public class ExecutionEntity extends PvmExecutionImpl implements
     persistentState.put("superExecution", this.superExecutionId);
     persistentState.put("superCaseExecutionId", this.superCaseExecutionId);
     persistentState.put("caseInstanceId", this.caseInstanceId);
-    if (forcedUpdate) {
-      persistentState.put("forcedUpdate", Boolean.TRUE);
-    }
     persistentState.put("suspensionState", this.suspensionState);
     persistentState.put("cachedEntityState", getCachedEntityState());
     return persistentState;
@@ -1080,7 +1075,9 @@ public class ExecutionEntity extends PvmExecutionImpl implements
   }
 
   public void forceUpdate() {
-    this.forcedUpdate = true;
+    Context.getCommandContext()
+      .getDbEntityManger()
+      .forceUpdate(this);
   }
 
   // toString /////////////////////////////////////////////////////////////////
@@ -1142,8 +1139,10 @@ public class ExecutionEntity extends PvmExecutionImpl implements
   }
 
   public void addEventSubscription(EventSubscriptionEntity eventSubscriptionEntity) {
-    getEventSubscriptionsInternal().add(eventSubscriptionEntity);
-
+    List<EventSubscriptionEntity> eventSubscriptionsInternal = getEventSubscriptionsInternal();
+    if(!eventSubscriptionsInternal.contains(eventSubscriptionEntity)) {
+      eventSubscriptionsInternal.add(eventSubscriptionEntity);
+    }
   }
 
   public void removeEventSubscription(EventSubscriptionEntity eventSubscriptionEntity) {
@@ -1171,7 +1170,10 @@ public class ExecutionEntity extends PvmExecutionImpl implements
   }
 
   public void addJob(JobEntity jobEntity) {
-    getJobsInternal().add(jobEntity);
+    List<JobEntity> jobsInternal = getJobsInternal();
+    if(!jobsInternal.contains(jobEntity)) {
+      jobsInternal.add(jobEntity);
+    }
   }
 
   public void removeJob(JobEntity job) {
@@ -1199,7 +1201,10 @@ public class ExecutionEntity extends PvmExecutionImpl implements
   }
 
   public void addIncident(IncidentEntity incident) {
-    getIncidentsInternal().add(incident);
+    List<IncidentEntity> incidentsInternal = getIncidentsInternal();
+    if(!incidentsInternal.contains(incident)) {
+      incidentsInternal.add(incident);
+    }
   }
 
   public void removeIncident(IncidentEntity incident) {
@@ -1237,7 +1242,10 @@ public class ExecutionEntity extends PvmExecutionImpl implements
   }
 
   public void addTask(TaskEntity taskEntity) {
-    getTasksInternal().add(taskEntity);
+    List<TaskEntity> tasksInternal = getTasksInternal();
+    if(!tasksInternal.contains(taskEntity)) {
+      tasksInternal.add(taskEntity);
+    }
   }
 
   public void removeTask(TaskEntity task) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/IncidentEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/IncidentEntity.java
@@ -380,4 +380,29 @@ public class IncidentEntity implements Incident, DbEntity, HasDbRevision, HasDbR
            + "]";
   }
 
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((id == null) ? 0 : id.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    IncidentEntity other = (IncidentEntity) obj;
+    if (id == null) {
+      if (other.id != null)
+        return false;
+    } else if (!id.equals(other.id))
+      return false;
+    return true;
+  }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/JobEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/JobEntity.java
@@ -414,6 +414,31 @@ public abstract class JobEntity implements Serializable, Job, DbEntity, HasDbRev
   }
 
   @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((id == null) ? 0 : id.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    JobEntity other = (JobEntity) obj;
+    if (id == null) {
+      if (other.id != null)
+        return false;
+    } else if (!id.equals(other.id))
+      return false;
+    return true;
+  }
+
+  @Override
   public String toString() {
     return this.getClass().getSimpleName()
            + "[id=" + id

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/TaskEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/TaskEntity.java
@@ -1020,4 +1020,29 @@ public class TaskEntity extends CorePersistentVariableScope implements Task, Del
           .getProcessEngine();
   }
 
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((id == null) ? 0 : id.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    TaskEntity other = (TaskEntity) obj;
+    if (id == null) {
+      if (other.id != null)
+        return false;
+    } else if (!id.equals(other.id))
+      return false;
+    return true;
+  }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
@@ -465,4 +465,29 @@ public class VariableInstanceEntity implements VariableInstance, ValueFields, Db
       + "]";
   }
 
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((id == null) ? 0 : id.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    VariableInstanceEntity other = (VariableInstanceEntity) obj;
+    if (id == null) {
+      if (other.id != null)
+        return false;
+    } else if (!id.equals(other.id))
+      return false;
+    return true;
+  }
+
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/exclusive/ExclusiveTaskTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/exclusive/ExclusiveTaskTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,52 +18,71 @@ import org.camunda.bpm.engine.runtime.Job;
 import org.camunda.bpm.engine.test.Deployment;
 
 /**
- * 
+ *
  * @author Daniel Meyer
  */
 public class ExclusiveTaskTest extends PluggableProcessEngineTestCase {
-  
+
   @Deployment
-  public void testNonExclusiveService() {   
-    // start process 
+  public void testNonExclusiveService() {
+    // start process
     runtimeService.startProcessInstanceByKey("exclusive");
     // now there should be 1 non-exclusive job in the database:
     Job job = managementService.createJobQuery().singleResult();
     assertNotNull(job);
     assertFalse(((JobEntity)job).isExclusive());
-               
+
     waitForJobExecutorToProcessAllJobs(6000L);
-    
+
     // all the jobs are done
-    assertEquals(0, managementService.createJobQuery().count());      
+    assertEquals(0, managementService.createJobQuery().count());
   }
 
   @Deployment
-  public void testExclusiveService() {   
-    // start process 
+  public void testExclusiveService() {
+    // start process
     runtimeService.startProcessInstanceByKey("exclusive");
     // now there should be 1 exclusive job in the database:
     Job job = managementService.createJobQuery().singleResult();
     assertNotNull(job);
     assertTrue(((JobEntity)job).isExclusive());
-               
+
     waitForJobExecutorToProcessAllJobs(6000L);
-    
+
     // all the jobs are done
-    assertEquals(0, managementService.createJobQuery().count());      
+    assertEquals(0, managementService.createJobQuery().count());
   }
-  
+
   @Deployment
-  public void testExclusiveServiceConcurrent() {   
-    // start process 
+  public void testExclusiveServiceConcurrent() {
+    // start process
     runtimeService.startProcessInstanceByKey("exclusive");
     // now there should be 3 exclusive jobs in the database:
     assertEquals(3, managementService.createJobQuery().count());
-                   
+
     waitForJobExecutorToProcessAllJobs(6000L);
-    
+
     // all the jobs are done
-    assertEquals(0, managementService.createJobQuery().count());      
+    assertEquals(0, managementService.createJobQuery().count());
   }
-  
+
+  @Deployment
+  public void testExclusiveSequence2() {
+
+    runtimeService.startProcessInstanceByKey("testProcess");
+
+    waitForJobExecutorToProcessAllJobs(6000L);
+
+    assertEquals(0, managementService.createJobQuery().count());
+  }
+
+  @Deployment
+  public void testExclusiveSequence3() {
+    runtimeService.startProcessInstanceByKey("testProcess");
+
+    waitForJobExecutorToProcessAllJobs(6000L);
+
+    assertEquals(0, managementService.createJobQuery().count());
+  }
+
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/exclusive/ExclusiveTaskTestReuseCache.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/exclusive/ExclusiveTaskTestReuseCache.java
@@ -1,0 +1,60 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.bpmn.exclusive;
+
+import org.camunda.bpm.engine.test.Deployment;
+
+/**
+ * @author Daniel Meyer
+ *
+ */
+public class ExclusiveTaskTestReuseCache extends ExclusiveTaskTest {
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    processEngineConfiguration.setDbEntityCacheReuseEnabled(true);
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    processEngineConfiguration.setDbEntityCacheReuseEnabled(false);
+    super.tearDown();
+  }
+
+  @Deployment(resources={"org/camunda/bpm/engine/test/bpmn/exclusive/ExclusiveTaskTest.testNonExclusiveService.bpmn20.xml"})
+  public void testNonExclusiveService() {
+    super.testNonExclusiveService();
+  }
+
+  @Deployment(resources={"org/camunda/bpm/engine/test/bpmn/exclusive/ExclusiveTaskTest.testExclusiveService.bpmn20.xml"})
+  public void testExclusiveService() {
+    super.testExclusiveService();
+  }
+
+  @Deployment(resources={"org/camunda/bpm/engine/test/bpmn/exclusive/ExclusiveTaskTest.testExclusiveServiceConcurrent.bpmn20.xml"})
+  public void testExclusiveServiceConcurrent() {
+    super.testExclusiveServiceConcurrent();
+  }
+
+  @Deployment(resources={"org/camunda/bpm/engine/test/bpmn/exclusive/ExclusiveTaskTest.testExclusiveSequence2.bpmn20.xml"})
+  public void testExclusiveSequence2() {
+    super.testExclusiveSequence2();
+  }
+
+  @Deployment(resources={"org/camunda/bpm/engine/test/bpmn/exclusive/ExclusiveTaskTest.testExclusiveSequence3.bpmn20.xml"})
+  public void testExclusiveSequence3() {
+    super.testExclusiveSequence3();
+  }
+
+}

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/exclusive/ExclusiveTaskTest.testExclusiveSequence2.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/exclusive/ExclusiveTaskTest.testExclusiveSequence2.bpmn20.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:camunda="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="testProcess">
+
+    <startEvent id="theStart" />
+
+    <sequenceFlow sourceRef="theStart" targetRef="service1" />
+
+    <serviceTask id="service1" camunda:expression="${true}" camunda:async="true" />
+
+    <sequenceFlow sourceRef="service1" targetRef="service2" />
+
+    <serviceTask id="service2" camunda:expression="${true}" camunda:async="true" />
+    
+    <sequenceFlow sourceRef="service2" targetRef="theEnd" />
+    
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/exclusive/ExclusiveTaskTest.testExclusiveSequence3.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/exclusive/ExclusiveTaskTest.testExclusiveSequence3.bpmn20.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:camunda="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="testProcess">
+
+    <startEvent id="theStart" />
+
+    <sequenceFlow sourceRef="theStart" targetRef="service1" />
+
+    <serviceTask id="service1" camunda:expression="${true}" camunda:async="true" />
+
+    <sequenceFlow sourceRef="service1" targetRef="service2" />
+
+    <serviceTask id="service2" camunda:expression="${true}" camunda:async="true" />
+    
+    <sequenceFlow sourceRef="service2" targetRef="service3" />
+    
+     <serviceTask id="service3" camunda:expression="${true}" camunda:async="true" />
+    
+    <sequenceFlow sourceRef="service3" targetRef="theEnd" />
+    
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>


### PR DESCRIPTION
Reuse the 1st level DbEntityCache for sequences of asynchronous
continuations executed by the same thread. (exclusive jobs).

Improves performance since the cache is not discarded when the command
context is flushed but reused by the next command.

Cache reuse is disabled by default, can be enabled by setting
"isDbEntityCacheReuseEnabled" to true.
