### PR TITLE
Fix copy and paste error in ldap plugin tests.

### DIFF
--- a/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapUserQueryTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapUserQueryTest.java
@@ -146,7 +146,7 @@ public class LdapUserQueryTest extends LdapIdentityProviderTest {
   public void testFilterByGroupIdAndEmailLike() {
     List<User> result = identityService.createUserQuery()
         .memberOfGroup("development")
-        .userEmail("*@camunda.org")
+        .userEmailLike("*@camunda.org")
         .list();
     assertEquals(3, result.size());
   }


### PR DESCRIPTION
I haven't tested this change but the test is testing the the wrong function here.  Changed it to be the correct function.