### PR TITLE
feat(rest): enable HistoricProcess deletion through REST API

### DIFF
--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/history/HistoricProcessInstanceResource.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/history/HistoricProcessInstanceResource.java
@@ -14,6 +14,7 @@ package org.camunda.bpm.engine.rest.sub.history;
 
 import org.camunda.bpm.engine.rest.dto.history.HistoricProcessInstanceDto;
 
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -23,5 +24,8 @@ public interface HistoricProcessInstanceResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   HistoricProcessInstanceDto getHistoricProcessInstance();
+  
+  @DELETE
+  void deleteHistoricProcessInstance();
 
 }

--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/history/impl/HistoricProcessInstanceResourceImpl.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/history/impl/HistoricProcessInstanceResourceImpl.java
@@ -12,8 +12,11 @@
  */
 package org.camunda.bpm.engine.rest.sub.history.impl;
 
+import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.HistoryService;
 import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
 import org.camunda.bpm.engine.rest.dto.history.HistoricProcessInstanceDto;
 import org.camunda.bpm.engine.rest.exception.InvalidRequestException;
@@ -41,6 +44,18 @@ public class HistoricProcessInstanceResourceImpl implements HistoricProcessInsta
     }
 
     return HistoricProcessInstanceDto.fromHistoricProcessInstance(instance);
+  }
+
+  @Override
+  public void deleteHistoricProcessInstance() {
+    HistoryService historyService = engine.getHistoryService();
+    try {
+      historyService.deleteHistoricProcessInstance(processInstanceId);
+    } catch (AuthorizationException e) {
+      throw e;
+    } catch (ProcessEngineException e) {
+      throw new InvalidRequestException(Status.NOT_FOUND, e, "Historic process instance with id " + processInstanceId + " does not exist");
+    }
   }
 
 }


### PR DESCRIPTION
- exposes HistoryService#deleteHistoricProcessInstance
  under DELETE /history/process-instance/{id}
- adds interaction tests of the exposed API
- adds missing tests of HistoryService#deleteHistoricProcessInstance

Closes CAM-3888