### PR TITLE
docs(IncidentManager): rename parameter to reflect its content

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/IncidentManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/IncidentManager.java
@@ -31,8 +31,8 @@ public class IncidentManager extends AbstractManager {
     return getDbEntityManager().selectList("selectIncidentsByExecutionId", id);
   }
 
-  public long findIncidentCountByQueryCriteria(IncidentQueryImpl jobQuery) {
-    return (Long) getDbEntityManager().selectOne("selectIncidentCountByQueryCriteria", jobQuery);
+  public long findIncidentCountByQueryCriteria(IncidentQueryImpl incidentQuery) {
+    return (Long) getDbEntityManager().selectOne("selectIncidentCountByQueryCriteria", incidentQuery);
   }
 
   public List<Incident> findIncidentByConfiguration(String configuration) {
@@ -48,8 +48,8 @@ public class IncidentManager extends AbstractManager {
   }
 
   @SuppressWarnings("unchecked")
-  public List<Incident> findIncidentByQueryCriteria(IncidentQueryImpl jobQuery, Page page) {
-    return getDbEntityManager().selectList("selectIncidentByQueryCriteria", jobQuery, page);
+  public List<Incident> findIncidentByQueryCriteria(IncidentQueryImpl incidentQuery, Page page) {
+    return getDbEntityManager().selectList("selectIncidentByQueryCriteria", incidentQuery, page);
   }
 
 }


### PR DESCRIPTION
The name jobQuery is confusing when using this manager, because it
actually expects an IncidentQuery. This is most likely a copy and paste
issue.
