### PR TITLE
feat(engine) towards improving meaningless API range queries

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/AbstractQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/AbstractQuery.java
@@ -175,7 +175,7 @@ public abstract class AbstractQuery<T extends Query<?,?>, U> extends ListQueryPa
   public long evaluateExpressionsAndExecuteCount(CommandContext commandContext) {
     validate();
     evaluateExpressions();
-    return executeCount(commandContext);
+    return isValid() ? executeCount(commandContext) : 0l;
   }
 
   public abstract long executeCount(CommandContext commandContext);
@@ -183,7 +183,19 @@ public abstract class AbstractQuery<T extends Query<?,?>, U> extends ListQueryPa
   public List<U> evaluateExpressionsAndExecuteList(CommandContext commandContext, Page page) {
     validate();
     evaluateExpressions();
-    return executeList(commandContext, page);
+    return isValid() ? executeList(commandContext, page) : new ArrayList<U>();
+  }
+
+  /**
+   * Whether or not the query is valid. If the query is invalid the SQL
+   * query is avoided and default result is returned. The returned
+   * result is the same as if the SQL was executed and there were no entries.
+   *
+   * @return Whether or not the query is valid
+   */
+  protected boolean isValid() {
+    checkQueryOk();
+    return true;
   }
 
   /**
@@ -193,7 +205,7 @@ public abstract class AbstractQuery<T extends Query<?,?>, U> extends ListQueryPa
   public abstract List<U> executeList(CommandContext commandContext, Page page);
 
   public U executeSingleResult(CommandContext commandContext) {
-    List<U> results = evaluateExpressionsAndExecuteList(commandContext, null);
+    List<U> results = isValid() ? evaluateExpressionsAndExecuteList(commandContext, null) : new ArrayList<U>();
     if (results.size() == 1) {
       return results.get(0);
     } else if (results.size() > 1) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/AbstractQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/AbstractQuery.java
@@ -175,7 +175,7 @@ public abstract class AbstractQuery<T extends Query<?,?>, U> extends ListQueryPa
   public long evaluateExpressionsAndExecuteCount(CommandContext commandContext) {
     validate();
     evaluateExpressions();
-    return isValid() ? executeCount(commandContext) : 0l;
+    return !hasExcludingConditions() ? executeCount(commandContext) : 0l;
   }
 
   public abstract long executeCount(CommandContext commandContext);
@@ -183,19 +183,19 @@ public abstract class AbstractQuery<T extends Query<?,?>, U> extends ListQueryPa
   public List<U> evaluateExpressionsAndExecuteList(CommandContext commandContext, Page page) {
     validate();
     evaluateExpressions();
-    return isValid() ? executeList(commandContext, page) : new ArrayList<U>();
+    return !hasExcludingConditions() ? executeList(commandContext, page) : new ArrayList<U>();
   }
 
   /**
-   * Whether or not the query is valid. If the query is invalid the SQL
-   * query is avoided and default result is returned. The returned
-   * result is the same as if the SQL was executed and there were no entries.
+   * Whether or not the query has excluding conditions. If the query has excluding conditions,
+   * (e.g. creation date is after end date )the SQL query is avoided and default result is
+   * returned. The returned result is the same as if the SQL was executed and there were no entries.
    *
-   * @return Whether or not the query is valid
+   * @return {@code true} if the query does have excluding conditions, {@code false} otherwise
    */
