### PR TITLE
Add filter for CORS support to REST API

### DIFF
--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/filter/CorsFilter.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/filter/CorsFilter.java
@@ -1,0 +1,39 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.rest.filter;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class CorsFilter implements Filter {
+
+  public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException,
+      ServletException {
+    HttpServletResponse response = (HttpServletResponse) res;
+    response.setHeader("Access-Control-Allow-Origin", "*");
+    response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE");
+    response.setHeader("Access-Control-Max-Age", "3600");
+    response.setHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    chain.doFilter(req, res);
+  }
+
+  public void init(FilterConfig filterConfig) {
+
+  }
+
+  public void destroy() {
+
+  }
+
+}

--- a/engine-rest/src/main/runtime/tomcat/webapp/WEB-INF/web.xml
+++ b/engine-rest/src/main/runtime/tomcat/webapp/WEB-INF/web.xml
@@ -10,7 +10,16 @@
     <filter-name>CacheControlFilter</filter-name>
     <url-pattern>/*</url-pattern>
   </filter-mapping>
-  
+
+  <filter>
+    <filter-name>CorsFilter</filter-name>
+    <filter-class>org.camunda.bpm.engine.rest.filter.CorsFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>CorsFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
   <!-- Http Basic Authentication Filter -->
   <!-- <filter>
     <filter-name>camunda-auth</filter-name>

--- a/engine-rest/src/main/runtime/was/webapp/WEB-INF/web.xml
+++ b/engine-rest/src/main/runtime/was/webapp/WEB-INF/web.xml
@@ -13,6 +13,15 @@
     <filter-name>CacheControlFilter</filter-name>
     <url-pattern>/*</url-pattern>
   </filter-mapping>
+
+  <filter>
+    <filter-name>CorsFilter</filter-name>
+    <filter-class>org.camunda.bpm.engine.rest.filter.CorsFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>CorsFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
   
   <!-- Http Basic Authentication Filter -->
   <!-- <filter>

--- a/engine-rest/src/main/runtime/wls/webapp/WEB-INF/web.xml
+++ b/engine-rest/src/main/runtime/wls/webapp/WEB-INF/web.xml
@@ -13,6 +13,15 @@
     <filter-name>CacheControlFilter</filter-name>
     <url-pattern>/*</url-pattern>
   </filter-mapping>
+
+  <filter>
+    <filter-name>CorsFilter</filter-name>
+    <filter-class>org.camunda.bpm.engine.rest.filter.CorsFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>CorsFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
   
   <!-- Http Basic Authentication Filter -->
   <!-- <filter>

--- a/engine-rest/src/main/webapp/WEB-INF/web.xml
+++ b/engine-rest/src/main/webapp/WEB-INF/web.xml
@@ -13,6 +13,15 @@
     <filter-name>CacheControlFilter</filter-name>
     <url-pattern>/*</url-pattern>
   </filter-mapping>
+
+  <filter>
+    <filter-name>CorsFilter</filter-name>
+    <filter-class>org.camunda.bpm.engine.rest.filter.CorsFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>CorsFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
   
   <!-- Http Basic Authentication Filter -->
   <!-- <filter>


### PR DESCRIPTION
This adds support for CORS to the REST API so that it may be used
from within JS, for example. Solves [CAM-3510].