### PR TITLE
Fix minor error in ldap plugin test.

### DIFF
--- a/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapUserQueryTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapUserQueryTest.java
@@ -76,7 +76,7 @@ public class LdapUserQueryTest extends LdapIdentityProviderTest {
     User user = identityService.createUserQuery().userLastName("The Crouch").singleResult();
     assertNotNull(user);
 
-    user = identityService.createUserQuery().userFirstNameLike("non-existing").singleResult();
+    user = identityService.createUserQuery().userLastName("non-existing").singleResult();
     assertNull(user);
   }
 


### PR DESCRIPTION
This looks like it was originally a copy and paste error.  The change is in the `testFilterByLastname` method.