### PR TITLE
fix(ParallelMultiInstanceBehavior): push context on context stack

### DIFF
--- a/engine-cdi/src/test/java/org/camunda/bpm/engine/cdi/test/impl/context/MultiInstanceTest.java
+++ b/engine-cdi/src/test/java/org/camunda/bpm/engine/cdi/test/impl/context/MultiInstanceTest.java
@@ -17,14 +17,12 @@ import java.util.Arrays;
 import org.camunda.bpm.engine.cdi.BusinessProcess;
 import org.camunda.bpm.engine.cdi.test.CdiProcessEngineTestCase;
 import org.camunda.bpm.engine.test.Deployment;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author Daniel Meyer
  *
  */
-@Ignore("see: https://app.camunda.com/jira/browse/CAM-986")
 public class MultiInstanceTest extends CdiProcessEngineTestCase {
   
   @Test


### PR DESCRIPTION
To make it possible for embedded tasks to access the local variables of
the ParallelMultiInstanceBehavior we need to push the "parallel" context
on top of the stack of contexts.

Closes #986