### PR TITLE
Add camunda-commons-utils dependency to camunda-engine-feel-juel module.

### DIFF
--- a/distro/jbossas7/modules/src/main/modules/org/camunda/bpm/dmn/camunda-engine-feel-juel/main/module.xml
+++ b/distro/jbossas7/modules/src/main/modules/org/camunda/bpm/dmn/camunda-engine-feel-juel/main/module.xml
@@ -7,5 +7,6 @@
     <module name="org.camunda.bpm.dmn.camunda-engine-feel-api" />
     <module name="org.camunda.commons.camunda-commons-logging" />
     <module name="org.camunda.commons.camunda-commons-typed-values" />
+    <module name="org.camunda.commons.camunda-commons-utils" />
   </dependencies>
 </module>

--- a/distro/wildfly/modules/src/main/modules/org/camunda/bpm/dmn/camunda-engine-feel-juel/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/camunda/bpm/dmn/camunda-engine-feel-juel/main/module.xml
@@ -7,5 +7,6 @@
     <module name="org.camunda.bpm.dmn.camunda-engine-feel-api" />
     <module name="org.camunda.commons.camunda-commons-logging" />
     <module name="org.camunda.commons.camunda-commons-typed-values" />
+    <module name="org.camunda.commons.camunda-commons-utils" />
   </dependencies>
 </module>


### PR DESCRIPTION
Camunda Feel Juel uses caching now. This requires new depency to camunda-commons-utils.
See https://github.com/camunda/camunda-engine-dmn/commit/8a9540241ba62ac7f6c61ddec8dd56cfd47fb996

related to #CAM-6423
