### PR TITLE
fix(ParallelMultiInstanceBehavior): push context on context stack

### DIFF
--- a/engine-cdi/src/test/java/org/camunda/bpm/engine/cdi/test/impl/context/MultiInstanceTest.java
+++ b/engine-cdi/src/test/java/org/camunda/bpm/engine/cdi/test/impl/context/MultiInstanceTest.java
@@ -17,14 +17,12 @@ import java.util.Arrays;
 import org.camunda.bpm.engine.cdi.BusinessProcess;
 import org.camunda.bpm.engine.cdi.test.CdiProcessEngineTestCase;
 import org.camunda.bpm.engine.test.Deployment;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author Daniel Meyer
  *
  */
-@Ignore("see: https://app.camunda.com/jira/browse/CAM-986")
 public class MultiInstanceTest extends CdiProcessEngineTestCase {
   
   @Test

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
@@ -182,23 +182,29 @@ public abstract class MultiInstanceActivityBehavior extends FlowNodeActivityBeha
         collection = (Collection) execution.getVariable(collectionVariable);
       }
 
-      Object value = null;
-      int index = 0;
-      Iterator it = collection.iterator();
-      while (index <= loopCounter) {
-        value = it.next();
-        index++;
-      }
+      Object value = getElementAtIndex(loopCounter, collection);
       setLoopVariable(execution, collectionElementVariable, value);
     }
+    doExecuteOriginalBehavior(execution, loopCounter);
+  }
 
