### PR TITLE
chore(build): define runOrder 'hourly' for surefire

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -480,6 +480,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.16</version>
           <configuration>
+            <runOrder>hourly</runOrder>
             <systemPropertyVariables>
               <myWorkingDir>${project.build.directory}</myWorkingDir>
             </systemPropertyVariables>


### PR DESCRIPTION
I propose to use the runOrder 'hourly', because the default runOrder of 'filesystem' is not reproducible so easy and probably differs from JVM to JVM and OS to OS.
RunOrder 'hourly' defines the following behavior: alphabetical on even hours, reverse alphabetical on odd hours.
So a bit of randomness is preserved but at the same time, we would be able to reproduce test issue which fail because of ordering easier.