### PR TITLE
test(add test): submit unit test for CAM-5063

### DIFF
--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/form/FormDataTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/form/FormDataTest.java
@@ -195,4 +195,25 @@ public class FormDataTest extends PluggableProcessEngineTestCase {
 
   }
 
+  @Deployment
+  public void testTwoTasksWithSameFormFieldId() {
+
+    // start process
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("FormDataTest.testTwoTasksWithSameFormFieldId");
+    assertNotNull(processInstance);
+
+    // submit task form for first task
+    Task userTask1 = taskService.createTaskQuery().singleResult();
+    assertEquals("userTask1", userTask1.getTaskDefinitionKey());
+    Map<String, Object> formValues = new HashMap<String, Object>();
+    formValues.put("actions", "postpone");
+    formService.submitTaskForm(userTask1.getId(), formValues);
+
+    assertEquals(formValues, runtimeService.getVariables(processInstance.getId()));
+
+    // try to get form data for second task
+    Task userTask2 = taskService.createTaskQuery().singleResult();
+    assertEquals("userTask2", userTask2.getTaskDefinitionKey());
+    formService.getTaskFormData(userTask2.getId());
+  }
 }

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/form/FormDataTest.testTwoTasksWithSameFormFieldId.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/form/FormDataTest.testTwoTasksWithSameFormFieldId.bpmn20.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+    xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+    xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+    xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+    typeLanguage="http://www.w3.org/2001/XMLSchema"
+    expressionLanguage="http://www.w3.org/1999/XPath"
+    targetNamespace="test">
+
+  <process id="FormDataTest.testTwoTasksWithSameFormFieldId">
+
+    <startEvent id="start">
+      <outgoing>sequenceFlow1</outgoing>
+    </startEvent>
+
+    <userTask id="userTask1" name="User Task 1">
+      <extensionElements>
+        <camunda:formData>
+          <camunda:formField id="actions" label="actions" type="enum">
+            <camunda:value id="accept" name="accept"/>
+            <camunda:value id="reject" name="reject"/>
+            <camunda:value id="postpone" name="postpone"/>
+          </camunda:formField>
+        </camunda:formData>
+      </extensionElements>
+
+      <incoming>sequenceFlow1</incoming>
+      <outgoing>sequenceFlow2</outgoing>
+    </userTask>
+
+    <userTask id="userTask2" name="User Task 2">
+      <extensionElements>
+        <camunda:formData>
+          <camunda:formField id="actions" label="actions" type="enum">
+            <camunda:value id="accept" name="accept"/>
+            <camunda:value id="reject" name="reject"/>
+          </camunda:formField>
+        </camunda:formData>
+      </extensionElements>
+
+      <incoming>sequenceFlow2</incoming>
+      <outgoing>sequenceFlow3</outgoing>
+    </userTask>
+
+    <endEvent id="end">
+      <incoming>sequenceFlow3</incoming>
+    </endEvent>
+
+    <sequenceFlow id="sequenceFlow1" sourceRef="start" targetRef="userTask1"/>
+    <sequenceFlow id="sequenceFlow2" sourceRef="userTask1" targetRef="userTask2"/>
+    <sequenceFlow id="sequenceFlow3" sourceRef="userTask2" targetRef="end"/>
+
+  </process>
+
+</definitions>


### PR DESCRIPTION
If there are 2 user tasks and each of them has a form field with same id of type enum but with different enum values. When execution arrive to second user task a exception will be thrown (ProcessEngineException: Invalid value for enum form property: "some property" )