### PR TITLE
feat(FailedJobIncidentHandler): make incident available to sub-classes

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/incident/FailedJobIncidentHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/incident/FailedJobIncidentHandler.java
@@ -31,6 +31,7 @@ import org.camunda.bpm.engine.runtime.Incident;
  *
  * @author nico.rehwaldt
  * @author roman.smirnov
+ * @author Falko Menge
  */
 public class FailedJobIncidentHandler implements IncidentHandler {
 
@@ -41,13 +42,19 @@ public class FailedJobIncidentHandler implements IncidentHandler {
   }
 
   public void handleIncident(String processDefinitionId, String activityId, String executionId, String jobId, String message) {
+    createIncident(processDefinitionId, activityId, executionId, jobId, message);
+  }
+
+  public Incident createIncident(String processDefinitionId, String activityId, String executionId, String jobId, String message) {
+    IncidentEntity newIncident;
     if(executionId != null) {
-      IncidentEntity newIncident = IncidentEntity.createAndInsertIncident(INCIDENT_HANDLER_TYPE, executionId, jobId, message);
+      newIncident = IncidentEntity.createAndInsertIncident(INCIDENT_HANDLER_TYPE, executionId, jobId, message);
       newIncident.createRecursiveIncidents();
 
     } else {
-      IncidentEntity.createAndInsertIncident(INCIDENT_HANDLER_TYPE, processDefinitionId, activityId, jobId, message);
+      newIncident = IncidentEntity.createAndInsertIncident(INCIDENT_HANDLER_TYPE, processDefinitionId, activityId, jobId, message);
     }
+    return newIncident;
   }
 
   public void resolveIncident(String processDefinitionId, String activityId, String executionId, String configuration) {


### PR DESCRIPTION
An incident can only be uniquely identified through its id. However, sub-classes of the FailedJobIncidentHandler like [UserTaskFailedJobIncidentHandler](https://github.com/camunda/camunda-consulting/blob/master/snippets/incidents-as-tasks/src/main/java/org/example/incidents_as_tasks/UserTaskFailedJobIncidentHandler.java) don't have access to the created incident and can therefore not reference or work with it. With this change code could look like this:

``` java
public class UserTaskFailedJobIncidentHandler extends FailedJobIncidentHandler
        implements IncidentHandler {

    @Override
    public void handleIncident(String processDefinitionId, String activityId,
            String executionId, String jobId, String message) {
        Incident incident = createIncident(processDefinitionId, activityId, executionId, jobId,
                message);
        TaskServiceImpl taskServiceImpl = getTaskService();
        Task task = taskServiceImpl.newTask();
        task.setName("Handle Incident");
        task.setAssignee("demo");
        taskServiceImpl.saveTask(task);
        taskServiceImpl.setVariable(task.getId(), "incidentId", incident.getId());
    }
```
