### PR TITLE
fix(engine): change createMembership to behave like save/create User

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/identity/db/DbIdentityServiceProvider.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/identity/db/DbIdentityServiceProvider.java
@@ -103,10 +103,12 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
 
   public void createMembership(String userId, String groupId) {
     checkAuthorization(Permissions.CREATE, Resources.GROUP_MEMBERSHIP, groupId);
-    Map<String, Object> parameters = new HashMap<String, Object>();
-    parameters.put("userId", userId);
-    parameters.put("groupId", groupId);
-    getDbSqlSession().getSqlSession().insert("insertMembership", parameters);
+    UserEntity user = findUserById(userId);
+    GroupEntity group = findGroupById(groupId);
+    MembershipEntity membership = new MembershipEntity();
+    membership.setUser(user);
+    membership.setGroup(group);
+    getDbEntityManager().insert(membership);
     createDefaultMembershipAuthorizations(userId, groupId);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/MembershipEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/MembershipEntity.java
@@ -26,17 +26,23 @@ public class MembershipEntity implements Serializable, DbEntity {
 
   protected UserEntity user;
   protected GroupEntity group;
+  
+  /** To Handle an MemberhipEntity inside the cache, a id is necessary.
+  * Even though it will not be saved inside the database
+  * */
+  protected String id;
 
   public Object getPersistentState() {
     // membership is not updatable
     return MembershipEntity.class;
   }
   public String getId() {
-    // membership doesn't have an id
-    return null;
+    // For the sake of Entity caching the id is necessary
+    return id;
   }
   public void setId(String id) {
-    // membership doesn't have an id
+    // For the sake of Entity caching the id is necessary
+    this.id = id;
   }
 
   public UserEntity getUser() {
@@ -50,6 +56,22 @@ public class MembershipEntity implements Serializable, DbEntity {
   }
   public void setGroup(GroupEntity group) {
     this.group = group;
+  }
+  
+  /**
+   * Necessary for the DB Driver due to he works with Reflection to fill the Tables
+   * @return the UserId
+   */
+  public String getUserId(){
+	  return user.getId();
+  }
+  
+  /**
+   * Necessary for the DB Driver due to he works with Reflection to fill the Tables
+   * @return the GroupId
+   */
+  public String getGroupId(){
+	  return group.getId();
   }
 
   @Override

--- a/engine/src/test/java/org/camunda/bpm/engine/test/db/identity/WriteMultipleEntitiesInOneStepTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/db/identity/WriteMultipleEntitiesInOneStepTest.java
@@ -1,0 +1,48 @@
+/**
+ *
+ */
+package org.camunda.bpm.engine.test.db.identity;
+
+import java.util.List;
+
+import org.camunda.bpm.engine.identity.Group;
+import org.camunda.bpm.engine.identity.User;
+import org.camunda.bpm.engine.impl.test.ResourceProcessEngineTestCase;
+import org.junit.Assert;
+
+/**
+ * @author Simon Jonischkeit
+ *
+ */
+public class WriteMultipleEntitiesInOneStepTest extends ResourceProcessEngineTestCase {
+  /**
+   *
+   */
+  public WriteMultipleEntitiesInOneStepTest() {
+    super("org/camunda/bpm/engine/test/db/WriteMultipleEntitiesInOneStepTest.camunda.cfg.xml");
+  }
+
+  public void testWriteMultipleEntitysInOneStep(){
+
+    // The User will be saved into the Db through the plugin in the plugin package beside the Test.
+    // The GroupCreated is the userId_group
+    Assert.assertTrue(identityService.checkPassword("multipleEntities", "inOneStep"));
+    User user = identityService.createUserQuery().userId("multipleEntities").singleResult();
+
+    Assert.assertNotNull(user);
+    Assert.assertEquals("multipleEntities", user.getId());
+    Assert.assertEquals("{SHA}pfdzmt+49nwknTy7xhZd7ZW5suI=", user.getPassword());
+
+    // It is expected, that the User is in exactly one Group
+    List<Group> groups = this.identityService.createGroupQuery().groupMember("multipleEntities").list();
+    Assert.assertEquals(1, groups.size());
+
+    Group group = groups.get(0);
+    Assert.assertEquals("multipleEntities_group", group.getId());
+
+    // clean the Db
+    identityService.deleteMembership("multipleEntities", "multipleEntities_group");
+    identityService.deleteGroup("multipleEntities_group");
+    identityService.deleteUser("multipleEntities");
+  }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/db/identity/plugin/TestDbIdentityServiceProviderExtention.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/db/identity/plugin/TestDbIdentityServiceProviderExtention.java
@@ -1,0 +1,45 @@
+/**
+ *
+ */
+package org.camunda.bpm.engine.test.db.identity.plugin;
+
+import org.camunda.bpm.engine.identity.Group;
+import org.camunda.bpm.engine.identity.User;
+import org.camunda.bpm.engine.impl.identity.db.DbIdentityServiceProvider;
+
+/**
+ * To create a testcase, that tests the write a Member/Group/Membership in
+ *  on step, an entry Point into the write option within the same Command Context is needed.
+ *  This is done by extending the to-test class and overriding a not in scope Method.
+ *  This Method will trigger the write of Member/Group/Membership in one step.
+ *  <br><br>
+ *  The Group will be the userId extended by _group
+ *  <br><br>
+ *  The checkPassword method must return true, because exactly the requested user with the
+ *  requested Password will be created within this Method
+ *
+ *  @author Simon Jonischkeit
+ */
+public class TestDbIdentityServiceProviderExtention extends DbIdentityServiceProvider{
+
+  //
+  @Override
+  public boolean checkPassword(final String userId, final String password) {
+
+    // Create and Save a User
+    final User user = super.createNewUser(userId);
+    user.setPassword(password);
+    super.saveUser(user);
+
+    // Create and Save a Group
+    final String groupId = userId+"_group";
+    final Group group = super.createNewGroup(groupId);
+    group.setName(groupId);
+    super.saveGroup(group);
+
+    // Create the corresponding Membership
+    super.createMembership(userId, groupId);
+
+    return super.checkPassword(userId, password);
+  }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/db/identity/plugin/TestDbIdentityServiceProviderFactory.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/db/identity/plugin/TestDbIdentityServiceProviderFactory.java
@@ -1,0 +1,26 @@
+/**
+ *
+ */
+package org.camunda.bpm.engine.test.db.identity.plugin;
+
+import org.camunda.bpm.engine.impl.interceptor.Session;
+import org.camunda.bpm.engine.impl.interceptor.SessionFactory;
+
+/**
+ * @author Simon Jonischkeit
+ *
+ */
+public class TestDbIdentityServiceProviderFactory implements SessionFactory{
+
+  @Override
+  public Class<?> getSessionType() {
+    // TODO Auto-generated method stub
+    return TestDbIdentityServiceProviderExtention.class;
+  }
+
+  @Override
+  public Session openSession() {
+    return new TestDbIdentityServiceProviderExtention();
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/db/identity/plugin/TestDbIdentityServiceProviderPlugin.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/db/identity/plugin/TestDbIdentityServiceProviderPlugin.java
@@ -1,0 +1,40 @@
+/**
+ * 
+ */
+package org.camunda.bpm.engine.test.db.identity.plugin;
+
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.cfg.ProcessEnginePlugin;
+
+/**
+ * @author Simon Jonischkeit
+ *
+ */
+public class TestDbIdentityServiceProviderPlugin implements ProcessEnginePlugin {
+  
+  TestDbIdentityServiceProviderFactory testFactory;
+  
+  public TestDbIdentityServiceProviderPlugin() {
+    testFactory = new TestDbIdentityServiceProviderFactory();
+  }
+
+  @Override
+  public void preInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
+    processEngineConfiguration.setIdentityProviderSessionFactory(testFactory);
+
+  }
+
+  @Override
+  public void postInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
+    // nothing to do here
+
+  }
+
+  @Override
+  public void postProcessEngineBuild(ProcessEngine processEngine) {
+    // nothing to do here
+
+  }
+
+}

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/db/WriteMultipleEntitiesInOneStepTest.camunda.cfg.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/db/WriteMultipleEntitiesInOneStepTest.camunda.cfg.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans" 
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="processEngineConfiguration" class="org.camunda.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+  
+    <property name="processEngineName" value="WriteMultipleEntitiesInOneStepTest-engine" />
+    
+    <!-- Database configurations -->
+    <property name="history" value="full" />
+    <property name="databaseSchemaUpdate" value="create-drop" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:WriteMultipleEntitiesInOneStepTest" />
+    
+    <property name="jdbcMaxActiveConnections" value="2" />
+    <property name="idBlockSize" value="3" />
+    
+    <!-- job executor configurations -->
+    <property name="jobExecutorActivate" value="false" />
+    
+    <!-- turn off metrics reporter -->
+    <property name="dbMetricsReporterActivate" value="false" />
+        
+    <property name="processEnginePlugins">
+  	  <list>
+        <bean class="org.camunda.bpm.engine.test.db.identity.plugin.TestDbIdentityServiceProviderPlugin" />
+  	  </list>
+	</property>
+    
+  </bean>
+
+</beans>


### PR DESCRIPTION
Change the createMembership to behave like save/crate Users and Groups.
The createMembership creates an MembershipEntity and hands it over to
the DbEntityManager so that it is saved in the cache and flushed with
the other Entities in the correct order.
The previous behavior is, that this method was bypassing the cache and
tried to write the Membership directly into the Database. That leads to
an Exception, when the User, Group and corresponding Membership are
written in one step (e.g. within the same Command Context)
My use case is a new identity service Plugin which delegates most
requests to the Camunda DBIdentitiyServiceProvider. During
authentication we want to update the Camunda DB.

related to CAM-4732