### PR TITLE
chore(engine): replace use of COALESCE with database specific if-null function.

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -799,6 +799,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
           properties.put("falseConstant", DbSqlSessionFactory.databaseSpecificFalseConstant.get(databaseType));
 
           properties.put("dbSpecificDummyTable" , DbSqlSessionFactory.databaseSpecificDummyTable.get(databaseType));
+          properties.put("dbSpecificIfNullFunction", DbSqlSessionFactory.databaseSpecificIfNull.get(databaseType));
 
           Map<String, String> constants = DbSqlSessionFactory.dbSpecificConstants.get(databaseType);
           for (Entry<String, String> entry : constants.entrySet()) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
@@ -55,6 +55,8 @@ public class DbSqlSessionFactory implements SessionFactory {
 
   public static final Map<String, String> databaseSpecificDummyTable = new HashMap<String, String>();
 
+  public static final Map<String, String> databaseSpecificIfNull = new HashMap<String, String>();
+
   public static final Map<String, String> databaseSpecificTrueConstant = new HashMap<String, String>();
   public static final Map<String, String> databaseSpecificFalseConstant = new HashMap<String, String>();
 
@@ -79,6 +81,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificDummyTable.put(H2, "");
     databaseSpecificTrueConstant.put(H2, "1");
     databaseSpecificFalseConstant.put(H2, "0");
+    databaseSpecificIfNull.put(H2, "IFNULL");
 
     HashMap<String, String> constants = new HashMap<String, String>();
     constants.put("constant.event", "'event'");
@@ -101,6 +104,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificDummyTable.put(MYSQL, "");
     databaseSpecificTrueConstant.put(MYSQL, "1");
     databaseSpecificFalseConstant.put(MYSQL, "0");
+    databaseSpecificIfNull.put(MYSQL, "IFNULL");
     addDatabaseSpecificStatement(MYSQL, "selectProcessDefinitionsByQueryCriteria", "selectProcessDefinitionsByQueryCriteria_mysql");
     addDatabaseSpecificStatement(MYSQL, "selectProcessDefinitionCountByQueryCriteria", "selectProcessDefinitionCountByQueryCriteria_mysql");
     addDatabaseSpecificStatement(MYSQL, "selectDeploymentsByQueryCriteria", "selectDeploymentsByQueryCriteria_mysql");
@@ -127,6 +131,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificDummyTable.put(POSTGRES, "");
     databaseSpecificTrueConstant.put(POSTGRES, "true");
     databaseSpecificFalseConstant.put(POSTGRES, "false");
+    databaseSpecificIfNull.put(POSTGRES, "NVL");
     addDatabaseSpecificStatement(POSTGRES, "insertByteArray", "insertByteArray_postgres");
     addDatabaseSpecificStatement(POSTGRES, "updateByteArray", "updateByteArray_postgres");
     addDatabaseSpecificStatement(POSTGRES, "selectByteArray", "selectByteArray_postgres");
@@ -170,6 +175,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificBitAnd3.put(ORACLE, ")");
     databaseSpecificTrueConstant.put(ORACLE, "1");
     databaseSpecificFalseConstant.put(ORACLE, "0");
+    databaseSpecificIfNull.put(ORACLE, "NVL");
 
     constants = new HashMap<String, String>();
     constants.put("constant.event", "cast('event' as nvarchar2(255))");
@@ -192,6 +198,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificDummyTable.put(DB2, "FROM SYSIBM.SYSDUMMY1");
     databaseSpecificTrueConstant.put(DB2, "1");
     databaseSpecificFalseConstant.put(DB2, "0");
+    databaseSpecificIfNull.put(MSSQL, "NVL");
     addDatabaseSpecificStatement(DB2, "selectExecutionByNativeQuery", "selectExecutionByNativeQuery_mssql_or_db2");
     addDatabaseSpecificStatement(DB2, "selectHistoricActivityInstanceByNativeQuery", "selectHistoricActivityInstanceByNativeQuery_mssql_or_db2");
     addDatabaseSpecificStatement(DB2, "selectHistoricCaseActivityInstanceByNativeQuery", "selectHistoricCaseActivityInstanceByNativeQuery_mssql_or_db2");
@@ -207,7 +214,6 @@ public class DbSqlSessionFactory implements SessionFactory {
     dbSpecificConstants.put(DB2, constants);
 
     // mssql
-
     databaseSpecificLimitBeforeStatements.put(MSSQL, "SELECT SUB.* FROM (");
     databaseSpecificInnerLimitAfterStatements.put(MSSQL, ")RES ) SUB WHERE SUB.rnk >= #{firstRow} AND SUB.rnk < #{lastRow}");
     databaseSpecificLimitAfterStatements.put(MSSQL, databaseSpecificInnerLimitAfterStatements.get(MSSQL) + " ORDER BY SUB.rnk");
@@ -222,6 +228,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificDummyTable.put(MSSQL, "");
     databaseSpecificTrueConstant.put(MSSQL, "1");
     databaseSpecificFalseConstant.put(MSSQL, "0");
+    databaseSpecificIfNull.put(MSSQL, "ISNULL");
     addDatabaseSpecificStatement(MSSQL, "selectExecutionByNativeQuery", "selectExecutionByNativeQuery_mssql_or_db2");
     addDatabaseSpecificStatement(MSSQL, "selectHistoricActivityInstanceByNativeQuery", "selectHistoricActivityInstanceByNativeQuery_mssql_or_db2");
     addDatabaseSpecificStatement(MSSQL, "selectHistoricCaseActivityInstanceByNativeQuery", "selectHistoricCaseActivityInstanceByNativeQuery_mssql_or_db2");

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Authorization.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Authorization.xml
@@ -164,13 +164,13 @@
 
   <select id="isUserAuthorizedForResource" resultType="integer">
 
-    <if test="permissionChecks != null &amp;&amp; permissionChecks.size() > 1">
+    <if test="permissionChecks != null &amp;&amp; permissionChecks.atomicChecks.size() > 1">
       SELECT
     </if>
 
     <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authorizationCheck" />
 
-   <if test="permissionChecks != null &amp;&amp; permissionChecks.size() > 1">
+   <if test="permissionChecks != null &amp;&amp; permissionChecks.atomicChecks.size() > 1">
       ${dbSpecificDummyTable}
     </if>
 
@@ -494,26 +494,129 @@
     </if>
   </sql>
 
+  <!-- 
+    input: "permissionChecks": an instance of CompositePermissionCheck
+  
+    limitation 1: can only handle at most two levels of composition (e.g. "(a or b) and (c or d)"); 
+      more levels are currently not implemented because MyBatis cannot process circular include statements
+      
+    limitation 2: can only a CompositePermissionCheck instance that contains atomic checks or composite cheks,
+      not a mixture of both (i.e. if you need "a or (b and c)", wrap "a" in another CompositePermissionCheck 
+   -->
   <sql id="authorizationCheck">
+    <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.atomicChecks" />
+    <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.compositeChecks" />
+  </sql>
+  
+  <!-- 
+    input: "permissionChecks": an instance of CompositePermissionCheck
+   -->
+  <sql id="atomicChecks">
+    <if test="permissionChecks.atomicChecks != null &amp;&amp; permissionChecks.atomicChecks.size() == 1">
 
-    <if test="permissionChecks != null &amp;&amp; permissionChecks.size() == 1">
-
-      <bind name="permCheck" value="permissionChecks[0]" />
+      <bind name="permCheck" value="permissionChecks.atomicChecks[0]" />
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>
 
     </if>
 
-    <if test="permissionChecks != null &amp;&amp; permissionChecks.size() > 1">
-
-      <foreach item="permCheck" index="index" collection="permissionChecks" separator=",">
-        ${dbSpecificIfNullFunction}((<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
-      </foreach>
-        , 0
-      <foreach item="permCheck" index="index" collection="permissionChecks">
-        )
-      </foreach>
+    <if test="permissionChecks.atomicChecks != null &amp;&amp; permissionChecks.atomicChecks.size() > 1">
+      <if test="permissionChecks.disjunctive">
+        <bind name="atomicChecks" value="permissionChecks.atomicChecks" />
+        <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.disjunctiveAtomicChecks" />
+      </if>
+      <if test="!permissionChecks.disjunctive">
+        <bind name="atomicChecks" value="permissionChecks.atomicChecks" />
+        <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.conjunctiveAtomicChecks" />
+      </if>
     </if>
-
+  </sql>
+  
+  <!-- 
+    input: "permissionChecks": an instance of CompositePermissionCheck
+   -->
+  <sql id="compositeChecks">
+    <if test="permissionChecks.compositeChecks != null &amp;&amp; permissionChecks.compositeChecks.size() > 1">
+      <if test="permissionChecks.disjunctive">
+        <bind name="compositeChecks" value="permissionChecks.compositeChecks" />
+        <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.disjunctiveCompositeChecks"/>
+      </if>
+      <if test="!permissionChecks.disjunctive">
+        <bind name="compositeChecks" value="permissionChecks.compositeChecks" />
+        <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.conjunctiveCompositeChecks"/>
+      </if>
+    </if>
+  </sql>
+  
+  <!-- 
+    input: "atomicChecks": list of PermissionCheck objects
+   -->
+  <sql id="disjunctiveAtomicChecks">
+    <foreach item="permCheck" index="index" collection="atomicChecks" separator=",">
+      ${dbSpecificIfNullFunction}((<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
+    </foreach>
+    , 0
+    <foreach item="permCheck" index="index" collection="atomicChecks">
+      )
+    </foreach>
+  </sql>
+  
+  <!-- 
+    input: "compositeChecks": a list of CompositePermissionCheck objects
+   -->
+  <sql id="disjunctiveCompositeChecks">
+    <foreach item="permissionChecks" index="index" collection="compositeChecks" separator=",">
+      ${dbSpecificIfNullFunction}(<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.atomicChecks" />
+    </foreach>
+    , 0
+    <foreach item="permissionChecks" index="index" collection="compositeChecks">
+      )
+    </foreach> 
+  </sql>
+  
+  <!-- 
+    input: "atomicChecks": list of PermissionCheck objects
+   -->
+  <sql id="conjunctiveAtomicChecks">
+    <!-- the BITAND function on databases like Oracle and DB2 takes exactly two arguments;
+      Instead of BITAND(a, b, c), we generate BITAND(BITAND(a, b), c)) instead -->
+    <foreach index="index" collection="atomicChecks">
+      <if test="index &lt; atomicChecks.size - 1">
+        ${bitand1}
+      </if>
+    </foreach>
+    <foreach  item="permCheck" index="i" collection="atomicChecks">
+      ${dbSpecificIfNullFunction}(
+        <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>
+      , 0)
+      <if test="i &gt; 0">
+        ${bitand3}
+      </if>
+      <if test="i &lt; atomicChecks.size - 1">
+        ${bitand2}
+      </if>
+    </foreach>
+  </sql>
+  
+  <!-- 
+    input: "compositeChecks": a list of CompositePermissionCheck objects
+   -->
+  <sql id="conjunctiveCompositeChecks">
+    <!-- the BITAND function on databases like Oracle and DB2 takes exactly two arguments;
+      Instead of BITAND(a, b, c), we generate BITAND(BITAND(a, b), c)) instead -->
+    <foreach index="index" collection="compositeChecks">
+      <if test="index &lt; compositeChecks.size - 1">
+        ${bitand1}
+      </if>
+    </foreach>
+    <foreach  item="permissionChecks" index="i" collection="compositeChecks">
+      <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.atomicChecks" />
+      <if test="i &gt; 0">
+        ${bitand3}
+      </if>
+      <if test="i &lt; compositeChecks.size - 1">
+        ${bitand2}
+      </if>
+    </foreach>
   </sql>
 
   <sql id="contextualAuthorizationCheck">

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Authorization.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Authorization.xml
@@ -504,15 +504,14 @@
     </if>
 
     <if test="permissionChecks != null &amp;&amp; permissionChecks.size() > 1">
-      COALESCE (
 
       <foreach item="permCheck" index="index" collection="permissionChecks" separator=",">
-
-        (<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
-
+        ${dbSpecificIfNullFunction}((<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
       </foreach>
-
-      , 0)
+        , 0
+      <foreach item="permCheck" index="index" collection="permissionChecks">
+        )
+      </foreach>
     </if>
 
   </sql>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Statistics.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Statistics.xml
@@ -105,11 +105,15 @@
 
                     <if test="isAuthorizationCheckEnabled &amp;&amp; authUserId != null">
                     and
-                        (COALESCE (
+                        (
                         <foreach item="permCheck" collection="processInstancePermissionChecks" separator=",">
-                          (<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
+                          ${dbSpecificIfNullFunction}((<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
                         </foreach>
-                          , 0) ) = 1
+                          , 0
+                        <foreach item="permCheck" collection="processInstancePermissionChecks">
+                          )
+                        </foreach>
+                        ) = 1
                     </if>
 
                 group by
@@ -133,11 +137,15 @@
 
                     <if test="isAuthorizationCheckEnabled &amp;&amp; authUserId != null">
                     and
-                        (COALESCE (
+                        (
                         <foreach item="permCheck" collection="jobPermissionChecks" separator=",">
-                          (<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
+                          ${dbSpecificIfNullFunction}((<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
                         </foreach>
-                          , 0) ) = 1
+                          , 0
+                        <foreach item="permCheck" collection="jobPermissionChecks">
+                          )
+                        </foreach>
+                        ) = 1
                     </if>
 
                 group by
@@ -173,11 +181,15 @@
 
                   <if test="isAuthorizationCheckEnabled &amp;&amp; authUserId != null">
                   and
-                      (COALESCE (
+                      (
                       <foreach item="permCheck" collection="incidentPermissionChecks" separator=",">
-                        (<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
+                        ${dbSpecificIfNullFunction}((<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
                       </foreach>
-                        , 0) ) = 1
+                        , 0
+                      <foreach item="permCheck" collection="incidentPermissionChecks">
+                        )
+                      </foreach>
+                      ) = 1
                   </if>
 
                 </where>
@@ -246,11 +258,15 @@
 
                     <if test="isAuthorizationCheckEnabled &amp;&amp; authUserId != null">
                     and
-                        (COALESCE (
+                        (
                         <foreach item="permCheck" collection="processInstancePermissionChecks" separator=",">
-                          (<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
+                          ${dbSpecificIfNullFunction}((<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
                         </foreach>
-                          , 0) ) = 1
+                          , 0
+                        <foreach item="permCheck" collection="processInstancePermissionChecks">
+                          )
+                        </foreach>
+                        ) = 1
                     </if>
 
                   group by
@@ -275,11 +291,15 @@
 
                     <if test="isAuthorizationCheckEnabled &amp;&amp; authUserId != null">
                     and
-                        (COALESCE (
+                        (
                         <foreach item="permCheck" collection="jobPermissionChecks" separator=",">
-                          (<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
+                          ${dbSpecificIfNullFunction}((<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
                         </foreach>
-                          , 0) ) = 1
+                          , 0
+                        <foreach item="permCheck" collection="jobPermissionChecks">
+                          )
+                        </foreach>
+                        ) = 1
                     </if>
 
                   group by
@@ -310,11 +330,15 @@
 
                     <if test="isAuthorizationCheckEnabled &amp;&amp; authUserId != null">
                     and
-                        (COALESCE (
+                        (
                         <foreach item="permCheck" collection="incidentPermissionChecks" separator=",">
-                          (<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
+                          ${dbSpecificIfNullFunction}((<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
                         </foreach>
-                          , 0) ) = 1
+                          , 0
+                        <foreach item="permCheck" collection="incidentPermissionChecks">
+                          )
+                        </foreach>
+                        ) = 1
                     </if>
 
                   group by
@@ -351,7 +375,7 @@
   </select>
 
   <sql id="selectActivityStatisticsByQueryCriteriaSql">
-	  from ( select ACTID.ACT_ID_ as ID_,
+      from ( select ACTID.ACT_ID_ as ID_,
         INSTANCE.INSTANCE_COUNT_
       <if test="failedJobsToInclude">
       , JOB.FAILED_JOBS_COUNT_
@@ -361,7 +385,7 @@
       , INC.INCIDENT_COUNT_
       </if>
 
-	    from
+        from
 
           <!-- collect activity ids -->
           (
@@ -385,11 +409,15 @@
 
                       <if test="isAuthorizationCheckEnabled &amp;&amp; authUserId != null">
                       and
-                          (COALESCE (
+                          (
                           <foreach item="permCheck" index="index" collection="processInstancePermissionChecks" separator=",">
-                            (<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
+                            ${dbSpecificIfNullFunction}((<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
                           </foreach>
-                            , 0) ) = 1
+                            , 0
+                          <foreach item="permCheck" index="index" collection="processInstancePermissionChecks">
+                            )
+                          </foreach>
+                          ) = 1
                       </if>
 
                   <if test="failedJobsToInclude">
@@ -407,11 +435,15 @@
                           and JOB.RETRIES_ = 0
                           <if test="isAuthorizationCheckEnabled &amp;&amp; authUserId != null">
                           and
-                              (COALESCE (
+                              (
                               <foreach item="permCheck" index="index" collection="jobPermissionChecks" separator=",">
-                                (<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
+                                ${dbSpecificIfNullFunction}((<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
                               </foreach>
-                                , 0) ) = 1
+                                , 0
+                              <foreach item="permCheck" index="index" collection="jobPermissionChecks">
+                                )
+                              </foreach>
+                              ) = 1
                           </if>
                   </if>
 
@@ -436,11 +468,15 @@
 
                           <if test="isAuthorizationCheckEnabled &amp;&amp; authUserId != null">
                           and
-                              (COALESCE (
+                              (
                               <foreach item="permCheck" index="index" collection="incidentPermissionChecks" separator=",">
-                                (<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
+                                ${dbSpecificIfNullFunction}((<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
                               </foreach>
-                                , 0) ) = 1
+                                , 0
+                              <foreach item="permCheck" index="index" collection="incidentPermissionChecks">
+                                )
+                              </foreach>
+                              ) = 1
                           </if>
                   </if>
 
@@ -449,14 +485,14 @@
 
           left outer join
 
-        	    <!-- Count and group all activity instances by activity ids.
-        	    The executions that are actual activity instances can be found with the IS_ACTIVE_.
-        	    This will not count parent executions such as the process instance itself. -->
-    	        (
+                <!-- Count and group all activity instances by activity ids.
+                The executions that are actual activity instances can be found with the IS_ACTIVE_.
+                This will not count parent executions such as the process instance itself. -->
+                (
                  select
                      E.ACT_ID_
                    , count(E.PROC_INST_ID_) as INSTANCE_COUNT_
-    	           from
+                   from
                     ${prefix}ACT_RU_EXECUTION E
                   <if test="isAuthorizationCheckEnabled &amp;&amp; authUserId != null">
                   inner join
@@ -464,29 +500,33 @@
                   on
                       E.PROC_DEF_ID_ = P.ID_
                   </if>
-    	           where
+                   where
                     E.PROC_DEF_ID_ = #{processDefinitionId}
                     and E.IS_ACTIVE_ = ${trueConstant}
                     <if test="isAuthorizationCheckEnabled &amp;&amp; authUserId != null">
                     and
-                        (COALESCE (
+                        (
                         <foreach item="permCheck" index="index" collection="processInstancePermissionChecks" separator=",">
-                          (<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
+                          ${dbSpecificIfNullFunction}((<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
                         </foreach>
-                          , 0) ) = 1
+                          , 0
+                        <foreach item="permCheck" index="index" collection="processInstancePermissionChecks">
+                          )
+                        </foreach>
+                        ) = 1
                     </if>
-    	           group by
+                   group by
                     E.ACT_ID_
                ) INSTANCE
           on
               ACTID.ACT_ID_ = INSTANCE.ACT_ID_
 
           <!-- failedJobs -->
-    	    <if test="failedJobsToInclude">
-    	    left outer join
+            <if test="failedJobsToInclude">
+            left outer join
 
-        	    <!-- Sum all failed jobs grouped by activity id -->
-        	    (
+                <!-- Sum all failed jobs grouped by activity id -->
+                (
                 select
                     JOBDEF.ACT_ID_
                   , count(JOB.ID_) as FAILED_JOBS_COUNT_
@@ -501,18 +541,22 @@
                     and JOB.RETRIES_ = 0
                     <if test="isAuthorizationCheckEnabled &amp;&amp; authUserId != null">
                     and
-                        (COALESCE (
+                        (
                         <foreach item="permCheck" index="index" collection="jobPermissionChecks" separator=",">
-                          (<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
+                          ${dbSpecificIfNullFunction}((<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
                         </foreach>
-                          , 0) ) = 1
+                          , 0
+                        <foreach item="permCheck" index="index" collection="jobPermissionChecks">
+                          )
+                        </foreach>
+                        ) = 1
                     </if>
                 group by
                     JOBDEF.ACT_ID_
               ) JOB
 
-    	    on ACTID.ACT_ID_ = JOB.ACT_ID_
-    	    </if>
+            on ACTID.ACT_ID_ = JOB.ACT_ID_
+            </if>
 
         <!-- incidents -->
         <if test="incidentsToInclude">
@@ -539,11 +583,15 @@
                   </if>
                   <if test="isAuthorizationCheckEnabled &amp;&amp; authUserId != null">
                   and
-                      (COALESCE (
+                      (
                       <foreach item="permCheck" index="index" collection="incidentPermissionChecks" separator=",">
-                        (<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
+                        ${dbSpecificIfNullFunction}((<include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>)
                       </foreach>
-                        , 0) ) = 1
+                        , 0
+                      <foreach item="permCheck" index="index" collection="incidentPermissionChecks">
+                        )
+                      </foreach>
+                      ) = 1
                   </if>
               group by
                   I.ACTIVITY_ID_, I.INCIDENT_TYPE_
@@ -551,7 +599,7 @@
 
         on ACTID.ACT_ID_ = INC.ACTIVITY_ID_
         </if>
-	    ) RES
+       ) RES
   </sql>
 
 </mapper>


### PR DESCRIPTION
This is a follow-up to https://github.com/camunda/camunda-bpm-platform/pull/149.
As suggested by Roman:
- added databaseSpecificIfNull map
- filled for every supported database
- used as ${dbSpecificIfNullFunction} in Authorization.xml and Statistics.xml nested, as a replacement of the COLALESCE function.
Test run successful against H2, Oracle 12 and MS SQL Server 2014 and IBM Informix 12.1.