### PR TITLE
fix(engine) isolate tenants when signals are thrown in multi-tenant context

### DIFF
--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
@@ -431,6 +431,7 @@ public abstract class MockProvider {
   public static final String EXAMPLE_HISTORIC_PROCESS_INSTANCE_SUB_PROCESS_INSTANCE_ID = "aSubProcessInstanceId";
   public static final String EXAMPLE_HISTORIC_PROCESS_INSTANCE_CASE_INSTANCE_ID = "aCaseInstanceId";
   public static final String EXAMPLE_HISTORIC_PROCESS_INSTANCE_SUB_CASE_INSTANCE_ID = "aSubCaseInstanceId";
+  public static final String EXAMPLE_HISTORIC_PROCESS_INSTANCE_TENANT_ID = "aTenantId";
 
   public static final String EXAMPLE_HISTORIC_PROCESS_INSTANCE_STARTED_AFTER = "2013-04-23T13:42:43";
   public static final String EXAMPLE_HISTORIC_PROCESS_INSTANCE_STARTED_BEFORE = "2013-01-23T13:42:43";

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/IntermediateThrowSignalEventActivityBehavior.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/IntermediateThrowSignalEventActivityBehavior.java
@@ -48,8 +48,8 @@ public class IntermediateThrowSignalEventActivityBehavior extends AbstractBpmnAc
     final EventSubscriptionManager eventSubscriptionManager = Context.getCommandContext().getEventSubscriptionManager();
 
     // trigger all event subscriptions for the signal (start and intermediate)
-    List<SignalEventSubscriptionEntity> catchSignalEventSubscription = eventSubscriptionManager
-      .findSignalEventSubscriptionsByEventName(signalDefinition.getEventName());
+    List<SignalEventSubscriptionEntity> catchSignalEventSubscription = eventSubscriptionManager.
+        findSignalEventSubscriptionsByEventNameAndTenantId(signalDefinition.getEventName(), execution.getTenantId());
     for (SignalEventSubscriptionEntity signalEventSubscriptionEntity : catchSignalEventSubscription) {
       if(isActiveEventSubscription(signalEventSubscriptionEntity)){
         signalEventSubscriptionEntity.eventReceived(null, signalDefinition.isAsync());

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/IntermediateThrowSignalEventActivityBehavior.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/IntermediateThrowSignalEventActivityBehavior.java
@@ -48,8 +48,17 @@ public class IntermediateThrowSignalEventActivityBehavior extends AbstractBpmnAc
     final EventSubscriptionManager eventSubscriptionManager = Context.getCommandContext().getEventSubscriptionManager();
 
     // trigger all event subscriptions for the signal (start and intermediate)
-    List<SignalEventSubscriptionEntity> catchSignalEventSubscription = eventSubscriptionManager.
-        findSignalEventSubscriptionsByEventNameAndTenantId(signalDefinition.getEventName(), execution.getTenantId());
+    List<SignalEventSubscriptionEntity> catchSignalEventSubscription;
+
+    // if tenantId included, include tenantId in subscription lookup
+    if (execution.getTenantId() == null){
+      catchSignalEventSubscription = eventSubscriptionManager.
+          findSignalEventSubscriptionsByEventName(signalDefinition.getEventName());
+    } else {
+      catchSignalEventSubscription = eventSubscriptionManager.
+          findSignalEventSubscriptionsByEventNameAndTenantId(signalDefinition.getEventName(), execution.getTenantId());
+    }
+
     for (SignalEventSubscriptionEntity signalEventSubscriptionEntity : catchSignalEventSubscription) {
       if(isActiveEventSubscription(signalEventSubscriptionEntity)){
         signalEventSubscriptionEntity.eventReceived(null, signalDefinition.isAsync());

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/SignalEndEventActivityBehavior.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/SignalEndEventActivityBehavior.java
@@ -36,13 +36,20 @@ public class SignalEndEventActivityBehavior extends FlowNodeActivityBehavior {
     
     CommandContext commandContext = Context.getCommandContext();
     
-    List<SignalEventSubscriptionEntity> findSignalEventSubscriptionsByEventName = commandContext
-        .getEventSubscriptionManager()
-        .findSignalEventSubscriptionsByEventName(signalDefinition.getEventName());
-      
-      for (SignalEventSubscriptionEntity signalEventSubscriptionEntity : findSignalEventSubscriptionsByEventName) {
-        signalEventSubscriptionEntity.eventReceived(null, signalDefinition.isAsync());
-      }
+    List<SignalEventSubscriptionEntity> findSignalEventSubscriptionsByEventName;
+
+    // if tenantId included, include tenantId in subscription lookup
+    if (execution.getTenantId() == null){
+      findSignalEventSubscriptionsByEventName = commandContext.getEventSubscriptionManager()
+          .findSignalEventSubscriptionsByEventName(signalDefinition.getEventName());
+    } else {
+      findSignalEventSubscriptionsByEventName = commandContext.getEventSubscriptionManager()
+          .findSignalEventSubscriptionsByEventNameAndTenantId(signalDefinition.getEventName(), execution.getTenantId());
+    }
+
+    for (SignalEventSubscriptionEntity signalEventSubscriptionEntity : findSignalEventSubscriptionsByEventName) {
+      signalEventSubscriptionEntity.eventReceived(null, signalDefinition.isAsync());
+    }
 
     leave(execution);
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/EventSubscriptionManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/EventSubscriptionManager.java
@@ -96,7 +96,7 @@ public class EventSubscriptionManager extends AbstractManager {
   }
 
   /**
-   * Find all signal event subscriptions with the given event name and tenant.
+   * find all signal event subscriptions with the given event name and tenant.
    */
   @SuppressWarnings("unchecked")
   public List<SignalEventSubscriptionEntity> findSignalEventSubscriptionsByEventNameAndTenantId(String eventName, String tenantId) {
@@ -105,7 +105,8 @@ public class EventSubscriptionManager extends AbstractManager {
     Map<String, Object> parameter = new HashMap<String, Object>();
     parameter.put("eventName", eventName);
     parameter.put("tenantId", tenantId);
-    Set<SignalEventSubscriptionEntity> eventSubscriptions = new HashSet<SignalEventSubscriptionEntity>( getDbEntityManager().selectList(query, parameter));
+    Set<SignalEventSubscriptionEntity> eventSubscriptions =
+        new HashSet<SignalEventSubscriptionEntity>( getDbEntityManager().selectList(query, parameter));
 
     // add events created in this command (not visible yet in query)
     for (SignalEventSubscriptionEntity entity : createdSignalSubscriptions) {

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/EventSubscription.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/EventSubscription.xml
@@ -124,10 +124,10 @@
       and (EVENT_NAME_ = #{parameter.eventName})
       and (EVT.EXECUTION_ID_ is null or EXC.SUSPENSION_STATE_ = 1)
       <if test="parameter.tenantId != null">
-        and EVT.TENANT_ID_ = #{parameter.tenantId}
+        and (EVT.TENANT_ID_ = #{parameter.tenantId})
       </if>
       <if test="parameter.tenantId == null">
-        and EVT.TENANT_ID_ is null
+        and (EVT.TENANT_ID_ is null)
       </if>
   </select>
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/signal/SignalEventTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/signal/SignalEventTest.java
@@ -43,7 +43,6 @@ import org.camunda.bpm.engine.variable.value.ObjectValue;
 
 /**
  * @author Daniel Meyer
- * @author Jan Vladimir Mostert
  */
 public class SignalEventTest extends PluggableProcessEngineTestCase {
 
@@ -515,95 +514,6 @@ public class SignalEventTest extends PluggableProcessEngineTestCase {
     assertEquals(SerializationDataFormats.JAVA.getName(), variableTyped.getSerializationDataFormat());
   }
 
-  /**
-   * Test that signal can be caught in a multi-tenant context given that both process instances
-   * are using a tenant id of null
-   */
-  public void testSignalCatchIntermediateInsideMultiTenantContextWithNullTenantId(){
-
-    org.camunda.bpm.engine.repository.Deployment deployment1 = repositoryService.createDeployment().
-        addClasspathResource("org/camunda/bpm/engine/test/bpmn/event/signal/SignalEventTests.catchAlertSignal.bpmn20.xml").
-        tenantId(null).deploy();
-
-    runtimeService.startProcessInstanceByKey("catchSignal");
-
-    assertEquals(1, createEventSubscriptionQuery().count());
-    assertEquals(1, runtimeService.createProcessInstanceQuery().count());
-
-    org.camunda.bpm.engine.repository.Deployment deployment2 = repositoryService.createDeployment().
-        addClasspathResource("org/camunda/bpm/engine/test/bpmn/event/signal/SignalEventTests.throwAlertSignal.bpmn20.xml").
-        tenantId(null).deploy();
-
-    runtimeService.startProcessInstanceByKey("throwSignal");
-
-    // we're expecting the signal to be caught due to tenants having the same null id
-    assertEquals(0, createEventSubscriptionQuery().count());
-    assertEquals(0, runtimeService.createProcessInstanceQuery().count());
-
-    repositoryService.deleteDeployment(deployment1.getId(), true);
-    repositoryService.deleteDeployment(deployment2.getId(), true);
-
-  }
-
-  /**
-   * Test that signal can be caught in a multi-tenant context given that both process instances
-   * are using the same tenant id
-   */
-  public void testSignalCatchIntermediateInsideMultiTenantContextWithSameTenantId(){
-
-    org.camunda.bpm.engine.repository.Deployment deployment1 = repositoryService.createDeployment().
-        addClasspathResource("org/camunda/bpm/engine/test/bpmn/event/signal/SignalEventTests.catchAlertSignal.bpmn20.xml").
-        tenantId("3").deploy();
-
-    runtimeService.startProcessInstanceByKey("catchSignal");
-
-    assertEquals(1, createEventSubscriptionQuery().count());
-    assertEquals(1, runtimeService.createProcessInstanceQuery().count());
-
-    org.camunda.bpm.engine.repository.Deployment deployment2 = repositoryService.createDeployment().
-        addClasspathResource("org/camunda/bpm/engine/test/bpmn/event/signal/SignalEventTests.throwAlertSignal.bpmn20.xml").
-        tenantId("3").deploy();
-
-    runtimeService.startProcessInstanceByKey("throwSignal");
-
-    // we're expecting the signal to be caught due to tenants having the same id
-    assertEquals(0, createEventSubscriptionQuery().count());
-    assertEquals(0, runtimeService.createProcessInstanceQuery().count());
-
-    repositoryService.deleteDeployment(deployment1.getId(), true);
-    repositoryService.deleteDeployment(deployment2.getId(), true);
-
-  }
-
-  /**
-   * Test that signal is not caught in a multi-tenant context given that both process instances
-   * are using different tenant ids
-   */
-  public void testSignalCatchIntermediateInsideMultiTenantContextWithDifferentTenantId(){
-
-    org.camunda.bpm.engine.repository.Deployment deployment1 = repositoryService.createDeployment().
-        addClasspathResource("org/camunda/bpm/engine/test/bpmn/event/signal/SignalEventTests.catchAlertSignal.bpmn20.xml").
-        tenantId("2").deploy();
-
-    runtimeService.startProcessInstanceByKey("catchSignal");
-
-    assertEquals(1, createEventSubscriptionQuery().count());
-    assertEquals(1, runtimeService.createProcessInstanceQuery().count());
-
-    org.camunda.bpm.engine.repository.Deployment deployment2 = repositoryService.createDeployment().
-        addClasspathResource("org/camunda/bpm/engine/test/bpmn/event/signal/SignalEventTests.throwAlertSignal.bpmn20.xml").
-        tenantId("1").deploy();
-
-    runtimeService.startProcessInstanceByKey("throwSignal");
-
-    // we're expecting the signal to be caught due to tenants having the different ids
-    assertEquals(1, createEventSubscriptionQuery().count());
-    assertEquals(1, runtimeService.createProcessInstanceQuery().count());
-
-    repositoryService.deleteDeployment(deployment1.getId(), true);
-    repositoryService.deleteDeployment(deployment2.getId(), true);
-
-  }
 
 
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/signal/SignalEventTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/signal/SignalEventTest.java
@@ -536,7 +536,7 @@ public class SignalEventTest extends PluggableProcessEngineTestCase {
 
     runtimeService.startProcessInstanceByKey("throwSignal");
 
-    // we're expecting the signal to be caught due to tenants having the same id
+    // we're expecting the signal to be caught due to tenants having the same null id
     assertEquals(0, createEventSubscriptionQuery().count());
     assertEquals(0, runtimeService.createProcessInstanceQuery().count());
 
@@ -596,7 +596,7 @@ public class SignalEventTest extends PluggableProcessEngineTestCase {
 
     runtimeService.startProcessInstanceByKey("throwSignal");
 
-    // we're expecting the signal to be caught due to tenants having the same id
+    // we're expecting the signal to be caught due to tenants having the different ids
     assertEquals(1, createEventSubscriptionQuery().count());
     assertEquals(1, runtimeService.createProcessInstanceQuery().count());
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/signal/SignalEventTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/signal/SignalEventTest.java
@@ -514,7 +514,4 @@ public class SignalEventTest extends PluggableProcessEngineTestCase {
     assertEquals(SerializationDataFormats.JAVA.getName(), variableTyped.getSerializationDataFormat());
   }
 
-
-
-
 }


### PR DESCRIPTION
Fix for  [CAM-5232](https://app.camunda.com/jira/browse/CAM-5232)

