### PR TITLE
feat(engine, engine-rest) provide support for filtering both assigned and unassigned tasks by candidate Group and User

### DIFF
--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/task/TaskQueryDto.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/task/TaskQueryDto.java
@@ -104,7 +104,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
   private String candidateGroupExpression;
   private String candidateUser;
   private String candidateUserExpression;
-  private Boolean candidateAssignedAndNotAssigned;
+  private Boolean includeAssignedTasks;
   private String taskDefinitionKey;
   private String[] taskDefinitionKeyIn;
   private String taskDefinitionKeyLike;
@@ -255,9 +255,9 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     this.candidateUserExpression = candidateUserExpression;
   }
   
-  @CamundaQueryParam("candidateAssignedAndNotAssigned")
-  public void setCandidateAssignedAndNotAssigned(Boolean candidateAssignedAndNotAssigned){
-    this.candidateAssignedAndNotAssigned = candidateAssignedAndNotAssigned;
+  @CamundaQueryParam("includeAssignedTasks")
+  public void setIncludeAssignedTasks(Boolean includeAssignedTasks){
+    this.includeAssignedTasks = includeAssignedTasks;
   }
 
   @CamundaQueryParam("taskDefinitionKey")
@@ -593,8 +593,8 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     return candidateUserExpression;
   }
   
-  public Boolean getCandidateAssignedAndNotAssigned(){
-    return candidateAssignedAndNotAssigned;
+  public Boolean getIncludeAssignedTasks(){
+    return includeAssignedTasks;
   }
 
   public String[] getTaskDefinitionKeyIn() {
@@ -1082,8 +1082,8 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
       }
     }
     
-    if(candidateAssignedAndNotAssigned != null && candidateAssignedAndNotAssigned == true){
-      query.taskCandidateAssignedAndNotAssigned();
+    if(includeAssignedTasks != null && includeAssignedTasks == true){
+      query.includeAssignedTasks();
     }
   }
 
@@ -1190,7 +1190,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     dto.candidateUser = taskQuery.getCandidateUser();
     dto.candidateGroup = taskQuery.getCandidateGroup();
     dto.candidateGroups = taskQuery.getCandidateGroupsInternal();
-    dto.candidateAssignedAndNotAssigned = taskQuery.isCandidateAssignedAndNotAssigned();
+    dto.includeAssignedTasks = taskQuery.isIncludeAssignedTasks();
 
     dto.processInstanceBusinessKey = taskQuery.getProcessInstanceBusinessKey();
     dto.processInstanceBusinessKeyLike = taskQuery.getProcessInstanceBusinessKeyLike();

--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/task/TaskQueryDto.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/task/TaskQueryDto.java
@@ -104,6 +104,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
   private String candidateGroupExpression;
   private String candidateUser;
   private String candidateUserExpression;
+  private Boolean candidateAssignedAndNotAssigned;
   private String taskDefinitionKey;
   private String[] taskDefinitionKeyIn;
   private String taskDefinitionKeyLike;
@@ -252,6 +253,11 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
   @CamundaQueryParam("candidateUserExpression")
   public void setCandidateUserExpression(String candidateUserExpression) {
     this.candidateUserExpression = candidateUserExpression;
+  }
+  
+  @CamundaQueryParam("candidateAssignedAndNotAssigned")
+  public void setCandidateAssignedAndNotAssigned(Boolean candidateAssignedAndNotAssigned){
+    this.candidateAssignedAndNotAssigned = candidateAssignedAndNotAssigned;
   }
 
   @CamundaQueryParam("taskDefinitionKey")
@@ -585,6 +591,10 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
 
   public String getCandidateUserExpression() {
     return candidateUserExpression;
+  }
+  
+  public Boolean getCandidateAssignedAndNotAssigned(){
+    return candidateAssignedAndNotAssigned;
   }
 
   public String[] getTaskDefinitionKeyIn() {
@@ -1071,6 +1081,10 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
 
       }
     }
+    
+    if(candidateAssignedAndNotAssigned != null && candidateAssignedAndNotAssigned == true){
+      query.taskCandidateAssignedAndNotAssigned();
+    }
   }
 
   @Override
