### PR TITLE
ManagementServiceTest: search column with uppercase and lowercase name.

### DIFF
--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/ManagementServiceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/ManagementServiceTest.java
@@ -739,13 +739,12 @@ public class ManagementServiceTest extends PluggableProcessEngineTestCase {
     assertEquals(expectedTaskNames.length, rowData.size());
     String columnKey = "NAME_";
 
-    // mybatis will return the correct case for postgres table columns from version 3.0.6 on
-    if (processEngineConfiguration.getDatabaseType().equals("postgres")) {
-      columnKey = "name_";
-    }
-
     for (int i=0; i < expectedTaskNames.length; i++) {
-      assertEquals(expectedTaskNames[i], rowData.get(i).get(columnKey));
+      Object o = rowData.get(i).get(columnKey);
+      if ( o == null ) {
+        o = rowData.get(i).get(columnKey.toLowerCase());
+      }
+      assertEquals(expectedTaskNames[i], o);
     }
   }
 


### PR DESCRIPTION
Related to CAM-5130.

Column names retrieved from the database schema are given in lower case letters for Informix as well as for Postgres obviously.
With this change, the column is searched first by the uppercase name, and, in case of not found, again with the lowercase name. There is no need anymore then to ask for the database type name.