### PR TITLE
fix(engine): ProcessDefinition.getDescription

### DIFF
--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
@@ -70,18 +70,21 @@ public class ProcessDefinitionQueryTest extends PluggableProcessEngineTestCase {
     ProcessDefinition processDefinition = processDefinitions.get(0);
     assertEquals("one", processDefinition.getKey());
     assertEquals("One", processDefinition.getName());
+    assertEquals("Desc one", processDefinition.getDescription());
     assertTrue(processDefinition.getId().startsWith("one:1"));
     assertEquals("Examples", processDefinition.getCategory());
 
     processDefinition = processDefinitions.get(1);
     assertEquals("one", processDefinition.getKey());
     assertEquals("One", processDefinition.getName());
+    assertEquals("Desc one", processDefinition.getDescription());
     assertTrue(processDefinition.getId().startsWith("one:2"));
     assertEquals("Examples", processDefinition.getCategory());
 
     processDefinition = processDefinitions.get(2);
     assertEquals("two", processDefinition.getKey());
     assertEquals("Two", processDefinition.getName());
+    assertNull(processDefinition.getDescription());
     assertTrue(processDefinition.getId().startsWith("two:1"));
     assertEquals("Examples2", processDefinition.getCategory());
   }

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/repository/one.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/repository/one.bpmn20.xml
@@ -5,7 +5,7 @@
              targetNamespace="Examples">
 
   <process id="one" name="One">
-  
+    <documentation>Desc one</documentation>
     <startEvent id="start" />
     <sequenceFlow id="flow1" sourceRef="start" targetRef="end" />
     <endEvent id="end" />


### PR DESCRIPTION
Modified the behaviour of ProcessDefinitionQuery, retrieving cached
ProcessDefinition and setting the description before returning.

Fixes: CAM-2731