### PR TITLE
[CAM-2726] Only select t1 columns, otherwise name column is not unique.

### DIFF
--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryTest.java
@@ -1178,7 +1178,7 @@ public class TaskQueryTest extends PluggableProcessEngineTestCase {
 
     // join task and variable instances
     assertEquals(1, taskService.createNativeTaskQuery().sql("SELECT count(*) FROM " + managementService.getTableName(Task.class) + " T1, "+managementService.getTableName(VariableInstanceEntity.class)+" V1 WHERE V1.TASK_ID_ = T1.ID_").count());
-    List<Task> tasks = taskService.createNativeTaskQuery().sql("SELECT * FROM " + managementService.getTableName(Task.class) + " T1, "+managementService.getTableName(VariableInstanceEntity.class)+" V1 WHERE V1.TASK_ID_ = T1.ID_").list();
+    List<Task> tasks = taskService.createNativeTaskQuery().sql("SELECT T1.* FROM " + managementService.getTableName(Task.class) + " T1, "+managementService.getTableName(VariableInstanceEntity.class)+" V1 WHERE V1.TASK_ID_ = T1.ID_").list();
     assertEquals(1, tasks.size());
     assertEquals("gonzoTask", tasks.get(0).getName());
 


### PR DESCRIPTION
Select only Tasks.\* as this is the return type.
