### PR TITLE
extend TestHelper and Deployment to accept BpmnModelInstances for deployment

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/test/Deployment.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/test/Deployment.java
@@ -13,6 +13,9 @@
 
 package org.camunda.bpm.engine.test;
 
+import org.camunda.bpm.engine.impl.test.TestHelper;
+import org.camunda.bpm.model.xml.ModelInstance;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -52,4 +55,5 @@ public @interface Deployment {
   /** Specify resources that make up the process definition. */
   public String[] resources() default {};
 
+  public Class<? extends TestHelper.ModelInstanceSupplier>[] modelInstances() default {};
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/impl/test/TestHelperDeployModelInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/impl/test/TestHelperDeployModelInstanceTest.java
@@ -1,0 +1,51 @@
+package org.camunda.bpm.engine.impl.test;
+
+
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.camunda.bpm.model.xml.ModelInstance;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class TestHelperDeployModelInstanceTest {
+
+  @Rule
+  public final ProcessEngineRule processEngineRule = new ProcessEngineRule();
+
+  public static class MyModel implements TestHelper.ModelInstanceSupplier {
+
+    @Override
+    public BpmnModelInstance get() {
+      return Bpmn.createExecutableProcess("dummyProcess").startEvent().userTask("foo").endEvent().done();
+    }
+  }
+
+
+  @Test
+  @Deployment(modelInstances = MyModel.class)
+  public void testDeployAndRemoveModelInstance() {
+    ProcessDefinition processDefinition = processEngineRule.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("dummyProcess").singleResult();
+
+    assertNotNull("process not deployed", processDefinition);
+
+    processEngineRule.getRuntimeService().startProcessInstanceByKey("dummyProcess");
+  }
+
+
+  /**
+   * deploy twice to see if cleanup is succesful.
+   */
+  @Test
+  @Deployment(modelInstances = MyModel.class)
+  public void testDeployAndRemoveModelInstanceAgain() {
+    ProcessDefinition processDefinition = processEngineRule.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("dummyProcess").singleResult();
+
+    assertNotNull("process not deployed", processDefinition);
+  }
+}


### PR DESCRIPTION
When testing processes with callactivities it is very helpful to deploy fake processes that simulate the actual sub process. This is even more elegant with the BpmnModel-Api, we do not pollute the test/resource space with primitive bpmn models ([reference here](https://thecattlecrew.wordpress.com/2014/07/18/camunda-bpm-mocking-subprocesses-with-bpmn-model-api/)).

One problem remained with this approach: we mix normal processes that are deployed via the @Deployment annotation and manual deployments of model instances. There is no automatic cleaning up with the engine rule resulting in exceptions or spoiled logs at least.

This PR resolves this issue by allowing ModelInstanceSuppliers as additional input und the Deployment resource. When a supplier is configured, it will be created via newInstance and the model is accessed via get(). It is then added to the deployment with a random resource-name. So the process gets deployed and can be used in tests. And its properly cleaned up after the test ran.