@@ -1176,6 +1190,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     dto.candidateUser = taskQuery.getCandidateUser();
     dto.candidateGroup = taskQuery.getCandidateGroup();
     dto.candidateGroups = taskQuery.getCandidateGroupsInternal();
+    dto.candidateAssignedAndNotAssigned = taskQuery.isCandidateAssignedAndNotAssigned();
 
     dto.processInstanceBusinessKey = taskQuery.getProcessInstanceBusinessKey();
     dto.processInstanceBusinessKeyLike = taskQuery.getProcessInstanceBusinessKeyLike();

--- a/engine-rest/src/test/java/org/camunda/bpm/engine/rest/AbstractTaskRestServiceQueryTest.java
+++ b/engine-rest/src/test/java/org/camunda/bpm/engine/rest/AbstractTaskRestServiceQueryTest.java
@@ -422,7 +422,7 @@ public abstract class AbstractTaskRestServiceQueryTest extends AbstractRestServi
     parameters.put("assigneeLike", "anAssigneeLike");
     parameters.put("candidateGroup", "aCandidateGroup");
     parameters.put("candidateUser", "aCandidate");
-    parameters.put("candidateAssignedAndNotAssigned", "true");
+    parameters.put("includeAssignedTasks", "true");
     parameters.put("taskDefinitionKey", "aTaskDefKey");
     parameters.put("taskDefinitionKeyLike", "aTaskDefKeyLike");
     parameters.put("description", "aDesc");
@@ -1267,7 +1267,7 @@ public abstract class AbstractTaskRestServiceQueryTest extends AbstractRestServi
 
     queryParameters.put("candidateGroups", candidateGroups);
     
-    queryParameters.put("candidateAssignedAndNotAssigned", true);
+    queryParameters.put("includeAssignedTasks", true);
 
     given().contentType(POST_JSON_CONTENT_TYPE).body(queryParameters)
       .header("accept", MediaType.APPLICATION_JSON)
@@ -1281,7 +1281,7 @@ public abstract class AbstractTaskRestServiceQueryTest extends AbstractRestServi
     verify(mockQuery).taskUnassigned();
     verify(mockQuery).active();
     verify(mockQuery).suspended();
-    verify(mockQuery).taskCandidateAssignedAndNotAssigned();
+    verify(mockQuery).includeAssignedTasks();
 
     verify(mockQuery).taskCandidateGroupIn(argThat(new EqualsList(candidateGroups)));
   }

--- a/engine-rest/src/test/java/org/camunda/bpm/engine/rest/AbstractTaskRestServiceQueryTest.java
+++ b/engine-rest/src/test/java/org/camunda/bpm/engine/rest/AbstractTaskRestServiceQueryTest.java
@@ -422,6 +422,7 @@ public abstract class AbstractTaskRestServiceQueryTest extends AbstractRestServi
     parameters.put("assigneeLike", "anAssigneeLike");
     parameters.put("candidateGroup", "aCandidateGroup");
     parameters.put("candidateUser", "aCandidate");
+    parameters.put("candidateAssignedAndNotAssigned", "true");
     parameters.put("taskDefinitionKey", "aTaskDefKey");
     parameters.put("taskDefinitionKeyLike", "aTaskDefKeyLike");
     parameters.put("description", "aDesc");
@@ -1265,6 +1266,8 @@ public abstract class AbstractTaskRestServiceQueryTest extends AbstractRestServi
     candidateGroups.add("worker");
 
     queryParameters.put("candidateGroups", candidateGroups);
+    
+    queryParameters.put("candidateAssignedAndNotAssigned", true);
 
     given().contentType(POST_JSON_CONTENT_TYPE).body(queryParameters)
       .header("accept", MediaType.APPLICATION_JSON)
@@ -1278,6 +1281,7 @@ public abstract class AbstractTaskRestServiceQueryTest extends AbstractRestServi
     verify(mockQuery).taskUnassigned();
     verify(mockQuery).active();
     verify(mockQuery).suspended();
