### PR TITLE
CAM-4470 - RestEngine - DELETE /task/{id}

### DIFF
--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/task/TaskResource.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/task/TaskResource.java
@@ -16,11 +16,13 @@ import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
@@ -123,4 +125,6 @@ public interface TaskResource {
   @Consumes(MediaType.APPLICATION_JSON)
   public void updateTask(TaskDto task);
 
+  @DELETE
+  void deleteTask(@PathParam("id") String id);
 }

--- a/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/task/impl/TaskResourceImpl.java
+++ b/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/task/impl/TaskResourceImpl.java
@@ -27,6 +27,7 @@ import org.camunda.bpm.engine.IdentityService;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.exception.NotValidException;
 import org.camunda.bpm.engine.form.FormData;
 import org.camunda.bpm.engine.impl.identity.Authentication;
 import org.camunda.bpm.engine.rest.dto.VariableValueDto;
@@ -333,4 +334,14 @@ public class TaskResourceImpl implements TaskResource {
     taskService.saveTask(task);
   }
 
+  @Override
+  public void deleteTask(String id) {
+	TaskService taskService = engine.getTaskService();
+	
+	try {
+		taskService.deleteTask(id);
+	} catch (NotValidException e) {
+		throw new InvalidRequestException(Status.BAD_REQUEST, e, "Could not delete task: " + e.getMessage());
+	}
+  }
 }

--- a/engine-rest/src/test/java/org/camunda/bpm/engine/rest/AbstractTaskRestServiceInteractionTest.java
+++ b/engine-rest/src/test/java/org/camunda/bpm/engine/rest/AbstractTaskRestServiceInteractionTest.java
@@ -2628,7 +2628,19 @@ public abstract class AbstractTaskRestServiceInteractionTest extends
     .when()
       .delete(SINGLE_TASK_DELETE_SINGLE_ATTACHMENT_URL);
   }
+  
+  @Test
+  public void testDeleteDeleteTask() {
 
+    given()
+      .pathParam("id", EXAMPLE_TASK_ID)
+      .expect()
+      .statusCode(Status.NO_CONTENT.getStatusCode())
+    .when()
+      .delete(SINGLE_TASK_URL);
+
+    verify(taskServiceMock).deleteTask(EXAMPLE_TASK_ID);
+  }
 
   @Test
   public void testPostCreateTask() {


### PR DESCRIPTION
Using the REST API, I can delete a Task

taskService.deleteTask() method is exposed in the REST Api
Http Request is:
DELETE /task/{id}