### PR TITLE
chore(build): erase redundancies in some pom.xml files

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -9,7 +9,6 @@
     <version>7.2.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.camunda.bpm</groupId>
   <artifactId>camunda-bom</artifactId>
   <packaging>pom</packaging>
   <name>camunda BPM - Bom</name>

--- a/distro/gf31/assembly/pom.xml
+++ b/distro/gf31/assembly/pom.xml
@@ -85,7 +85,6 @@
     <dependency>
       <groupId>org.camunda.bpm.javaee</groupId>
       <artifactId>camunda-ejb-client</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -104,7 +103,6 @@
     <dependency>
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/distro/gf31/pom.xml
+++ b/distro/gf31/pom.xml
@@ -10,7 +10,6 @@
 
   <groupId>org.camunda.bpm.glassfish</groupId>
   <artifactId>camunda-glassfish</artifactId>
-  <version>7.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>camunda BPM - Glassfish 3.1.x</name>

--- a/distro/jbossas7/assembly/pom.xml
+++ b/distro/jbossas7/assembly/pom.xml
@@ -54,7 +54,6 @@
     <dependency>
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine-spring</artifactId>
-      <version>${project.version}</version>
     </dependency>
     
     <dependency>

--- a/distro/tomcat/assembly/pom.xml
+++ b/distro/tomcat/assembly/pom.xml
@@ -38,8 +38,7 @@
     <dependency>
       <groupId>javax.mail</groupId>
       <artifactId>mail</artifactId>
-      <version>1.4.1</version>
-    </dependency>   
+    </dependency>
 
     <dependency>
       <groupId>org.mybatis</groupId>
@@ -69,7 +68,6 @@
     <dependency>
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine-spring</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/distro/wildfly/assembly/pom.xml
+++ b/distro/wildfly/assembly/pom.xml
@@ -48,7 +48,6 @@
     <dependency>
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine-spring</artifactId>
-      <version>${project.version}</version>
     </dependency>
     
     <dependency>

--- a/engine-cdi/pom.xml
+++ b/engine-cdi/pom.xml
@@ -3,7 +3,6 @@
   <modelVersion>4.0.0</modelVersion>
 
   <name>camunda BPM - engine - Cdi</name>
-  <groupId>org.camunda.bpm</groupId>
   <artifactId>camunda-engine-cdi</artifactId>
   <packaging>jar</packaging>
 
@@ -56,7 +55,6 @@
         <dependency>
           <groupId>org.jboss.arquillian.container</groupId>
           <artifactId>arquillian-weld-ee-embedded-1.1</artifactId>
-          <version>1.0.0.CR3</version>
           <scope>test</scope>
         </dependency>
         <dependency>
@@ -123,7 +121,6 @@
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
-      <version>1.0.0.CR7</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/engine-rest/pom.xml
+++ b/engine-rest/pom.xml
@@ -77,7 +77,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
       <scope>test</scope>
     </dependency>
 
@@ -164,7 +163,6 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
-      <version>2.1.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/javaee/ejb-service/pom.xml
+++ b/javaee/ejb-service/pom.xml
@@ -20,7 +20,6 @@
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine</artifactId>
       <scope>provided</scope>
-      <version>${project.version}</version>
     </dependency>
     
     <dependency>

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -97,7 +97,6 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
-      <version>2.2.1</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Import of the repository into Eclipse raises some warnings:
- GroupId is duplicate of parent groupId
- Overriding managed version 1.0.0.CR3 for arquillian-weld-ee-embedded-1.1
- Overriding managed version 1.0.0.CR7 for arquillian-junit-container
- Overriding managed version 1.4.1 for mail
- Overriding managed version 2.3.0 for groovy-all
- Overriding managed version 4.11 for junit
- Overriding managed version 7.2.0-SNAPSHOT for camunda-ejb-client
- Overriding managed version 7.2.0-SNAPSHOT for camunda-engine
- Overriding managed version 7.2.0-SNAPSHOT for camunda-engine-spring   pom.xml
- Version is duplicate of parent version

This PR removes these warnings.
The only remaining one then is 'maven-enforcer-plugin (goal "enforce") is ignored by m2e.'
