### PR TITLE
enhance deployment annotation scan on parent class

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/test/TestHelper.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/test/TestHelper.java
@@ -107,7 +107,15 @@ public abstract class TestHelper {
     // if not found on method, try on class level
     if (deploymentAnnotation == null) {
       onMethod = false;
-      deploymentAnnotation = testClass.getAnnotation(Deployment.class);
+      Class<?> lookForAnnotationClass = testClass;
+      while (lookForAnnotationClass != Object.class) {
+        deploymentAnnotation = lookForAnnotationClass.getAnnotation(Deployment.class);
+        if (deploymentAnnotation != null) {
+          testClass = lookForAnnotationClass;
+          break;
+        }
+        lookForAnnotationClass = lookForAnnotationClass.getSuperclass();
+      }
     }
 
     if (deploymentAnnotation != null) {
@@ -512,5 +520,6 @@ public abstract class TestHelper {
       }
     }
   }
+
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/testing/ProcessEngineRuleParentClassDeployment.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/testing/ProcessEngineRuleParentClassDeployment.java
@@ -1,0 +1,7 @@
+package org.camunda.bpm.engine.test.standalone.testing;
+
+import org.camunda.bpm.engine.test.Deployment;
+
+@Deployment
+public class ProcessEngineRuleParentClassDeployment {
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/testing/ProcessEngineRuleParentClassDeploymentTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/testing/ProcessEngineRuleParentClassDeploymentTest.java
@@ -1,0 +1,22 @@
+package org.camunda.bpm.engine.test.standalone.testing;
+
+
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+
+public class ProcessEngineRuleParentClassDeploymentTest extends ProcessEngineRuleParentClassDeployment  {
+
+  @Rule
+  public final ProcessEngineRule processEngineRule = new ProcessEngineRule(true);
+
+  @Test
+  public void testDeploymentOnParentClassLevel() {
+    assertNotNull("process is not deployed",processEngineRule.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTest").singleResult());
+  }
+
+
+}

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/standalone/testing/ProcessEngineRuleParentClassDeployment.bpmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/standalone/testing/ProcessEngineRuleParentClassDeployment.bpmn
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  targetNamespace="Examples">
+
+  <message id="messageId" name="newMessage" />
+
+  <process id="testHelperDeploymentTest" name="The One Task Process" isExecutable="true">
+    <documentation>This is a process for testing purposes</documentation>
+
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+    <userTask id="theTask" name="my task" />
+    <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+
+    <boundaryEvent id="message" attachedToRef="theTask">
+      <messageEventDefinition messageRef="messageId" />
+    </boundaryEvent>
+
+  </process>
+
+</definitions>


### PR DESCRIPTION
We figured out that when using test class hierarchies (for example with the Enclosed-Runner) the Deployment annotation on parent classes is not recognized right now.
This PR is a simple enhancement iterating up to Object.class while looking for the deployment annotation, allowing annotating a class higher up in the hierarchy.