-    // If loopcounter == 1, then historic activity instance already created, no need to
-    // pass through executeActivity again since it will create a new historic activity
-    if (loopCounter == 0) {
-      innerActivityBehavior.execute(execution);
-    } else {
-      execution.executeActivity(activity);
+  /**
+   * Subclasses get the chance to adapt their behavior according to the current loop counter.
+   * @param execution
+   * @param loopCounter
+   * @throws Exception
+   */
+  protected abstract void doExecuteOriginalBehavior(ActivityExecution execution, int loopCounter) throws Exception;
+
+  private Object getElementAtIndex(int i, Collection<?> collection) {
+    Object value = null;
+    int index = 0;
+    Iterator<?> it = collection.iterator();
+    while (index <= i) {
+      value = it.next();
+      index++;
     }
+    return value;
   }
 
   protected boolean usesCollection() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/ParallelMultiInstanceBehavior.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/ParallelMultiInstanceBehavior.java
@@ -18,6 +18,7 @@ import java.util.logging.Level;
 
 import org.camunda.bpm.engine.impl.bpmn.parser.BpmnParse;
 import org.camunda.bpm.engine.impl.bpmn.parser.EventSubscriptionDeclaration;
+import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
 import org.camunda.bpm.engine.impl.jobexecutor.TimerDeclarationImpl;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
@@ -25,9 +26,9 @@ import org.camunda.bpm.engine.impl.pvm.delegate.ActivityBehavior;
 import org.camunda.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
 
-
 /**
  * @author Joram Barrez
+ * @author Ronny Bräunlich
  */
 public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior {
 
@@ -36,10 +37,10 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
   }
 
   /**
-   * Handles the parallel case of spawning the instances.
-   * Will create child executions accordingly for every instance needed.
+   * Handles the parallel case of spawning the instances. Will create child
+   * executions accordingly for every instance needed.
    */
-   protected void createInstances(ActivityExecution execution, int nrOfInstances) throws Exception {
+  protected void createInstances(ActivityExecution execution, int nrOfInstances) throws Exception {
 
     setLoopVariable(execution, NUMBER_OF_INSTANCES, nrOfInstances);
     setLoopVariable(execution, NUMBER_OF_COMPLETED_INSTANCES, 0);
@@ -47,8 +48,49 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
 
     fixMiRootActivityInstanceId(execution);
 
+    List<ActivityExecution> concurrentExecutions = createConcurrentExecutions(execution, nrOfInstances);
+    // Before the activities are executed, all executions MUST be created up front
+    // Do not try to merge this loop with the one in createConcurrentExecutions(), as it will lead to bugs,
+    // due to possible child execution pruning.
+    for (int loopCounter = 0; loopCounter < nrOfInstances; loopCounter++) {
+      ActivityExecution concurrentExecution = concurrentExecutions.get(loopCounter);
+      // executions can be inactive, if instances are all automatics
+      // (no-waitstate) and completionCondition has been met in the meantime
+      if (concurrentExecution.isActive() && !concurrentExecution.isEnded() && concurrentExecution.getParent().isActive()
+          && !concurrentExecution.getParent().isEnded()) {
+        setLoopVariable(concurrentExecution, LOOP_COUNTER, loopCounter);
+        if (loopCounter == 0) {
+          executeOriginalBehavior(concurrentExecution, loopCounter);
+        }else{
+          executeOriginalBehavior(concurrentExecution, loopCounter);
+        }
+      }
+    }
+    if (!concurrentExecutions.isEmpty()) {
+      execution.inactivate();
+    }
+  }
+
+  protected void doExecuteOriginalBehavior(ActivityExecution execution, int loopCounter) throws Exception {
+    // If loopcounter == 0, then historic activity instance already created, no need to
+    // pass through executeActivity again since it will create a new historic activity
+    if (loopCounter == 0) {
+      try {
+        //we have to put the execution on the execution stack for the first iteration because execute won't do this for
+        //us and because we created new Executions in createInstances
+        Context.setExecutionContext((ExecutionEntity) execution);
+        innerActivityBehavior.execute(execution);
+      } finally {
+        Context.removeExecutionContext();
+      }
+    } else {
+      execution.executeActivity(activity);
+    }
+  }
+
+  private List<ActivityExecution> createConcurrentExecutions(ActivityExecution execution, int nrOfInstances) {
     List<ActivityExecution> concurrentExecutions = new ArrayList<ActivityExecution>();
-    for (int loopCounter=0; loopCounter<nrOfInstances; loopCounter++) {
+    for (int loopCounter = 0; loopCounter < nrOfInstances; loopCounter++) {
       ActivityExecution concurrentExecution = execution.createExecution(loopCounter != 0);
       concurrentExecution.setActive(true);
       concurrentExecution.setConcurrent(true);
@@ -70,42 +112,25 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
         declaration.createSubscriptionForParallelMultiInstance((ExecutionEntity) concurrentExecution);
       }
 
-      if (ioMapping != null) {
-        ioMapping.executeInputParameters((AbstractVariableScope) concurrentExecution);
-      }
+      executeIoMapping((AbstractVariableScope) concurrentExecution);
 
       // create timer job for the current execution
-      List<TimerDeclarationImpl> timerDeclarations = (List<TimerDeclarationImpl>) concurrentExecution.getActivity().getProperty(BpmnParse.PROPERTYNAME_TIMER_DECLARATION);
-      if (timerDeclarations!=null) {
-        for (TimerDeclarationImpl timerDeclaration : timerDeclarations) {
-          timerDeclaration.createTimerInstanceForParallelMultiInstance((ExecutionEntity) concurrentExecution);
-        }
-      }
+      createTimerJobsForExecution(concurrentExecution);
 
       concurrentExecutions.add(concurrentExecution);
       logLoopDetails(concurrentExecution, "initialized", loopCounter, 0, nrOfInstances, nrOfInstances);
     }
+    return concurrentExecutions;
+  }
 
-    // Before the activities are executed, all executions MUST be created up front
-    // Do not try to merge this loop with the previous one, as it will lead to bugs,
-    // due to possible child execution pruning.
-    for (int loopCounter=0; loopCounter<nrOfInstances; loopCounter++) {
-      ActivityExecution concurrentExecution = concurrentExecutions.get(loopCounter);
-      // executions can be inactive, if instances are all automatics (no-waitstate)
-      // and completionCondition has been met in the meantime
-      if (concurrentExecution.isActive() && !concurrentExecution.isEnded()
-              && concurrentExecution.getParent().isActive()
-              && !concurrentExecution.getParent().isEnded()) {
-
-        setLoopVariable(concurrentExecution, LOOP_COUNTER, loopCounter);
-        executeOriginalBehavior(concurrentExecution, loopCounter);
+  protected void createTimerJobsForExecution(ActivityExecution execution) {
+    @SuppressWarnings("unchecked")
+    List<TimerDeclarationImpl> timerDeclarations = (List<TimerDeclarationImpl>) execution.getActivity().getProperty(BpmnParse.PROPERTYNAME_TIMER_DECLARATION);
+    if (timerDeclarations != null) {
+      for (TimerDeclarationImpl timerDeclaration : timerDeclarations) {
+        timerDeclaration.createTimerInstanceForParallelMultiInstance((ExecutionEntity) execution);
       }
     }
-
-    if (!concurrentExecutions.isEmpty()) {
-      execution.inactivate();
-    }
-
   }
 
   /**
@@ -115,7 +140,7 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
    */
   public void leave(ActivityExecution execution) {
 
-    if(!isExtraScopeNeeded() && !execution.getActivityInstanceId().equals(execution.getParent().getActivityInstanceId())) {
+    if (!isExtraScopeNeeded() && !execution.getActivityInstanceId().equals(execution.getParent().getActivityInstanceId())) {
       callActivityEndListeners(execution);
     }
 
@@ -157,8 +182,7 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
       }
       for (ExecutionEntity executionToRemove : executionsToRemove) {
         if (LOGGER.isLoggable(Level.FINE)) {
-          LOGGER.fine("Execution " + executionToRemove + " still active, "
-                  + "but multi-instance is completed. Removing this execution.");
+          LOGGER.fine("Execution " + executionToRemove + " still active, " + "but multi-instance is completed. Removing this execution.");
         }
         executionToRemove.inactivate();
         executionToRemove.deleteCascade("multi-instance completed");
@@ -166,14 +190,13 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
 
       executionEntity.takeAll(activity.getOutgoingTransitions(), joinedExecutions);
     } else {
-      if(isExtraScopeNeeded()) {
+      if (isExtraScopeNeeded()) {
         callActivityEndListeners(execution);
       } else {
         executionEntity.setActivityInstanceId(null);
       }
     }
   }
-
 
   protected void fixMiRootActivityInstanceId(ActivityExecution execution) {
     ActivityExecution miRoot = execution.getParent();
@@ -185,6 +208,5 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
     ActivityExecution miRoot = miEnteringExecution.getParent();
     miRoot.setActivityInstanceId(miEnteringExecution.getActivityInstanceId());
   }
-
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/SequentialMultiInstanceBehavior.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/SequentialMultiInstanceBehavior.java
@@ -30,6 +30,7 @@ import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
 /**
  * @author Joram Barrez
  * @author Falko Menge
+ * @author Ronny Bräunlich
  */
 public class SequentialMultiInstanceBehavior extends MultiInstanceActivityBehavior {
 
@@ -76,24 +77,10 @@ public class SequentialMultiInstanceBehavior extends MultiInstanceActivityBehavi
         declaration.handleSequentialMultiInstanceLeave((ExecutionEntity) execution);
       }
 
-      // delete all existing jobs
-      List<JobEntity> jobs = ((ExecutionEntity)execution).getJobs();
-      for (JobEntity jobEntity : jobs) {
-        jobEntity.delete();
-      }
-
+      deleteExistingJobs(execution);
       callActivityEndListeners(execution);
-
       executeIoMapping((AbstractVariableScope) execution);
-
-      // create timer job for the current execution
-      List<TimerDeclarationImpl> timerDeclarations = (List<TimerDeclarationImpl>) execution.getActivity().getProperty(BpmnParse.PROPERTYNAME_TIMER_DECLARATION);
-      if (timerDeclarations!=null) {
-        for (TimerDeclarationImpl timerDeclaration : timerDeclarations) {
-          timerDeclaration.createTimerInstance((ExecutionEntity) execution);
-        }
-      }
-
+      crateTimerJobsForExecution(execution);
 
       try {
         executeOriginalBehavior(execution, loopCounter);
@@ -103,6 +90,34 @@ public class SequentialMultiInstanceBehavior extends MultiInstanceActivityBehavi
       } catch (Exception e) {
         throw new ProcessEngineException("Could not execute inner activity behavior of multi instance behavior", e);
       }
+    }
+  }
+
+  @Override
+  protected void doExecuteOriginalBehavior(ActivityExecution execution, int loopCounter) throws Exception {
+    // If loopcounter == 0, then historic activity instance already created, no need to
+    // pass through executeActivity again since it will create a new historic activity
+    if (loopCounter == 0) {
+      innerActivityBehavior.execute(execution);
+    } else {
+      execution.executeActivity(activity);
+    }
+  }
+  
+  private void crateTimerJobsForExecution(ActivityExecution execution) {
+    @SuppressWarnings("unchecked")
+    List<TimerDeclarationImpl> timerDeclarations = (List<TimerDeclarationImpl>) execution.getActivity().getProperty(BpmnParse.PROPERTYNAME_TIMER_DECLARATION);
+    if (timerDeclarations!=null) {
+      for (TimerDeclarationImpl timerDeclaration : timerDeclarations) {
+        timerDeclaration.createTimerInstance((ExecutionEntity) execution);
+      }
+    }
+  }
+
+  private void deleteExistingJobs(ActivityExecution execution) {
+    List<JobEntity> jobs = ((ExecutionEntity)execution).getJobs();
+    for (JobEntity jobEntity : jobs) {
+      jobEntity.delete();
     }
   }
 


### PR DESCRIPTION
-the make it possible for parallel activities to access the loop
variable on the first iteration we push the context for the first
iteration on the context stack
-add abstract method doExecuteOriginalBehavior() to
MultiInstanceActivityBehavior to give subclasses chance to make some
smaller changes to behavior
-smaller refactorings in Sequential- and ParallelMultiInstanceBehavior

Closes #986