### PR TITLE
Remove final qualifier from MultipartPayloadProvider

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/mapper/MultipartPayloadProvider.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/mapper/MultipartPayloadProvider.java
@@ -48,7 +48,7 @@ import java.lang.reflect.Type;
 */
 @Provider
 @Consumes(MediaType.MULTIPART_FORM_DATA)
-public final class MultipartPayloadProvider implements MessageBodyReader<MultipartFormData> {
+public class MultipartPayloadProvider implements MessageBodyReader<MultipartFormData> {
 
   public static final String TYPE_NAME = "multipart";
   public static final String SUB_TYPE_NAME = "form-data";


### PR DESCRIPTION
Final qualifier messes with resteasy-cdi features deploying a custom JAX-RS application to Wildfly.
Fixes #CAM-5155.