### PR TITLE
fix(engine) tomcat undeploy steps

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/container/impl/ContainerIntegrationLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/container/impl/ContainerIntegrationLogger.java
@@ -240,7 +240,7 @@ public class ContainerIntegrationLogger extends ProcessEngineLogger {
         "Class '{}' has wrong type. Must extend {}", expectedType.getName()), e);
   }
 
-  public void timeoutDuringSutdownOfThreadPool(int i, TimeUnit seconds) {
+  public void timeoutDuringShutdownOfThreadPool(int i, TimeUnit seconds) {
     logError(
         "033",
         "Timeout during shutdown of managed thread pool. The current running tasks could not end within {} {} after shutdown operation.",

--- a/engine/src/main/java/org/camunda/bpm/container/impl/deployment/StopProcessApplicationsStep.java
+++ b/engine/src/main/java/org/camunda/bpm/container/impl/deployment/StopProcessApplicationsStep.java
@@ -25,7 +25,7 @@ import org.camunda.bpm.container.impl.spi.ServiceTypes;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 
 /**
- * <p>Deployment operation step that is responsible for stopping all process applications</p>
+ * <p>Deployment operation step that is responsible for stopping (undeploying) all process applications</p>
  *
  * @author Daniel Meyer
  *

--- a/engine/src/main/java/org/camunda/bpm/container/impl/jmx/services/JmxManagedThreadPool.java
+++ b/engine/src/main/java/org/camunda/bpm/container/impl/jmx/services/JmxManagedThreadPool.java
@@ -51,7 +51,7 @@ public class JmxManagedThreadPool extends SeExecutorService implements JmxManage
     // Waits for 1 minute to finish all currently executing jobs
     try {
       if(!threadPoolExecutor.awaitTermination(60L, TimeUnit.SECONDS)) {
-        LOG.timeoutDuringSutdownOfThreadPool(60, TimeUnit.SECONDS);
+        LOG.timeoutDuringShutdownOfThreadPool(60, TimeUnit.SECONDS);
       }
     }
     catch (InterruptedException e) {

--- a/engine/src/main/java/org/camunda/bpm/container/impl/tomcat/TomcatBpmPlatformBootstrap.java
+++ b/engine/src/main/java/org/camunda/bpm/container/impl/tomcat/TomcatBpmPlatformBootstrap.java
@@ -27,6 +27,7 @@ import org.camunda.bpm.container.impl.deployment.UnregisterBpmPlatformPluginsSte
 import org.camunda.bpm.container.impl.deployment.jobexecutor.StartJobExecutorStep;
 import org.camunda.bpm.container.impl.deployment.jobexecutor.StartManagedThreadPoolStep;
 import org.camunda.bpm.container.impl.deployment.jobexecutor.StopJobExecutorStep;
+import org.camunda.bpm.container.impl.deployment.jobexecutor.StopManagedThreadPoolStep;
 import org.camunda.bpm.container.impl.tomcat.deployment.TomcatAttachments;
 import org.camunda.bpm.container.impl.tomcat.deployment.TomcatParseBpmPlatformXmlStep;
 import org.camunda.bpm.engine.ProcessEngine;
@@ -88,9 +89,10 @@ public class TomcatBpmPlatformBootstrap implements LifecycleListener {
 
     containerDelegate.getServiceContainer().createUndeploymentOperation("undeploy BPM platform")
       .addAttachment(TomcatAttachments.SERVER, server)
+      .addStep(new StopJobExecutorStep())
+      .addStep(new StopManagedThreadPoolStep())
       .addStep(new StopProcessApplicationsStep())
       .addStep(new StopProcessEnginesStep())
-      .addStep(new StopJobExecutorStep())
       .addStep(new UnregisterBpmPlatformPluginsStep())
       .execute();
 


### PR DESCRIPTION
Fix for CAM-5505 (Tomcat part).

It is a bit unclear why the original implementation had StopJobExecutorStep after application/engine undeploy step. The fix tries to stop all activity first, then undeploy apps/engine.

Testing was minimal (builds)