### PR TITLE
Fix CAM-2819

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/JobEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/JobEntity.java
@@ -50,7 +50,7 @@ public abstract class JobEntity implements Serializable, Job, DbEntity, HasDbRev
 
   public static final boolean DEFAULT_EXCLUSIVE = true;
   public static final int DEFAULT_RETRIES = 3;
-  private static final int MAX_EXCEPTION_MESSAGE_LENGTH = 255;
+  private static final int MAX_EXCEPTION_MESSAGE_LENGTH = 2000;
 
   private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
Increase the maximum length of the Job exception message match the size of the database column it is persisted to. Prevent unnecessary truncation of persisted Job exception messages and Incident messages to 255 characters.
