### PR TITLE
improve(engine) add form-related exceptions

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/form/FormException.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/form/FormException.java
@@ -1,0 +1,36 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.engine.impl.form;
+
+import org.camunda.bpm.engine.ProcessEngineException;
+
+public class FormException extends ProcessEngineException {
+
+  public FormException() {
+    super();
+  }
+
+  public FormException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public FormException(String message) {
+    super(message);
+  }
+
+  public FormException(Throwable cause) {
+    super(cause);
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/form/handler/FormFieldValidationConstraintHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/form/handler/FormFieldValidationConstraintHandler.java
@@ -12,11 +12,13 @@
  */
 package org.camunda.bpm.engine.impl.form.handler;
 
-import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.delegate.VariableScope;
 import org.camunda.bpm.engine.form.FormFieldValidationConstraint;
 import org.camunda.bpm.engine.impl.form.FormFieldValidationConstraintImpl;
+import org.camunda.bpm.engine.impl.form.validator.FormFieldValidationException;
 import org.camunda.bpm.engine.impl.form.validator.FormFieldValidator;
+import org.camunda.bpm.engine.impl.form.validator.FormFieldValidatorContext;
+import org.camunda.bpm.engine.impl.form.validator.FormFieldValidatorException;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.camunda.bpm.engine.variable.VariableMap;
 
@@ -39,10 +41,14 @@ public class FormFieldValidationConstraintHandler {
   // submit /////////////////////////////////
 
   public void validate(Object submittedValue, VariableMap submittedValues, FormFieldHandler formFieldHandler, VariableScope variableScope) {
-    boolean isValid = validator.validate(submittedValue, new DefaultFormFieldValidatorContext(variableScope, config,
-      submittedValues, formFieldHandler));
-    if(!isValid) {
-      throw new ProcessEngineException("Invalid value submitted for form field '"+formFieldHandler.getId()+"': validation of "+this+" failed.");
+    try {
+
+      FormFieldValidatorContext context = new DefaultFormFieldValidatorContext(variableScope, config, submittedValues, formFieldHandler);
+      if(!validator.validate(submittedValue, context)) {
+        throw new FormFieldValidatorException(formFieldHandler.getId(), name, config, submittedValue, "Invalid value submitted for form field '"+formFieldHandler.getId()+"': validation of "+this+" failed.");
+      }
+    } catch(FormFieldValidationException e) {
+      throw new FormFieldValidatorException(formFieldHandler.getId(), name, config, submittedValue, "Invalid value submitted for form field '"+formFieldHandler.getId()+"': validation of "+this+" failed.", e);
     }
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/form/validator/AbstractNumericValidator.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/form/validator/AbstractNumericValidator.java
@@ -12,7 +12,7 @@
  */
 package org.camunda.bpm.engine.impl.form.validator;
 
-import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.impl.form.FormException;
 
 /**
  * @author Daniel Meyer
@@ -36,7 +36,7 @@ public abstract class AbstractNumericValidator implements FormFieldValidator {
       try {
         configuration = Double.parseDouble(configurationString);
       } catch( NumberFormatException e) {
-        throw new ProcessEngineException("Cannot validate Double value "+submittedValue +": configuration "+configurationString+" cannot be parsed as Double.");
+        throw new FormFieldConfigurationException(configurationString, "Cannot validate Double value "+submittedValue +": configuration "+configurationString+" cannot be parsed as Double.");
       }
       return validate((Double) submittedValue, configuration);
     }
@@ -48,7 +48,7 @@ public abstract class AbstractNumericValidator implements FormFieldValidator {
       try {
         configuration = Float.parseFloat(configurationString);
       } catch( NumberFormatException e) {
-        throw new ProcessEngineException("Cannot validate Float value "+submittedValue +": configuration "+configurationString+" cannot be parsed as Float.");
+        throw new FormFieldConfigurationException(configurationString, "Cannot validate Float value "+submittedValue +": configuration "+configurationString+" cannot be parsed as Float.");
       }
       return validate((Float) submittedValue, configuration);
     }
@@ -60,7 +60,7 @@ public abstract class AbstractNumericValidator implements FormFieldValidator {
       try {
         configuration = Long.parseLong(configurationString);
       } catch(NumberFormatException e) {
-        throw new ProcessEngineException("Cannot validate Long value "+submittedValue +": configuration "+configurationString+" cannot be parsed as Long.");
+        throw new FormFieldConfigurationException(configurationString, "Cannot validate Long value "+submittedValue +": configuration "+configurationString+" cannot be parsed as Long.");
       }
       return validate((Long) submittedValue, configuration);
     }
@@ -72,7 +72,7 @@ public abstract class AbstractNumericValidator implements FormFieldValidator {
       try {
         configuration = Integer.parseInt(configurationString);
       } catch( NumberFormatException e) {
-        throw new ProcessEngineException("Cannot validate Integer value "+submittedValue +": configuration "+configurationString+" cannot be parsed as Integer.");
+        throw new FormFieldConfigurationException(configurationString, "Cannot validate Integer value "+submittedValue +": configuration "+configurationString+" cannot be parsed as Integer.");
       }
       return validate((Integer) submittedValue, configuration);
     }
@@ -84,12 +84,12 @@ public abstract class AbstractNumericValidator implements FormFieldValidator {
       try {
         configuration = Short.parseShort(configurationString);
       } catch( NumberFormatException e) {
-        throw new ProcessEngineException("Cannot validate Short value "+submittedValue +": configuration "+configurationString+" cannot be parsed as Short.");
+        throw new FormFieldConfigurationException(configurationString, "Cannot validate Short value "+submittedValue +": configuration "+configurationString+" cannot be parsed as Short.");
       }
       return validate((Short) submittedValue, configuration);
     }
 
-    throw new ProcessEngineException("Numeric validator "+getClass().getSimpleName()+" cannot be used on non-numeric value "+submittedValue);
+    throw new FormFieldValidationException("Numeric validator "+getClass().getSimpleName()+" cannot be used on non-numeric value "+submittedValue);
   }
 
   protected boolean isNullValid() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/form/validator/FormFieldConfigurationException.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/form/validator/FormFieldConfigurationException.java
@@ -1,0 +1,50 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.engine.impl.form.validator;
+
+import org.camunda.bpm.engine.impl.form.FormException;
+
+public class FormFieldConfigurationException extends FormException {
+
+  private final String configuration;
+
+  public FormFieldConfigurationException(String configuration) {
+    super();
+
+    this.configuration = configuration;
+  }
+
+  public FormFieldConfigurationException(String configuration, String message, Throwable cause) {
+    super(message, cause);
+
+    this.configuration = configuration;
+  }
+
+  public FormFieldConfigurationException(String configuration, String message) {
+    super(message);
+
+    this.configuration = configuration;
+  }
+
+  public FormFieldConfigurationException(String configuration, Throwable cause) {
+    super(cause);
+
+    this.configuration = configuration;
+  }
+
+  public String getConfiguration() {
+    return configuration;
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/form/validator/FormFieldValidationException.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/form/validator/FormFieldValidationException.java
@@ -1,0 +1,60 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.engine.impl.form.validator;
+
+import org.camunda.bpm.engine.impl.form.FormException;
+
+/**
+ * Runtime exception for use within a {@linkplain FormFieldValidator}.
+ * Optionally contains a detail which uniquely identifies the problem.
+ *
+ * @author Thomas Skjolberg
+ */
+public class FormFieldValidationException extends FormException {
+
+  /** optional object for detailing the nature of the validation error */
+  private Object detail;
+
+  public FormFieldValidationException() {
+    super();
+  }
+
+  public FormFieldValidationException(Object detail) {
+    super();
+
+    this.detail = detail;
+  }
+
+  public FormFieldValidationException(Object detail, String message, Throwable cause) {
+    super(message, cause);
+
+    this.detail = detail;
+  }
+
+  public FormFieldValidationException(Object detail, String message) {
+    super(message);
+
+    this.detail = detail;
+  }
+
+  public FormFieldValidationException(Object detail, Throwable cause) {
+    super(cause);
+
+    this.detail = detail;
+  }
+
+  public <T> T getDetail() {
+    return (T) detail;
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/form/validator/FormFieldValidatorException.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/form/validator/FormFieldValidatorException.java
@@ -1,0 +1,66 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.engine.impl.form.validator;
+
+import org.camunda.bpm.engine.impl.form.FormException;
+
+/**
+ * Runtime exception for validation of form fields.
+ *
+ * @author Thomas Skjolberg
+ */
+public class FormFieldValidatorException extends FormException {
+
+  /** bpmn element id */
+  private final String id;
+  private final String name;
+  private final String config;
+  private final Object value;
+
+  public FormFieldValidatorException(String id, String name, String config, Object value, String message,
+      Throwable cause) {
+    super(message, cause);
+
+    this.id = id;
+    this.name = name;
+    this.config = config;
+    this.value = value;
+  }
+
+  public FormFieldValidatorException(String id, String name, String config, Object value, String message) {
+    super(message);
+
+    this.id = id;
+    this.name = name;
+    this.config = config;
+    this.value = value;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getConfig() {
+    return config;
+  }
+
+  public Object getValue() {
+    return value;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/form/validator/MaxLengthValidator.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/form/validator/MaxLengthValidator.java
@@ -13,6 +13,7 @@
 package org.camunda.bpm.engine.impl.form.validator;
 
 import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.impl.form.FormException;
 
 
 /**
@@ -26,7 +27,8 @@ public class MaxLengthValidator extends AbstractTextValueValidator {
     try {
       maxLength = Integer.parseInt(configuration);
     } catch (NumberFormatException e) {
-      throw new ProcessEngineException("Cannot validate \"maxlength\": configuration "+configuration+" cannot be interpreted as Integer");    
+      // do not throw validation exception, as the issue is not with the submitted value
+      throw new FormFieldConfigurationException(configuration, "Cannot validate \"maxlength\": configuration "+configuration+" cannot be interpreted as Integer");    
     }
 
     return submittedValue.length() < maxLength;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/form/validator/MinLengthValidator.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/form/validator/MinLengthValidator.java
@@ -13,6 +13,7 @@
 package org.camunda.bpm.engine.impl.form.validator;
 
 import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.impl.form.FormException;
 
 /**
  *
@@ -26,7 +27,8 @@ public class MinLengthValidator extends AbstractTextValueValidator {
     try {
       maxLength = Integer.parseInt(configuration);
     } catch (NumberFormatException e) {
-      throw new ProcessEngineException("Cannot validate \"minlength\": configuration "+configuration+" cannot be interpreted as Integer");
+      // do not throw validation exception, as the issue is not with the submitted value
+      throw new FormFieldConfigurationException(configuration, "Cannot validate \"minlength\": configuration "+configuration+" cannot be interpreted as Integer");
     }
 
     return submittedValue.length() >= maxLength;

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/form/BuiltInValidatorsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/form/BuiltInValidatorsTest.java
@@ -21,6 +21,7 @@ import org.camunda.bpm.engine.impl.ProcessEngineImpl;
 import org.camunda.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
 import org.camunda.bpm.engine.impl.core.variable.scope.CoreVariableStore;
 import org.camunda.bpm.engine.impl.core.variable.scope.SimpleVariableStore;
+import org.camunda.bpm.engine.impl.form.FormException;
 import org.camunda.bpm.engine.impl.form.handler.FormFieldHandler;
 import org.camunda.bpm.engine.impl.form.validator.FormFieldValidator;
 import org.camunda.bpm.engine.impl.form.validator.FormFieldValidatorContext;
@@ -93,8 +94,7 @@ public class BuiltInValidatorsTest extends PluggableProcessEngineTestCase {
     try {
       validator.validate(4, new TestValidatorContext("4.4"));
       fail("exception expected");
-    } catch (ProcessEngineException e) {
-      e.printStackTrace();
+    } catch (FormException e) {
       assertTrue(e.getMessage().contains("Cannot validate Integer value 4: configuration 4.4 cannot be parsed as Integer."));
     }
 
@@ -117,8 +117,7 @@ public class BuiltInValidatorsTest extends PluggableProcessEngineTestCase {
     try {
       validator.validate(4, new TestValidatorContext("4.4"));
       fail("exception expected");
-    } catch (ProcessEngineException e) {
-      e.printStackTrace();
+    } catch (FormException e) {
       assertTrue(e.getMessage().contains("Cannot validate Integer value 4: configuration 4.4 cannot be parsed as Integer."));
     }
 
@@ -141,7 +140,7 @@ public class BuiltInValidatorsTest extends PluggableProcessEngineTestCase {
     try {
       validator.validate("test", new TestValidatorContext("4.4"));
       fail("exception expected");
-    } catch (ProcessEngineException e) {
+    } catch (FormException e) {
       assertTrue(e.getMessage().contains("Cannot validate \"maxlength\": configuration 4.4 cannot be interpreted as Integer"));
     }
   }
@@ -157,7 +156,7 @@ public class BuiltInValidatorsTest extends PluggableProcessEngineTestCase {
     try {
       validator.validate("test", new TestValidatorContext("4.4"));
       fail("exception expected");
-    } catch (ProcessEngineException e) {
+    } catch (FormException e) {
       assertTrue(e.getMessage().contains("Cannot validate \"minlength\": configuration 4.4 cannot be interpreted as Integer"));
     }
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/form/CustomValidatorWithDetail.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/form/CustomValidatorWithDetail.java
@@ -1,0 +1,48 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.api.form;
+
+import org.camunda.bpm.engine.impl.form.validator.FormFieldValidationException;
+import org.camunda.bpm.engine.impl.form.validator.FormFieldValidator;
+import org.camunda.bpm.engine.impl.form.validator.FormFieldValidatorContext;
+
+/**
+ * @author Thomas Skjolberg
+ *
+ */
+public class CustomValidatorWithDetail implements FormFieldValidator {
+
+  public CustomValidatorWithDetail() {
+    System.out.println("CREATED");
+  }
+
+  public boolean validate(Object submittedValue, FormFieldValidatorContext validatorContext) {
+    if (submittedValue == null) {
+      return true;
+    }
+
+    if (submittedValue.equals("A") || submittedValue.equals("B")) {
+      return true;
+    }
+
+    if (submittedValue.equals("C")) {
+      // instead of returning false, use an exception to specify details about
+      // what went wrong
+      throw new FormFieldValidationException("EXPIRED", "Unable to validate " + submittedValue);
+    }
+
+    // return false in the generic case
+    return false;
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/form/FormDataTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/form/FormDataTest.java
@@ -23,6 +23,8 @@ import org.camunda.bpm.engine.form.FormField;
 import org.camunda.bpm.engine.form.FormFieldValidationConstraint;
 import org.camunda.bpm.engine.form.TaskFormData;
 import org.camunda.bpm.engine.impl.form.type.EnumFormType;
+import org.camunda.bpm.engine.impl.form.validator.FormFieldValidationException;
+import org.camunda.bpm.engine.impl.form.validator.FormFieldValidatorException;
 import org.camunda.bpm.engine.impl.test.PluggableProcessEngineTestCase;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.task.Task;
@@ -179,9 +181,10 @@ public class FormDataTest extends PluggableProcessEngineTestCase {
     assertEquals(formValues, runtimeService.getVariables(processInstance.getId()));
     runtimeService.deleteProcessInstance(processInstance.getId(), "test complete");
 
-    // invalid submit
     runtimeService.startProcessInstanceByKey("FormDataTest.testFormFieldSubmit");
     task = taskService.createTaskQuery().singleResult();
+    // invalid submit 1
+
     formValues = new HashMap<String, Object>();
     formValues.put("stringField", "1234");
     formValues.put("longField", 9L);
@@ -189,8 +192,25 @@ public class FormDataTest extends PluggableProcessEngineTestCase {
     try {
       formService.submitTaskForm(task.getId(), formValues);
       fail();
-    } catch(ProcessEngineException e) {
-      assertTrue(e.getMessage().contains("validation of minlength(5) failed"));
+    } catch (FormFieldValidatorException e) {
+      assertEquals(e.getName(), "minlength");
+    }
+
+    // invalid submit 2
+    formValues = new HashMap<String, Object>();
+
+    formValues.put("customFieldWithValidationDetails", "C");
+    try {
+      formService.submitTaskForm(task.getId(), formValues);
+      fail();
+    } catch (FormFieldValidatorException e) {
+      assertEquals(e.getName(), "validator");
+      assertEquals(e.getId(), "customFieldWithValidationDetails");
+
+      assertTrue(e.getCause() instanceof FormFieldValidationException);
+
+      FormFieldValidationException exception = (FormFieldValidationException) e.getCause();
+      assertEquals(exception.getDetail(), "EXPIRED");
     }
 
   }

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/form/FormDataTest.testFormFieldSubmit.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/form/FormDataTest.testFormFieldSubmit.bpmn20.xml
@@ -33,6 +33,12 @@
               <camunda:constraint name="validator" config="org.camunda.bpm.engine.test.api.form.CustomValidator" />
             </camunda:validation>
           </camunda:formField>
+          <camunda:formField id="customFieldWithValidationDetails" label="Custom Field with validation details" type="string">
+            <camunda:validation>
+              <camunda:constraint name="validator" config="org.camunda.bpm.engine.test.api.form.CustomValidatorWithDetail" />
+            </camunda:validation>
+          </camunda:formField>
+          
         </camunda:formData>
       </extensionElements>
     </userTask>


### PR DESCRIPTION
See https://app.camunda.com/jira/browse/CAM-2757.

The resulting code uses two-fold exception strategy, keeping the current API intact and simple to use.  
 - validation error details in FormFieldValidationException, wrapped by
 - field id, name, config, submitted value in FormFieldValidatorException.

So users can throw FormFieldValidationException in their validator, or just return false, the result is a FormFieldValidatorException with or without cause.

Perhaps the exception names could be more distinct, if you have any suggestions.