### PR TITLE
chore(ProcessEngineRule): replace deprecated TestWatchman super class

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/test/ProcessEngineRule.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/test/ProcessEngineRule.java
@@ -30,8 +30,8 @@ import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.impl.test.TestHelper;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
-import org.junit.rules.TestWatchman;
-import org.junit.runners.model.FrameworkMethod;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 
 
 /** Convenience for ProcessEngine and services initialization in the form of a JUnit rule.
@@ -70,7 +70,7 @@ import org.junit.runners.model.FrameworkMethod;
  *
  * @author Tom Baeyens
  */
-public class ProcessEngineRule extends TestWatchman {
+public class ProcessEngineRule extends TestWatcher {
 
   protected String configurationResource = "camunda.cfg.xml";
   protected String configurationResourceCompat = "activiti.cfg.xml";
@@ -100,14 +100,14 @@ public class ProcessEngineRule extends TestWatchman {
   }
 
   @Override
-  public void starting(FrameworkMethod method) {
+  public void starting(Description description) {
     if (processEngine==null) {
       initializeProcessEngine();
     }
 
     initializeServices();
 
-    deploymentId = TestHelper.annotationDeploymentSetUp(processEngine, method.getMethod().getDeclaringClass(), method.getName());
+    deploymentId = TestHelper.annotationDeploymentSetUp(processEngine, description.getTestClass(), description.getMethodName());
   }
 
   protected void initializeProcessEngine() {
@@ -138,8 +138,8 @@ public class ProcessEngineRule extends TestWatchman {
   }
 
   @Override
-  public void finished(FrameworkMethod method) {
-    TestHelper.annotationDeploymentTearDown(processEngine, deploymentId, method.getMethod().getDeclaringClass(), method.getName());
+  public void finished(Description description) {
+    TestHelper.annotationDeploymentTearDown(processEngine, deploymentId, description.getTestClass(), description.getMethodName());
 
     ClockUtil.reset();
   }


### PR DESCRIPTION
TestWatchman is deprecated since JUnit 4.9. ProcessEngineRule therefore
did not support RuleChain. This commit fixes the problem by using the
new type TestWatcher as a super class.

Signed-off-by: Franziska Sauerwein franziska.sauerwein@gmail.com
Signed-off-by: Fabian Knittel fabian.knittel@lettink.de
