### PR TITLE
Generated getter for attributtes

### DIFF
--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/runtime/VariableInstanceQueryDto.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/runtime/VariableInstanceQueryDto.java
@@ -123,6 +123,46 @@ public class VariableInstanceQueryDto extends AbstractQueryDto<VariableInstanceQ
   protected VariableInstanceQuery createNewQuery(ProcessEngine engine) {
     return engine.getRuntimeService().createVariableInstanceQuery();
   }
+  
+  public String getVariableName() {
+		return variableName;
+	}
+
+	public String getVariableNameLike() {
+		return variableNameLike;
+	}
+
+	public List<VariableQueryParameterDto> getVariableValues() {
+		return variableValues;
+	}
+
+	public String[] getExecutionIdIn() {
+		return executionIdIn;
+	}
+
+	public String[] getProcessInstanceIdIn() {
+		return processInstanceIdIn;
+	}
+
+	public String[] getCaseExecutionIdIn() {
+		return caseExecutionIdIn;
+	}
+
+	public String[] getCaseInstanceIdIn() {
+		return caseInstanceIdIn;
+	}
+
+	public String[] getTaskIdIn() {
+		return taskIdIn;
+	}
+
+	public String[] getVariableScopeIdIn() {
+		return variableScopeIdIn;
+	}
+
+	public String[] getActivityInstanceIdIn() {
+		return activityInstanceIdIn;
+	}
 
   @Override
   protected void applyFilters(VariableInstanceQuery query) {


### PR DESCRIPTION
Getters needed for JavaBean specification, and JacksonJsonProvider needs to serialize attributes.