### PR TITLE
Cam-5345 fix npe in initHistoryLevel

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -1302,7 +1302,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     if (isDmnEnabled()) {
       DecisionRequirementsDefinitionDeployer decisionRequirementsDefinitionDeployer = getDecisionRequirementsDefinitionDeployer();
       DecisionDefinitionDeployer decisionDefinitionDeployer = getDecisionDefinitionDeployer();
-      // the DecisionRequirementsDefinition deployer must be before the DecisionDefinitionDeployer 
+      // the DecisionRequirementsDefinition deployer must be before the DecisionDefinitionDeployer
       defaultDeployers.add(decisionRequirementsDefinitionDeployer);
       defaultDeployers.add(decisionDefinitionDeployer);
     }
@@ -1498,36 +1498,36 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   // history //////////////////////////////////////////////////////////////////
 
   public void initHistoryLevel() {
-    if(historyLevel == null) {
-      if(historyLevels == null) {
-        historyLevels = new ArrayList<HistoryLevel>();
-        historyLevels.add(HistoryLevel.HISTORY_LEVEL_NONE);
-        historyLevels.add(HistoryLevel.HISTORY_LEVEL_ACTIVITY);
-        historyLevels.add(HistoryLevel.HISTORY_LEVEL_AUDIT);
-        historyLevels.add(HistoryLevel.HISTORY_LEVEL_FULL);
-      }
+    if (historyLevel != null) {
+      setHistory(historyLevel.getName());
+    }
 
-      if(customHistoryLevels != null) {
-        historyLevels.addAll(customHistoryLevels);
-      }
+    if(historyLevels == null) {
+      historyLevels = new ArrayList<HistoryLevel>();
+      historyLevels.add(HistoryLevel.HISTORY_LEVEL_NONE);
+      historyLevels.add(HistoryLevel.HISTORY_LEVEL_ACTIVITY);
+      historyLevels.add(HistoryLevel.HISTORY_LEVEL_AUDIT);
+      historyLevels.add(HistoryLevel.HISTORY_LEVEL_FULL);
+    }
 
-      if(HISTORY_VARIABLE.equalsIgnoreCase(history)) {
-        historyLevel = HistoryLevel.HISTORY_LEVEL_ACTIVITY;
-        LOG.usingDeprecatedHistoryLevelVariable();
+    if(customHistoryLevels != null) {
+      historyLevels.addAll(customHistoryLevels);
+    }
 
-      } else {
-        for (HistoryLevel historyLevel : historyLevels) {
-          if(historyLevel.getName().equalsIgnoreCase(history)) {
-            this.historyLevel = historyLevel;
-          }
+    if(HISTORY_VARIABLE.equalsIgnoreCase(history)) {
+      historyLevel = HistoryLevel.HISTORY_LEVEL_ACTIVITY;
+      LOG.usingDeprecatedHistoryLevelVariable();
+    } else {
+      for (HistoryLevel historyLevel : historyLevels) {
+        if(historyLevel.getName().equalsIgnoreCase(history)) {
+          this.historyLevel = historyLevel;
         }
       }
+    }
 
-
-      // do allow null for history level in case of "auto"
-      if(historyLevel == null && !ProcessEngineConfiguration.HISTORY_AUTO.equalsIgnoreCase(history)) {
-        throw new ProcessEngineException("invalid history level: "+history);
-      }
+    // do allow null for history level in case of "auto"
+    if(historyLevel == null && !ProcessEngineConfiguration.HISTORY_AUTO.equalsIgnoreCase(history)) {
+      throw new ProcessEngineException("invalid history level: "+history);
     }
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/cfg/ProcessEngineConfigurationImplTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/cfg/ProcessEngineConfigurationImplTest.java
@@ -1,0 +1,41 @@
+package org.camunda.bpm.engine.test.cfg;
+
+
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
+import org.camunda.bpm.engine.impl.history.HistoryLevel;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ProcessEngineConfigurationImplTest {
+
+
+    @Test
+    public void shouldInitHistoryLevelByObject() throws Exception {
+        ProcessEngineConfigurationImpl config = new StandaloneInMemProcessEngineConfiguration();
+        config.setHistoryLevel(HistoryLevel.HISTORY_LEVEL_FULL);
+
+        config.initHistoryLevel();
+
+        assertThat(config.getHistoryLevels().size(), is(4));
+        assertThat(config.getHistoryLevel(), is(HistoryLevel.HISTORY_LEVEL_FULL));
+        assertThat(config.getHistory(), is(HistoryLevel.HISTORY_LEVEL_FULL.getName()));
+    }
+
+    @Test
+    public void shouldInitHistoryLevelByString() throws Exception {
+        ProcessEngineConfigurationImpl config = new StandaloneInMemProcessEngineConfiguration();
+
+        config.setHistory(HistoryLevel.HISTORY_LEVEL_FULL.getName());
+
+        config.initHistoryLevel();
+
+        assertThat(config.getHistoryLevels().size(), is(4));
+        assertThat(config.getHistoryLevel(), is(HistoryLevel.HISTORY_LEVEL_FULL));
+        assertThat(config.getHistory(), is(HistoryLevel.HISTORY_LEVEL_FULL.getName()));
+    }
+}


### PR DESCRIPTION
* remove check for null around initiliazation
* write historyLevel.name to history if set

the configuration allows setting of "history" and "historyLevel" but did not bundle these properties. Now setting the Level also sets the string.