### PR TITLE
fix(engine): non-recursive execution of BPMN Activities

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
@@ -73,6 +73,8 @@ public abstract class MultiInstanceActivityBehavior extends AbstractBpmnActivity
   protected void performInstance(ActivityExecution execution, PvmActivity activity, int loopCounter) {
     setLoopVariable(execution, LOOP_COUNTER, loopCounter);
     evaluateCollectionVariable(execution, loopCounter);
+    execution.setEnded(false);
+    execution.setActive(true);
     execution.executeActivity(activity);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/ParallelMultiInstanceActivityBehavior.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/ParallelMultiInstanceActivityBehavior.java
@@ -41,12 +41,11 @@ public class ParallelMultiInstanceActivityBehavior extends MultiInstanceActivity
     }
 
     // start the concurrent child executions
-    for (int i = 0; i < nrOfInstances; i++) {
+    // start executions in reverse order (order will be reversed again in command context with the effect that they are
+    // actually be started in correct order :) )
+    for (int i = (nrOfInstances - 1); i >= 0; i--) {
       ActivityExecution activityExecution = concurrentExecutions.get(i);
-      // check for active execution: the completion condition may be satisfied before all executions are started
-      if(activityExecution.isActive()) {
-        performInstance(activityExecution, innerActivity, i);
-      }
+      performInstance(activityExecution, innerActivity, i);
     }
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/helper/CompensationUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/helper/CompensationUtil.java
@@ -22,13 +22,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.bpmn.parser.BpmnParse;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.persistence.entity.CompensateEventSubscriptionEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.EventSubscriptionEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
-import org.camunda.bpm.engine.impl.pvm.PvmActivity;
 import org.camunda.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
 import org.camunda.bpm.engine.impl.pvm.process.ScopeImpl;
@@ -75,11 +73,13 @@ public class CompensationUtil {
       compensatingExecution.setConcurrent(true);
     }
 
-    // signal compensation events in reverse order of their 'created' timestamp
+    // signal compensation events in order of their 'created' timestamp
+    // order will be reversed again in command context with the effect that they are
+    // actually be started in correct order :)
     Collections.sort(eventSubscriptions, new Comparator<EventSubscriptionEntity>() {
       @Override
       public int compare(EventSubscriptionEntity o1, EventSubscriptionEntity o2) {
-        return o2.getCreated().compareTo(o1.getCreated());
+        return o1.getCreated().compareTo(o2.getCreated());
       }
     });
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -484,6 +484,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected MetricsReporterIdProvider metricsReporterIdProvider;
 
+  protected boolean isBpmnStacktraceVerbose = false;
+
   // buildProcessEngine ///////////////////////////////////////////////////////
 
   @Override
@@ -2726,5 +2728,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public void setMetricsReporterIdProvider(MetricsReporterIdProvider metricsReporterIdProvider) {
     this.metricsReporterIdProvider = metricsReporterIdProvider;
+  }
+
+  public ProcessEngineConfigurationImpl setBpmnStacktraceVerbose(boolean isBpmnStacktraceVerbose) {
+    this.isBpmnStacktraceVerbose = isBpmnStacktraceVerbose;
+    return this;
+  }
+
+  public boolean isBpmnStacktraceVerbose() {
+    return this.isBpmnStacktraceVerbose;
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/AtomicOperationInvocation.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/AtomicOperationInvocation.java
@@ -1,0 +1,117 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.interceptor;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.camunda.bpm.application.ProcessApplicationReference;
+import org.camunda.bpm.engine.impl.context.Context;
+import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.camunda.bpm.engine.impl.pvm.runtime.AtomicOperation;
+import org.camunda.bpm.engine.impl.pvm.runtime.operation.PvmAtomicOperation;
+
+/**
+ * An invocation of an atomic operation
+ *
+ * @author Daniel Meyer
+ *
+ */
+public class AtomicOperationInvocation {
+
+  private static Logger log = Logger.getLogger(CommandContext.class.getName());
+
+  protected AtomicOperation operation;
+
+  protected ExecutionEntity execution;
+
+  protected boolean performAsync;
+
+  // for logging
+  protected String applicationContextName = null;
+  protected String activityId = null;
+
+  public AtomicOperationInvocation(AtomicOperation operation, ExecutionEntity execution, boolean performAsync) {
+    init(operation, execution, performAsync);
+  }
+
+  protected void init(AtomicOperation operation, ExecutionEntity execution, boolean performAsync) {
+    this.operation = operation;
+    this.execution = execution;
+    this.performAsync = performAsync;
+  }
+
+  public void execute(BpmnStackTrace stackTrace) {
+
+    if(operation != PvmAtomicOperation.ACTIVITY_START_CANCEL_SCOPE
+        && operation != PvmAtomicOperation.ACTIVITY_START_INTERRUPT_SCOPE) {
+      // execution might be replaced in the meantime:
+      ExecutionEntity replacedBy = execution.getReplacedBy();
+      if(replacedBy != null) {
+        execution = replacedBy;
+      }
+    }
+
+    // execution might have ended in the meanwhile
+    if(execution.isEnded() &&
+        (operation == PvmAtomicOperation.TRANSITION_NOTIFY_LISTENER_TAKE
+      || operation == PvmAtomicOperation.ACTIVITY_START_CREATE_SCOPE)) {
+      return;
+    }
+
+    ProcessApplicationReference currentPa = Context.getCurrentProcessApplication();
+    if(currentPa != null) {
+      applicationContextName = currentPa.getName();
+    }
+    activityId = execution.getActivityId();
+    stackTrace.add(this);
+
+    try {
+      Context.setExecutionContext(execution);
+      if(!performAsync) {
+        if (log.isLoggable(Level.FINEST)) {
+          log.finest("AtomicOperation: " + operation + " on " + execution);
+        }
+        operation.execute(execution);
+      }
+      else {
+        execution.scheduleAtomicOperationAsync(operation);
+      }
+    } finally {
+      Context.removeExecutionContext();
+    }
+  }
+
+  // getters / setters ////////////////////////////////////
+
+  public AtomicOperation getOperation() {
+    return operation;
+  }
+
+  public ExecutionEntity getExecution() {
+    return execution;
+  }
+
+  public boolean isPerformAsync() {
+    return performAsync;
+  }
+
+  public String getApplicationContextName() {
+    return applicationContextName;
+  }
+
+  public String getActivityId() {
+    return activityId;
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/BpmnStackTrace.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/BpmnStackTrace.java
@@ -1,0 +1,121 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.interceptor;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ *
+ * @author Daniel Meyer
+ *
+ */
+public class BpmnStackTrace {
+
+  public final static Logger log = Logger.getLogger(BpmnStackTrace.class.getName());
+
+  protected List<AtomicOperationInvocation> perfromedInvocations = new ArrayList<AtomicOperationInvocation>();
+
+  public void printStackTrace(boolean verbose) {
+    if(perfromedInvocations.isEmpty()) {
+      return;
+    }
+
+    StringWriter writer = new StringWriter();
+    writer.write("BPMN Stack Trace:\n");
+
+    if(!verbose) {
+      logNonVerbose(writer);
+    }
+    else {
+      logVerbose(writer);
+    }
+
+    log.severe(writer.toString());
+
+    perfromedInvocations.clear();
+  }
+
+  protected void logNonVerbose(StringWriter writer) {
+
+    // log the failed operation verbosely
+    writeInvocation(perfromedInvocations.get(perfromedInvocations.size() - 1), writer);
+
+    // log human consumable trace of activity ids only
+    List<String> activities = collectActivityTrace();
+    logActivityTrace(writer, activities);
+  }
+
+  protected void logVerbose(StringWriter writer) {
+    // log process engine developer consumable trace
+    Collections.reverse(perfromedInvocations);
+    for (AtomicOperationInvocation invocation : perfromedInvocations) {
+      writeInvocation(invocation, writer);
+    }
+  }
+
+  protected void logActivityTrace(StringWriter writer, List<String> activities) {
+    for (int i = 0; i < activities.size(); i++) {
+      if(i != 0) {
+        writer.write("\t  ^\n");
+        writer.write("\t  |\n");
+      }
+      writer.write("\t");
+      writer.write(activities.get(i));
+      writer.write("\n");
+    }
+  }
+
+  protected List<String> collectActivityTrace() {
+    List<String> activities = new ArrayList<String>();
+    for (AtomicOperationInvocation atomicOperationInvocation : perfromedInvocations) {
+      String activityId = atomicOperationInvocation.getActivityId();
+      if(activityId == null) {
+        continue;
+      }
+      if(activities.isEmpty() ||
+          !activityId.equals(activities.get(0))) {
+        activities.add(0, activityId);
+      }
+    }
+    return activities;
+  }
+
+  public void add(AtomicOperationInvocation atomicOperationInvocation) {
+    perfromedInvocations.add(atomicOperationInvocation);
+  }
+
+  protected void writeInvocation(AtomicOperationInvocation invocation, StringWriter writer) {
+    writer.write("\t");
+    writer.write(invocation.getActivityId());
+    writer.write(" (");
+    writer.write(invocation.getOperation().getCanonicalName());
+    writer.write(", ");
+    writer.write(invocation.getExecution().toString());
+
+    if(invocation.isPerformAsync()) {
+      writer.write(", ASYNC");
+    }
+
+    if(invocation.getApplicationContextName() != null) {
+      writer.write(", pa=");
+      writer.write(invocation.getApplicationContextName());
+    }
+
+    writer.write(")\n");
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandContext.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandContext.java
@@ -99,6 +99,11 @@ public class CommandContext {
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected FailedJobCommandFactory failedJobCommandFactory;
 
+  protected List<AtomicOperationInvocation> queuedInvocations = new ArrayList<AtomicOperationInvocation>();
+  protected BpmnStackTrace bpmnStackTrace = new BpmnStackTrace();
+
+  protected boolean isExecuting = false;
+
   protected List<CommandContextListener> commandContextListeners = new LinkedList<CommandContextListener>();
 
   public CommandContext(ProcessEngineConfigurationImpl processEngineConfiguration) {
@@ -121,36 +126,62 @@ public class CommandContext {
   }
 
   public void performOperation(final AtomicOperation executionOperation, final ExecutionEntity execution, final boolean performAsync) {
+    AtomicOperationInvocation invocation = new AtomicOperationInvocation(executionOperation, execution, performAsync);
+    queuedInvocations.add(0, invocation);
+    performNext();
+  }
 
-    ProcessApplicationReference targetProcessApplication = getTargetProcessApplication(execution);
+  protected void performNext() {
+    AtomicOperationInvocation nextInvocation = queuedInvocations.get(0);
 
+    if(nextInvocation.operation.isAsyncCapable() && isExecuting) {
+      // will be picked up by while loop below
+      return;
+    }
+
+    ProcessApplicationReference targetProcessApplication = getTargetProcessApplication((ExecutionEntity) nextInvocation.execution);
     if(requiresContextSwitch(targetProcessApplication)) {
 
       Context.executeWithinProcessApplication(new Callable<Void>() {
         public Void call() throws Exception {
-          performOperation(executionOperation, execution, performAsync);
+          performNext();
           return null;
         }
 
       }, targetProcessApplication);
-
-    } else {
-      try {
-        Context.setExecutionContext(execution);
-        if (log.isLoggable(Level.FINEST)) {
-          log.finest("AtomicOperation: " + executionOperation + " on " + this);
+    }
+    else {
+      if(!nextInvocation.operation.isAsyncCapable()) {
+        // if operation is not async capable, perform right away.
+        invokeNext();
+      }
+      else {
+        try  {
+          isExecuting = true;
+          while (!queuedInvocations.isEmpty()) {
+            // assumption: all operations are executed within the same process application...
+            nextInvocation = queuedInvocations.get(0);
+            invokeNext();
+          }
         }
-        if (performAsync) {
-          execution.scheduleAtomicOperationAsync(executionOperation);
-        } else {
-          executionOperation.execute(execution);
-
+        finally {
+          isExecuting = false;
         }
-      } finally {
-        Context.removeExecutionContext();
       }
     }
+  }
 
+  protected void invokeNext() {
+    AtomicOperationInvocation invocation = queuedInvocations.remove(0);
+    try {
+      invocation.execute(bpmnStackTrace);
+    }
+    catch(RuntimeException e) {
+      // log bpmn stacktrace
+      bpmnStackTrace.printStackTrace(Context.getProcessEngineConfiguration().isBpmnStacktraceVerbose());
+      // rethrow
+      throw e;
+    }
   }
 
   public void performOperation(final CmmnAtomicOperation executionOperation, final CaseExecutionEntity execution) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/delegate/ActivityExecution.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/delegate/ActivityExecution.java
@@ -257,4 +257,6 @@ public interface ActivityExecution extends DelegateExecution {
    */
   public Map<ScopeImpl, PvmExecutionImpl> createActivityExecutionMapping();
 
+  void setEnded(boolean b);
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/AtomicOperation.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/AtomicOperation.java
@@ -46,4 +46,5 @@ public interface AtomicOperation extends CoreAtomicOperation<PvmExecutionImpl> {
   AtomicOperation DELETE_CASCADE = PvmAtomicOperation.DELETE_CASCADE;
   AtomicOperation DELETE_CASCADE_FIRE_ACTIVITY_END = PvmAtomicOperation.DELETE_CASCADE_FIRE_ACTIVITY_END;
 
+  boolean isAsyncCapable();
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/PvmExecutionImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/PvmExecutionImpl.java
@@ -24,12 +24,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.camunda.bpm.engine.ProcessEngineException;
-import org.camunda.bpm.engine.impl.bpmn.parser.BpmnParse;
 import org.camunda.bpm.engine.impl.cmmn.execution.CmmnExecution;
 import org.camunda.bpm.engine.impl.cmmn.model.CmmnCaseDefinition;
 import org.camunda.bpm.engine.impl.core.instance.CoreExecution;
 import org.camunda.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
-import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.camunda.bpm.engine.impl.pvm.PvmActivity;
 import org.camunda.bpm.engine.impl.pvm.PvmException;
 import org.camunda.bpm.engine.impl.pvm.PvmExecution;
@@ -855,11 +853,13 @@ public abstract class PvmExecutionImpl extends CoreExecution implements Activity
       execution.end(_transitions.isEmpty());
     }
 
-    // ending a recyclable execution might have replaced this execution as well
     PvmExecutionImpl propagatingExecution = this;
     if (getReplacedBy() != null) {
       propagatingExecution = getReplacedBy();
     }
+
+    propagatingExecution.isActive = true;
+    propagatingExecution.isEnded = false;
 
     if (_transitions.isEmpty()) {
       propagatingExecution.end(!propagatingExecution.isConcurrent());
@@ -1427,6 +1427,10 @@ public abstract class PvmExecutionImpl extends CoreExecution implements Activity
     this.isActive = isActive;
   }
 
+  public void setEnded(boolean isEnded) {
+    this.isEnded = isEnded;
+  }
+
   @Override
   public boolean isEnded() {
     return isEnded;
@@ -1540,5 +1544,4 @@ public abstract class PvmExecutionImpl extends CoreExecution implements Activity
       }
     }
   }
-
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/AbstractPvmEventAtomicOperation.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/AbstractPvmEventAtomicOperation.java
@@ -26,4 +26,8 @@ public abstract class AbstractPvmEventAtomicOperation extends AbstractEventAtomi
 
   protected abstract CoreModelElement getScope(PvmExecutionImpl execution);
 
+  public boolean isAsyncCapable() {
+    return false;
+  }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperation.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperation.java
@@ -50,5 +50,4 @@ public interface PvmAtomicOperation extends CoreAtomicOperation<PvmExecutionImpl
 
   PvmAtomicOperation DELETE_CASCADE = new PvmAtomicOperationDeleteCascade();
   PvmAtomicOperation DELETE_CASCADE_FIRE_ACTIVITY_END = new PvmAtomicOperationDeleteCascadeFireActivityEnd();
-
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationActivityEnd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationActivityEnd.java
@@ -36,6 +36,10 @@ public class PvmAtomicOperationActivityEnd implements PvmAtomicOperation {
     return execution.getActivity().isAsyncAfter();
   }
 
+  public boolean isAsyncCapable() {
+    return false;
+  }
+
   public void execute(PvmExecutionImpl execution) {
     // restore activity instance id
     if (execution.getActivityInstanceId() == null) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationActivityExecute.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationActivityExecute.java
@@ -50,4 +50,8 @@ public class PvmAtomicOperationActivityExecute implements PvmAtomicOperation {
   public String getCanonicalName() {
     return "activity-execute";
   }
+
+  public boolean isAsyncCapable() {
+    return false;
+  }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationActivityInitStack.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationActivityInitStack.java
@@ -61,4 +61,7 @@ public class PvmAtomicOperationActivityInitStack implements PvmAtomicOperation {
     return execution;
   }
 
+  public boolean isAsyncCapable() {
+    return false;
+  }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationActivityStartCancelScope.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationActivityStartCancelScope.java
@@ -40,4 +40,8 @@ public class PvmAtomicOperationActivityStartCancelScope extends PvmAtomicOperati
     return execution.getNextActivity();
   }
 
+  public boolean isAsyncCapable() {
+    return false;
+  }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationActivityStartConcurrent.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationActivityStartConcurrent.java
@@ -31,4 +31,8 @@ public class PvmAtomicOperationActivityStartConcurrent extends PvmAtomicOperatio
     return "activity-start-concurrent";
   }
 
+  public boolean isAsyncCapable() {
+    return false;
+  }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationActivityStartCreateScope.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationActivityStartCreateScope.java
@@ -27,6 +27,10 @@ public class PvmAtomicOperationActivityStartCreateScope extends PvmAtomicOperati
         && !execution.hasProcessInstanceStartContext();
   }
 
+  public boolean isAsyncCapable() {
+    return true;
+  }
+
   public String getCanonicalName() {
     return "activity-start-create-scope";
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationCancelActivity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationCancelActivity.java
@@ -56,6 +56,7 @@ public abstract class PvmAtomicOperationCancelActivity implements PvmAtomicOpera
 
     propagatingExecution.setActivity(cancellingActivity);
     propagatingExecution.setActive(true);
+    propagatingExecution.setEnded(false);
     activityCancelled(propagatingExecution);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationDeleteCascade.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationDeleteCascade.java
@@ -13,8 +13,6 @@
 
 package org.camunda.bpm.engine.impl.pvm.runtime.operation;
 
-import java.util.List;
-
 import org.camunda.bpm.engine.impl.pvm.runtime.PvmExecutionImpl;
 
 
@@ -24,6 +22,10 @@ import org.camunda.bpm.engine.impl.pvm.runtime.PvmExecutionImpl;
 public class PvmAtomicOperationDeleteCascade implements PvmAtomicOperation {
 
   public boolean isAsync(PvmExecutionImpl execution) {
+    return false;
+  }
+
+  public boolean isAsyncCapable() {
     return false;
   }
 
@@ -64,4 +66,5 @@ public class PvmAtomicOperationDeleteCascade implements PvmAtomicOperation {
   public String getCanonicalName() {
     return "delete-cascade";
   }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationInterruptScope.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationInterruptScope.java
@@ -50,4 +50,8 @@ public abstract class PvmAtomicOperationInterruptScope implements PvmAtomicOpera
     return false;
   }
 
+  public boolean isAsyncCapable() {
+    return false;
+  }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationProcessStart.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationProcessStart.java
@@ -32,6 +32,10 @@ public class PvmAtomicOperationProcessStart extends AbstractPvmEventAtomicOperat
     return startContext != null && startContext.isAsync();
   }
 
+  public boolean isAsyncCapable() {
+    return true;
+  }
+
   protected ScopeImpl getScope(PvmExecutionImpl execution) {
     return execution.getProcessDefinition();
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationTransitionCreateScope.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationTransitionCreateScope.java
@@ -34,4 +34,8 @@ public class PvmAtomicOperationTransitionCreateScope extends PvmAtomicOperationC
     execution.performOperation(TRANSITION_NOTIFY_LISTENER_START);
 
   }
+
+  public boolean isAsyncCapable() {
+    return true;
+  }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationTransitionDestroyScope.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationTransitionDestroyScope.java
@@ -13,13 +13,13 @@
 package org.camunda.bpm.engine.impl.pvm.runtime.operation;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.pvm.PvmActivity;
 import org.camunda.bpm.engine.impl.pvm.PvmTransition;
-import org.camunda.bpm.engine.impl.pvm.process.TransitionImpl;
 import org.camunda.bpm.engine.impl.pvm.runtime.LegacyBehavior;
 import org.camunda.bpm.engine.impl.pvm.runtime.OutgoingExecution;
 import org.camunda.bpm.engine.impl.pvm.runtime.PvmExecutionImpl;
@@ -35,6 +35,10 @@ public class PvmAtomicOperationTransitionDestroyScope implements PvmAtomicOperat
   private static Logger log = Logger.getLogger(PvmAtomicOperationTransitionDestroyScope.class.getName());
 
   public boolean isAsync(PvmExecutionImpl instance) {
+    return false;
+  }
+
+  public boolean isAsyncCapable() {
     return false;
   }
 
@@ -100,7 +104,7 @@ public class PvmAtomicOperationTransitionDestroyScope implements PvmAtomicOperat
 
           if (i == 1 && !propagatingExecution.isConcurrent()) {
             outgoingExecutions.remove(0);
-            // get ahold of the concurrent execution that replaced the scope propagating execution
+            // get a hold of the concurrent execution that replaced the scope propagating execution
             PvmExecutionImpl replacingExecution = null;
             for (PvmExecutionImpl concurrentChild : scopeExecution.getNonEventScopeExecutions())  {
               if (!(concurrentChild == propagatingExecution)) {
@@ -115,6 +119,10 @@ public class PvmAtomicOperationTransitionDestroyScope implements PvmAtomicOperat
 
         outgoingExecutions.add(new OutgoingExecution(concurrentExecution, transition));
       }
+
+      // start executions in reverse order (order will be reversed again in command context with the effect that they are
+      // actually be started in correct order :) )
+      Collections.reverse(outgoingExecutions);
 
       for (OutgoingExecution outgoingExecution : outgoingExecutions) {
         outgoingExecution.take();

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationTransitionNotifyListenerTake.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationTransitionNotifyListenerTake.java
@@ -27,4 +27,8 @@ public class PvmAtomicOperationTransitionNotifyListenerTake extends AbstractPvmA
   public String getCanonicalName() {
     return "transition-notify-listener-take";
   }
+
+  public boolean isAsyncCapable() {
+    return true;
+  }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/gateway/ExclusiveGatewayTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/gateway/ExclusiveGatewayTest.java
@@ -236,7 +236,7 @@ public class ExclusiveGatewayTest extends PluggableProcessEngineTestCase {
 
   // see CAM-4172
   @Deployment
-  public void FAILING_testLoopWithManyIterations() {
+  public void testLoopWithManyIterations() {
     int numOfIterations = 1000;
 
     // this should not fail

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/iomapping/InputOutputTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/iomapping/InputOutputTest.java
@@ -18,8 +18,10 @@ import static org.junit.Assert.assertThat;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -755,19 +757,24 @@ public class InputOutputTest extends PluggableProcessEngineTestCase {
     variables.put("nrOfLoops", 2);
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("miParallelActivity", variables);
 
+    Set<Integer> counters = new HashSet<Integer>();
+
     // first mi execution
     Execution miExecution1 = runtimeService.createExecutionQuery().activityId("miTask")
         .variableValueEquals("loopCounter", 0).singleResult();
     assertNotNull(miExecution1);
     assertFalse(instance.getId().equals(miExecution1.getId()));
-    assertEquals(1, runtimeService.getVariableLocal(miExecution1.getId(), "miCounterValue"));
+    counters.add((Integer) runtimeService.getVariableLocal(miExecution1.getId(), "miCounterValue"));
 
     // second mi execution
     Execution miExecution2 = runtimeService.createExecutionQuery().activityId("miTask")
         .variableValueEquals("loopCounter", 1).singleResult();
     assertNotNull(miExecution2);
     assertFalse(instance.getId().equals(miExecution2.getId()));
-    assertEquals(2, runtimeService.getVariableLocal(miExecution2.getId(), "miCounterValue"));
+    counters.add((Integer) runtimeService.getVariableLocal(miExecution2.getId(), "miCounterValue"));
+
+    assertTrue(counters.contains(1));
+    assertTrue(counters.contains(2));
 
     assertEquals(2, runtimeService.createVariableInstanceQuery().variableName("miCounterValue").count());
 
@@ -786,18 +793,23 @@ public class InputOutputTest extends PluggableProcessEngineTestCase {
     variables.put("nrOfLoops", 2);
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("miParallelSubprocess", variables);
 
+    Set<Integer> counters = new HashSet<Integer>();
+
     // first parallel mi execution
     Execution miScopeExecution1 = runtimeService.createExecutionQuery().activityId("task")
         .variableValueEquals("loopCounter", 0).singleResult();
     assertNotNull(miScopeExecution1);
-    assertEquals(1, runtimeService.getVariableLocal(miScopeExecution1.getId(), "miCounterValue"));
+    counters.add((Integer) runtimeService.getVariableLocal(miScopeExecution1.getId(), "miCounterValue"));
 
     // second parallel mi execution
     Execution miScopeExecution2 = runtimeService.createExecutionQuery().activityId("task")
         .variableValueEquals("loopCounter", 1).singleResult();
     assertNotNull(miScopeExecution2);
     assertFalse(instance.getId().equals(miScopeExecution2.getId()));
-    assertEquals(2, runtimeService.getVariableLocal(miScopeExecution2.getId(), "miCounterValue"));
+    counters.add((Integer) runtimeService.getVariableLocal(miScopeExecution2.getId(), "miCounterValue"));
+
+    assertTrue(counters.contains(1));
+    assertTrue(counters.contains(2));
 
     assertEquals(2, runtimeService.createVariableInstanceQuery().variableName("miCounterValue").count());
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/multiinstance/MultiInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/multiinstance/MultiInstanceTest.java
@@ -447,6 +447,17 @@ public class MultiInstanceTest extends PluggableProcessEngineTestCase {
     assertEquals(10, sum);
   }
 
+  @Deployment(resources="org/camunda/bpm/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialScriptTasks.bpmn20.xml")
+  public void testSequentialScriptTasksNoStackOverflow() {
+    Map<String, Object> vars = new HashMap<String, Object>();
+    vars.put("sum", 0);
+    vars.put("nrOfLoops", 200);
+    runtimeService.startProcessInstanceByKey("miSequentialScriptTask", vars);
+    Execution waitStateExecution = runtimeService.createExecutionQuery().singleResult();
+    int sum = (Integer) runtimeService.getVariable(waitStateExecution.getId(), "sum");
+    assertEquals(19900, sum);
+  }
+
   @Deployment(resources = {"org/camunda/bpm/engine/test/bpmn/multiinstance/MultiInstanceTest.testSequentialScriptTasks.bpmn20.xml"})
   public void testSequentialScriptTasksHistory() {
     Map<String, Object> vars = new HashMap<String, Object>();

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.java
@@ -208,8 +208,9 @@ public class HistoricActivityInstanceStateTest extends PluggableProcessEngineTes
   @Deployment
   public void testBoundaryErrorCancel() {
     ProcessInstance processInstance = startProcess();
+    runtimeService.correlateMessage("continue");
+    assertProcessEnded(processInstance.getId());
 
-    assertTrue(processInstance.isEnded());
 
     List<HistoricActivityInstance> allInstances = getAllActivityInstances();
 
@@ -266,8 +267,8 @@ public class HistoricActivityInstanceStateTest extends PluggableProcessEngineTes
   @Deployment
   public void testEventSubprocessErrorCancel() {
     ProcessInstance processInstance = startProcess();
-
-    assertTrue(processInstance.isEnded());
+    runtimeService.correlateMessage("continue");
+    assertProcessEnded(processInstance.getId());
 
     List<HistoricActivityInstance> allInstances = getAllActivityInstances();
 
@@ -307,8 +308,8 @@ public class HistoricActivityInstanceStateTest extends PluggableProcessEngineTes
   @Deployment
   public void testEventSubprocessSignalCancel() {
     ProcessInstance processInstance = startProcess();
-
-    assertTrue(processInstance.isEnded());
+    runtimeService.correlateMessage("continue");
+    assertProcessEnded(processInstance.getId());
 
     List<HistoricActivityInstance> allInstances = getAllActivityInstances();
 
@@ -328,8 +329,8 @@ public class HistoricActivityInstanceStateTest extends PluggableProcessEngineTes
   @Deployment
   public void testEndTerminateEventCancel() {
     ProcessInstance processInstance = startProcess();
-
-    assertTrue(processInstance.isEnded());
+    runtimeService.correlateMessage("continue");
+    assertProcessEnded(processInstance.getId());
 
     List<HistoricActivityInstance> allInstances = getAllActivityInstances();
 
@@ -344,8 +345,8 @@ public class HistoricActivityInstanceStateTest extends PluggableProcessEngineTes
   @Deployment
   public void testEndTerminateEventCancelInSubprocess() {
     ProcessInstance processInstance = startProcess();
-
-    assertTrue(processInstance.isEnded());
+    runtimeService.correlateMessage("continue");
+    assertProcessEnded(processInstance.getId());
 
     List<HistoricActivityInstance> allInstances = getAllActivityInstances();
 
@@ -366,8 +367,8 @@ public class HistoricActivityInstanceStateTest extends PluggableProcessEngineTes
   @Deployment
   public void testEndTerminateEventCancelWithSubprocess() {
     ProcessInstance processInstance = startProcess();
-
-    assertTrue(processInstance.isEnded());
+    runtimeService.correlateMessage("continue");
+    assertProcessEnded(processInstance.getId());
 
     List<HistoricActivityInstance> allInstances = getAllActivityInstances();
 
@@ -386,8 +387,8 @@ public class HistoricActivityInstanceStateTest extends PluggableProcessEngineTes
       "org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.testEndTerminateEventWithCallActivity.bpmn" })
   public void testEndTerminateEventCancelWithCallActivity() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process1");
-
-    assertTrue(processInstance.isEnded());
+    runtimeService.correlateMessage("continue");
+    assertProcessEnded(processInstance.getId());
 
     List<HistoricActivityInstance> allInstances = getAllActivityInstances();
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/pvm/PvmEventTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/pvm/PvmEventTest.java
@@ -18,7 +18,6 @@ import java.util.List;
 
 import org.camunda.bpm.engine.impl.cmd.FoxDeleteProcessInstanceCmd;
 import org.camunda.bpm.engine.impl.pvm.ProcessDefinitionBuilder;
-import org.camunda.bpm.engine.impl.pvm.PvmExecution;
 import org.camunda.bpm.engine.impl.pvm.PvmProcessDefinition;
 import org.camunda.bpm.engine.impl.pvm.PvmProcessInstance;
 import org.camunda.bpm.engine.impl.pvm.runtime.ExecutionImpl;
@@ -212,11 +211,11 @@ public class PvmEventTest extends PvmTestCase {
     expectedEvents.add("end on Activity(start)");
     expectedEvents.add("start on Activity(fork)");
     expectedEvents.add("end on Activity(fork)");
-    expectedEvents.add("start on Activity(c1)");
-    expectedEvents.add("end on Activity(c1)");
-    expectedEvents.add("start on Activity(join)");
     expectedEvents.add("start on Activity(c2)");
     expectedEvents.add("end on Activity(c2)");
+    expectedEvents.add("start on Activity(join)");
+    expectedEvents.add("start on Activity(c1)");
+    expectedEvents.add("end on Activity(c1)");
     expectedEvents.add("start on Activity(join)");
     expectedEvents.add("end on Activity(join)");
     expectedEvents.add("end on Activity(join)");

--- a/engine/src/test/java/org/camunda/bpm/engine/test/pvm/PvmParallelEndTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/pvm/PvmParallelEndTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,11 +31,11 @@ public class PvmParallelEndTest extends PvmTestCase {
    *                   +----+
    *              +--->|end1|
    *              |    +----+
-   *              |        
-   * +-----+   +----+      
-   * |start|-->|fork|      
-   * +-----+   +----+      
-   *              |        
+   *              |
+   * +-----+   +----+
+   * |start|-->|fork|
+   * +-----+   +----+
+   *              |
    *              |    +----+
    *              +--->|end2|
    *                   +----+
@@ -59,10 +59,10 @@ public class PvmParallelEndTest extends PvmTestCase {
         .behavior(new End())
       .endActivity()
     .buildProcessDefinition();
-    
-    PvmProcessInstance processInstance = processDefinition.createProcessInstance(); 
+
+    PvmProcessInstance processInstance = processDefinition.createProcessInstance();
     processInstance.start();
-    
+
     assertTrue(processInstance.isEnded());
   }
 }

--- a/engine/src/test/resources/camunda.cfg.xml
+++ b/engine/src/test/resources/camunda.cfg.xml
@@ -22,6 +22,8 @@
     <!-- job executor configurations -->
     <property name="jobExecutorActivate" value="false" />
 
+    <property name="bpmnStacktraceVerbose" value="false" />
+
     <!-- turn off metrics reporter -->
     <property name="dbMetricsReporterActivate" value="false" />
 

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/gateway/ExclusiveGatewayTest.testLoopWithManyIterations.bpmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/gateway/ExclusiveGatewayTest.testLoopWithManyIterations.bpmn
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:camunda="http://activiti.org/bpmn" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_-6sYICPyEeW8tp4uY6NXtg" exporter="camunda modeler" exporterVersion="2.7.0" targetNamespace="http://activiti.org/bpmn">
+  <bpmn2:process id="testProcess" isExecutable="true">
+    <bpmn2:exclusiveGateway id="ExclusiveGateway_1">
+      <bpmn2:incoming>SequenceFlow_5</bpmn2:incoming>
+      <bpmn2:incoming>SequenceFlow_6</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
+    </bpmn2:exclusiveGateway>
+    <bpmn2:scriptTask id="ManualTask_1" camunda:resultVariable="i" name="i++" scriptFormat="juel">
+      <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_3</bpmn2:outgoing>
+      <bpmn2:script>${i+1}</bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_2" name="" sourceRef="ExclusiveGateway_1" targetRef="ManualTask_1"/>
+    <bpmn2:exclusiveGateway id="ExclusiveGateway_2" default="SequenceFlow_4">
+      <bpmn2:incoming>SequenceFlow_3</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_4</bpmn2:outgoing>
+      <bpmn2:outgoing>SequenceFlow_5</bpmn2:outgoing>
+    </bpmn2:exclusiveGateway>
+    <bpmn2:sequenceFlow id="SequenceFlow_3" name="" sourceRef="ManualTask_1" targetRef="ExclusiveGateway_2"/>
+    <bpmn2:endEvent id="EndEvent_1">
+      <bpmn2:incoming>SequenceFlow_4</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_4" name="" sourceRef="ExclusiveGateway_2" targetRef="EndEvent_1"/>
+    <bpmn2:sequenceFlow id="SequenceFlow_5" name="" sourceRef="ExclusiveGateway_2" targetRef="ExclusiveGateway_1">
+      <bpmn2:conditionExpression xsi:type="bpmn2:tFormalExpression"><![CDATA[${i <= numOfIterations}]]></bpmn2:conditionExpression>
+    </bpmn2:sequenceFlow>
+    <bpmn2:scriptTask id="ScriptTask_1" camunda:resultVariable="i" name="i = 0" scriptFormat="juel">
+      <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_6</bpmn2:outgoing>
+      <bpmn2:script>0</bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_6" name="" sourceRef="ScriptTask_1" targetRef="ExclusiveGateway_1"/>
+    <bpmn2:startEvent id="StartEvent_1">
+      <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_1" name="" sourceRef="StartEvent_1" targetRef="ScriptTask_1"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="testProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="96.0" y="282.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="0.0" width="0.0" x="114.0" y="323.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_ExclusiveGateway_2" bpmnElement="ExclusiveGateway_1" isMarkerVisible="true">
+        <dc:Bounds height="50.0" width="50.0" x="332.0" y="275.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="_BPMNShape_StartEvent_2" targetElement="_BPMNShape_ScriptTask_2">
+        <di:waypoint xsi:type="dc:Point" x="132.0" y="300.0"/>
+        <di:waypoint xsi:type="dc:Point" x="183.0" y="300.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="6.0" width="6.0" x="131.0" y="300.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_2" bpmnElement="ManualTask_1">
+        <dc:Bounds height="80.0" width="100.0" x="432.0" y="260.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="_BPMNShape_ExclusiveGateway_2" targetElement="_BPMNShape_ManualTask_2">
+        <di:waypoint xsi:type="dc:Point" x="382.0" y="300.0"/>
+        <di:waypoint xsi:type="dc:Point" x="432.0" y="300.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ExclusiveGateway_3" bpmnElement="ExclusiveGateway_2" isMarkerVisible="true">
+        <dc:Bounds height="50.0" width="50.0" x="582.0" y="275.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_3" bpmnElement="SequenceFlow_3" sourceElement="_BPMNShape_ManualTask_2" targetElement="_BPMNShape_ExclusiveGateway_3">
+        <di:waypoint xsi:type="dc:Point" x="532.0" y="300.0"/>
+        <di:waypoint xsi:type="dc:Point" x="582.0" y="300.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_EndEvent_2" bpmnElement="EndEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="682.0" y="282.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_4" bpmnElement="SequenceFlow_4" sourceElement="_BPMNShape_ExclusiveGateway_3" targetElement="_BPMNShape_EndEvent_2">
+        <di:waypoint xsi:type="dc:Point" x="632.0" y="300.0"/>
+        <di:waypoint xsi:type="dc:Point" x="682.0" y="300.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_5" bpmnElement="SequenceFlow_5" sourceElement="_BPMNShape_ExclusiveGateway_3" targetElement="_BPMNShape_ExclusiveGateway_2">
+        <di:waypoint xsi:type="dc:Point" x="607.0" y="325.0"/>
+        <di:waypoint xsi:type="dc:Point" x="607.0" y="415.0"/>
+        <di:waypoint xsi:type="dc:Point" x="357.0" y="415.0"/>
+        <di:waypoint xsi:type="dc:Point" x="357.0" y="325.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="6.0" width="6.0" x="594.0" y="415.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ScriptTask_2" bpmnElement="ScriptTask_1">
+        <dc:Bounds height="80.0" width="100.0" x="183.0" y="260.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_6" bpmnElement="SequenceFlow_6" sourceElement="_BPMNShape_ScriptTask_2" targetElement="_BPMNShape_ExclusiveGateway_2">
+        <di:waypoint xsi:type="dc:Point" x="283.0" y="300.0"/>
+        <di:waypoint xsi:type="dc:Point" x="332.0" y="300.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.testBoundaryErrorCancel.bpmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.testBoundaryErrorCancel.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_YuW_kHhpEeOIo7MT9hPoCg" targetNamespace="http://camunda.org/schema/1.0/bpmn">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_YuW_kHhpEeOIo7MT9hPoCg" exporter="camunda modeler" exporterVersion="2.7.0" targetNamespace="http://camunda.org/schema/1.0/bpmn">
   <bpmn2:process id="process" isExecutable="true">
     <bpmn2:endEvent id="endAfterBoundary">
       <bpmn2:incoming>SequenceFlow_7</bpmn2:incoming>
@@ -22,14 +22,20 @@
       </bpmn2:parallelGateway>
       <bpmn2:sequenceFlow id="SequenceFlow_6" name="" sourceRef="subprocessStart" targetRef="gtw"/>
       <bpmn2:sequenceFlow id="SequenceFlow_8" name="" sourceRef="gtw" targetRef="userTask"/>
-      <bpmn2:sequenceFlow id="SequenceFlow_10" name="" sourceRef="gtw" targetRef="errorSubprocessEnd"/>
+      <bpmn2:sequenceFlow id="SequenceFlow_10" name="" sourceRef="gtw" targetRef="IntermediateCatchEvent_1"/>
       <bpmn2:endEvent id="errorSubprocessEnd">
-        <bpmn2:incoming>SequenceFlow_10</bpmn2:incoming>
+        <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
         <bpmn2:errorEventDefinition id="_ErrorEventDefinition_2" errorRef="Error_1"/>
       </bpmn2:endEvent>
       <bpmn2:userTask id="userTask">
         <bpmn2:incoming>SequenceFlow_8</bpmn2:incoming>
       </bpmn2:userTask>
+      <bpmn2:intermediateCatchEvent id="IntermediateCatchEvent_1">
+        <bpmn2:incoming>SequenceFlow_10</bpmn2:incoming>
+        <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
+        <bpmn2:messageEventDefinition id="_MessageEventDefinition_3" messageRef="Message_1"/>
+      </bpmn2:intermediateCatchEvent>
+      <bpmn2:sequenceFlow id="SequenceFlow_1" name="" sourceRef="IntermediateCatchEvent_1" targetRef="errorSubprocessEnd"/>
     </bpmn2:subProcess>
     <bpmn2:sequenceFlow id="SequenceFlow_9" name="" sourceRef="subprocess" targetRef="end"/>
     <bpmn2:startEvent id="start">
@@ -41,6 +47,7 @@
     </bpmn2:endEvent>
   </bpmn2:process>
   <bpmn2:error id="Error_1" errorCode="100" name="error"/>
+  <bpmn2:message id="Message_1" name="continue"/>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
@@ -123,14 +130,23 @@
           <dc:Bounds height="6.0" width="6.0" x="509.0" y="152.0"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_10" bpmnElement="SequenceFlow_10" sourceElement="_BPMNShape_ParallelGateway_2" targetElement="_BPMNShape_EndEvent_5">
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_10" bpmnElement="SequenceFlow_10" sourceElement="_BPMNShape_ParallelGateway_2" targetElement="_BPMNShape_IntermediateCatchEvent_3">
         <di:waypoint xsi:type="dc:Point" x="472.0" y="180.0"/>
-        <di:waypoint xsi:type="dc:Point" x="554.0" y="180.0"/>
-        <di:waypoint xsi:type="dc:Point" x="554.0" y="209.0"/>
-        <di:waypoint xsi:type="dc:Point" x="648.0" y="210.0"/>
+        <di:waypoint xsi:type="dc:Point" x="504.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="504.0" y="206.0"/>
+        <di:waypoint xsi:type="dc:Point" x="536.0" y="206.0"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="6.0" width="6.0" x="551.0" y="195.0"/>
+          <dc:Bounds height="6.0" width="6.0" x="501.0" y="181.0"/>
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_3" bpmnElement="IntermediateCatchEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="536.0" y="188.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="_BPMNShape_IntermediateCatchEvent_3" targetElement="_BPMNShape_EndEvent_5">
+        <di:waypoint xsi:type="dc:Point" x="572.0" y="206.0"/>
+        <di:waypoint xsi:type="dc:Point" x="610.0" y="206.0"/>
+        <di:waypoint xsi:type="dc:Point" x="610.0" y="210.0"/>
+        <di:waypoint xsi:type="dc:Point" x="648.0" y="210.0"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.testEndTerminateEventCancel.bpmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.testEndTerminateEventCancel.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_I-CDQINSEeONV-WZeb9wPQ" targetNamespace="http://camunda.org/schema/1.0/bpmn">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_I-CDQINSEeONV-WZeb9wPQ" exporter="camunda modeler" exporterVersion="2.7.0" targetNamespace="http://camunda.org/schema/1.0/bpmn">
   <bpmn2:process id="process" isExecutable="true">
     <bpmn2:startEvent id="start">
       <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
@@ -11,11 +11,7 @@
     </bpmn2:parallelGateway>
     <bpmn2:sequenceFlow id="SequenceFlow_1" name="" sourceRef="start" targetRef="gtw"/>
     <bpmn2:sequenceFlow id="SequenceFlow_2" name="" sourceRef="gtw" targetRef="userTask"/>
-    <bpmn2:sequenceFlow id="SequenceFlow_4" name="" sourceRef="gtw" targetRef="terminateEnd"/>
-    <bpmn2:endEvent id="terminateEnd">
-      <bpmn2:incoming>SequenceFlow_4</bpmn2:incoming>
-      <bpmn2:terminateEventDefinition id="_TerminateEventDefinition_2"/>
-    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_4" name="" sourceRef="gtw" targetRef="IntermediateCatchEvent_1"/>
     <bpmn2:userTask id="userTask">
       <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
       <bpmn2:outgoing>SequenceFlow_3</bpmn2:outgoing>
@@ -24,7 +20,18 @@
     <bpmn2:endEvent id="end">
       <bpmn2:incoming>SequenceFlow_3</bpmn2:incoming>
     </bpmn2:endEvent>
+    <bpmn2:endEvent id="terminateEnd">
+      <bpmn2:incoming>SequenceFlow_5</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_TerminateEventDefinition_2"/>
+    </bpmn2:endEvent>
+    <bpmn2:intermediateCatchEvent id="IntermediateCatchEvent_1">
+      <bpmn2:incoming>SequenceFlow_4</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_5</bpmn2:outgoing>
+      <bpmn2:messageEventDefinition id="_MessageEventDefinition_5" messageRef="Message_1"/>
+    </bpmn2:intermediateCatchEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_5" name="" sourceRef="IntermediateCatchEvent_1" targetRef="terminateEnd"/>
   </bpmn2:process>
+  <bpmn2:message id="Message_1" name="continue"/>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_5" bpmnElement="start">
@@ -62,19 +69,25 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_EndEvent_9" bpmnElement="terminateEnd">
-        <dc:Bounds height="36.0" width="36.0" x="444.0" y="348.0"/>
+        <dc:Bounds height="36.0" width="36.0" x="576.0" y="352.0"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="0.0" width="0.0" x="462.0" y="389.0"/>
+          <dc:Bounds height="0.0" width="0.0" x="594.0" y="393.0"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_4" bpmnElement="SequenceFlow_4" sourceElement="_BPMNShape_ExclusiveGateway_2" targetElement="_BPMNShape_EndEvent_9">
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_4" bpmnElement="SequenceFlow_4" sourceElement="_BPMNShape_ExclusiveGateway_2" targetElement="_BPMNShape_IntermediateCatchEvent_5">
         <di:waypoint xsi:type="dc:Point" x="352.0" y="327.0"/>
-        <di:waypoint xsi:type="dc:Point" x="352.0" y="366.0"/>
-        <di:waypoint xsi:type="dc:Point" x="410.0" y="366.0"/>
-        <di:waypoint xsi:type="dc:Point" x="444.0" y="366.0"/>
+        <di:waypoint xsi:type="dc:Point" x="352.0" y="370.0"/>
+        <di:waypoint xsi:type="dc:Point" x="429.0" y="370.0"/>
         <bpmndi:BPMNLabel>
           <dc:Bounds height="6.0" width="6.0" x="349.0" y="352.0"/>
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_5" bpmnElement="IntermediateCatchEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="429.0" y="352.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_5" bpmnElement="SequenceFlow_5" sourceElement="_BPMNShape_IntermediateCatchEvent_5" targetElement="_BPMNShape_EndEvent_9">
+        <di:waypoint xsi:type="dc:Point" x="465.0" y="370.0"/>
+        <di:waypoint xsi:type="dc:Point" x="576.0" y="370.0"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.testEndTerminateEventCancelInSubprocess.bpmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.testEndTerminateEventCancelInSubprocess.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_I-CDQINSEeONV-WZeb9wPQ" targetNamespace="http://camunda.org/schema/1.0/bpmn">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_I-CDQINSEeONV-WZeb9wPQ" exporter="camunda modeler" exporterVersion="2.7.0" targetNamespace="http://camunda.org/schema/1.0/bpmn">
   <bpmn2:process id="process" isExecutable="true">
     <bpmn2:subProcess id="subprocess">
       <bpmn2:incoming>SequenceFlow_6</bpmn2:incoming>
@@ -15,18 +15,24 @@
         <bpmn2:outgoing>SequenceFlow_4</bpmn2:outgoing>
       </bpmn2:parallelGateway>
       <bpmn2:sequenceFlow id="SequenceFlow_2" name="" sourceRef="gtw" targetRef="userTask"/>
-      <bpmn2:sequenceFlow id="SequenceFlow_4" name="" sourceRef="gtw" targetRef="terminateEnd"/>
+      <bpmn2:sequenceFlow id="SequenceFlow_4" name="" sourceRef="gtw" targetRef="IntermediateCatchEvent_1"/>
       <bpmn2:startEvent id="subprocessStart">
         <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
       </bpmn2:startEvent>
       <bpmn2:sequenceFlow id="SequenceFlow_1" name="" sourceRef="subprocessStart" targetRef="gtw"/>
       <bpmn2:endEvent id="terminateEnd">
-        <bpmn2:incoming>SequenceFlow_4</bpmn2:incoming>
+        <bpmn2:incoming>SequenceFlow_5</bpmn2:incoming>
         <bpmn2:terminateEventDefinition id="_TerminateEventDefinition_2"/>
       </bpmn2:endEvent>
       <bpmn2:endEvent id="subprocessEnd">
         <bpmn2:incoming>SequenceFlow_3</bpmn2:incoming>
       </bpmn2:endEvent>
+      <bpmn2:intermediateCatchEvent id="IntermediateCatchEvent_1">
+        <bpmn2:incoming>SequenceFlow_4</bpmn2:incoming>
+        <bpmn2:outgoing>SequenceFlow_5</bpmn2:outgoing>
+        <bpmn2:messageEventDefinition id="_MessageEventDefinition_8" messageRef="Message_1"/>
+      </bpmn2:intermediateCatchEvent>
+      <bpmn2:sequenceFlow id="SequenceFlow_5" name="" sourceRef="IntermediateCatchEvent_1" targetRef="terminateEnd"/>
     </bpmn2:subProcess>
     <bpmn2:sequenceFlow id="sequenceFlow" name="" sourceRef="subprocess" targetRef="end"/>
     <bpmn2:startEvent id="start">
@@ -37,6 +43,7 @@
       <bpmn2:incoming>sequenceFlow</bpmn2:incoming>
     </bpmn2:endEvent>
   </bpmn2:process>
+  <bpmn2:message id="Message_1" name="continue"/>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_5" bpmnElement="subprocessStart">
@@ -88,13 +95,13 @@
           <dc:Bounds height="0.0" width="0.0" x="630.0" y="355.0"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_4" bpmnElement="SequenceFlow_4" sourceElement="_BPMNShape_ExclusiveGateway_2" targetElement="_BPMNShape_EndEvent_9">
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_4" bpmnElement="SequenceFlow_4" sourceElement="_BPMNShape_ExclusiveGateway_2" targetElement="_BPMNShape_IntermediateCatchEvent_8">
         <di:waypoint xsi:type="dc:Point" x="520.0" y="293.0"/>
-        <di:waypoint xsi:type="dc:Point" x="520.0" y="332.0"/>
-        <di:waypoint xsi:type="dc:Point" x="578.0" y="332.0"/>
-        <di:waypoint xsi:type="dc:Point" x="612.0" y="332.0"/>
+        <di:waypoint xsi:type="dc:Point" x="520.0" y="303.0"/>
+        <di:waypoint xsi:type="dc:Point" x="547.0" y="303.0"/>
+        <di:waypoint xsi:type="dc:Point" x="547.0" y="314.0"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="6.0" width="6.0" x="517.0" y="318.0"/>
+          <dc:Bounds height="6.0" width="6.0" x="519.0" y="303.0"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_SubProcess_4" bpmnElement="subprocess" isExpanded="true">
@@ -125,6 +132,14 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds height="6.0" width="6.0" x="352.0" y="258.0"/>
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_8" bpmnElement="IntermediateCatchEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="529.0" y="314.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_7" bpmnElement="SequenceFlow_5" sourceElement="_BPMNShape_IntermediateCatchEvent_8" targetElement="_BPMNShape_EndEvent_9">
+        <di:waypoint xsi:type="dc:Point" x="565.0" y="332.0"/>
+        <di:waypoint xsi:type="dc:Point" x="578.0" y="332.0"/>
+        <di:waypoint xsi:type="dc:Point" x="612.0" y="332.0"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.testEndTerminateEventCancelWithSubprocess.bpmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.testEndTerminateEventCancelWithSubprocess.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_I-CDQINSEeONV-WZeb9wPQ" targetNamespace="http://camunda.org/schema/1.0/bpmn">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_I-CDQINSEeONV-WZeb9wPQ" exporter="camunda modeler" exporterVersion="2.7.0" targetNamespace="http://camunda.org/schema/1.0/bpmn">
   <bpmn2:process id="process" isExecutable="true">
     <bpmn2:subProcess id="subprocess">
       <bpmn2:incoming>SequenceFlow_7</bpmn2:incoming>
@@ -22,7 +22,7 @@
     </bpmn2:endEvent>
     <bpmn2:sequenceFlow id="SequenceFlow_12" name="" sourceRef="subprocess" targetRef="end"/>
     <bpmn2:endEvent id="terminateEnd">
-      <bpmn2:incoming>SequenceFlow_11</bpmn2:incoming>
+      <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
       <bpmn2:terminateEventDefinition id="_TerminateEventDefinition_3"/>
     </bpmn2:endEvent>
     <bpmn2:parallelGateway id="gtw">
@@ -31,12 +31,19 @@
       <bpmn2:outgoing>SequenceFlow_11</bpmn2:outgoing>
     </bpmn2:parallelGateway>
     <bpmn2:sequenceFlow id="SequenceFlow_7" name="" sourceRef="gtw" targetRef="subprocess"/>
-    <bpmn2:sequenceFlow id="SequenceFlow_11" name="" sourceRef="gtw" targetRef="terminateEnd"/>
+    <bpmn2:sequenceFlow id="SequenceFlow_11" name="" sourceRef="gtw" targetRef="IntermediateCatchEvent_1"/>
     <bpmn2:startEvent id="start">
       <bpmn2:outgoing>SequenceFlow_5</bpmn2:outgoing>
     </bpmn2:startEvent>
     <bpmn2:sequenceFlow id="SequenceFlow_5" name="" sourceRef="start" targetRef="gtw"/>
+    <bpmn2:intermediateCatchEvent id="IntermediateCatchEvent_1">
+      <bpmn2:incoming>SequenceFlow_11</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
+      <bpmn2:messageEventDefinition id="_MessageEventDefinition_4" messageRef="Message_1"/>
+    </bpmn2:intermediateCatchEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_1" name="" sourceRef="IntermediateCatchEvent_1" targetRef="terminateEnd"/>
   </bpmn2:process>
+  <bpmn2:message id="Message_1" name="continue"/>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
       <bpmndi:BPMNShape id="_BPMNShape_EndEvent_10" bpmnElement="terminateEnd">
@@ -105,12 +112,12 @@
           <dc:Bounds height="6.0" width="6.0" x="652.0" y="124.0"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_12" bpmnElement="SequenceFlow_11" sourceElement="_BPMNShape_ParallelGateway_4" targetElement="_BPMNShape_EndEvent_10">
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_12" bpmnElement="SequenceFlow_11" sourceElement="_BPMNShape_ParallelGateway_4" targetElement="_BPMNShape_IntermediateCatchEvent_4">
         <di:waypoint xsi:type="dc:Point" x="337.0" y="247.0"/>
         <di:waypoint xsi:type="dc:Point" x="337.0" y="293.0"/>
-        <di:waypoint xsi:type="dc:Point" x="559.0" y="293.0"/>
+        <di:waypoint xsi:type="dc:Point" x="423.0" y="293.0"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="6.0" width="6.0" x="424.0" y="293.0"/>
+          <dc:Bounds height="6.0" width="6.0" x="354.0" y="293.0"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_EndEvent_12" bpmnElement="end">
@@ -119,6 +126,13 @@
       <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_13" bpmnElement="SequenceFlow_12" sourceElement="_BPMNShape_SubProcess_5" targetElement="_BPMNShape_EndEvent_12">
         <di:waypoint xsi:type="dc:Point" x="744.0" y="123.0"/>
         <di:waypoint xsi:type="dc:Point" x="795.0" y="123.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_4" bpmnElement="IntermediateCatchEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="423.0" y="275.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="_BPMNShape_IntermediateCatchEvent_4" targetElement="_BPMNShape_EndEvent_10">
+        <di:waypoint xsi:type="dc:Point" x="459.0" y="293.0"/>
+        <di:waypoint xsi:type="dc:Point" x="559.0" y="293.0"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.testEndTerminateEventWithCallActivity.bpmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.testEndTerminateEventWithCallActivity.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_D7uMsINiEeOQe9eRV-5Giw" targetNamespace="http://camunda.org/schema/1.0/bpmn">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_D7uMsINiEeOQe9eRV-5Giw" exporter="camunda modeler" exporterVersion="2.7.0" targetNamespace="http://camunda.org/schema/1.0/bpmn">
   <bpmn2:process id="process1" isExecutable="true">
     <bpmn2:startEvent id="start">
       <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
@@ -19,12 +19,19 @@
       <bpmn2:incoming>SequenceFlow_3</bpmn2:incoming>
     </bpmn2:endEvent>
     <bpmn2:sequenceFlow id="SequenceFlow_3" name="" sourceRef="callActivity" targetRef="end"/>
-    <bpmn2:sequenceFlow id="SequenceFlow_4" name="" sourceRef="ParallelGateway_1" targetRef="terminateEnd"/>
+    <bpmn2:sequenceFlow id="SequenceFlow_4" name="" sourceRef="ParallelGateway_1" targetRef="IntermediateCatchEvent_1"/>
     <bpmn2:endEvent id="terminateEnd">
-      <bpmn2:incoming>SequenceFlow_4</bpmn2:incoming>
+      <bpmn2:incoming>SequenceFlow_5</bpmn2:incoming>
       <bpmn2:terminateEventDefinition id="_TerminateEventDefinition_4"/>
     </bpmn2:endEvent>
+    <bpmn2:intermediateCatchEvent id="IntermediateCatchEvent_1" name="wait">
+      <bpmn2:incoming>SequenceFlow_4</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_5</bpmn2:outgoing>
+      <bpmn2:messageEventDefinition id="_MessageEventDefinition_2" messageRef="Message_1"/>
+    </bpmn2:intermediateCatchEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_5" name="" sourceRef="IntermediateCatchEvent_1" targetRef="terminateEnd"/>
   </bpmn2:process>
+  <bpmn2:message id="Message_1" name="continue"/>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process1">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_13" bpmnElement="start">
@@ -56,18 +63,25 @@
         <di:waypoint xsi:type="dc:Point" x="534.0" y="160.0"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_EndEvent_20" bpmnElement="terminateEnd">
-        <dc:Bounds height="36.0" width="36.0" x="416.0" y="314.0"/>
+        <dc:Bounds height="36.0" width="36.0" x="491.0" y="314.0"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="0.0" width="0.0" x="434.0" y="355.0"/>
+          <dc:Bounds height="0.0" width="0.0" x="509.0" y="355.0"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_4" bpmnElement="SequenceFlow_4" sourceElement="_BPMNShape_ParallelGateway_6" targetElement="_BPMNShape_EndEvent_20">
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_4" bpmnElement="SequenceFlow_4" sourceElement="_BPMNShape_ParallelGateway_6" targetElement="_BPMNShape_IntermediateCatchEvent_2">
         <di:waypoint xsi:type="dc:Point" x="307.0" y="285.0"/>
         <di:waypoint xsi:type="dc:Point" x="308.0" y="332.0"/>
-        <di:waypoint xsi:type="dc:Point" x="416.0" y="332.0"/>
+        <di:waypoint xsi:type="dc:Point" x="369.0" y="332.0"/>
         <bpmndi:BPMNLabel>
           <dc:Bounds height="6.0" width="6.0" x="305.0" y="310.0"/>
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_2" bpmnElement="IntermediateCatchEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="369.0" y="314.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_5" bpmnElement="SequenceFlow_5" sourceElement="_BPMNShape_IntermediateCatchEvent_2" targetElement="_BPMNShape_EndEvent_20">
+        <di:waypoint xsi:type="dc:Point" x="405.0" y="332.0"/>
+        <di:waypoint xsi:type="dc:Point" x="491.0" y="332.0"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.testEventSubprocessErrorCancel.bpmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.testEventSubprocessErrorCancel.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_YuW_kHhpEeOIo7MT9hPoCg" targetNamespace="http://camunda.org/schema/1.0/bpmn">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_YuW_kHhpEeOIo7MT9hPoCg" exporter="camunda modeler" exporterVersion="2.7.0" targetNamespace="http://camunda.org/schema/1.0/bpmn">
   <bpmn2:process id="process" isExecutable="true">
     <bpmn2:startEvent id="start">
       <bpmn2:outgoing>SequenceFlow_3</bpmn2:outgoing>
@@ -15,9 +15,9 @@
       <bpmn2:outgoing>SequenceFlow_5</bpmn2:outgoing>
     </bpmn2:parallelGateway>
     <bpmn2:sequenceFlow id="SequenceFlow_4" name="" sourceRef="gtw" targetRef="userTask"/>
-    <bpmn2:sequenceFlow id="SequenceFlow_5" name="" sourceRef="gtw" targetRef="errorEnd"/>
+    <bpmn2:sequenceFlow id="SequenceFlow_5" name="" sourceRef="gtw" targetRef="IntermediateCatchEvent_1"/>
     <bpmn2:endEvent id="errorEnd">
-      <bpmn2:incoming>SequenceFlow_5</bpmn2:incoming>
+      <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
       <bpmn2:errorEventDefinition id="_ErrorEventDefinition_3" errorRef="Error_1"/>
     </bpmn2:endEvent>
     <bpmn2:subProcess id="eventSubprocess" triggeredByEvent="true">
@@ -34,8 +34,15 @@
       <bpmn2:incoming>SequenceFlow_12</bpmn2:incoming>
     </bpmn2:endEvent>
     <bpmn2:sequenceFlow id="SequenceFlow_12" name="" sourceRef="userTask" targetRef="end"/>
+    <bpmn2:intermediateCatchEvent id="IntermediateCatchEvent_1">
+      <bpmn2:incoming>SequenceFlow_5</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
+      <bpmn2:messageEventDefinition id="_MessageEventDefinition_7" messageRef="Message_1"/>
+    </bpmn2:intermediateCatchEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_1" name="" sourceRef="IntermediateCatchEvent_1" targetRef="errorEnd"/>
   </bpmn2:process>
   <bpmn2:error id="Error_1" errorCode="100" name="error"/>
+  <bpmn2:message id="Message_1" name="continue"/>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
@@ -84,12 +91,13 @@
           <dc:Bounds height="0.0" width="0.0" x="378.0" y="245.0"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_5" bpmnElement="SequenceFlow_5" sourceElement="_BPMNShape_ParallelGateway_3" targetElement="_BPMNShape_EndEvent_6">
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_5" bpmnElement="SequenceFlow_5" sourceElement="_BPMNShape_ParallelGateway_3" targetElement="_BPMNShape_IntermediateCatchEvent_7">
         <di:waypoint xsi:type="dc:Point" x="253.0" y="151.0"/>
-        <di:waypoint xsi:type="dc:Point" x="253.0" y="222.0"/>
-        <di:waypoint xsi:type="dc:Point" x="360.0" y="222.0"/>
+        <di:waypoint xsi:type="dc:Point" x="253.0" y="177.0"/>
+        <di:waypoint xsi:type="dc:Point" x="271.0" y="177.0"/>
+        <di:waypoint xsi:type="dc:Point" x="271.0" y="204.0"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="6.0" width="6.0" x="254.0" y="222.0"/>
+          <dc:Bounds height="6.0" width="6.0" x="251.0" y="177.0"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_4" bpmnElement="eventSubprocessStart">
@@ -114,6 +122,13 @@
       <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_12" bpmnElement="SequenceFlow_12" sourceElement="_BPMNShape_UserTask_5" targetElement="_BPMNShape_EndEvent_4">
         <di:waypoint xsi:type="dc:Point" x="448.0" y="87.0"/>
         <di:waypoint xsi:type="dc:Point" x="528.0" y="87.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_7" bpmnElement="IntermediateCatchEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="253.0" y="204.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="_BPMNShape_IntermediateCatchEvent_7" targetElement="_BPMNShape_EndEvent_6">
+        <di:waypoint xsi:type="dc:Point" x="289.0" y="222.0"/>
+        <di:waypoint xsi:type="dc:Point" x="360.0" y="222.0"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.testEventSubprocessSignalCancel.bpmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceStateTest.testEventSubprocessSignalCancel.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_YuW_kHhpEeOIo7MT9hPoCg" targetNamespace="http://camunda.org/schema/1.0/bpmn">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_YuW_kHhpEeOIo7MT9hPoCg" exporter="camunda modeler" exporterVersion="2.7.0" targetNamespace="http://camunda.org/schema/1.0/bpmn">
   <bpmn2:process id="process" isExecutable="true">
     <bpmn2:startEvent id="start">
       <bpmn2:outgoing>SequenceFlow_3</bpmn2:outgoing>
@@ -15,9 +15,9 @@
       <bpmn2:outgoing>SequenceFlow_5</bpmn2:outgoing>
     </bpmn2:parallelGateway>
     <bpmn2:sequenceFlow id="SequenceFlow_4" name="" sourceRef="gtw" targetRef="userTask"/>
-    <bpmn2:sequenceFlow id="SequenceFlow_5" name="" sourceRef="gtw" targetRef="signalEnd"/>
+    <bpmn2:sequenceFlow id="SequenceFlow_5" name="" sourceRef="gtw" targetRef="IntermediateCatchEvent_1"/>
     <bpmn2:endEvent id="signalEnd">
-      <bpmn2:incoming>SequenceFlow_5</bpmn2:incoming>
+      <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
       <bpmn2:signalEventDefinition id="_ErrorEventDefinition_3" signalRef="Signal_1"/>
     </bpmn2:endEvent>
     <bpmn2:subProcess id="eventSubprocess" triggeredByEvent="true">
@@ -34,8 +34,15 @@
       <bpmn2:incoming>SequenceFlow_12</bpmn2:incoming>
     </bpmn2:endEvent>
     <bpmn2:sequenceFlow id="SequenceFlow_12" name="" sourceRef="userTask" targetRef="end"/>
+    <bpmn2:intermediateCatchEvent id="IntermediateCatchEvent_1">
+      <bpmn2:incoming>SequenceFlow_5</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
+      <bpmn2:messageEventDefinition id="_MessageEventDefinition_6" messageRef="Message_1"/>
+    </bpmn2:intermediateCatchEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_1" name="" sourceRef="IntermediateCatchEvent_1" targetRef="signalEnd"/>
   </bpmn2:process>
   <bpmn2:signal id="Signal_1" name="interrupt"/>
+  <bpmn2:message id="Message_1" name="continue"/>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
@@ -84,12 +91,13 @@
           <dc:Bounds height="0.0" width="0.0" x="378.0" y="245.0"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_5" bpmnElement="SequenceFlow_5" sourceElement="_BPMNShape_ParallelGateway_3" targetElement="_BPMNShape_EndEvent_6">
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_5" bpmnElement="SequenceFlow_5" sourceElement="_BPMNShape_ParallelGateway_3" targetElement="_BPMNShape_IntermediateCatchEvent_6">
         <di:waypoint xsi:type="dc:Point" x="253.0" y="151.0"/>
-        <di:waypoint xsi:type="dc:Point" x="253.0" y="222.0"/>
-        <di:waypoint xsi:type="dc:Point" x="360.0" y="222.0"/>
+        <di:waypoint xsi:type="dc:Point" x="253.0" y="177.0"/>
+        <di:waypoint xsi:type="dc:Point" x="279.0" y="177.0"/>
+        <di:waypoint xsi:type="dc:Point" x="279.0" y="204.0"/>
         <bpmndi:BPMNLabel>
-          <dc:Bounds height="6.0" width="6.0" x="254.0" y="222.0"/>
+          <dc:Bounds height="6.0" width="6.0" x="252.0" y="177.0"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_4" bpmnElement="eventSubprocessStart">
@@ -114,6 +122,13 @@
       <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_12" bpmnElement="SequenceFlow_12" sourceElement="_BPMNShape_UserTask_5" targetElement="_BPMNShape_EndEvent_4">
         <di:waypoint xsi:type="dc:Point" x="448.0" y="87.0"/>
         <di:waypoint xsi:type="dc:Point" x="528.0" y="87.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_6" bpmnElement="IntermediateCatchEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="261.0" y="204.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="_BPMNShape_IntermediateCatchEvent_6" targetElement="_BPMNShape_EndEvent_6">
+        <di:waypoint xsi:type="dc:Point" x="297.0" y="222.0"/>
+        <di:waypoint xsi:type="dc:Point" x="360.0" y="222.0"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
Before this commit atomic operations were executed recursively.
This caused the problem that if a BPMN process had many activities
that were executed sequentially, the stack grew very large until the
execution failed with a StackOverflowException.

This commit changes that behavior. It introduces an operation loop
and list of queued operations in the CommandContext.

Implementation Considerations:
- The implementation tries to change the execution oder as little as
  possible: concurrency is still depth-first, operations are executed
  in the same order as before as much as possible. This way, users
  are affected by this internal change as little as possible.

- This also means that not all atomic operations are executed
  using the loop: a majority of the operations are executed
  recursively but without growing the stack. Inuitively, operations
  "within" a given activity are executed recursively but the
  recursion is broken after the activity.

- This fixes the problem with as little impact on user code as
  possible.

fixes #CAM-4172