### PR TITLE
provide an annotation for the required history level of a test

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/test/AbstractProcessEngineTestCase.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/test/AbstractProcessEngineTestCase.java
@@ -99,9 +99,14 @@ public abstract class AbstractProcessEngineTestCase extends PvmTestCase {
 
     try {
 
-      deploymentId = TestHelper.annotationDeploymentSetUp(processEngine, getClass(), getName());
+      boolean hasRequiredHistoryLevel = TestHelper.annotationRequiredHistoryLevelCheck(processEngine, getClass(), getName());
+      // ignore test case when current history level is too low
+      if (hasRequiredHistoryLevel) {
 
-      super.runBare();
+        deploymentId = TestHelper.annotationDeploymentSetUp(processEngine, getClass(), getName());
+
+        super.runBare();
+      }
 
     }
     catch (AssertionFailedError e) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/test/TestHelper.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/test/TestHelper.java
@@ -241,12 +241,7 @@ public abstract class TestHelper {
 
     // if not found on method, try on class level
     if (annotation == null) {
-
-      Class<?> lookForAnnotationClass = testClass;
-      while (annotation == null && lookForAnnotationClass != Object.class) {
-        annotation = lookForAnnotationClass.getAnnotation(annotationClass);
-        lookForAnnotationClass = lookForAnnotationClass.getSuperclass();
-      }
+      annotation = testClass.getAnnotation(annotationClass);
     }
     return annotation;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/test/ProcessEngineRule.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/test/ProcessEngineRule.java
@@ -145,7 +145,7 @@ public class ProcessEngineRule extends TestWatcher implements ProcessEngineServi
   }
 
   @Override
-  public Statement apply(Statement base, Description description) {
+  public Statement apply(final Statement base, final Description description) {
 
     if (processEngine == null) {
       initializeProcessEngine();
@@ -153,22 +153,15 @@ public class ProcessEngineRule extends TestWatcher implements ProcessEngineServi
 
     initializeServices();
 
-    boolean hasRequiredHistoryLevel = TestHelper.annotationRequiredHistoryLevelCheck(processEngine, description);
+    final boolean hasRequiredHistoryLevel = TestHelper.annotationRequiredHistoryLevelCheck(processEngine, description);
+    return new Statement() {
 
-    if (hasRequiredHistoryLevel) {
-      // run test case
-      return base;
-
-    } else {
-      // ignore test case
-      return new Statement() {
-
-        @Override
-        public void evaluate() throws Throwable {
-          Assume.assumeTrue("ignored because the current history level is too low", false);
-        }
-      };
-    }
+      @Override
+      public void evaluate() throws Throwable {
+        Assume.assumeTrue("ignored because the current history level is too low", hasRequiredHistoryLevel);
+        ProcessEngineRule.super.apply(base, description).evaluate();
+      }
+    };
   }
 
   protected void initializeProcessEngine() {

--- a/engine/src/main/java/org/camunda/bpm/engine/test/ProcessEngineRule.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/test/ProcessEngineRule.java
@@ -33,8 +33,10 @@ import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.impl.test.TestHelper;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
+import org.junit.Assume;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 /**
  * Convenience for ProcessEngine and services initialization in the form of a
@@ -77,6 +79,12 @@ import org.junit.runner.Description;
  * clock will automatically be reset to use the current system time rather then
  * the time that was set during a test method. In other words, you don't have to
  * clean up your own time messing mess ;-)
+ * </p>
+ * <p>
+ * If you need the history service for your tests then you can specify the
+ * required history level of the test method or class, using the
+ * {@link RequiredHistoryLevel} annotation. If the current history level of the
+ * process engine is lower than the specified one then the test is skipped.
  * </p>
  *
  * @author Tom Baeyens
@@ -132,14 +140,35 @@ public class ProcessEngineRule extends TestWatcher implements ProcessEngineServi
 
   @Override
   public void starting(Description description) {
+    deploymentId = TestHelper.annotationDeploymentSetUp(processEngine, description.getTestClass(), description.getMethodName(),
+        description.getAnnotation(Deployment.class));
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+
     if (processEngine == null) {
       initializeProcessEngine();
     }
 
     initializeServices();
 
-    deploymentId = TestHelper.annotationDeploymentSetUp(processEngine, description.getTestClass(), description.getMethodName(),
-        description.getAnnotation(Deployment.class));
+    boolean hasRequiredHistoryLevel = TestHelper.annotationRequiredHistoryLevelCheck(processEngine, description);
+
+    if (hasRequiredHistoryLevel) {
+      // run test case
+      return base;
+
+    } else {
+      // ignore test case
+      return new Statement() {
+
+        @Override
+        public void evaluate() throws Throwable {
+          Assume.assumeTrue("ignored because the current history level is too low", false);
+        }
+      };
+    }
   }
 
   protected void initializeProcessEngine() {

--- a/engine/src/main/java/org/camunda/bpm/engine/test/ProcessEngineTestCase.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/test/ProcessEngineTestCase.java
@@ -16,8 +16,6 @@ package org.camunda.bpm.engine.test;
 import java.io.FileNotFoundException;
 import java.util.Date;
 
-import junit.framework.TestCase;
-
 import org.camunda.bpm.engine.AuthorizationService;
 import org.camunda.bpm.engine.CaseService;
 import org.camunda.bpm.engine.FilterService;
@@ -33,6 +31,8 @@ import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.impl.test.ProcessEngineAssert;
 import org.camunda.bpm.engine.impl.test.TestHelper;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
+
+import junit.framework.TestCase;
 
 
 /** Convenience for ProcessEngine and services initialization in the form of a JUnit base class.
@@ -82,6 +82,8 @@ public class ProcessEngineTestCase extends TestCase {
   protected AuthorizationService authorizationService;
   protected CaseService caseService;
 
+  protected boolean skipTest = false;
+
   /** uses 'camunda.cfg.xml' as it's configuration resource */
   public ProcessEngineTestCase() {
   }
@@ -99,7 +101,20 @@ public class ProcessEngineTestCase extends TestCase {
       initializeServices();
     }
 
-    deploymentId = TestHelper.annotationDeploymentSetUp(processEngine, getClass(), getName());
+    boolean hasRequiredHistoryLevel = TestHelper.annotationRequiredHistoryLevelCheck(processEngine, getClass(), getName());
+    // ignore test case when current history level is too low
+    skipTest = !hasRequiredHistoryLevel;
+
+    if (!skipTest) {
+      deploymentId = TestHelper.annotationDeploymentSetUp(processEngine, getClass(), getName());
+    }
+  }
+
+  @Override
+  protected void runTest() throws Throwable {
+    if (!skipTest) {
+      super.runTest();
+    }
   }
 
   protected void initializeProcessEngine() {

--- a/engine/src/main/java/org/camunda/bpm/engine/test/RequiredHistoryLevel.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/test/RequiredHistoryLevel.java
@@ -13,6 +13,7 @@
 
 package org.camunda.bpm.engine.test;
 
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -38,6 +39,7 @@ import java.lang.annotation.RetentionPolicy;
  * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 public @interface RequiredHistoryLevel {
 
   /**

--- a/engine/src/main/java/org/camunda/bpm/engine/test/RequiredHistoryLevel.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/test/RequiredHistoryLevel.java
@@ -1,0 +1,48 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.engine.test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotation for a test method or class to specify the required history level.
+ * If the current history level of the process engine is lower than the
+ * specified one then the test method is skipped.
+ *
+ * <p>Usage:</p>
+ *
+ * <pre>
+ * package org.example;
+ *
+ * ...
+ *
+ * public class ExampleTest {
+ *
+ *   &#64;RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_ACTIVITY)
+ *   public void testWithHistory() {
+ *
+ *     // test something with the history service (e.g. variables)
+ *   }
+ * </pre>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequiredHistoryLevel {
+
+  /**
+   * The required history level.
+   */
+  public String value();
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/testing/ProcessEngineRuleRequiredHistoryLevelClassTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/testing/ProcessEngineRuleRequiredHistoryLevelClassTest.java
@@ -15,59 +15,22 @@ package org.camunda.bpm.engine.test.standalone.testing;
 
 import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
-import org.camunda.bpm.engine.RuntimeService;
-import org.camunda.bpm.engine.TaskService;
-import org.camunda.bpm.engine.task.Task;
-import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.RequiredHistoryLevel;
 import org.junit.Rule;
 import org.junit.Test;
 
-
-/**
- * Test runners follow the this rule:
- *   - if the class extends Testcase, run as Junit 3
- *   - otherwise use Junit 4
- *
- * So this test can be included in the regular test suite without problems.
- *
- * @author Joram Barrez
- */
-public class ProcessEngineRuleJunit4Test {
+@RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_AUDIT)
+public class ProcessEngineRuleRequiredHistoryLevelClassTest {
 
   @Rule
-  public ProcessEngineRule engineRule = new ProcessEngineRule(true);
+  public final ProcessEngineRule engineRule = new ProcessEngineRule(true);
 
   @Test
-  @Deployment
-  public void ruleUsageExample() {
-    RuntimeService runtimeService = engineRule.getRuntimeService();
-    runtimeService.startProcessInstanceByKey("ruleUsage");
-
-    TaskService taskService = engineRule.getTaskService();
-    Task task = taskService.createTaskQuery().singleResult();
-    assertEquals("My Task", task.getName());
-
-    taskService.complete(task.getId());
-    assertEquals(0, runtimeService.createProcessInstanceQuery().count());
-  }
-
-  /**
-   * The rule should work with tests that have no deployment annotation
-   */
-  @Test
-  public void testWithoutDeploymentAnnotation() {
-    assertEquals("aString", "aString");
-  }
-
-  @Test
-  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_AUDIT)
-  public void requiredHistoryLevelAudit() {
+  public void requiredHistoryLevelOnClass() {
 
     assertThat(currentHistoryLevel(),
         either(is(ProcessEngineConfiguration.HISTORY_AUDIT))
@@ -77,18 +40,11 @@ public class ProcessEngineRuleJunit4Test {
 
   @Test
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_ACTIVITY)
-  public void requiredHistoryLevelActivity() {
+  public void overrideRequiredHistoryLevelOnClass() {
 
     assertThat(currentHistoryLevel(),
         either(is(ProcessEngineConfiguration.HISTORY_ACTIVITY))
         .or(is(ProcessEngineConfiguration.HISTORY_FULL)));
-  }
-
-  @Test
-  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
-  public void requiredHistoryLevelFull() {
-
-    assertThat(currentHistoryLevel(), is(ProcessEngineConfiguration.HISTORY_FULL));
   }
 
   protected String currentHistoryLevel() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/testing/ProcessEngineRuleRequiredHistoryLevelSuperClassTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/testing/ProcessEngineRuleRequiredHistoryLevelSuperClassTest.java
@@ -1,0 +1,38 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.engine.test.standalone.testing;
+
+import static org.hamcrest.CoreMatchers.either;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.junit.Test;
+
+/**
+ * Checks if the test is ignored than the current history level is lower than
+ * the required history level which is specified on the super class.
+ */
+public class ProcessEngineRuleRequiredHistoryLevelSuperClassTest extends ProcessEngineRuleRequiredHistoryLevelClassTest {
+
+  @Test
+  public void requiredHistoryLevelOnSuperClass() {
+
+    assertThat(currentHistoryLevel(),
+        either(is(ProcessEngineConfiguration.HISTORY_AUDIT))
+        .or(is(ProcessEngineConfiguration.HISTORY_ACTIVITY))
+        .or(is(ProcessEngineConfiguration.HISTORY_FULL)));
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/testing/ProcessEngineTestCaseTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/testing/ProcessEngineTestCaseTest.java
@@ -13,11 +13,17 @@
 
 package org.camunda.bpm.engine.test.standalone.testing;
 
+import static org.hamcrest.CoreMatchers.either;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.impl.ProcessEngineImpl;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.ProcessEngineTestCase;
+import org.camunda.bpm.engine.test.RequiredHistoryLevel;
 
 
 /**
@@ -43,6 +49,34 @@ public class ProcessEngineTestCaseTest extends ProcessEngineTestCase {
     }
   }
 
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_AUDIT)
+  public void testRequiredHistoryLevelAudit() {
+
+    assertThat(currentHistoryLevel(),
+        either(is(ProcessEngineConfiguration.HISTORY_AUDIT))
+        .or(is(ProcessEngineConfiguration.HISTORY_ACTIVITY))
+        .or(is(ProcessEngineConfiguration.HISTORY_FULL)));
+  }
+
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_ACTIVITY)
+  public void testRequiredHistoryLevelActivity() {
+
+    assertThat(currentHistoryLevel(),
+        either(is(ProcessEngineConfiguration.HISTORY_ACTIVITY))
+        .or(is(ProcessEngineConfiguration.HISTORY_FULL)));
+  }
+
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+  public void testRequiredHistoryLevelFull() {
+
+    assertThat(currentHistoryLevel(), is(ProcessEngineConfiguration.HISTORY_FULL));
+  }
+
+  protected String currentHistoryLevel() {
+    return processEngine.getProcessEngineConfiguration().getHistory();
+  }
+
+  @Override
   protected void tearDown() throws Exception {
     super.tearDown();
     processEngine.close();


### PR DESCRIPTION
- annotate a test method or class to set the required history level
- if the current history level of the process engine is too low then the
test is skipped
- supported for AbstractProcessEngineTestCase and ProcessEngineRule