### PR TITLE
CAM-4053 fixed

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/metrics/MetricsQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/metrics/MetricsQueryImpl.java
@@ -97,4 +97,7 @@ public class MetricsQueryImpl implements Serializable, Command<Object>, MetricsQ
     return reporter;
   }
 
+  public CommandExecutor getCommandExecutor() {
+    return commandExecutor;
+  }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/MeterLogManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/MeterLogManager.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.metrics.Meter;
 import org.camunda.bpm.engine.impl.metrics.MetricsQueryImpl;
+import org.camunda.bpm.engine.impl.metrics.reporter.DbMetricsReporter;
 import org.camunda.bpm.engine.impl.persistence.AbstractManager;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 
@@ -51,10 +52,13 @@ public class MeterLogManager extends AbstractManager {
   }
 
   protected boolean shouldAddCurrentUnloggedCount(MetricsQueryImpl query) {
+      
+      DbMetricsReporter reporter = Context.getProcessEngineConfiguration().getDbMetricsReporter();
+      if (reporter == null){
+          reporter = new DbMetricsReporter(Context.getProcessEngineConfiguration().getMetricsRegistry(), query.getCommandExecutor());
+      }   
 
-    long reportingIntervalInSeconds = Context.getProcessEngineConfiguration()
-      .getDbMetricsReporter()
-      .getReportingIntervalInSeconds();
+    long reportingIntervalInSeconds = reporter.getReportingIntervalInSeconds();
 
     return query.getName() != null
         && (query.getEndDate() == null

--- a/engine/src/test/java/org/camunda/bpm/engine/test/metrics/MetricsDisabledTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/metrics/MetricsDisabledTest.java
@@ -29,7 +29,7 @@ public class MetricsDisabledTest extends ResourceProcessEngineTestCase {
 
   // FAILING, see https://app.camunda.com/jira/browse/CAM-4053
   // (to run, remove "FAILING" from methodname)
-  public void FAILING_testQueryMetricsIfMetricsIsDisabled() {
+  public void testQueryMetricsIfMetricsIsDisabled() {
 
     // given
     // that the metrics are disabled (see xml configuration referenced in constructor)


### PR DESCRIPTION
added getter-Method for CommandExecutor in MetricsQueryImpl.java
added a check for DbMetricsReporter in MeterLogMangar.java

test is successful 
![testerfolgreich](https://cloud.githubusercontent.com/assets/12895272/8164486/ae0b45f0-1389-11e5-9c71-fc65f2cc45e1.jpg)
