### PR TITLE
chore(qa): enforce JDK 6/7 for JBoss AS

### DIFF
--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -254,6 +254,34 @@
         </testResources>
         <plugins>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>1.3.1</version>
+            <executions>
+              <execution>
+                <id>enforce-java</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireJavaVersion>
+                      <version>[1.6,1.8)</version>
+                      <message>
+                        *************************************************
+                        *                                               *
+                        * You must use JDK 6/7 to run JBoss AS 7.2.0!!! *
+                        *                                               *
+                        *************************************************
+                      </message>
+                    </requireJavaVersion>
+                  </rules>
+                  <failFast>true</failFast>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
             <executions>

--- a/qa/integration-tests-webapps/pom.xml
+++ b/qa/integration-tests-webapps/pom.xml
@@ -192,6 +192,34 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>1.3.1</version>
+            <executions>
+              <execution>
+                <id>enforce-java</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireJavaVersion>
+                      <version>[1.6,1.8)</version>
+                      <message>
+                        *************************************************
+                        *                                               *
+                        * You must use JDK 6/7 to run JBoss AS 7.2.0!!! *
+                        *                                               *
+                        *************************************************
+                      </message>
+                    </requireJavaVersion>
+                  </rules>
+                  <failFast>true</failFast>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>org.codehaus.cargo</groupId>
             <artifactId>cargo-maven2-plugin</artifactId>
             <executions>


### PR DESCRIPTION
as it just hangs without any error message when it is started with JDK 8 during engine-it/webapps-it

related to #CAM-6410