+    verify(mockQuery).taskCandidateAssignedAndNotAssigned();
 
     verify(mockQuery).taskCandidateGroupIn(argThat(new EqualsList(candidateGroups)));
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
@@ -61,7 +61,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   protected String candidateUser;
   protected String candidateGroup;
   protected List<String> candidateGroups;
-  protected Boolean candidateAssignedAndNotAssigned = false;
+  protected Boolean includeAssignedTasks = false;
   protected String processInstanceId;
   protected String executionId;
   protected String[] activityInstanceIdIn;
@@ -316,13 +316,13 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
     return this;
   }
 
-  public TaskQuery taskCandidateAssignedAndNotAssigned() {
+  public TaskQuery includeAssignedTasks() {
     if (candidateUser == null && candidateGroup == null && candidateGroups == null && !expressions.containsKey("taskCandidateUser")
         && !expressions.containsKey("taskCandidateGroup") && !expressions.containsKey("taskCandidateGroupIn")) {
       throw new ProcessEngineException("Invalud query usage: candidateUser, candidateGroup, candidateGroups or candidateGroupIn must be set prviously.");
     }
 
-    candidateAssignedAndNotAssigned = true;
+    includeAssignedTasks = true;
     return this;
   }
 
@@ -937,8 +937,8 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
     return candidateGroup;
   }
   
-  public Boolean isCandidateAssignedAndNotAssigned(){
-    return candidateAssignedAndNotAssigned;
+  public Boolean isIncludeAssignedTasks(){
+    return includeAssignedTasks;
   }
 
   public String getProcessInstanceId() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
@@ -61,6 +61,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   protected String candidateUser;
   protected String candidateGroup;
   protected List<String> candidateGroups;
+  protected Boolean candidateAssignedAndNotAssigned = false;
   protected String processInstanceId;
   protected String executionId;
   protected String[] activityInstanceIdIn;
@@ -312,6 +313,16 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
     }
 
     expressions.put("taskCandidateGroupIn", candidateGroupsExpression);
+    return this;
+  }
+
+  public TaskQuery taskCandidateAssignedAndNotAssigned() {
+    if (candidateUser == null && candidateGroup == null && candidateGroups == null && !expressions.containsKey("taskCandidateUser")
+        && !expressions.containsKey("taskCandidateGroup") && !expressions.containsKey("taskCandidateGroupIn")) {
+      throw new ProcessEngineException("Invalud query usage: candidateUser, candidateGroup, candidateGroups or candidateGroupIn must be set prviously.");
+    }
+
+    candidateAssignedAndNotAssigned = true;
     return this;
   }
 
@@ -924,6 +935,10 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
 
   public String getCandidateGroup() {
     return candidateGroup;
+  }
+  
+  public Boolean isCandidateAssignedAndNotAssigned(){
+    return candidateAssignedAndNotAssigned;
   }
 
   public String getProcessInstanceId() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/json/JsonTaskQueryConverter.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/json/JsonTaskQueryConverter.java
