### PR TITLE
Duplicate subexpressions in HtmlReportBuilder.java

### DIFF
--- a/qa/performance-tests-engine/src/main/java/org/camunda/bpm/qa/performance/engine/framework/report/HtmlReportBuilder.java
+++ b/qa/performance-tests-engine/src/main/java/org/camunda/bpm/qa/performance/engine/framework/report/HtmlReportBuilder.java
@@ -107,7 +107,7 @@ public class HtmlReportBuilder {
                   .endElement();
      }
 
-     if(jsonSourceFileName != null && jsonSourceFileName != null) {
+     if(jsonSourceFileName != null) {
         sourceRow.startElement(new HtmlElementWriter("span").textContent("&nbsp;|&nbsp;")).endElement();
      }
 


### PR DESCRIPTION
`jsonSourceFileName != null` is repeated.