### PR TITLE
extend TestHelper to allow deployment annotation on test class

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/test/TestHelper.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/test/TestHelper.java
@@ -89,6 +89,8 @@ public abstract class TestHelper {
   public static String annotationDeploymentSetUp(ProcessEngine processEngine, Class<?> testClass, String methodName, Deployment deploymentAnnotation) {
     String deploymentId = null;
     Method method = null;
+    boolean onMethod = true;
+
     try {
       method = testClass.getDeclaredMethod(methodName, (Class<?>[])null);
     } catch (Exception e) {
@@ -101,12 +103,17 @@ public abstract class TestHelper {
     if (deploymentAnnotation == null) {
       deploymentAnnotation = method.getAnnotation(Deployment.class);
     }
+    // if not found on method, try on class level
+    if (deploymentAnnotation == null) {
+      onMethod = false;
+      deploymentAnnotation = testClass.getAnnotation(Deployment.class);
+    }
 
     if (deploymentAnnotation != null) {
       LOG.debug("annotation @Deployment creates deployment for {}.{}", ClassNameUtil.getClassNameWithoutPackage(testClass), methodName);
       String[] resources = deploymentAnnotation.resources();
       if (resources.length == 0 && method != null) {
-        String name = method.getName();
+        String name = onMethod ? method.getName() : null;
         String resource = getBpmnProcessDefinitionResource(testClass, name);
         resources = new String[]{resource};
       }
@@ -145,7 +152,7 @@ public abstract class TestHelper {
    */
   public static String getBpmnProcessDefinitionResource(Class< ? > type, String name) {
     for (String suffix : RESOURCE_SUFFIXES) {
-      String resource = type.getName().replace('.', '/') + "." + name + "." + suffix;
+      String resource = createResourceName(type, name, suffix);
       InputStream inputStream = ReflectUtil.getResourceAsStream(resource);
       if (inputStream == null) {
         continue;
@@ -153,7 +160,15 @@ public abstract class TestHelper {
         return resource;
       }
     }
-    return type.getName().replace('.', '/') + "." + name + "." + BpmnDeployer.BPMN_RESOURCE_SUFFIXES[0];
+    return createResourceName(type, name, BpmnDeployer.BPMN_RESOURCE_SUFFIXES[0]);
+  }
+
+  private static String createResourceName(Class< ? > type, String name, String suffix) {
+    StringBuffer r = new StringBuffer(type.getName().replace('.', '/'));
+    if (name != null) {
+      r.append("." + name);
+    }
+    return r.append("." + suffix).toString();
   }
 
   public static void assertAndEnsureCleanDbAndCache(ProcessEngine processEngine) {

--- a/engine/src/test/java/org/camunda/bpm/engine/impl/test/TestHelperDeploymentTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/impl/test/TestHelperDeploymentTest.java
@@ -1,0 +1,29 @@
+package org.camunda.bpm.engine.impl.test;
+
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+
+@Deployment
+public class TestHelperDeploymentTest {
+
+  @Rule
+  public final ProcessEngineRule processEngineRule = new ProcessEngineRule();
+
+  @Test
+  public void testDeploymentOnClassLevel() {
+    assertNotNull("process is not deployed",processEngineRule.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTest").singleResult());
+  }
+
+  @Test
+  @Deployment
+  public void testDeploymentOnMethodOverridesClass() {
+    assertNotNull("process is not deployed",processEngineRule.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTestOverride").singleResult());
+  }
+
+}

--- a/engine/src/test/resources/org/camunda/bpm/engine/impl/test/TestHelperDeploymentTest.bpmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/impl/test/TestHelperDeploymentTest.bpmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  targetNamespace="Examples">
+
+  <message id="messageId" name="newMessage" />
+
+  <process id="testHelperDeploymentTest" name="The One Task Process" isExecutable="true">
+    <documentation>This is a process for testing purposes</documentation>
+
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+    <userTask id="theTask" name="my task" />
+    <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+
+    <boundaryEvent id="message" attachedToRef="theTask">
+      <messageEventDefinition messageRef="messageId" />
+    </boundaryEvent>
+
+  </process>
+
+</definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/impl/test/TestHelperDeploymentTest.testDeploymentOnMethodOverridesClass.bpmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/impl/test/TestHelperDeploymentTest.testDeploymentOnMethodOverridesClass.bpmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  targetNamespace="Examples">
+
+  <message id="messageId" name="newMessage" />
+
+  <process id="testHelperDeploymentTestOverride" name="The One Task Process" isExecutable="true">
+    <documentation>This is a process for testing purposes</documentation>
+
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+    <userTask id="theTask" name="my task" />
+    <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+
+    <boundaryEvent id="message" attachedToRef="theTask">
+      <messageEventDefinition messageRef="messageId" />
+    </boundaryEvent>
+
+  </process>
+
+</definitions>


### PR DESCRIPTION
If you use the Deployment annotation on class level, it automatically applies to all test methods. If the annotation is present on the method, it is still default, overriding the class level.