### PR TITLE
test(engine): use Integer.MIN_VALUE + 1 as the small value.

### DIFF
--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/JobDefinitionPriorityTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/JobDefinitionPriorityTest.java
@@ -334,9 +334,9 @@ public class JobDefinitionPriorityTest extends PluggableProcessEngineTestCase {
     assertEquals(Integer.MAX_VALUE, (int) jobDefinition.getJobPriority());
 
     // it is possible to set the min integer value
-    managementService.setJobDefinitionPriority(jobDefinition.getId(), Integer.MIN_VALUE);
+    managementService.setJobDefinitionPriority(jobDefinition.getId(), Integer.MIN_VALUE + 1);
     jobDefinition = managementService.createJobDefinitionQuery().singleResult();
-    assertEquals(Integer.MIN_VALUE, (int) jobDefinition.getJobPriority());
+    assertEquals(Integer.MIN_VALUE + 1, (int) jobDefinition.getJobPriority());
   }
 
   protected Job getJobThatIsNot(Job other) {


### PR DESCRIPTION
Value range for a column of type integer in IBM Informix is -2,147,483,647 to 2,147,483,647 or 2^31-1 to -2^31+1 or Integer.MAX_VALUE to Integer.MIN_VALUE + 1.
