### PR TITLE
test(call-activity) add test for combination of all vars + mapping

### DIFF
--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/callactivity/CallActivityAdvancedTest.java
@@ -40,6 +40,7 @@ import org.camunda.bpm.model.bpmn.instance.camunda.CamundaOut;
  * @author Joram Barrez
  * @author Nils Preusker
  * @author Bernd Ruecker
+ * @author Falko Menge
  */
 public class CallActivityAdvancedTest extends PluggableProcessEngineTestCase {
 
@@ -632,6 +633,61 @@ public class CallActivityAdvancedTest extends PluggableProcessEngineTestCase {
     Task taskInSubProcess = taskQuery.singleResult();
     assertEquals("Task in subprocess", taskInSubProcess.getName());
     assertEquals("Hello from the super process.", runtimeService.getVariable(taskInSubProcess.getProcessInstanceId(), "superVariable"));
+    assertEquals("Hello from the super process.", taskService.getVariable(taskInSubProcess.getId(), "superVariable"));
+    assertEquals("Only a test.", runtimeService.getVariable(taskInSubProcess.getProcessInstanceId(), "testVariable"));
+    assertEquals("Only a test.", taskService.getVariable(taskInSubProcess.getId(), "testVariable"));
+
+    // changed variables in sub process
+    runtimeService.setVariable(taskInSubProcess.getProcessInstanceId(), "superVariable", "Hello from sub process.");
+    runtimeService.setVariable(taskInSubProcess.getProcessInstanceId(), "testVariable", "Variable changed in sub process.");
+
+    taskService.complete(taskInSubProcess.getId());
+
+    // task after sub process in super process
+    taskQuery = taskService.createTaskQuery();
+    Task taskAfterSubProcess = taskQuery.singleResult();
+    assertEquals("Task after subprocess", taskAfterSubProcess.getName());
+
+    // variables are changed after finished sub process
+    assertEquals("Hello from sub process.", runtimeService.getVariable(processInstance.getId(), "superVariable"));
+    assertEquals("Variable changed in sub process.", runtimeService.getVariable(processInstance.getId(), "testVariable"));
+
+    taskService.complete(taskAfterSubProcess.getId());
+
+    assertProcessEnded(processInstance.getId());
+    assertEquals(0, runtimeService.createExecutionQuery().list().size());
+  }
+
+  /**
+   * Test case for handing all over process variables to a sub process
+   */
+  @Deployment(resources = {
+    "org/camunda/bpm/engine/test/bpmn/callactivity/CallActivity.testSubProcessAllDataInputOutputWithAdditionalInputMapping.bpmn20.xml",
+    "org/camunda/bpm/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml" })
+  public void testSubProcessAllDataInputOutputWithAdditionalInputMapping() {
+    Map<String, Object> vars = new HashMap<String, Object>();
+    vars.put("superVariable", "Hello from the super process.");
+    vars.put("testVariable", "Only a test.");
+
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("subProcessAllDataInputOutput", vars);
+
+    // one task in the super process should be active after starting the process instance
+    TaskQuery taskQuery = taskService.createTaskQuery();
+    Task taskBeforeSubProcess = taskQuery.singleResult();
+    assertEquals("Task before subprocess", taskBeforeSubProcess.getName());
+    assertEquals("Hello from the super process.", runtimeService.getVariable(taskBeforeSubProcess.getProcessInstanceId(), "superVariable"));
+    assertEquals("Hello from the super process.", taskService.getVariable(taskBeforeSubProcess.getId(), "superVariable"));
+    assertEquals("Only a test.", runtimeService.getVariable(taskBeforeSubProcess.getProcessInstanceId(), "testVariable"));
+    assertEquals("Only a test.", taskService.getVariable(taskBeforeSubProcess.getId(), "testVariable"));
+
+    taskService.complete(taskBeforeSubProcess.getId());
+
+    // one task in sub process should be active after starting sub process instance
+    taskQuery = taskService.createTaskQuery();
+    Task taskInSubProcess = taskQuery.singleResult();
+    assertEquals("Task in subprocess", taskInSubProcess.getName());
+    assertEquals("Hello from the super process.", runtimeService.getVariable(taskInSubProcess.getProcessInstanceId(), "superVariable"));
+    assertEquals("Hello from the super process.", runtimeService.getVariable(taskInSubProcess.getProcessInstanceId(), "subVariable"));
     assertEquals("Hello from the super process.", taskService.getVariable(taskInSubProcess.getId(), "superVariable"));
     assertEquals("Only a test.", runtimeService.getVariable(taskInSubProcess.getProcessInstanceId(), "testVariable"));
     assertEquals("Only a test.", taskService.getVariable(taskInSubProcess.getId(), "testVariable"));

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/callactivity/CallActivity.testSubProcessAllDataInputOutputWithAdditionalInputMapping.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/callactivity/CallActivity.testSubProcessAllDataInputOutputWithAdditionalInputMapping.bpmn20.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+  
+  <process id="subProcessAllDataInputOutput">
+  
+    <startEvent id="theStart" />
+    
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="userTask1" />
+    
+    <userTask id="userTask1" name="Task before subprocess" />
+    
+    <sequenceFlow id="flow2" sourceRef="userTask1" targetRef="callSubProcess" />
+    
+    <callActivity id="callSubProcess" calledElement="simpleSubProcess" >
+	  <extensionElements>
+	    <activiti:in variables="all" />
+	    <activiti:in source="superVariable" target="subVariable" />
+	    <activiti:out variables="all" />
+	  </extensionElements>
+    </callActivity>
+    
+    <sequenceFlow id="flow3" sourceRef="callSubProcess" targetRef="userTask2" />
+    
+    <userTask id="userTask2" name="Task after subprocess" />
+  
+    <sequenceFlow id="flow4" sourceRef="userTask2" targetRef="theEnd" />
+    
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>


### PR DESCRIPTION
This Pull Request adds an addition test case that combines passing all variables of a parent process to a child process and additionally some mapped variables.
