### PR TITLE
add logInfo when process engine is finally closed

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessEngineImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessEngineImpl.java
@@ -98,7 +98,7 @@ public class ProcessEngineImpl implements ProcessEngine {
     executeSchemaOperations();
 
     if (name == null) {
-      LOG.processEngineCreated("default");
+      LOG.processEngineCreated(ProcessEngines.NAME_DEFAULT);
     } else {
       LOG.processEngineCreated(name);
     }
@@ -142,6 +142,8 @@ public class ProcessEngineImpl implements ProcessEngine {
     commandExecutorSchemaOperations.execute(new SchemaOperationProcessEngineClose());
 
     processEngineConfiguration.close();
+
+    LOG.processEngineClosed(name);
   }
 
   // getters and setters //////////////////////////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessEngineLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessEngineLogger.java
@@ -144,5 +144,9 @@ public class ProcessEngineLogger extends BaseLogger {
     logError("006", "Exception while closing process engine {}", string, e);
   }
 
+  public void processEngineClosed(String name) {
+    logInfo("007", "Process Engine {} closed", name);
+  }
+
 }
 


### PR DESCRIPTION
To track the application lifecycle it would be nice if the engine clearly logs when it is closed. So I added a Logger method and the statement to engine.close()