-  protected boolean isValid() {
+  protected boolean hasExcludingConditions() {
     checkQueryOk();
-    return true;
+    return false;
   }
 
   /**
@@ -205,7 +205,7 @@ public abstract class AbstractQuery<T extends Query<?,?>, U> extends ListQueryPa
   public abstract List<U> executeList(CommandContext commandContext, Page page);
 
   public U executeSingleResult(CommandContext commandContext) {
-    List<U> results = isValid() ? evaluateExpressionsAndExecuteList(commandContext, null) : new ArrayList<U>();
+    List<U> results = !hasExcludingConditions() ? evaluateExpressionsAndExecuteList(commandContext, null) : new ArrayList<U>();
     if (results.size() == 1) {
       return results.get(0);
     } else if (results.size() > 1) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/DeploymentQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/DeploymentQueryImpl.java
@@ -86,7 +86,7 @@ public class DeploymentQueryImpl extends AbstractQuery<DeploymentQuery, Deployme
   }
 
   @Override
-  public boolean hasExcludingConditions() {
+  protected boolean hasExcludingConditions() {
     return super.hasExcludingConditions() || CompareUtil.hasExcludingOrder(deploymentAfter, deploymentBefore);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/DeploymentQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/DeploymentQueryImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
+import org.camunda.bpm.engine.impl.util.CompareUtil;
 import org.camunda.bpm.engine.repository.Deployment;
 import org.camunda.bpm.engine.repository.DeploymentQuery;
 
@@ -82,6 +83,11 @@ public class DeploymentQueryImpl extends AbstractQuery<DeploymentQuery, Deployme
     ensureNotNull("deploymentAfter", after);
     this.deploymentAfter = after;
     return this;
+  }
+
+  @Override
+  public boolean isValid() {
+    return super.isValid() && CompareUtil.validateOrder(deploymentAfter, deploymentBefore);
   }
 
   //sorting ////////////////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/DeploymentQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/DeploymentQueryImpl.java
@@ -87,7 +87,7 @@ public class DeploymentQueryImpl extends AbstractQuery<DeploymentQuery, Deployme
 
   @Override
   protected boolean hasExcludingConditions() {
-    return super.hasExcludingConditions() || CompareUtil.hasExcludingOrder(deploymentAfter, deploymentBefore);
+    return super.hasExcludingConditions() || CompareUtil.areNotInAnAscendingOrder(deploymentAfter, deploymentBefore);
   }
 
   //sorting ////////////////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/DeploymentQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/DeploymentQueryImpl.java
@@ -86,8 +86,8 @@ public class DeploymentQueryImpl extends AbstractQuery<DeploymentQuery, Deployme
   }
 
   @Override
-  public boolean isValid() {
-    return super.isValid() && CompareUtil.validateOrder(deploymentAfter, deploymentBefore);
+  public boolean hasExcludingConditions() {
+    return super.hasExcludingConditions() || CompareUtil.hasExcludingOrder(deploymentAfter, deploymentBefore);
   }
 
   //sorting ////////////////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricActivityInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricActivityInstanceQueryImpl.java
@@ -153,11 +153,11 @@ public class HistoricActivityInstanceQueryImpl extends AbstractQuery<HistoricAct
   }
 
   @Override
-  public boolean isValid() {
-    boolean valid = super.isValid();
-    valid = valid && CompareUtil.validateOrder(startedAfter, startedBefore);
-    valid = valid && CompareUtil.validateOrder(finishedAfter, finishedBefore);
-    return valid;
+  public boolean hasExcludingConditions() {
+    boolean excluding = super.hasExcludingConditions();
+    excluding = excluding || CompareUtil.hasExcludingOrder(startedAfter, startedBefore);
+    excluding = excluding || CompareUtil.hasExcludingOrder(finishedAfter, finishedBefore);
+    return excluding;
   }
 
   // ordering /////////////////////////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricActivityInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricActivityInstanceQueryImpl.java
@@ -153,7 +153,7 @@ public class HistoricActivityInstanceQueryImpl extends AbstractQuery<HistoricAct
   }
 
   @Override
-  public boolean hasExcludingConditions() {
+  protected boolean hasExcludingConditions() {
     boolean excluding = super.hasExcludingConditions();
     excluding = excluding || CompareUtil.hasExcludingOrder(startedAfter, startedBefore);
     excluding = excluding || CompareUtil.hasExcludingOrder(finishedAfter, finishedBefore);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricActivityInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricActivityInstanceQueryImpl.java
@@ -155,8 +155,8 @@ public class HistoricActivityInstanceQueryImpl extends AbstractQuery<HistoricAct
   @Override
   protected boolean hasExcludingConditions() {
     boolean excluding = super.hasExcludingConditions();
-    excluding = excluding || CompareUtil.hasExcludingOrder(startedAfter, startedBefore);
-    excluding = excluding || CompareUtil.hasExcludingOrder(finishedAfter, finishedBefore);
+    excluding = excluding || CompareUtil.areNotInAnAscendingOrder(startedAfter, startedBefore);
+    excluding = excluding || CompareUtil.areNotInAnAscendingOrder(finishedAfter, finishedBefore);
     return excluding;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricActivityInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricActivityInstanceQueryImpl.java
@@ -22,7 +22,7 @@ import org.camunda.bpm.engine.history.HistoricActivityInstanceQuery;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 import org.camunda.bpm.engine.impl.pvm.runtime.ActivityInstanceState;
-
+import org.camunda.bpm.engine.impl.util.CompareUtil;
 
 /**
  * @author Tom Baeyens
@@ -150,6 +150,14 @@ public class HistoricActivityInstanceQueryImpl extends AbstractQuery<HistoricAct
   public HistoricActivityInstanceQueryImpl finishedBefore(Date date) {
     finishedBefore = date;
     return this;
+  }
+
+  @Override
+  public boolean isValid() {
+    boolean valid = super.isValid();
+    valid = valid && CompareUtil.validateOrder(startedAfter, startedBefore);
+    valid = valid && CompareUtil.validateOrder(finishedAfter, finishedBefore);
+    return valid;
   }
 
   // ordering /////////////////////////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseActivityInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseActivityInstanceQueryImpl.java
@@ -31,6 +31,7 @@ import org.camunda.bpm.engine.history.HistoricCaseActivityInstance;
 import org.camunda.bpm.engine.history.HistoricCaseActivityInstanceQuery;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
+import org.camunda.bpm.engine.impl.util.CompareUtil;
 
 /**
  * @author Sebastian Menski
@@ -208,6 +209,14 @@ public class HistoricCaseActivityInstanceQueryImpl extends AbstractQuery<Histori
     ensureNull(NotValidException.class, "Already querying for case activity instance state '" + caseActivityInstanceState + "'", "caseActivityState", caseActivityInstanceState);
     this.caseActivityInstanceState = TERMINATED.getStateCode();
     return this;
+  }
+
+  @Override
+  public boolean isValid() {
+    boolean valid = super.isValid();
+    valid = valid && CompareUtil.validateOrder(createdAfter, createdBefore);
+    valid = valid && CompareUtil.validateOrder(endedAfter, endedAfter);
+    return valid;
   }
 
   // ordering

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseActivityInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseActivityInstanceQueryImpl.java
@@ -215,7 +215,7 @@ public class HistoricCaseActivityInstanceQueryImpl extends AbstractQuery<Histori
   public boolean isValid() {
     boolean valid = super.isValid();
     valid = valid && CompareUtil.validateOrder(createdAfter, createdBefore);
-    valid = valid && CompareUtil.validateOrder(endedAfter, endedAfter);
+    valid = valid && CompareUtil.validateOrder(endedAfter, endedBefore);
     return valid;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseActivityInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseActivityInstanceQueryImpl.java
@@ -212,7 +212,7 @@ public class HistoricCaseActivityInstanceQueryImpl extends AbstractQuery<Histori
   }
 
   @Override
-  public boolean hasExcludingConditions() {
+  protected boolean hasExcludingConditions() {
     boolean excluding = super.hasExcludingConditions();
     excluding = excluding || CompareUtil.hasExcludingOrder(createdAfter, createdBefore);
     excluding = excluding || CompareUtil.hasExcludingOrder(endedAfter, endedBefore);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseActivityInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseActivityInstanceQueryImpl.java
@@ -214,8 +214,8 @@ public class HistoricCaseActivityInstanceQueryImpl extends AbstractQuery<Histori
   @Override
   protected boolean hasExcludingConditions() {
     boolean excluding = super.hasExcludingConditions();
-    excluding = excluding || CompareUtil.hasExcludingOrder(createdAfter, createdBefore);
-    excluding = excluding || CompareUtil.hasExcludingOrder(endedAfter, endedBefore);
+    excluding = excluding || CompareUtil.areNotInAnAscendingOrder(createdAfter, createdBefore);
+    excluding = excluding || CompareUtil.areNotInAnAscendingOrder(endedAfter, endedBefore);
     return excluding;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseActivityInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseActivityInstanceQueryImpl.java
@@ -212,11 +212,11 @@ public class HistoricCaseActivityInstanceQueryImpl extends AbstractQuery<Histori
   }
 
   @Override
-  public boolean isValid() {
-    boolean valid = super.isValid();
-    valid = valid && CompareUtil.validateOrder(createdAfter, createdBefore);
-    valid = valid && CompareUtil.validateOrder(endedAfter, endedBefore);
-    return valid;
+  public boolean hasExcludingConditions() {
+    boolean excluding = super.hasExcludingConditions();
+    excluding = excluding || CompareUtil.hasExcludingOrder(createdAfter, createdBefore);
+    excluding = excluding || CompareUtil.hasExcludingOrder(endedAfter, endedBefore);
+    return excluding;
   }
 
   // ordering

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseInstanceQueryImpl.java
@@ -249,7 +249,7 @@ public class HistoricCaseInstanceQueryImpl extends AbstractVariableQueryImpl<His
   }
 
   @Override
-  public boolean hasExcludingConditions() {
+  protected boolean hasExcludingConditions() {
     boolean excluding = super.hasExcludingConditions();
     excluding = excluding || CompareUtil.hasExcludingOrder(createdAfter, createdBefore);
     excluding = excluding || CompareUtil.hasExcludingOrder(closedAfter, closedBefore);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseInstanceQueryImpl.java
@@ -251,10 +251,10 @@ public class HistoricCaseInstanceQueryImpl extends AbstractVariableQueryImpl<His
   @Override
   protected boolean hasExcludingConditions() {
     boolean excluding = super.hasExcludingConditions();
-    excluding = excluding || CompareUtil.hasExcludingOrder(createdAfter, createdBefore);
-    excluding = excluding || CompareUtil.hasExcludingOrder(closedAfter, closedBefore);
-    excluding = excluding || CompareUtil.hasExcludingContains(caseInstanceId, caseInstanceIds);
-    excluding = excluding || CompareUtil.hasExcludingNotContains(caseDefinitionKey, caseKeyNotIn);
+    excluding = excluding || CompareUtil.areNotInAnAscendingOrder(createdAfter, createdBefore);
+    excluding = excluding || CompareUtil.areNotInAnAscendingOrder(closedAfter, closedBefore);
+    excluding = excluding || CompareUtil.elementIsNotContainedInList(caseInstanceId, caseInstanceIds);
+    excluding = excluding || CompareUtil.elementIsContainedInList(caseDefinitionKey, caseKeyNotIn);
     return excluding;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseInstanceQueryImpl.java
@@ -18,7 +18,6 @@ import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotContainsNull;
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotEmpty;
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNull;
 
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -250,13 +249,13 @@ public class HistoricCaseInstanceQueryImpl extends AbstractVariableQueryImpl<His
   }
 
   @Override
-  public boolean isValid() {
-    boolean valid = super.isValid();
-    valid = valid && CompareUtil.validateOrder(createdAfter, createdBefore);
-    valid = valid && CompareUtil.validateOrder(closedAfter, closedBefore);
-    valid = valid && CompareUtil.validateContains(caseInstanceId, caseInstanceIds);
-    valid = valid && CompareUtil.validateNotContains(caseDefinitionKey, caseKeyNotIn);
-    return valid;
+  public boolean hasExcludingConditions() {
+    boolean excluding = super.hasExcludingConditions();
+    excluding = excluding || CompareUtil.hasExcludingOrder(createdAfter, createdBefore);
+    excluding = excluding || CompareUtil.hasExcludingOrder(closedAfter, closedBefore);
+    excluding = excluding || CompareUtil.hasExcludingContains(caseInstanceId, caseInstanceIds);
+    excluding = excluding || CompareUtil.hasExcludingNotContains(caseDefinitionKey, caseKeyNotIn);
+    return excluding;
   }
 
   public String getBusinessKey() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricCaseInstanceQueryImpl.java
@@ -18,6 +18,7 @@ import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotContainsNull;
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotEmpty;
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNull;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -28,7 +29,7 @@ import org.camunda.bpm.engine.history.HistoricCaseInstanceQuery;
 import org.camunda.bpm.engine.impl.cmmn.execution.CaseExecutionState;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
-
+import org.camunda.bpm.engine.impl.util.CompareUtil;
 
 /**
  * @author Sebastian Menski
@@ -246,6 +247,16 @@ public class HistoricCaseInstanceQueryImpl extends AbstractVariableQueryImpl<His
     return commandContext
       .getHistoricCaseInstanceManager()
       .findHistoricCaseInstancesByQueryCriteria(this, page);
+  }
+
+  @Override
+  public boolean isValid() {
+    boolean valid = super.isValid();
+    valid = valid && CompareUtil.validateOrder(createdAfter, createdBefore);
+    valid = valid && CompareUtil.validateOrder(closedAfter, closedBefore);
+    valid = valid && CompareUtil.validateContains(caseInstanceId, caseInstanceIds);
+    valid = valid && CompareUtil.validateNotContains(caseDefinitionKey, caseKeyNotIn);
+    return valid;
   }
 
   public String getBusinessKey() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricJobLogQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricJobLogQueryImpl.java
@@ -25,6 +25,7 @@ import org.camunda.bpm.engine.history.JobState;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 import org.camunda.bpm.engine.impl.util.CollectionUtil;
+import org.camunda.bpm.engine.impl.util.CompareUtil;
 
 /**
  * @author Roman Smirnov
@@ -163,6 +164,13 @@ public class HistoricJobLogQueryImpl extends AbstractQuery<HistoricJobLogQuery, 
   public HistoricJobLogQuery deletionLog() {
     setState(JobState.DELETED);
     return this;
+  }
+
+  @Override
+  protected boolean isValid() {
+    boolean valid = super.isValid();
+    valid = valid && CompareUtil.validateOrder(jobPriorityHigherThanOrEqual, jobPriorityLowerThanOrEqual);
+    return valid;
   }
 
   // order by //////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricJobLogQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricJobLogQueryImpl.java
@@ -169,7 +169,7 @@ public class HistoricJobLogQueryImpl extends AbstractQuery<HistoricJobLogQuery, 
   @Override
   protected boolean hasExcludingConditions() {
     boolean excluding = super.hasExcludingConditions();
-    excluding = excluding || CompareUtil.hasExcludingOrder(jobPriorityHigherThanOrEqual, jobPriorityLowerThanOrEqual);
+    excluding = excluding || CompareUtil.areNotInAnAscendingOrder(jobPriorityHigherThanOrEqual, jobPriorityLowerThanOrEqual);
     return excluding;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricJobLogQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricJobLogQueryImpl.java
@@ -167,10 +167,10 @@ public class HistoricJobLogQueryImpl extends AbstractQuery<HistoricJobLogQuery, 
   }
 
   @Override
-  protected boolean isValid() {
-    boolean valid = super.isValid();
-    valid = valid && CompareUtil.validateOrder(jobPriorityHigherThanOrEqual, jobPriorityLowerThanOrEqual);
-    return valid;
+  protected boolean hasExcludingConditions() {
+    boolean excluding = super.hasExcludingConditions();
+    excluding = excluding || CompareUtil.hasExcludingOrder(jobPriorityHigherThanOrEqual, jobPriorityLowerThanOrEqual);
+    return excluding;
   }
 
   // order by //////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -177,7 +177,7 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   }
 
   @Override
-  public boolean hasExcludingConditions() {
+  protected boolean hasExcludingConditions() {
     boolean excluding = super.hasExcludingConditions();
     excluding = excluding || (finished && unfinished);
     excluding = excluding || CompareUtil.hasExcludingOrder(startedAfter, startedBefore);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -180,10 +180,10 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   protected boolean hasExcludingConditions() {
     boolean excluding = super.hasExcludingConditions();
     excluding = excluding || (finished && unfinished);
-    excluding = excluding || CompareUtil.hasExcludingOrder(startedAfter, startedBefore);
-    excluding = excluding || CompareUtil.hasExcludingOrder(finishedAfter, finishedBefore);
-    excluding = excluding || CompareUtil.hasExcludingNotContains(processDefinitionKey, processKeyNotIn);
-    excluding = excluding || CompareUtil.hasExcludingContains(processInstanceId, processInstanceIds);
+    excluding = excluding || CompareUtil.areNotInAnAscendingOrder(startedAfter, startedBefore);
+    excluding = excluding || CompareUtil.areNotInAnAscendingOrder(finishedAfter, finishedBefore);
+    excluding = excluding || CompareUtil.elementIsContainedInList(processDefinitionKey, processKeyNotIn);
+    excluding = excluding || CompareUtil.elementIsNotContainedInList(processInstanceId, processInstanceIds);
     return excluding;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -177,14 +177,14 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   }
 
   @Override
-  public boolean isValid() {
-    boolean valid = super.isValid();
-    valid = valid && !(finished && unfinished);
-    valid = valid && CompareUtil.validateOrder(startedAfter, startedBefore);
-    valid = valid && CompareUtil.validateOrder(finishedAfter, finishedBefore);
-    valid = valid && CompareUtil.validateNotContains(processDefinitionKey, processKeyNotIn);
-    valid = valid && CompareUtil.validateContains(processInstanceId, processInstanceIds);
-    return valid;
+  public boolean hasExcludingConditions() {
+    boolean excluding = super.hasExcludingConditions();
+    excluding = excluding || (finished && unfinished);
+    excluding = excluding || CompareUtil.hasExcludingOrder(startedAfter, startedBefore);
+    excluding = excluding || CompareUtil.hasExcludingOrder(finishedAfter, finishedBefore);
+    excluding = excluding || CompareUtil.hasExcludingNotContains(processDefinitionKey, processKeyNotIn);
+    excluding = excluding || CompareUtil.hasExcludingContains(processInstanceId, processInstanceIds);
+    return excluding;
   }
 
 	public HistoricProcessInstanceQuery orderByProcessInstanceBusinessKey() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -26,7 +26,7 @@ import org.camunda.bpm.engine.history.HistoricProcessInstance;
 import org.camunda.bpm.engine.history.HistoricProcessInstanceQuery;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
-
+import org.camunda.bpm.engine.impl.util.CompareUtil;
 
 /**
  * @author Tom Baeyens
@@ -174,6 +174,17 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   public HistoricProcessInstanceQuery caseInstanceId(String caseInstanceId) {
     this.caseInstanceId = caseInstanceId;
     return this;
+  }
+
+  @Override
+  public boolean isValid() {
+    boolean valid = super.isValid();
+    valid = valid && !(finished && unfinished);
+    valid = valid && CompareUtil.validateOrder(startedAfter, startedBefore);
+    valid = valid && CompareUtil.validateOrder(finishedAfter, finishedBefore);
+    valid = valid && CompareUtil.validateNotContains(processDefinitionKey, processKeyNotIn);
+    valid = valid && CompareUtil.validateContains(processInstanceId, processInstanceIds);
+    return valid;
   }
 
 	public HistoricProcessInstanceQuery orderByProcessInstanceBusinessKey() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -291,13 +291,13 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
   }
 
   @Override
-  public boolean isValid() {
-    boolean valid = super.isValid();
-    valid = valid && !(finished && unfinished);
-    valid = valid && !(processFinished && processUnfinished);
-    valid = valid && CompareUtil.validateOrder(dueAfter, dueDate, dueBefore);
-    valid = valid && CompareUtil.validateOrder(followUpAfter, followUpDate, followUpBefore);
-    return valid;
+  public boolean hasExcludingConditions() {
+    boolean excluding = super.hasExcludingConditions();
+    excluding = excluding || (finished && unfinished);
+    excluding = excluding ||(processFinished && processUnfinished);
+    excluding = excluding || CompareUtil.hasExcludingOrder(dueAfter, dueDate, dueBefore);
+    excluding = excluding || CompareUtil.hasExcludingOrder(followUpAfter, followUpDate, followUpBefore);
+    return excluding;
   }
 
   // ordering /////////////////////////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -291,7 +291,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
   }
 
   @Override
-  public boolean hasExcludingConditions() {
+  protected boolean hasExcludingConditions() {
     boolean excluding = super.hasExcludingConditions();
     excluding = excluding || (finished && unfinished);
     excluding = excluding ||(processFinished && processUnfinished);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -295,8 +295,8 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
     boolean excluding = super.hasExcludingConditions();
     excluding = excluding || (finished && unfinished);
     excluding = excluding ||(processFinished && processUnfinished);
-    excluding = excluding || CompareUtil.hasExcludingOrder(dueAfter, dueDate, dueBefore);
-    excluding = excluding || CompareUtil.hasExcludingOrder(followUpAfter, followUpDate, followUpBefore);
+    excluding = excluding || CompareUtil.areNotInAnAscendingOrder(dueAfter, dueDate, dueBefore);
+    excluding = excluding || CompareUtil.areNotInAnAscendingOrder(followUpAfter, followUpDate, followUpBefore);
     return excluding;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -24,6 +24,7 @@ import org.camunda.bpm.engine.history.HistoricTaskInstanceQuery;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
+import org.camunda.bpm.engine.impl.util.CompareUtil;
 import org.camunda.bpm.engine.impl.variable.serializer.VariableSerializers;
 
 
@@ -287,6 +288,16 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
   public HistoricTaskInstanceQuery taskFollowUpAfter(Date followUpAfter) {
     this.followUpAfter = followUpAfter;
     return this;
+  }
+
+  @Override
+  public boolean isValid() {
+    boolean valid = super.isValid();
+    valid = valid && !(finished && unfinished);
+    valid = valid && !(processFinished && processUnfinished);
+    valid = valid && CompareUtil.validateOrder(dueAfter, dueDate, dueBefore);
+    valid = valid && CompareUtil.validateOrder(followUpAfter, followUpDate, followUpBefore);
+    return valid;
   }
 
   // ordering /////////////////////////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/JobQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/JobQueryImpl.java
@@ -204,7 +204,7 @@ public class JobQueryImpl extends AbstractQuery<JobQuery, Job> implements JobQue
   }
 
   @Override
-  public boolean hasExcludingConditions() {
+  protected boolean hasExcludingConditions() {
     boolean excluding = super.hasExcludingConditions();
     excluding = excluding || CompareUtil.hasExcludingOrder(priorityHigherThanOrEqual, priorityLowerThanOrEqual);
     excluding = excluding || isExcludingDueDate();

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/JobQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/JobQueryImpl.java
@@ -206,7 +206,7 @@ public class JobQueryImpl extends AbstractQuery<JobQuery, Job> implements JobQue
   @Override
   protected boolean hasExcludingConditions() {
     boolean excluding = super.hasExcludingConditions();
-    excluding = excluding || CompareUtil.hasExcludingOrder(priorityHigherThanOrEqual, priorityLowerThanOrEqual);
+    excluding = excluding || CompareUtil.areNotInAnAscendingOrder(priorityHigherThanOrEqual, priorityLowerThanOrEqual);
     excluding = excluding || isExcludingDueDate();
     return excluding;
   }
@@ -241,7 +241,7 @@ public class JobQueryImpl extends AbstractQuery<JobQuery, Job> implements JobQue
       dueDates.add(duedateLowerThanOrEqual);
     }
 
-    return CompareUtil.hasExcludingOrder(dueDates);
+    return CompareUtil.areNotInAnAscendingOrder(dueDates);
   }
 
   //sorting //////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/JobQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/JobQueryImpl.java
@@ -206,7 +206,7 @@ public class JobQueryImpl extends AbstractQuery<JobQuery, Job> implements JobQue
   @Override
   public boolean isValid() {
     boolean valid = super.isValid();
-    valid = valid && CompareUtil.validateOrder(priorityLowerThanOrEqual, priorityHigherThanOrEqual);
+    valid = valid && CompareUtil.validateOrder(priorityHigherThanOrEqual, priorityLowerThanOrEqual);
     valid = valid && validateQueryByDueDate();
     return valid;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/JobQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/JobQueryImpl.java
@@ -14,6 +14,7 @@
 package org.camunda.bpm.engine.impl;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import org.camunda.bpm.engine.ProcessEngineException;
@@ -21,6 +22,7 @@ import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 import org.camunda.bpm.engine.impl.persistence.entity.SuspensionState;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
+import org.camunda.bpm.engine.impl.util.CompareUtil;
 import org.camunda.bpm.engine.runtime.Job;
 import org.camunda.bpm.engine.runtime.JobQuery;
 
@@ -199,6 +201,47 @@ public class JobQueryImpl extends AbstractQuery<JobQuery, Job> implements JobQue
   public JobQuery suspended() {
     suspensionState = SuspensionState.SUSPENDED;
     return this;
+  }
+
+  @Override
+  public boolean isValid() {
+    boolean valid = super.isValid();
+    valid = valid && CompareUtil.validateOrder(priorityLowerThanOrEqual, priorityHigherThanOrEqual);
+    valid = valid && validateQueryByDueDate();
+    return valid;
+  }
+
+  private boolean validateQueryByDueDate() {
+    List<Date> dueDates = new ArrayList<Date>();
+    if (duedateHigherThan != null && duedateHigherThanOrEqual != null) {
+      if (duedateHigherThan.compareTo(duedateHigherThanOrEqual) <= 0) {
+        dueDates.add(duedateHigherThan);
+        dueDates.add(duedateHigherThanOrEqual);
+      } else {
+        dueDates.add(duedateHigherThanOrEqual);
+        dueDates.add(duedateHigherThan);
+      }
+    } else if (duedateHigherThan != null) {
+      dueDates.add(duedateHigherThan);
+    } else if (duedateHigherThanOrEqual != null) {
+      dueDates.add(duedateHigherThanOrEqual);
+    }
+
+    if (duedateLowerThan != null && duedateLowerThanOrEqual != null) {
+      if (duedateLowerThan.compareTo(duedateLowerThanOrEqual) <= 0) {
+        dueDates.add(duedateLowerThan);
+        dueDates.add(duedateLowerThanOrEqual);
+      } else {
+        dueDates.add(duedateLowerThanOrEqual);
+        dueDates.add(duedateLowerThan);
+      }
+    } else if (duedateLowerThan != null) {
+      dueDates.add(duedateLowerThan);
+    } else if (duedateLowerThanOrEqual != null) {
+      dueDates.add(duedateLowerThanOrEqual);
+    }
+
+    return CompareUtil.validateOrder(dueDates);
   }
 
   //sorting //////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/JobQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/JobQueryImpl.java
@@ -204,14 +204,14 @@ public class JobQueryImpl extends AbstractQuery<JobQuery, Job> implements JobQue
   }
 
   @Override
-  public boolean isValid() {
-    boolean valid = super.isValid();
-    valid = valid && CompareUtil.validateOrder(priorityHigherThanOrEqual, priorityLowerThanOrEqual);
-    valid = valid && validateQueryByDueDate();
-    return valid;
+  public boolean hasExcludingConditions() {
+    boolean excluding = super.hasExcludingConditions();
+    excluding = excluding || CompareUtil.hasExcludingOrder(priorityHigherThanOrEqual, priorityLowerThanOrEqual);
+    excluding = excluding || isExcludingDueDate();
+    return excluding;
   }
 
-  private boolean validateQueryByDueDate() {
+  private boolean isExcludingDueDate() {
     List<Date> dueDates = new ArrayList<Date>();
     if (duedateHigherThan != null && duedateHigherThanOrEqual != null) {
       if (duedateHigherThan.compareTo(duedateHigherThanOrEqual) <= 0) {
@@ -241,7 +241,7 @@ public class JobQueryImpl extends AbstractQuery<JobQuery, Job> implements JobQue
       dueDates.add(duedateLowerThanOrEqual);
     }
 
-    return CompareUtil.validateOrder(dueDates);
+    return CompareUtil.hasExcludingOrder(dueDates);
   }
 
   //sorting //////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessDefinitionQueryImpl.java
@@ -208,7 +208,7 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
   }
 
   @Override
-  public boolean hasExcludingConditions() {
+  protected boolean hasExcludingConditions() {
     return super.hasExcludingConditions() || CompareUtil.hasExcludingContains(id, ids);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessDefinitionQueryImpl.java
@@ -27,6 +27,7 @@ import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.SuspensionState;
+import org.camunda.bpm.engine.impl.util.CompareUtil;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.camunda.bpm.engine.repository.ProcessDefinitionQuery;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
@@ -204,6 +205,11 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
     ensureNotNull("incident messageLike", incidentMessageLike);
     this.incidentMessageLike = incidentMessageLike;
     return this;
+  }
+
+  @Override
+  public boolean isValid() {
+    return super.isValid() && CompareUtil.validateContains(id, ids);
   }
 
   //sorting ////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessDefinitionQueryImpl.java
@@ -209,7 +209,7 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
 
   @Override
   protected boolean hasExcludingConditions() {
-    return super.hasExcludingConditions() || CompareUtil.hasExcludingContains(id, ids);
+    return super.hasExcludingConditions() || CompareUtil.elementIsNotContainedInArray(id, ids);
   }
 
   //sorting ////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessDefinitionQueryImpl.java
@@ -208,8 +208,8 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
   }
 
   @Override
-  public boolean isValid() {
-    return super.isValid() && CompareUtil.validateContains(id, ids);
+  public boolean hasExcludingConditions() {
+    return super.hasExcludingConditions() || CompareUtil.hasExcludingContains(id, ids);
   }
 
   //sorting ////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
@@ -16,6 +16,7 @@ import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotEmpty;
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -31,6 +32,7 @@ import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 import org.camunda.bpm.engine.impl.persistence.entity.SuspensionState;
 import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
+import org.camunda.bpm.engine.impl.util.CompareUtil;
 import org.camunda.bpm.engine.impl.variable.serializer.VariableSerializers;
 import org.camunda.bpm.engine.task.DelegationState;
 import org.camunda.bpm.engine.task.Task;
@@ -706,6 +708,19 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   public TaskQuery taskNameCaseInsensitive() {
     this.taskNameCaseInsensitive = true;
     return this;
+  }
+
+  @Override
+  public boolean isValid() {
+    boolean valid = super.isValid();
+    valid = valid && CompareUtil.validateOrder(minPriority, priority, maxPriority);
+    valid = valid && CompareUtil.validateOrder(dueAfter, dueDate, dueBefore);
+    valid = valid && CompareUtil.validateOrder(followUpAfter, followUpDate, followUpBefore);
+    valid = valid && CompareUtil.validateOrder(createTimeAfter, createTime, createTimeBefore);
+    valid = valid && CompareUtil.validateContains(key, taskDefinitionKeys);
+    valid = valid && CompareUtil.validateContains(processDefinitionKey, processDefinitionKeys);
+    valid = valid && CompareUtil.validateContains(processInstanceBusinessKey, processInstanceBusinessKeys);
+    return valid;
   }
 
   public List<String> getCandidateGroups() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
@@ -710,7 +710,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   }
 
   @Override
-  public boolean hasExcludingConditions() {
+  protected boolean hasExcludingConditions() {
     boolean excluding = super.hasExcludingConditions();
     excluding = excluding || CompareUtil.hasExcludingOrder(minPriority, priority, maxPriority);
     excluding = excluding || CompareUtil.hasExcludingOrder(dueAfter, dueDate, dueBefore);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
@@ -712,13 +712,13 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   @Override
   protected boolean hasExcludingConditions() {
     boolean excluding = super.hasExcludingConditions();
-    excluding = excluding || CompareUtil.hasExcludingOrder(minPriority, priority, maxPriority);
-    excluding = excluding || CompareUtil.hasExcludingOrder(dueAfter, dueDate, dueBefore);
-    excluding = excluding || CompareUtil.hasExcludingOrder(followUpAfter, followUpDate, followUpBefore);
-    excluding = excluding || CompareUtil.hasExcludingOrder(createTimeAfter, createTime, createTimeBefore);
-    excluding = excluding || CompareUtil.hasExcludingContains(key, taskDefinitionKeys);
-    excluding = excluding || CompareUtil.hasExcludingContains(processDefinitionKey, processDefinitionKeys);
-    excluding = excluding || CompareUtil.hasExcludingContains(processInstanceBusinessKey, processInstanceBusinessKeys);
+    excluding = excluding || CompareUtil.areNotInAnAscendingOrder(minPriority, priority, maxPriority);
+    excluding = excluding || CompareUtil.areNotInAnAscendingOrder(dueAfter, dueDate, dueBefore);
+    excluding = excluding || CompareUtil.areNotInAnAscendingOrder(followUpAfter, followUpDate, followUpBefore);
+    excluding = excluding || CompareUtil.areNotInAnAscendingOrder(createTimeAfter, createTime, createTimeBefore);
+    excluding = excluding || CompareUtil.elementIsNotContainedInArray(key, taskDefinitionKeys);
+    excluding = excluding || CompareUtil.elementIsNotContainedInArray(processDefinitionKey, processDefinitionKeys);
+    excluding = excluding || CompareUtil.elementIsNotContainedInArray(processInstanceBusinessKey, processInstanceBusinessKeys);
     return excluding;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
@@ -16,7 +16,6 @@ import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotEmpty;
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -711,16 +710,16 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   }
 
   @Override
-  public boolean isValid() {
-    boolean valid = super.isValid();
-    valid = valid && CompareUtil.validateOrder(minPriority, priority, maxPriority);
-    valid = valid && CompareUtil.validateOrder(dueAfter, dueDate, dueBefore);
-    valid = valid && CompareUtil.validateOrder(followUpAfter, followUpDate, followUpBefore);
-    valid = valid && CompareUtil.validateOrder(createTimeAfter, createTime, createTimeBefore);
-    valid = valid && CompareUtil.validateContains(key, taskDefinitionKeys);
-    valid = valid && CompareUtil.validateContains(processDefinitionKey, processDefinitionKeys);
-    valid = valid && CompareUtil.validateContains(processInstanceBusinessKey, processInstanceBusinessKeys);
-    return valid;
+  public boolean hasExcludingConditions() {
+    boolean excluding = super.hasExcludingConditions();
+    excluding = excluding || CompareUtil.hasExcludingOrder(minPriority, priority, maxPriority);
+    excluding = excluding || CompareUtil.hasExcludingOrder(dueAfter, dueDate, dueBefore);
+    excluding = excluding || CompareUtil.hasExcludingOrder(followUpAfter, followUpDate, followUpBefore);
+    excluding = excluding || CompareUtil.hasExcludingOrder(createTimeAfter, createTime, createTimeBefore);
+    excluding = excluding || CompareUtil.hasExcludingContains(key, taskDefinitionKeys);
+    excluding = excluding || CompareUtil.hasExcludingContains(processDefinitionKey, processDefinitionKeys);
+    excluding = excluding || CompareUtil.hasExcludingContains(processInstanceBusinessKey, processInstanceBusinessKeys);
+    return excluding;
   }
 
   public List<String> getCandidateGroups() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/UserOperationLogQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/UserOperationLogQueryImpl.java
@@ -18,6 +18,7 @@ import org.camunda.bpm.engine.history.UserOperationLogEntry;
 import org.camunda.bpm.engine.history.UserOperationLogQuery;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
+import org.camunda.bpm.engine.impl.util.CompareUtil;
 
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
@@ -170,5 +171,10 @@ public class UserOperationLogQueryImpl extends AbstractQuery<UserOperationLogQue
     return commandContext
         .getOperationLogManager()
         .findOperationLogEntriesByQueryCriteria(this, page);
+  }
+
+  @Override
+  public boolean isValid() {
+    return super.isValid() && CompareUtil.validateOrder(timestampAfter, timestampBefore);
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/UserOperationLogQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/UserOperationLogQueryImpl.java
@@ -174,7 +174,7 @@ public class UserOperationLogQueryImpl extends AbstractQuery<UserOperationLogQue
   }
 
   @Override
-  public boolean hasExcludingConditions() {
+  protected boolean hasExcludingConditions() {
     return super.hasExcludingConditions() || CompareUtil.hasExcludingOrder(timestampAfter, timestampBefore);
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/UserOperationLogQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/UserOperationLogQueryImpl.java
@@ -175,6 +175,6 @@ public class UserOperationLogQueryImpl extends AbstractQuery<UserOperationLogQue
 
   @Override
   protected boolean hasExcludingConditions() {
-    return super.hasExcludingConditions() || CompareUtil.hasExcludingOrder(timestampAfter, timestampBefore);
+    return super.hasExcludingConditions() || CompareUtil.areNotInAnAscendingOrder(timestampAfter, timestampBefore);
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/UserOperationLogQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/UserOperationLogQueryImpl.java
@@ -174,7 +174,7 @@ public class UserOperationLogQueryImpl extends AbstractQuery<UserOperationLogQue
   }
 
   @Override
-  public boolean isValid() {
-    return super.isValid() && CompareUtil.validateOrder(timestampAfter, timestampBefore);
+  public boolean hasExcludingConditions() {
+    return super.hasExcludingConditions() || CompareUtil.hasExcludingOrder(timestampAfter, timestampBefore);
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/VariableInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/VariableInstanceQueryImpl.java
@@ -25,6 +25,7 @@ import org.camunda.bpm.engine.impl.db.PermissionCheck;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 import org.camunda.bpm.engine.impl.persistence.entity.VariableInstanceEntity;
+import org.camunda.bpm.engine.impl.util.CompareUtil;
 import org.camunda.bpm.engine.runtime.VariableInstance;
 import org.camunda.bpm.engine.runtime.VariableInstanceQuery;
 import org.camunda.bpm.engine.variable.type.ValueType;
@@ -143,6 +144,11 @@ public class VariableInstanceQueryImpl extends AbstractVariableQueryImpl<Variabl
   public VariableInstanceQuery orderByActivityInstanceId() {
     orderBy(VariableInstanceQueryProperty.ACTIVITY_INSTANCE_ID);
     return this;
+  }
+
+  @Override
+  public boolean isValid() {
+    return super.isValid() && CompareUtil.validateContains(variableName, variableNames);
   }
 
   // results ////////////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/VariableInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/VariableInstanceQueryImpl.java
@@ -146,7 +146,7 @@ public class VariableInstanceQueryImpl extends AbstractVariableQueryImpl<Variabl
   }
 
   @Override
-  public boolean hasExcludingConditions() {
+  protected boolean hasExcludingConditions() {
     return super.hasExcludingConditions() || CompareUtil.hasExcludingContains(variableName, variableNames);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/VariableInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/VariableInstanceQueryImpl.java
@@ -147,7 +147,7 @@ public class VariableInstanceQueryImpl extends AbstractVariableQueryImpl<Variabl
 
   @Override
   protected boolean hasExcludingConditions() {
-    return super.hasExcludingConditions() || CompareUtil.hasExcludingContains(variableName, variableNames);
+    return super.hasExcludingConditions() || CompareUtil.elementIsNotContainedInArray(variableName, variableNames);
   }
 
   // results ////////////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/VariableInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/VariableInstanceQueryImpl.java
@@ -15,7 +15,6 @@ package org.camunda.bpm.engine.impl;
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -147,8 +146,8 @@ public class VariableInstanceQueryImpl extends AbstractVariableQueryImpl<Variabl
   }
 
   @Override
-  public boolean isValid() {
-    return super.isValid() && CompareUtil.validateContains(variableName, variableNames);
+  public boolean hasExcludingConditions() {
+    return super.hasExcludingConditions() || CompareUtil.hasExcludingContains(variableName, variableNames);
   }
 
   // results ////////////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmmn/entity/repository/CaseDefinitionQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmmn/entity/repository/CaseDefinitionQueryImpl.java
@@ -165,8 +165,8 @@ public class CaseDefinitionQueryImpl extends AbstractQuery<CaseDefinitionQuery, 
   }
 
   @Override
-  public boolean isValid() {
-    return super.isValid() && CompareUtil.validateContains(id, ids);
+  public boolean hasExcludingConditions() {
+    return super.hasExcludingConditions() || CompareUtil.hasExcludingContains(id, ids);
   }
 
   //results ////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmmn/entity/repository/CaseDefinitionQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmmn/entity/repository/CaseDefinitionQueryImpl.java
@@ -166,7 +166,7 @@ public class CaseDefinitionQueryImpl extends AbstractQuery<CaseDefinitionQuery, 
 
   @Override
   protected boolean hasExcludingConditions() {
-    return super.hasExcludingConditions() || CompareUtil.hasExcludingContains(id, ids);
+    return super.hasExcludingConditions() || CompareUtil.elementIsNotContainedInArray(id, ids);
   }
 
   //results ////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmmn/entity/repository/CaseDefinitionQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmmn/entity/repository/CaseDefinitionQueryImpl.java
@@ -22,6 +22,7 @@ import org.camunda.bpm.engine.impl.AbstractQuery;
 import org.camunda.bpm.engine.impl.Page;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
+import org.camunda.bpm.engine.impl.util.CompareUtil;
 import org.camunda.bpm.engine.repository.CaseDefinition;
 import org.camunda.bpm.engine.repository.CaseDefinitionQuery;
 
@@ -161,6 +162,11 @@ public class CaseDefinitionQueryImpl extends AbstractQuery<CaseDefinitionQuery, 
   public CaseDefinitionQuery orderByDeploymentId() {
     orderBy(CaseDefinitionQueryProperty.DEPLOYMENT_ID);
     return this;
+  }
+
+  @Override
+  public boolean isValid() {
+    return super.isValid() && CompareUtil.validateContains(id, ids);
   }
 
   //results ////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmmn/entity/repository/CaseDefinitionQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmmn/entity/repository/CaseDefinitionQueryImpl.java
@@ -165,7 +165,7 @@ public class CaseDefinitionQueryImpl extends AbstractQuery<CaseDefinitionQuery, 
   }
 
   @Override
-  public boolean hasExcludingConditions() {
+  protected boolean hasExcludingConditions() {
     return super.hasExcludingConditions() || CompareUtil.hasExcludingContains(id, ids);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/CompareUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/CompareUtil.java
@@ -1,0 +1,125 @@
+package org.camunda.bpm.engine.impl.util;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Util class for comparisons.
+ *
+ * @author Filip Hrisafov
+ */
+public class CompareUtil {
+
+  /**
+   * Compares that all not null values are are in an ascending order. The check is done based on the {@link Comparable#compareTo(Object)} method
+   *
+   * @param values to validate
+   * @param <T> the type of the comparable
+   * @return {@code true} if the not null values are in an ascending order or all the values are null, {@code false} otherwise
+   */
+  public static <T extends Comparable<T>> boolean validateOrder(T... values) {
+    boolean valid = true;
+    if (values.length > 0) {
+      T min = values[0];
+      int i = 1;
+      while (i < values.length) {
+        T value = values[i];
+        if (min == null) {
+          min = value;
+        } else if (value != null) {
+          if (min.compareTo(value) <= 0) {
+            min = value;
+          } else {
+            valid = false;
+            break;
+          }
+        }
+        i++;
+      }
+    }
+    return valid;
+  }
+
+  public static <T extends Comparable<T>> boolean validateOrder(List<T> unsorted) {
+    boolean valid = true;
+    if (!unsorted.isEmpty()) {
+      T min = unsorted.get(0);
+      for (T next : unsorted) {
+        if (min.compareTo(next) <= 0) {
+          min = next;
+        } else {
+          valid = false;
+          break;
+        }
+      }
+    }
+    return valid;
+  }
+
+  /**
+   * Checks if the element is contained within the list of values. If the element, or the list are null then true is returned.
+   *
+   * @param element to check
+   * @param values to check in
+   * @param <T> the type of the element
+   * @return {@code false} if the element and values are not {@code null} and the values does not contain the element, {@code true} otherwise
+   */
+  public static <T> boolean validateContains(T element, Collection<T> values) {
+    boolean valid = true;
+    if (element != null && values != null) {
+      valid = values.contains(element);
+    }
+    return valid;
+  }
+
+  /**
+   * Checks if the element is contained within the list of values. If the element, or the list are null then true is returned.
+   *
+   * @param element to check
+   * @param values to check in
+   * @param <T> the type of the element
+   * @return {@code false} if the element and values are not {@code null} and the values does not contain the element, {@code true} otherwise
+   */
+  public static <T> boolean validateContains(T element, T... values) {
+    boolean valid = true;
+    if (element != null && values != null) {
+      valid = validateContains(element, Arrays.asList(values));
+    }
+    return valid;
+  }
+
+  /**
+   * Checks if the element is not contained within the list of values. If the element, or the list are null then true is returned.
+   *
+   * @param element to check
+   * @param values to check in
+   * @param <T> the type of the element
+   * @return {@code false} if the element and values are not {@code null} and the values contain the element, {@code true} otherwise
+   */
+  public static <T> boolean validateNotContains(T element, Collection<T> values) {
+    boolean valid = true;
+    if (element != null && values != null) {
+      valid = !values.contains(element);
+    }
+
+    return valid;
+  }
+
+  /**
+   * Checks if the element is not contained within the list of values. If the element, or the list are null then true is returned.
+   *
+   * @param element to check
+   * @param values to check in
+   * @param <T> the type of the element
+   * @return {@code false} if the element and values are not {@code null} and the values contain the element, {@code true} otherwise
+   */
+  public static <T> boolean validateNotContains(T element, T... values) {
+    boolean valid = true;
+    if (element != null && values != null) {
+      valid = validateNotContains(element, Arrays.asList(values));
+    }
+
+    return valid;
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/CompareUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/CompareUtil.java
@@ -12,14 +12,18 @@ import java.util.List;
 public class CompareUtil {
 
   /**
-   * Compares that all not null values are are in an ascending order. The check is done based on the {@link Comparable#compareTo(Object)} method
+   * Compares that all not null values are are in an ascending order. The check is done based on the {@link Comparable#compareTo(Object)} method.
+   *
+   * E.g. if we have {@code minPriority = 10}, {@code priority = 13} and {@code maxPriority = 5} and
+   * {@code Integer[] values = {minPriority, priority, maxPriority}}. Then a call to {@link CompareUtil#hasExcludingOrder(Comparable[] values)}
+   * will return {@code true}
    *
    * @param values to validate
    * @param <T> the type of the comparable
-   * @return {@code true} if the not null values are in an ascending order or all the values are null, {@code false} otherwise
+   * @return {@code false} if the not null values are in an ascending order or all the values are null, {@code true} otherwise
    */
-  public static <T extends Comparable<T>> boolean validateOrder(T... values) {
-    boolean valid = true;
+  public static <T extends Comparable<T>> boolean hasExcludingOrder(T... values) {
+    boolean excluding = false;
     if (values.length > 0) {
       T min = values[0];
       int i = 1;
@@ -31,30 +35,41 @@ public class CompareUtil {
           if (min.compareTo(value) <= 0) {
             min = value;
           } else {
-            valid = false;
+            excluding = true;
             break;
           }
         }
         i++;
       }
     }
-    return valid;
+    return excluding;
   }
 
-  public static <T extends Comparable<T>> boolean validateOrder(List<T> unsorted) {
-    boolean valid = true;
-    if (!unsorted.isEmpty()) {
-      T min = unsorted.get(0);
-      for (T next : unsorted) {
+  /**
+   * Compares that all not null values are are in an ascending order. The check is done based on the {@link Comparable#compareTo(Object)} method.
+   *
+   * E.g. if we have {@code minPriority = 10}, {@code priority = 13} and {@code maxPriority = 5} and
+   * {@code IList<Integer> values = {minPriority, priority, maxPriority}}. Then a call to {@link CompareUtil#hasExcludingOrder(List values)}
+   * will return {@code true}
+   *
+   * @param values to validate
+   * @param <T> the type of the comparable
+   * @return {@code false} if the not null values are in an ascending order or all the values are null, {@code true} otherwise
+   */
+  public static <T extends Comparable<T>> boolean hasExcludingOrder(List<T> values) {
+    boolean excluding = false;
+    if (!values.isEmpty()) {
+      T min = values.get(0);
+      for (T next : values) {
         if (min.compareTo(next) <= 0) {
           min = next;
         } else {
-          valid = false;
+          excluding = true;
           break;
         }
       }
     }
-    return valid;
+    return excluding;
   }
 
   /**
@@ -63,14 +78,14 @@ public class CompareUtil {
    * @param element to check
    * @param values to check in
    * @param <T> the type of the element
-   * @return {@code false} if the element and values are not {@code null} and the values does not contain the element, {@code true} otherwise
+   * @return {@code true} if the element and values are not {@code null} and the values does not contain the element, {@code false} otherwise
    */
-  public static <T> boolean validateContains(T element, Collection<T> values) {
-    boolean valid = true;
+  public static <T> boolean hasExcludingContains(T element, Collection<T> values) {
+    boolean excluding = false;
     if (element != null && values != null) {
-      valid = values.contains(element);
+      excluding = !values.contains(element);
     }
-    return valid;
+    return excluding;
   }
 
   /**
@@ -79,14 +94,14 @@ public class CompareUtil {
    * @param element to check
    * @param values to check in
    * @param <T> the type of the element
-   * @return {@code false} if the element and values are not {@code null} and the values does not contain the element, {@code true} otherwise
+   * @return {@code true} if the element and values are not {@code null} and the values does not contain the element, {@code false} otherwise
    */
-  public static <T> boolean validateContains(T element, T... values) {
-    boolean valid = true;
+  public static <T> boolean hasExcludingContains(T element, T... values) {
+    boolean excluding = false;
     if (element != null && values != null) {
-      valid = validateContains(element, Arrays.asList(values));
+      excluding = hasExcludingContains(element, Arrays.asList(values));
     }
-    return valid;
+    return excluding;
   }
 
   /**
@@ -95,15 +110,15 @@ public class CompareUtil {
    * @param element to check
    * @param values to check in
    * @param <T> the type of the element
-   * @return {@code false} if the element and values are not {@code null} and the values contain the element, {@code true} otherwise
+   * @return {@code true} if the element and values are not {@code null} and the values contain the element, {@code false} otherwise
    */
-  public static <T> boolean validateNotContains(T element, Collection<T> values) {
-    boolean valid = true;
+  public static <T> boolean hasExcludingNotContains(T element, Collection<T> values) {
+    boolean excluding = false;
     if (element != null && values != null) {
-      valid = !values.contains(element);
+      excluding = values.contains(element);
     }
 
-    return valid;
+    return excluding;
   }
 
   /**
@@ -112,14 +127,14 @@ public class CompareUtil {
    * @param element to check
    * @param values to check in
    * @param <T> the type of the element
-   * @return {@code false} if the element and values are not {@code null} and the values contain the element, {@code true} otherwise
+   * @return {@code true} if the element and values are not {@code null} and the values contain the element, {@code false} otherwise
    */
-  public static <T> boolean validateNotContains(T element, T... values) {
-    boolean valid = true;
+  public static <T> boolean hasExcludingNotContains(T element, T... values) {
+    boolean excluding = false;
     if (element != null && values != null) {
-      valid = validateNotContains(element, Arrays.asList(values));
+      excluding = hasExcludingNotContains(element, Arrays.asList(values));
     }
 
-    return valid;
+    return excluding;
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/CompareUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/CompareUtil.java
@@ -15,32 +15,17 @@ public class CompareUtil {
    * Compares that all not null values are are in an ascending order. The check is done based on the {@link Comparable#compareTo(Object)} method.
    *
    * E.g. if we have {@code minPriority = 10}, {@code priority = 13} and {@code maxPriority = 5} and
-   * {@code Integer[] values = {minPriority, priority, maxPriority}}. Then a call to {@link CompareUtil#hasExcludingOrder(Comparable[] values)}
+   * {@code Integer[] values = {minPriority, priority, maxPriority}}. Then a call to {@link CompareUtil#areNotInAnAscendingOrder(Comparable[] values)}
    * will return {@code true}
    *
    * @param values to validate
    * @param <T> the type of the comparable
    * @return {@code false} if the not null values are in an ascending order or all the values are null, {@code true} otherwise
    */
-  public static <T extends Comparable<T>> boolean hasExcludingOrder(T... values) {
+  public static <T extends Comparable<T>> boolean areNotInAnAscendingOrder(T... values) {
     boolean excluding = false;
-    if (values.length > 0) {
-      T min = values[0];
-      int i = 1;
-      while (i < values.length) {
-        T value = values[i];
-        if (min == null) {
-          min = value;
-        } else if (value != null) {
-          if (min.compareTo(value) <= 0) {
-            min = value;
-          } else {
-            excluding = true;
-            break;
-          }
-        }
-        i++;
-      }
+    if (values != null) {
+      excluding = areNotInAnAscendingOrder(Arrays.asList(values));
     }
     return excluding;
   }
@@ -49,23 +34,25 @@ public class CompareUtil {
    * Compares that all not null values are are in an ascending order. The check is done based on the {@link Comparable#compareTo(Object)} method.
    *
    * E.g. if we have {@code minPriority = 10}, {@code priority = 13} and {@code maxPriority = 5} and
-   * {@code IList<Integer> values = {minPriority, priority, maxPriority}}. Then a call to {@link CompareUtil#hasExcludingOrder(List values)}
+   * {@code List<Integer> values = {minPriority, priority, maxPriority}}. Then a call to {@link CompareUtil#areNotInAnAscendingOrder(List values)}
    * will return {@code true}
    *
    * @param values to validate
    * @param <T> the type of the comparable
    * @return {@code false} if the not null values are in an ascending order or all the values are null, {@code true} otherwise
    */
-  public static <T extends Comparable<T>> boolean hasExcludingOrder(List<T> values) {
+  public static <T extends Comparable<T>> boolean areNotInAnAscendingOrder(List<T> values) {
     boolean excluding = false;
     if (!values.isEmpty()) {
-      T min = values.get(0);
-      for (T next : values) {
-        if (min.compareTo(next) <= 0) {
-          min = next;
-        } else {
-          excluding = true;
-          break;
+      int lastNotNul = -1;
+      for (int i = 0; i< values.size(); i++) {
+        T value = values.get(i);
+        if (value != null) {
+          if (lastNotNul != -1 && values.get(lastNotNul).compareTo(value) > 0) {
+            excluding = true;
+            break;
+          }
+          lastNotNul = i;
         }
       }
     }
@@ -80,12 +67,12 @@ public class CompareUtil {
    * @param <T> the type of the element
    * @return {@code true} if the element and values are not {@code null} and the values does not contain the element, {@code false} otherwise
    */
-  public static <T> boolean hasExcludingContains(T element, Collection<T> values) {
-    boolean excluding = false;
+  public static <T> boolean elementIsNotContainedInList(T element, Collection<T> values) {
+    boolean notCaontained = false;
     if (element != null && values != null) {
-      excluding = !values.contains(element);
+      notCaontained = !values.contains(element);
     }
-    return excluding;
+    return notCaontained;
   }
 
   /**
@@ -96,12 +83,12 @@ public class CompareUtil {
    * @param <T> the type of the element
    * @return {@code true} if the element and values are not {@code null} and the values does not contain the element, {@code false} otherwise
    */
-  public static <T> boolean hasExcludingContains(T element, T... values) {
-    boolean excluding = false;
+  public static <T> boolean elementIsNotContainedInArray(T element, T... values) {
+    boolean notContained = false;
     if (element != null && values != null) {
-      excluding = hasExcludingContains(element, Arrays.asList(values));
+      notContained = elementIsNotContainedInList(element, Arrays.asList(values));
     }
-    return excluding;
+    return notContained;
   }
 
   /**
@@ -112,13 +99,13 @@ public class CompareUtil {
    * @param <T> the type of the element
    * @return {@code true} if the element and values are not {@code null} and the values contain the element, {@code false} otherwise
    */
-  public static <T> boolean hasExcludingNotContains(T element, Collection<T> values) {
-    boolean excluding = false;
+  public static <T> boolean elementIsContainedInList(T element, Collection<T> values) {
+    boolean contained = false;
     if (element != null && values != null) {
-      excluding = values.contains(element);
+      contained = values.contains(element);
     }
 
-    return excluding;
+    return contained;
   }
 
   /**
@@ -129,12 +116,12 @@ public class CompareUtil {
    * @param <T> the type of the element
    * @return {@code true} if the element and values are not {@code null} and the values contain the element, {@code false} otherwise
    */
-  public static <T> boolean hasExcludingNotContains(T element, T... values) {
-    boolean excluding = false;
+  public static <T> boolean elementIsContainedInArray(T element, T... values) {
+    boolean contained = false;
     if (element != null && values != null) {
-      excluding = hasExcludingNotContains(element, Arrays.asList(values));
+      contained = elementIsContainedInList(element, Arrays.asList(values));
     }
 
-    return excluding;
+    return contained;
   }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/HistoryServiceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/HistoryServiceTest.java
@@ -170,6 +170,8 @@ public class HistoryServiceTest extends PluggableProcessEngineTestCase {
     for (HistoricProcessInstance historicProcessInstance : processInstances) {
       assertTrue(processInstanceIds.contains(historicProcessInstance.getId()));
     }
+
+    assertEquals(0, processInstanceQuery.processInstanceId("dummy").count());
   }
 
   public void testHistoricProcessInstanceQueryByProcessInstanceIdsEmpty() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/JobQueryByPriorityTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/JobQueryByPriorityTest.java
@@ -75,6 +75,21 @@ public class JobQueryByPriorityTest extends PluggableProcessEngineTestCase {
   }
 
   @Deployment(resources = "org/camunda/bpm/engine/test/api/mgmt/jobPrioExpressionProcess.bpmn20.xml")
+  public void testFilterByJobPriorityLowerThanOrEqualsAndHigherThanOrEqual() {
+    // given five jobs with priorities from 1 to 5
+    List<ProcessInstance> instances = new ArrayList<ProcessInstance>();
+
+    for (int i = 0; i < 5; i++) {
+      instances.add(runtimeService.startProcessInstanceByKey("jobPrioExpressionProcess",
+          Variables.createVariables().putValue("priority", i)));
+    }
+
+    // when making a job query and filtering by disjunctive job priority
+    // then the no jobs are returned
+    assertEquals(0, managementService.createJobQuery().priorityLowerThanOrEquals(2).priorityHigherThanOrEquals(3).count());
+  }
+
+  @Deployment(resources = "org/camunda/bpm/engine/test/api/mgmt/jobPrioExpressionProcess.bpmn20.xml")
   public void testFilterByJobPriorityHigherThanOrEquals() {
     // given five jobs with priorities from 1 to 5
     List<ProcessInstance> instances = new ArrayList<ProcessInstance>();

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/CaseDefinitionQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/CaseDefinitionQueryTest.java
@@ -76,6 +76,8 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
 
     // collect all ids
     List<CaseDefinition> caseDefinitions = repositoryService.createCaseDefinitionQuery().list();
+    // no point of the test if the caseDefinitions is empty
+    assertFalse(caseDefinitions.isEmpty());
     List<String> ids = new ArrayList<String>();
     for (CaseDefinition caseDefinition : caseDefinitions) {
       ids.add(caseDefinition.getId());
@@ -91,6 +93,8 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
         fail("Expected to find case definition "+ caseDefinition);
       }
     }
+
+    assertEquals(0, repositoryService.createCaseDefinitionQuery().caseDefinitionIdIn(ids.toArray(new String[ids.size()])).caseDefinitionId("nonExistent").count());
   }
 
   public void testQueryByDeploymentId() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
@@ -464,6 +464,8 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
         fail("Expected to find process definition "+processDefinition);
       }
     }
+
+    assertEquals(0, repositoryService.createProcessDefinitionQuery().processDefinitionId("dummyId").processDefinitionIdIn(ids).count());
   }
 
   public void testQueryByLatestAndName() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/VariableInstanceQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/VariableInstanceQueryTest.java
@@ -155,6 +155,8 @@ public class VariableInstanceQueryTest extends PluggableProcessEngineTestCase {
       assertEquals(variableValue, variableInstance.getValue());
       assertEquals("string", variableInstance.getTypeName());
     }
+
+    assertEquals(0, runtimeService.createVariableInstanceQuery().variableName("task").variableNameIn("process", "execution").count());
   }
 
   @Test

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryTest.java
@@ -264,6 +264,9 @@ public class TaskQueryTest extends PluggableProcessEngineTestCase {
 
     query = taskService.createTaskQuery().taskMaxPriority(3);
     assertEquals(6, query.list().size());
+
+    query = taskService.createTaskQuery().taskMinPriority(50).taskMaxPriority(10);
+    assertEquals(0, query.list().size());
   }
 
   public void testQueryByInvalidPriority() {
@@ -630,6 +633,9 @@ public class TaskQueryTest extends PluggableProcessEngineTestCase {
     // No task should be found with UnexistingKey
     Long count = taskService.createTaskQuery().taskDefinitionKeyIn("unexistingKey").count();
     assertEquals(0L, count.longValue());
+
+    count = taskService.createTaskQuery().taskDefinitionKey("unexistingKey").taskDefinitionKeyIn("taskKey1").count();
+    assertEquals(0l, count.longValue());
   }
 
   @Deployment
@@ -1300,6 +1306,10 @@ public class TaskQueryTest extends PluggableProcessEngineTestCase {
 
     assertNotNull(tasks);
     assertEquals("theTask", task.getTaskDefinitionKey());
+
+    long count = taskService.createTaskQuery().processInstanceBusinessKeyIn("BUSINESS-KEY-1").processInstanceBusinessKey("NON-EXISTING-KEY")
+        .count();
+    assertEquals(0l, count);
   }
 
   @Deployment(resources={"org/camunda/bpm/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml"})

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricActivityInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricActivityInstanceTest.java
@@ -339,6 +339,7 @@ public class HistoricActivityInstanceTest extends PluggableProcessEngineTestCase
     assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("theTask").startedBefore(hourAgo.getTime()).count());
     assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("theTask").startedAfter(hourAgo.getTime()).count());
     assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("theTask").startedAfter(hourFromNow.getTime()).count());
+    assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("theTask").startedAfter(hourFromNow.getTime()).startedBefore(hourAgo.getTime()).count());
 
     // After finishing process
     taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId());
@@ -347,6 +348,7 @@ public class HistoricActivityInstanceTest extends PluggableProcessEngineTestCase
     assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedBefore(hourFromNow.getTime()).count());
     assertEquals(1, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedAfter(hourAgo.getTime()).count());
     assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedAfter(hourFromNow.getTime()).count());
+    assertEquals(0, historyService.createHistoricActivityInstanceQuery().activityId("theTask").finishedBefore(hourAgo.getTime()).finishedAfter(hourFromNow.getTime()).count());
   }
 
   @Deployment

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
@@ -320,11 +320,15 @@ public class HistoricCaseActivityInstanceTest extends CmmnProcessEngineTestCase 
     assertCount(0, historicQuery().createdBefore(beforeCreate));
     assertCount(6, historicQuery().createdBefore(ended));
 
+    assertCount(0, historicQuery().createdBefore(beforeCreate).createdAfter(ended));
+
     assertCount(6, historicQuery().endedAfter(created));
     assertCount(0, historicQuery().endedAfter(afterEnd));
 
     assertCount(0, historicQuery().endedBefore(created));
     assertCount(6, historicQuery().endedBefore(afterEnd));
+
+    assertCount(0, historicQuery().endedBefore(afterEnd).endedAfter(created));
   }
 
   @Deployment(resources = {"org/camunda/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
@@ -328,7 +328,7 @@ public class HistoricCaseActivityInstanceTest extends CmmnProcessEngineTestCase 
     assertCount(0, historicQuery().endedBefore(created));
     assertCount(6, historicQuery().endedBefore(afterEnd));
 
-    assertCount(0, historicQuery().endedBefore(afterEnd).endedAfter(created));
+    assertCount(0, historicQuery().endedBefore(created).endedAfter(afterEnd));
   }
 
   @Deployment(resources = {"org/camunda/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricCaseInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricCaseInstanceTest.java
@@ -143,11 +143,16 @@ public class HistoricCaseInstanceTest extends CmmnProcessEngineTestCase {
     assertCount(0, historicQuery().createdBefore(beforeCreate));
     assertCount(1, historicQuery().createdBefore(closed));
 
+    assertCount(0, historicQuery().createdBefore(beforeCreate).createdAfter(closed));
+
     assertCount(1, historicQuery().closedAfter(created));
     assertCount(0, historicQuery().closedAfter(afterClose));
 
     assertCount(0, historicQuery().closedBefore(created));
     assertCount(1, historicQuery().closedBefore(afterClose));
+
+//    TODO method fails due to the call to closed() in the query
+//    assertCount(0, historicQuery().closedBefore(created).closedAfter(afterClose));
 
     assertCount(1, historicQuery().closedBefore(afterClose).closedAfter(created));
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricCaseInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricCaseInstanceTest.java
@@ -151,8 +151,7 @@ public class HistoricCaseInstanceTest extends CmmnProcessEngineTestCase {
     assertCount(0, historicQuery().closedBefore(created));
     assertCount(1, historicQuery().closedBefore(afterClose));
 
-//    TODO method fails due to the call to closed() in the query
-//    assertCount(0, historicQuery().closedBefore(created).closedAfter(afterClose));
+    assertCount(0, historicQuery().closedBefore(created).closedAfter(afterClose));
 
     assertCount(1, historicQuery().closedBefore(afterClose).closedAfter(created));
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricJobLogQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricJobLogQueryTest.java
@@ -407,6 +407,15 @@ public class HistoricJobLogQueryTest extends PluggableProcessEngineTestCase {
     for (HistoricJobLog log : jobLogs) {
       assertTrue(log.getJobPriority() >= 1 && log.getJobPriority() <= 3);
     }
+
+    // (4) lower and higher than or equal are disjunctive
+    jobLogs = historyService.createHistoricJobLogQuery()
+        .jobPriorityHigherThanOrEquals(3)
+        .jobPriorityLowerThanOrEquals(1)
+        .orderByJobPriority()
+        .asc()
+        .list();
+    assertEquals(0, jobLogs.size());
   }
 
   @Deployment(resources = {"org/camunda/bpm/engine/test/history/HistoricJobLogTest.testAsyncContinuation.bpmn20.xml"})

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricProcessInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricProcessInstanceTest.java
@@ -87,12 +87,17 @@ public class HistoricProcessInstanceTest extends PluggableProcessEngineTestCase 
     assertEquals(processInstance.getProcessDefinitionId(), historicProcessInstance.getProcessDefinitionId());
     assertEquals(noon, historicProcessInstance.getStartTime());
     assertEquals(twentyFiveSecsAfterNoon, historicProcessInstance.getEndTime());
-    assertEquals(new Long(25*1000), historicProcessInstance.getDurationInMillis());
-    assertTrue(((HistoricProcessInstanceEventEntity)historicProcessInstance).getDurationRaw() >= 25000);
+    assertEquals(new Long(25 * 1000), historicProcessInstance.getDurationInMillis());
+    assertTrue(((HistoricProcessInstanceEventEntity) historicProcessInstance).getDurationRaw() >= 25000);
     assertNull(historicProcessInstance.getCaseInstanceId());
 
     assertEquals(0, historyService.createHistoricProcessInstanceQuery().unfinished().count());
     assertEquals(1, historyService.createHistoricProcessInstanceQuery().finished().count());
+
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess", "myBusinessKey");
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().finished().count());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().unfinished().count());
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().finished().unfinished().count());
   }
 
   @Deployment(resources = {"org/camunda/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})
@@ -255,6 +260,7 @@ public class HistoricProcessInstanceTest extends PluggableProcessEngineTestCase 
     assertEquals(0, historyService.createHistoricProcessInstanceQuery().startedBefore(hourAgo.getTime()).count());
     assertEquals(1, historyService.createHistoricProcessInstanceQuery().startedAfter(hourAgo.getTime()).count());
     assertEquals(0, historyService.createHistoricProcessInstanceQuery().startedAfter(hourFromNow.getTime()).count());
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().startedAfter(hourFromNow.getTime()).startedBefore(hourAgo.getTime()).count());
 
     // General fields
     assertEquals(0, historyService.createHistoricProcessInstanceQuery().finished().count());
@@ -278,6 +284,7 @@ public class HistoricProcessInstanceTest extends PluggableProcessEngineTestCase 
     assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKeyNotIn(exludeIds).count());
 
     exludeIds.add("oneTaskProcess");
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTaskProcess").processDefinitionKeyNotIn(exludeIds).count());
     assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionKeyNotIn(exludeIds).count());
 
     try {
@@ -296,6 +303,7 @@ public class HistoricProcessInstanceTest extends PluggableProcessEngineTestCase 
     assertEquals(1, historyService.createHistoricProcessInstanceQuery().finishedBefore(hourFromNow.getTime()).count());
     assertEquals(1, historyService.createHistoricProcessInstanceQuery().finishedAfter(hourAgo.getTime()).count());
     assertEquals(0, historyService.createHistoricProcessInstanceQuery().finishedAfter(hourFromNow.getTime()).count());
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().finishedAfter(hourFromNow.getTime()).finishedBefore(hourAgo.getTime()).count());
   }
 
   @Deployment(resources = {"org/camunda/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricTaskInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricTaskInstanceTest.java
@@ -215,11 +215,18 @@ public class HistoricTaskInstanceTest extends PluggableProcessEngineTestCase {
     assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskDueAfter(anHourAgo.getTime()).count());
     assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDueAfter(anHourLater.getTime()).count());
 
+    assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskDueDate(dueDate).taskDueBefore(anHourLater.getTime()).count());
+    assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDueDate(dueDate).taskDueBefore(anHourAgo.getTime()).count());
+    assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskDueDate(dueDate).taskDueAfter(anHourAgo.getTime()).count());
+    assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDueDate(dueDate).taskDueAfter(anHourLater.getTime()).count());
+    assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDueBefore(anHourAgo.getTime()).taskDueAfter(anHourLater.getTime()).count());
+
     // Finished and Unfinished - Add anther other instance that has a running task (unfinished)
     runtimeService.startProcessInstanceByKey("HistoricTaskQueryTest");
 
     assertEquals(1, historyService.createHistoricTaskInstanceQuery().finished().count());
     assertEquals(1, historyService.createHistoricTaskInstanceQuery().unfinished().count());
+    assertEquals(0, historyService.createHistoricTaskInstanceQuery().unfinished().finished().count());
   }
 
   @Deployment
@@ -437,11 +444,13 @@ public class HistoricTaskInstanceTest extends PluggableProcessEngineTestCase {
     assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskFollowUpDate(otherDate.getTime()).count());
     assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskFollowUpBefore(otherDate.getTime()).count());
     assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskFollowUpAfter(otherDate.getTime()).count());
+    assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskFollowUpAfter(otherDate.getTime()).taskFollowUpDate(followUpDate).count());
 
     otherDate.add(Calendar.YEAR, -2);
     assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskFollowUpAfter(otherDate.getTime()).count());
     assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskFollowUpBefore(otherDate.getTime()).count());
     assertEquals(followUpDate, historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult().getFollowUpDate());
+    assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskFollowUpBefore(otherDate.getTime()).taskFollowUpDate(followUpDate).count());
 
     taskService.complete(task.getId());
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/OperationLogQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/OperationLogQueryTest.java
@@ -167,6 +167,7 @@ public class OperationLogQueryTest extends PluggableProcessEngineTestCase {
     assertEquals(13, query().afterTimestamp(yesterday).count());
     // filter by time, created tomorrow
     assertEquals(5, query().afterTimestamp(today).count());
+    assertEquals(0, query().afterTimestamp(today).beforeTimestamp(yesterday).count());
 
     // remove log entries of manually created tasks
     processEngineConfiguration.getCommandExecutorTxRequired().execute(new Command<Object>() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/util/CompareUtilTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/util/CompareUtilTest.java
@@ -17,62 +17,62 @@ import static org.junit.Assert.assertThat;
 public class CompareUtilTest {
 
   @Test
-  public void testHasEcludingOrderDate() {
+  public void testDateNotInAnAscendingOrder() {
     Calendar calendar = Calendar.getInstance();
     calendar.set(2015, Calendar.MARCH, 15);
     Date first = calendar.getTime();
     calendar.set(2015, Calendar.AUGUST, 15);
     Date second = calendar.getTime();
     Date nullDate = null;
-    assertThat(CompareUtil.hasExcludingOrder(null, first, null, second), is(false));
-    assertThat(CompareUtil.hasExcludingOrder(null, first, null, first), is(false));
-    assertThat(CompareUtil.hasExcludingOrder(null, second, null, first), is(true));
-    assertThat(CompareUtil.hasExcludingOrder(nullDate, nullDate, nullDate), is(false));
+    assertThat(CompareUtil.areNotInAnAscendingOrder(null, first, null, second), is(false));
+    assertThat(CompareUtil.areNotInAnAscendingOrder(null, first, null, first), is(false));
+    assertThat(CompareUtil.areNotInAnAscendingOrder(null, second, null, first), is(true));
+    assertThat(CompareUtil.areNotInAnAscendingOrder(nullDate, nullDate, nullDate), is(false));
 
-    assertThat(CompareUtil.hasExcludingOrder(Arrays.asList(first, second)), is(false));
-    assertThat(CompareUtil.hasExcludingOrder(Arrays.asList(first, first)), is(false));
-    assertThat(CompareUtil.hasExcludingOrder(Arrays.asList(second, first)), is(true));
+    assertThat(CompareUtil.areNotInAnAscendingOrder(Arrays.asList(first, second)), is(false));
+    assertThat(CompareUtil.areNotInAnAscendingOrder(Arrays.asList(first, first)), is(false));
+    assertThat(CompareUtil.areNotInAnAscendingOrder(Arrays.asList(second, first)), is(true));
   }
 
   @Test
-  public void testHasExcludingContains() {
+  public void testIsNotContainedIn() {
     String element = "test";
     String [] values = {"test", "test1", "test2"};
     String [] values2 = {"test1", "test2"};
     String [] nullValues = null;
     List<String> nullList = null;
 
-    assertThat(CompareUtil.hasExcludingContains(element, values), is(false));
-    assertThat(CompareUtil.hasExcludingContains(element, values2), is(true));
-    assertThat(CompareUtil.hasExcludingContains(null, values), is(false));
-    assertThat(CompareUtil.hasExcludingContains(null, nullValues), is(false));
-    assertThat(CompareUtil.hasExcludingContains(element, nullValues), is(false));
+    assertThat(CompareUtil.elementIsNotContainedInArray(element, values), is(false));
+    assertThat(CompareUtil.elementIsNotContainedInArray(element, values2), is(true));
+    assertThat(CompareUtil.elementIsNotContainedInArray(null, values), is(false));
+    assertThat(CompareUtil.elementIsNotContainedInArray(null, nullValues), is(false));
+    assertThat(CompareUtil.elementIsNotContainedInArray(element, nullValues), is(false));
 
-    assertThat(CompareUtil.hasExcludingContains(element, Arrays.asList(values)), is(false));
-    assertThat(CompareUtil.hasExcludingContains(element, Arrays.asList(values2)), is(true));
-    assertThat(CompareUtil.hasExcludingContains(null, Arrays.asList(values)), is(false));
-    assertThat(CompareUtil.hasExcludingContains(null, nullList), is(false));
-    assertThat(CompareUtil.hasExcludingContains(element, nullList), is(false));
+    assertThat(CompareUtil.elementIsNotContainedInList(element, Arrays.asList(values)), is(false));
+    assertThat(CompareUtil.elementIsNotContainedInList(element, Arrays.asList(values2)), is(true));
+    assertThat(CompareUtil.elementIsNotContainedInList(null, Arrays.asList(values)), is(false));
+    assertThat(CompareUtil.elementIsNotContainedInList(null, nullList), is(false));
+    assertThat(CompareUtil.elementIsNotContainedInList(element, nullList), is(false));
   }
 
   @Test
-  public void testHasExcludingNotContains() {
+  public void testIsContainedIn() {
     String element = "test";
     String [] values = {"test", "test1", "test2"};
     String [] values2 = {"test1", "test2"};
     String [] nullValues = null;
     List<String> nullList = null;
 
-    assertThat(CompareUtil.hasExcludingNotContains(element, values), is(true));
-    assertThat(CompareUtil.hasExcludingNotContains(element, values2), is(false));
-    assertThat(CompareUtil.hasExcludingNotContains(null, values), is(false));
-    assertThat(CompareUtil.hasExcludingNotContains(null, nullValues), is(false));
-    assertThat(CompareUtil.hasExcludingNotContains(element, nullValues), is(false));
+    assertThat(CompareUtil.elementIsContainedInArray(element, values), is(true));
+    assertThat(CompareUtil.elementIsContainedInArray(element, values2), is(false));
+    assertThat(CompareUtil.elementIsContainedInArray(null, values), is(false));
+    assertThat(CompareUtil.elementIsContainedInArray(null, nullValues), is(false));
+    assertThat(CompareUtil.elementIsContainedInArray(element, nullValues), is(false));
 
-    assertThat(CompareUtil.hasExcludingNotContains(element, Arrays.asList(values)), is(true));
-    assertThat(CompareUtil.hasExcludingNotContains(element, Arrays.asList(values2)), is(false));
-    assertThat(CompareUtil.hasExcludingNotContains(null, Arrays.asList(values)), is(false));
-    assertThat(CompareUtil.hasExcludingNotContains(null, nullList), is(false));
-    assertThat(CompareUtil.hasExcludingNotContains(element, nullList), is(false));
+    assertThat(CompareUtil.elementIsContainedInList(element, Arrays.asList(values)), is(true));
+    assertThat(CompareUtil.elementIsContainedInList(element, Arrays.asList(values2)), is(false));
+    assertThat(CompareUtil.elementIsContainedInList(null, Arrays.asList(values)), is(false));
+    assertThat(CompareUtil.elementIsContainedInList(null, nullList), is(false));
+    assertThat(CompareUtil.elementIsContainedInList(element, nullList), is(false));
   }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/util/CompareUtilTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/util/CompareUtilTest.java
@@ -17,62 +17,62 @@ import static org.junit.Assert.assertThat;
 public class CompareUtilTest {
 
   @Test
-  public void testValidateOrderDate() {
+  public void testHasEcludingOrderDate() {
     Calendar calendar = Calendar.getInstance();
     calendar.set(2015, Calendar.MARCH, 15);
     Date first = calendar.getTime();
     calendar.set(2015, Calendar.AUGUST, 15);
     Date second = calendar.getTime();
     Date nullDate = null;
-    assertThat(CompareUtil.validateOrder(null, first, null, second), is(true));
-    assertThat(CompareUtil.validateOrder(null, first, null, first), is(true));
-    assertThat(CompareUtil.validateOrder(null, second, null, first), is(false));
-    assertThat(CompareUtil.validateOrder(nullDate, nullDate, nullDate), is(true));
+    assertThat(CompareUtil.hasExcludingOrder(null, first, null, second), is(false));
+    assertThat(CompareUtil.hasExcludingOrder(null, first, null, first), is(false));
+    assertThat(CompareUtil.hasExcludingOrder(null, second, null, first), is(true));
+    assertThat(CompareUtil.hasExcludingOrder(nullDate, nullDate, nullDate), is(false));
 
-    assertThat(CompareUtil.validateOrder(Arrays.asList(first, second)), is(true));
-    assertThat(CompareUtil.validateOrder(Arrays.asList(first, first)), is(true));
-    assertThat(CompareUtil.validateOrder(Arrays.asList(second, first)), is(false));
+    assertThat(CompareUtil.hasExcludingOrder(Arrays.asList(first, second)), is(false));
+    assertThat(CompareUtil.hasExcludingOrder(Arrays.asList(first, first)), is(false));
+    assertThat(CompareUtil.hasExcludingOrder(Arrays.asList(second, first)), is(true));
   }
 
   @Test
-  public void testValidateContains() {
+  public void testHasExcludingContains() {
     String element = "test";
     String [] values = {"test", "test1", "test2"};
     String [] values2 = {"test1", "test2"};
     String [] nullValues = null;
     List<String> nullList = null;
 
-    assertThat(CompareUtil.validateContains(element, values), is(true));
-    assertThat(CompareUtil.validateContains(element, values2), is(false));
-    assertThat(CompareUtil.validateContains(null, values), is(true));
-    assertThat(CompareUtil.validateContains(null, nullValues), is(true));
-    assertThat(CompareUtil.validateContains(element, nullValues), is(true));
+    assertThat(CompareUtil.hasExcludingContains(element, values), is(false));
+    assertThat(CompareUtil.hasExcludingContains(element, values2), is(true));
+    assertThat(CompareUtil.hasExcludingContains(null, values), is(false));
+    assertThat(CompareUtil.hasExcludingContains(null, nullValues), is(false));
+    assertThat(CompareUtil.hasExcludingContains(element, nullValues), is(false));
 
-    assertThat(CompareUtil.validateContains(element, Arrays.asList(values)), is(true));
-    assertThat(CompareUtil.validateContains(element, Arrays.asList(values2)), is(false));
-    assertThat(CompareUtil.validateContains(null, Arrays.asList(values)), is(true));
-    assertThat(CompareUtil.validateContains(null, nullList), is(true));
-    assertThat(CompareUtil.validateContains(element, nullList), is(true));
+    assertThat(CompareUtil.hasExcludingContains(element, Arrays.asList(values)), is(false));
+    assertThat(CompareUtil.hasExcludingContains(element, Arrays.asList(values2)), is(true));
+    assertThat(CompareUtil.hasExcludingContains(null, Arrays.asList(values)), is(false));
+    assertThat(CompareUtil.hasExcludingContains(null, nullList), is(false));
+    assertThat(CompareUtil.hasExcludingContains(element, nullList), is(false));
   }
 
   @Test
-  public void testValidateNotContains() {
+  public void testHasExcludingNotContains() {
     String element = "test";
     String [] values = {"test", "test1", "test2"};
     String [] values2 = {"test1", "test2"};
     String [] nullValues = null;
     List<String> nullList = null;
 
-    assertThat(CompareUtil.validateNotContains(element, values), is(false));
-    assertThat(CompareUtil.validateNotContains(element, values2), is(true));
-    assertThat(CompareUtil.validateNotContains(null, values), is(true));
-    assertThat(CompareUtil.validateNotContains(null, nullValues), is(true));
-    assertThat(CompareUtil.validateNotContains(element, nullValues), is(true));
+    assertThat(CompareUtil.hasExcludingNotContains(element, values), is(true));
+    assertThat(CompareUtil.hasExcludingNotContains(element, values2), is(false));
+    assertThat(CompareUtil.hasExcludingNotContains(null, values), is(false));
+    assertThat(CompareUtil.hasExcludingNotContains(null, nullValues), is(false));
+    assertThat(CompareUtil.hasExcludingNotContains(element, nullValues), is(false));
 
-    assertThat(CompareUtil.validateNotContains(element, Arrays.asList(values)), is(false));
-    assertThat(CompareUtil.validateNotContains(element, Arrays.asList(values2)), is(true));
-    assertThat(CompareUtil.validateNotContains(null, Arrays.asList(values)), is(true));
-    assertThat(CompareUtil.validateNotContains(null, nullList), is(true));
-    assertThat(CompareUtil.validateNotContains(element, nullList), is(true));
+    assertThat(CompareUtil.hasExcludingNotContains(element, Arrays.asList(values)), is(true));
+    assertThat(CompareUtil.hasExcludingNotContains(element, Arrays.asList(values2)), is(false));
+    assertThat(CompareUtil.hasExcludingNotContains(null, Arrays.asList(values)), is(false));
+    assertThat(CompareUtil.hasExcludingNotContains(null, nullList), is(false));
+    assertThat(CompareUtil.hasExcludingNotContains(element, nullList), is(false));
   }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/util/CompareUtilTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/util/CompareUtilTest.java
@@ -1,0 +1,78 @@
+package org.camunda.bpm.engine.test.util;
+
+import org.camunda.bpm.engine.impl.util.CompareUtil;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class CompareUtilTest {
+
+  @Test
+  public void testValidateOrderDate() {
+    Calendar calendar = Calendar.getInstance();
+    calendar.set(2015, Calendar.MARCH, 15);
+    Date first = calendar.getTime();
+    calendar.set(2015, Calendar.AUGUST, 15);
+    Date second = calendar.getTime();
+    Date nullDate = null;
+    assertThat(CompareUtil.validateOrder(null, first, null, second), is(true));
+    assertThat(CompareUtil.validateOrder(null, first, null, first), is(true));
+    assertThat(CompareUtil.validateOrder(null, second, null, first), is(false));
+    assertThat(CompareUtil.validateOrder(nullDate, nullDate, nullDate), is(true));
+
+    assertThat(CompareUtil.validateOrder(Arrays.asList(first, second)), is(true));
+    assertThat(CompareUtil.validateOrder(Arrays.asList(first, first)), is(true));
+    assertThat(CompareUtil.validateOrder(Arrays.asList(second, first)), is(false));
+  }
+
+  @Test
+  public void testValidateContains() {
+    String element = "test";
+    String [] values = {"test", "test1", "test2"};
+    String [] values2 = {"test1", "test2"};
+    String [] nullValues = null;
+    List<String> nullList = null;
+
+    assertThat(CompareUtil.validateContains(element, values), is(true));
+    assertThat(CompareUtil.validateContains(element, values2), is(false));
+    assertThat(CompareUtil.validateContains(null, values), is(true));
+    assertThat(CompareUtil.validateContains(null, nullValues), is(true));
+    assertThat(CompareUtil.validateContains(element, nullValues), is(true));
+
+    assertThat(CompareUtil.validateContains(element, Arrays.asList(values)), is(true));
+    assertThat(CompareUtil.validateContains(element, Arrays.asList(values2)), is(false));
+    assertThat(CompareUtil.validateContains(null, Arrays.asList(values)), is(true));
+    assertThat(CompareUtil.validateContains(null, nullList), is(true));
+    assertThat(CompareUtil.validateContains(element, nullList), is(true));
+  }
+
+  @Test
+  public void testValidateNotContains() {
+    String element = "test";
+    String [] values = {"test", "test1", "test2"};
+    String [] values2 = {"test1", "test2"};
+    String [] nullValues = null;
+    List<String> nullList = null;
+
+    assertThat(CompareUtil.validateNotContains(element, values), is(false));
+    assertThat(CompareUtil.validateNotContains(element, values2), is(true));
+    assertThat(CompareUtil.validateNotContains(null, values), is(true));
+    assertThat(CompareUtil.validateNotContains(null, nullValues), is(true));
+    assertThat(CompareUtil.validateNotContains(element, nullValues), is(true));
+
+    assertThat(CompareUtil.validateNotContains(element, Arrays.asList(values)), is(false));
+    assertThat(CompareUtil.validateNotContains(element, Arrays.asList(values2)), is(true));
+    assertThat(CompareUtil.validateNotContains(null, Arrays.asList(values)), is(true));
+    assertThat(CompareUtil.validateNotContains(null, nullList), is(true));
+    assertThat(CompareUtil.validateNotContains(element, nullList), is(true));
+  }
+}


### PR DESCRIPTION
This is just some idea that I had regarding the improving of the meaningless API range queries. While working on it I noticed that there are equal meaningless API call as well, like for example when there is `processInstanceId` and `processInstanceIdIn`, so I took those into consideration as well.

Let me know what you think, and whether the direction is OK.

Cheers,
Filip