### PR TITLE
chore(engine) change paramater to use ClockUtil.getDate()

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/history/producer/DefaultHistoryEventProducer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/history/producer/DefaultHistoryEventProducer.java
@@ -17,7 +17,6 @@ import static org.camunda.bpm.engine.impl.util.JobExceptionUtil.getJobExceptionS
 import static org.camunda.bpm.engine.impl.util.StringUtil.toByteArray;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import org.camunda.bpm.engine.delegate.DelegateExecution;
@@ -39,7 +38,6 @@ import org.camunda.bpm.engine.impl.history.event.HistoryEvent;
 import org.camunda.bpm.engine.impl.history.event.HistoryEventType;
 import org.camunda.bpm.engine.impl.history.event.HistoryEventTypes;
 import org.camunda.bpm.engine.impl.history.event.UserOperationLogEntryEventEntity;
-import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.oplog.UserOperationLogContext;
 import org.camunda.bpm.engine.impl.oplog.UserOperationLogContextEntry;
 import org.camunda.bpm.engine.impl.persistence.entity.ByteArrayEntity;
@@ -686,7 +684,7 @@ public class DefaultHistoryEventProducer implements HistoryEventProducer {
   }
 
   protected void initHistoricJobLogEvent(HistoricJobLogEventEntity evt, Job job, HistoryEventType eventType) {
-    evt.setTimestamp(new Date());
+    evt.setTimestamp(ClockUtil.getCurrentTime());
 
     JobEntity jobEntity = (JobEntity) job;
     evt.setJobId(jobEntity.getId());


### PR DESCRIPTION
- HistoricJobLogEvent uses ClockUtil now.

related to 4875