### PR TITLE
fix(pom): fixed wrong imports

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -222,8 +222,23 @@
         ${camunda.artifact};${camunda.osgi.version};-noimport:=true,
         ${camunda.artifact}.application.*;${camunda.osgi.version};-noimport:=true,
         ${camunda.artifact}.container.*;${camunda.osgi.version};-noimport:=true,
-        ${camunda.artifact}.engine.*
+		!${camunda.artifact}.engine.variable*,
+        ${camunda.artifact}.engine.*;${camunda.osgi.version};-noimport:=true
       </camunda.osgi.export.pkg>
+	  <camunda.osgi.import.defaults>
+		org.camunda.bpm.engine.variable;${camunda.osgi.import.camunda.commons.version},
+		org.camunda.bpm.engine.variable.context;${camunda.osgi.import.camunda.commons.version},
+		org.camunda.bpm.engine.variable.impl;${camunda.osgi.import.camunda.commons.version},
+		org.camunda.bpm.engine.variable.impl.context;${camunda.osgi.import.camunda.commons.version},
+		org.camunda.bpm.engine.variable.impl.type;${camunda.osgi.import.camunda.commons.version},
+		org.camunda.bpm.engine.variable.impl.value;${camunda.osgi.import.camunda.commons.version},
+		org.camunda.bpm.engine.variable.impl.value.builder;${camunda.osgi.import.camunda.commons.version},
+		org.camunda.bpm.engine.variable.type;${camunda.osgi.import.camunda.commons.version},
+		org.camunda.bpm.engine.variable.value;${camunda.osgi.import.camunda.commons.version},
+		org.camunda.bpm.engine.variable.value.builder;${camunda.osgi.import.camunda.commons.version},
+		org.camunda.commons.logging;${camunda.osgi.import.camunda.commons.version},
+		org.camunda.commons.utils;${camunda.osgi.import.camunda.commons.version}
+	  </camunda.osgi.import.defaults>
       <camunda.osgi.import.additional>
           junit*;resolution:=optional,
           org.junit*;resolution:=optional,

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -48,6 +48,7 @@
     <camunda.artifact />
     <camunda.osgi.import.camunda.spin.version>version="[$(version;==;${camunda.spin.version.clean}),$(version;=+;${camunda.spin.version.clean}))"</camunda.osgi.import.camunda.spin.version>
     <camunda.osgi.import.camunda.connect.version>version="[$(version;==;${camunda.connect.version.clean}),$(version;=+;${camunda.connect.version.clean}))"</camunda.osgi.import.camunda.connect.version>
+    <camunda.osgi.import.camunda.commons.version>version="[$(version;==;${camunda.commons.version.clean}),$(version;=+;${camunda.commons.version.clean}))"</camunda.osgi.import.camunda.commons.version>
     <camunda.osgi.import.camunda.version>version="[$(version;==;${camunda.osgi.version.clean}),$(version;=+;${camunda.osgi.version.clean}))"</camunda.osgi.import.camunda.version>
     <camunda.osgi.import.strict.version>version="[$(version;===;${camunda.osgi.version.clean}),$(version;==+;${camunda.osgi.version.clean}))"</camunda.osgi.import.strict.version>
     <camunda.osgi.import.default.version>[$(version;==;$(@)),$(version;+;$(@)))</camunda.osgi.import.default.version>
@@ -563,6 +564,7 @@
             <camunda.osgi.version.clean>${project.version}</camunda.osgi.version.clean>
             <camunda.connect.version.clean>${version.camunda.connect}</camunda.connect.version.clean>
             <camunda.spin.version.clean>${version.camunda.spin}</camunda.spin.version.clean>
+            <camunda.commons.version.clean>${version.camunda.commons}</camunda.commons.version.clean>
            </versions>
           </configuration>
         </plugin>


### PR DESCRIPTION
-due to the split packages created by extracting commons-variables the engine still thought it was responsible for exporting the packages, this resulted in unresolvable imports/exports

Fixes CAM-5094