### PR TITLE
chore(engine/sql): specify the table name for the result set of queries with a join

### DIFF
--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/EventSubscription.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/EventSubscription.xml
@@ -85,9 +85,9 @@
   </sql>
   
   <select id="selectSignalEventSubscriptionsByEventName" resultMap="eventSubscriptionResultMap" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject">
-    select * 
+    select EVT.*
     from ${prefix}ACT_RU_EVENT_SUBSCR EVT
-    inner join ${prefix}ACT_RU_EXECUTION EXC on EVT.EXECUTION_ID_ = EXC.ID_ 
+    inner join ${prefix}ACT_RU_EXECUTION EXC on EVT.EXECUTION_ID_ = EXC.ID_
     where (EVENT_TYPE_ = 'signal')
     	and (EVENT_NAME_ = #{parameter})
     	and EXC.SUSPENSION_STATE_ = 1

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Resource.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Resource.xml
@@ -56,9 +56,9 @@
   </select>
   
   <sql id="resourcesFromLastDeploymentWithName">
-    select *
+    select B.*
     from ${prefix}ACT_GE_BYTEARRAY B
-    inner join 
+    inner join
       (select B.NAME_, MAX(D.DEPLOY_TIME_) DEPLOY_TIME_
       from ${prefix}ACT_GE_BYTEARRAY B
         inner join ${prefix}ACT_RE_DEPLOYMENT D


### PR DESCRIPTION
A query on multiple tables should always specify the columns to retrieve.

related to #CAM-2957
