### PR TITLE
add CdiEventListener to processApplication by default

### DIFF
--- a/javaee/ejb-client/pom.xml
+++ b/javaee/ejb-client/pom.xml
@@ -15,6 +15,10 @@
 
   <dependencies>
     <dependency>
+        <groupId>org.camunda.bpm</groupId>
+        <artifactId>camunda-engine-cdi</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.spec</groupId>
       <artifactId>jboss-javaee-web-6.0</artifactId>
       <type>pom</type>

--- a/javaee/ejb-client/src/main/java/org/camunda/bpm/application/impl/ejb/DefaultEjbProcessApplication.java
+++ b/javaee/ejb-client/src/main/java/org/camunda/bpm/application/impl/ejb/DefaultEjbProcessApplication.java
@@ -20,12 +20,20 @@ import java.util.Map;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-import javax.ejb.*;
+import javax.ejb.ConcurrencyManagement;
+import javax.ejb.ConcurrencyManagementType;
+import javax.ejb.Local;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
 
 import org.camunda.bpm.application.ProcessApplication;
 import org.camunda.bpm.application.ProcessApplicationInterface;
 import org.camunda.bpm.application.impl.EjbProcessApplication;
-
+import org.camunda.bpm.engine.cdi.impl.event.CdiEventListener;
+import org.camunda.bpm.engine.delegate.ExecutionListener;
+import org.camunda.bpm.engine.delegate.TaskListener;
 
 /**
  * 
@@ -35,14 +43,16 @@ import org.camunda.bpm.application.impl.EjbProcessApplication;
  */
 @Singleton
 @Startup
-@ConcurrencyManagement(ConcurrencyManagementType.BEAN) 
+@ConcurrencyManagement(ConcurrencyManagementType.BEAN)
 @TransactionAttribute(TransactionAttributeType.REQUIRED)
 @ProcessApplication
 @Local(ProcessApplicationInterface.class)
 public class DefaultEjbProcessApplication extends EjbProcessApplication {
-  
+
   protected Map<String, String> properties = new HashMap<String, String>();
-  
+
+  private final CdiEventListener cdiEventListener = new CdiEventListener();
+
   @PostConstruct
   public void start() {
     deploy();
@@ -52,9 +62,18 @@ public class DefaultEjbProcessApplication extends EjbProcessApplication {
   public void stop() {
     undeploy();
   }
-  
+
   public Map<String, String> getProperties() {
     return properties;
   }
-    
+
+  @Override
+  public ExecutionListener getExecutionListener() {
+    return cdiEventListener;
+  }
+
+  @Override
+  public TaskListener getTaskListener() {
+    return cdiEventListener;
+  }
 }


### PR DESCRIPTION
changes:
- add transitive dependency to engine-cdi (must be deployed together with the ejb-client.jar so no use in scoping it "provided"
- include the CdiEventListener setup from the web site example

Effect: using the default ejb processApplication enables cdi eventing by default without the need to write and deploy a custom PA.
Figuring out the correct usage took some time and I dont want to write a custom processApplication for every JEE/BPM project.

discussion:

- EJB is not CDI so one could argue that this is breaking, since I could run on a container not supporting CDI. But is pure JEE5 a supported platform for 7.2.0?
- Performance: a view events get fired even if no one is listening.  Idea: enable/disable via configuration. How about checking if the ProcessApplicationEventListenerPlugin is enabled? How can I access the processEngineConfiguration from within the ProcessApplication to check?