### PR TITLE
Use constant value instead of variable in select statement.

### DIFF
--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Report.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Report.xml
@@ -28,7 +28,11 @@
 
   <select id="selectHistoricProcessInstanceDurationReport" parameterType="org.camunda.bpm.engine.impl.HistoricProcessInstanceReportImpl" resultMap="durationReportResultMap">
     SELECT
-      MIN(RES.DURATION_) AS MIN_, MAX(RES.DURATION_) AS MAX_, AVG(RES.DURATION_) AS AVG_, RES.PERIOD_, #{reportPeriodUnitName} as PERIOD_UNIT_
+      MIN(RES.DURATION_) AS MIN_, MAX(RES.DURATION_) AS MAX_, AVG(RES.DURATION_) AS AVG_, RES.PERIOD_,
+    <choose>
+      <when test="reportPeriodUnitName.equals('MONTH')">'${constant.datepart.month}'</when>
+      <when test="reportPeriodUnitName.equals('QUARTER')">'${constant.datepart.quarter}'</when>
+    </choose> AS PERIOD_UNIT_
     FROM
       (
         SELECT
@@ -41,7 +45,7 @@
 
   <select id="selectHistoricProcessInstanceDurationReport_oracle" parameterType="org.camunda.bpm.engine.impl.HistoricProcessInstanceReportImpl" resultMap="durationReportResultMap">
     SELECT
-      MIN(RES.DURATION_) AS MIN_, MAX(RES.DURATION_) AS MAX_, AVG(RES.DURATION_) AS AVG_, RES.PERIOD_, #{reportPeriodUnitName} as PERIOD_UNIT_
+      MIN(RES.DURATION_) AS MIN_, MAX(RES.DURATION_) AS MAX_, AVG(RES.DURATION_) AS AVG_, RES.PERIOD_, #{reportPeriodUnitName} AS PERIOD_UNIT_
     FROM
       (
         SELECT

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Report.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Report.xml
@@ -28,11 +28,7 @@
 
   <select id="selectHistoricProcessInstanceDurationReport" parameterType="org.camunda.bpm.engine.impl.HistoricProcessInstanceReportImpl" resultMap="durationReportResultMap">
     SELECT
-      MIN(RES.DURATION_) AS MIN_, MAX(RES.DURATION_) AS MAX_, AVG(RES.DURATION_) AS AVG_, RES.PERIOD_,
-    <choose>
-      <when test="reportPeriodUnitName.equals('MONTH')">'${constant.datepart.month}'</when>
-      <when test="reportPeriodUnitName.equals('QUARTER')">'${constant.datepart.quarter}'</when>
-    </choose> AS PERIOD_UNIT_
+      MIN(RES.DURATION_) AS MIN_, MAX(RES.DURATION_) AS MAX_, AVG(RES.DURATION_) AS AVG_, RES.PERIOD_, '${reportPeriodUnitName}' AS PERIOD_UNIT_
     FROM
       (
         SELECT


### PR DESCRIPTION
Related to CAM-5255.

The new statement in Report.xml introduced with changes related to CAM-5158 contains a placeholder/variable in the select list as a column.
IBM Informix does not like it and gives sends a "Syntax error".
I found a working solution (checked against H2 and Informix) to replace the variable with a constant text based on the report type without doubling the statement.
Using directly the include with apostrophes around it ('<include refid="periodUnitFunction"/>') did not work, because it also puts additional wide spaces between the apostrophes.