### PR TITLE
chore(engine): re-fix OSGi imports

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -226,8 +226,8 @@
       ${camunda.artifact}.engine.*;${camunda.osgi.version};-noimport:=true
     </camunda.osgi.export.pkg>
     <camunda.osgi.import.defaults>
-      ${camunda.artifact}.engine.variable.*;version=${camunda.osgi.import.camunda.commons.version},
-      org.camunda.commons.*;version=${camunda.osgi.import.camunda.commons.version}
+      org.camunda.bpm.engine.variable.*;${camunda.osgi.import.camunda.commons.version},
+      org.camunda.commons.*;${camunda.osgi.import.camunda.commons.version},
     </camunda.osgi.import.defaults>
     <camunda.osgi.import.additional>
       junit*;resolution:=optional,


### PR DESCRIPTION
There was an issue with the OSGi import declaration and a wrong assumption about the actual resolved contents of Maven properties like `${camunda.osgi.import.camunda.commons.version}`.

Dropping the OSGi import `version=` prefix resolves the issue as the properties already contain the string `version=`, which made the import declaration look like `version=version=...`, which in turn led to BND writing the package import version statement as `version=version`, which - of course - would never be resolved.