@@ -58,6 +58,7 @@ public class JsonTaskQueryConverter extends JsonObjectConverter<TaskQuery> {
   public static final String CANDIDATE_USER = "candidateUser";
   public static final String CANDIDATE_GROUP = "candidateGroup";
   public static final String CANDIDATE_GROUPS = "candidateGroups";
+  public static final String CANDIDATE_ASSIGNED_AND_NOT_ASSIGNED = "candidateAssignedAndNotAssigned";
   public static final String INSTANCE_ID = "instanceId";
   public static final String PROCESS_INSTANCE_ID = "processInstanceId";
   public static final String EXECUTION_ID = "executionId";
@@ -263,6 +264,9 @@ public class JsonTaskQueryConverter extends JsonObjectConverter<TaskQuery> {
     }
     if (json.has(CANDIDATE_GROUP)) {
       query.taskCandidateGroup(json.getString(CANDIDATE_GROUP));
+    }
+    if (json.has(CANDIDATE_ASSIGNED_AND_NOT_ASSIGNED) && json.getBoolean(CANDIDATE_ASSIGNED_AND_NOT_ASSIGNED)){
+      query.taskCandidateAssignedAndNotAssigned();
     }
     if (json.has(CANDIDATE_GROUPS) && !json.has(CANDIDATE_USER) && !json.has(CANDIDATE_GROUP)) {
       query.taskCandidateGroupIn(getList(json.getJSONArray(CANDIDATE_GROUPS)));

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/json/JsonTaskQueryConverter.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/json/JsonTaskQueryConverter.java
@@ -58,7 +58,7 @@ public class JsonTaskQueryConverter extends JsonObjectConverter<TaskQuery> {
   public static final String CANDIDATE_USER = "candidateUser";
   public static final String CANDIDATE_GROUP = "candidateGroup";
   public static final String CANDIDATE_GROUPS = "candidateGroups";
-  public static final String CANDIDATE_ASSIGNED_AND_NOT_ASSIGNED = "candidateAssignedAndNotAssigned";
+  public static final String INCLUDE_ASSIGNED_TASKS = "includeAssignedTasks";
   public static final String INSTANCE_ID = "instanceId";
   public static final String PROCESS_INSTANCE_ID = "processInstanceId";
   public static final String EXECUTION_ID = "executionId";
@@ -265,8 +265,8 @@ public class JsonTaskQueryConverter extends JsonObjectConverter<TaskQuery> {
     if (json.has(CANDIDATE_GROUP)) {
       query.taskCandidateGroup(json.getString(CANDIDATE_GROUP));
     }
-    if (json.has(CANDIDATE_ASSIGNED_AND_NOT_ASSIGNED) && json.getBoolean(CANDIDATE_ASSIGNED_AND_NOT_ASSIGNED)){
-      query.taskCandidateAssignedAndNotAssigned();
+    if (json.has(INCLUDE_ASSIGNED_TASKS) && json.getBoolean(INCLUDE_ASSIGNED_TASKS)){
+      query.includeAssignedTasks();
     }
     if (json.has(CANDIDATE_GROUPS) && !json.has(CANDIDATE_USER) && !json.has(CANDIDATE_GROUP)) {
       query.taskCandidateGroupIn(getList(json.getJSONArray(CANDIDATE_GROUPS)));

--- a/engine/src/main/java/org/camunda/bpm/engine/task/TaskQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/task/TaskQuery.java
@@ -125,6 +125,14 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    *   When passed group list is empty or <code>null</code>.
    */
   TaskQuery taskCandidateGroupInExpression(String candidateGroupsExpression);
+  
+  /** Select both assigned and not assigned tasks for the candidate User or Group.
+   *  By default the candidate User or Group query returns only the not assigned tasks
+   * 
+   * @throws ProcessEngineException
+   *    When the group or user for the candidate is not provided
+   * */
+  TaskQuery taskCandidateAssignedAndNotAssigned();
 
   /** Only select tasks for the given process instance id. */
   TaskQuery processInstanceId(String processInstanceId);

--- a/engine/src/main/java/org/camunda/bpm/engine/task/TaskQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/task/TaskQuery.java
@@ -132,7 +132,7 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * @throws ProcessEngineException
    *    When the group or user for the candidate is not provided
    * */
-  TaskQuery taskCandidateAssignedAndNotAssigned();
+  TaskQuery includeAssignedTasks();
 
   /** Only select tasks for the given process instance id. */
   TaskQuery processInstanceId(String processInstanceId);

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
@@ -366,7 +366,7 @@
         </foreach>
       </if>
       <if test="candidateUser != null || candidateGroups != null">
-      	<if test="!candidateAssignedAndNotAssigned">
+      	<if test="!includeAssignedTasks">
       	  and RES.ASSIGNEE_ is null
       	</if>
         and I.TYPE_ = 'candidate'

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
@@ -366,7 +366,9 @@
         </foreach>
       </if>
       <if test="candidateUser != null || candidateGroups != null">
-        and RES.ASSIGNEE_ is null
+      	<if test="!candidateAssignedAndNotAssigned">
+      	  and RES.ASSIGNEE_ is null
+      	</if>
         and I.TYPE_ = 'candidate'
         and
         (

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryTest.java
@@ -340,17 +340,17 @@ public class TaskQueryTest extends PluggableProcessEngineTestCase {
     } catch(ProcessEngineException e) {}
   }
   
-  public void testQueryByAssignedAndNotAssigned() {
+  public void testQueryByIncludeAssignedTasks() {
     try {
-      TaskQuery query = taskService.createTaskQuery().taskCandidateAssignedAndNotAssigned();
+      taskService.createTaskQuery().includeAssignedTasks();
       fail("expected exception");
     } catch (ProcessEngineException e) {
       // OK
     }
   }
   
-  public void testQueryByCandidateUserAssignedAndNotAssigned() {
-    TaskQuery query = taskService.createTaskQuery().taskCandidateUser("fozzie").taskCandidateAssignedAndNotAssigned();
+  public void testQueryByCandidateUserIncludeAssignedTasks() {
+    TaskQuery query = taskService.createTaskQuery().taskCandidateUser("fozzie").includeAssignedTasks();
     assertEquals(4, query.count());
     assertEquals(4, query.list().size());
     try {
@@ -360,7 +360,7 @@ public class TaskQueryTest extends PluggableProcessEngineTestCase {
       // OK
     }
     
-    query = taskService.createTaskQuery().taskCandidateUser("gonzo").taskCandidateAssignedAndNotAssigned();
+    query = taskService.createTaskQuery().taskCandidateUser("gonzo").includeAssignedTasks();
     assertEquals(0, query.count());
     assertEquals(0, query.list().size());
   }
@@ -390,8 +390,8 @@ public class TaskQueryTest extends PluggableProcessEngineTestCase {
     }
   }
   
-  public void testQueryByCandidateGroupAssignedAndNotAssigned() {
-    TaskQuery query = taskService.createTaskQuery().taskCandidateGroup("management").taskCandidateAssignedAndNotAssigned();
+  public void testQueryByCandidateGroupIncludeAssignedTasks() {
+    TaskQuery query = taskService.createTaskQuery().taskCandidateGroup("management").includeAssignedTasks();
     assertEquals(4, query.count());
     assertEquals(4, query.list().size());
     try {
@@ -401,7 +401,7 @@ public class TaskQueryTest extends PluggableProcessEngineTestCase {
       // OK
     }
 
-    query = taskService.createTaskQuery().taskCandidateGroup("sales").taskCandidateAssignedAndNotAssigned();
+    query = taskService.createTaskQuery().taskCandidateGroup("sales").includeAssignedTasks();
     assertEquals(0, query.count());
     assertEquals(0, query.list().size());
   }
@@ -440,9 +440,9 @@ public class TaskQueryTest extends PluggableProcessEngineTestCase {
     }
   }
   
-  public void testQueryByCandidateGroupInAssignedAndNotAssigned() {
+  public void testQueryByCandidateGroupInIncludeAssignedTasks() {
     List<String> groups = Arrays.asList("management", "accountancy");
-    TaskQuery query = taskService.createTaskQuery().taskCandidateGroupIn(groups).taskCandidateAssignedAndNotAssigned();
+    TaskQuery query = taskService.createTaskQuery().taskCandidateGroupIn(groups).includeAssignedTasks();
     assertEquals(6, query.count());
     assertEquals(6, query.list().size());
     try {
@@ -454,7 +454,7 @@ public class TaskQueryTest extends PluggableProcessEngineTestCase {
 
     // Unexisting groups or groups that don't have candidate tasks shouldn't influence other results
     groups = Arrays.asList("management", "accountancy", "sales", "unexising");
-    query = taskService.createTaskQuery().taskCandidateGroupIn(groups).taskCandidateAssignedAndNotAssigned();
+    query = taskService.createTaskQuery().taskCandidateGroupIn(groups).includeAssignedTasks();
     assertEquals(6, query.count());
     assertEquals(6, query.list().size());
   }


### PR DESCRIPTION
Adds the ability to filter tasks by both assigned and not assigned when searching for Candidate User or Group.

Related to [CAM-3257](https://app.camunda.com/jira/browse/CAM-3257)

I am not sure if the tests for the rest API are enough. I added tests where I thought that is necessary. 