### PR TITLE
Don't start new instances if there are some running

### DIFF
--- a/examples/invoice/src/main/java/org/camunda/bpm/example/invoice/InvoiceProcessApplication.java
+++ b/examples/invoice/src/main/java/org/camunda/bpm/example/invoice/InvoiceProcessApplication.java
@@ -18,6 +18,7 @@ import static org.camunda.bpm.engine.variable.Variables.fileValue;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.logging.Logger;
 
 import org.camunda.bpm.BpmPlatform;
 import org.camunda.bpm.application.PostDeploy;
@@ -39,6 +40,8 @@ import org.camunda.bpm.engine.task.Task;
  */
 @ProcessApplication
 public class InvoiceProcessApplication extends ServletProcessApplication {
+  
+  private static final Logger LOGGER = Logger.getLogger(InvoiceProcessApplication.class.getName());
 
   /**
    * In a @PostDeploy Hook you can interact with the process engine and access
@@ -94,80 +97,90 @@ public class InvoiceProcessApplication extends ServletProcessApplication {
     ProcessDefinition processDefinition = processDefinitionQuery.singleResult();
 
     InputStream invoiceInputStream = InvoiceProcessApplication.class.getClassLoader().getResourceAsStream("invoice.pdf");
+    
+    long numberOfRunningProcessInstances = processEngine.getRuntimeService().createProcessInstanceQuery().processDefinitionId(processDefinition.getId()).count();
+    
+    if (numberOfRunningProcessInstances == 0) { // start three process instances
 
-    // process instance 1
-    processEngine.getRuntimeService().startProcessInstanceById(processDefinition.getId(), createVariables()
-        .putValue("creditor", "Great Pizza for Everyone Inc.")
-        .putValue("amount", 30.00d)
-        .putValue("invoiceCategory", "Travel Expenses")
-        .putValue("invoiceNumber", "GPFE-23232323")
-        .putValue("invoiceDocument", fileValue("invoice.pdf")
-            .file(invoiceInputStream)
-            .mimeType("application/pdf")
-            .create()));
-
-    IoUtil.closeSilently(invoiceInputStream);
-    invoiceInputStream = InvoiceProcessApplication.class.getClassLoader().getResourceAsStream("invoice.pdf");
-
-    // process instance 2
-    try {
-      Calendar calendar = Calendar.getInstance();
-      calendar.add(Calendar.DAY_OF_MONTH, -14);
-      ClockUtil.setCurrentTime(calendar.getTime());
-
-      ProcessInstance pi = processEngine.getRuntimeService().startProcessInstanceById(processDefinition.getId(), createVariables()
-          .putValue("creditor", "Bobby's Office Supplies")
-          .putValue("amount", 900.00d)
-          .putValue("invoiceCategory", "Misc")
-          .putValue("invoiceNumber", "BOS-43934")
-          .putValue("invoiceDocument", fileValue("invoice.pdf")
-              .file(invoiceInputStream)
-              .mimeType("application/pdf")
-              .create()));
-
-      calendar.add(Calendar.DAY_OF_MONTH, 14);
-      ClockUtil.setCurrentTime(calendar.getTime());
-
-      processEngine.getIdentityService().setAuthentication("demo", Arrays.asList(Groups.CAMUNDA_ADMIN));
-      Task task = processEngine.getTaskService().createTaskQuery().processInstanceId(pi.getId()).singleResult();
-      processEngine.getTaskService().claim(task.getId(), "demo");
-      processEngine.getTaskService().complete(task.getId(), createVariables().putValue("approved", true));
-    }
-    finally{
-      ClockUtil.reset();
-      processEngine.getIdentityService().clearAuthentication();
-    }
-
-    IoUtil.closeSilently(invoiceInputStream);
-    invoiceInputStream = InvoiceProcessApplication.class.getClassLoader().getResourceAsStream("invoice.pdf");
-
-    // process instance 3
-    try {
-      Calendar calendar = Calendar.getInstance();
-      calendar.add(Calendar.DAY_OF_MONTH, -5);
-      ClockUtil.setCurrentTime(calendar.getTime());
-
-      ProcessInstance pi = processEngine.getRuntimeService().startProcessInstanceById(processDefinition.getId(), createVariables()
-          .putValue("creditor", "Papa Steve's all you can eat")
-          .putValue("amount", 10.99d)
+      LOGGER.info("Start 3 instances of " + processDefinition.getName() + ", version " + processDefinition.getVersion());
+      // process instance 1
+      processEngine.getRuntimeService().startProcessInstanceById(processDefinition.getId(), createVariables()
+          .putValue("creditor", "Great Pizza for Everyone Inc.")
+          .putValue("amount", 30.00d)
           .putValue("invoiceCategory", "Travel Expenses")
-          .putValue("invoiceNumber", "PSACE-5342")
+          .putValue("invoiceNumber", "GPFE-23232323")
           .putValue("invoiceDocument", fileValue("invoice.pdf")
               .file(invoiceInputStream)
               .mimeType("application/pdf")
               .create()));
 
-      calendar.add(Calendar.DAY_OF_MONTH, 5);
-      ClockUtil.setCurrentTime(calendar.getTime());
+      IoUtil.closeSilently(invoiceInputStream);
+      invoiceInputStream = InvoiceProcessApplication.class.getClassLoader().getResourceAsStream("invoice.pdf");
 
-      processEngine.getIdentityService().setAuthenticatedUserId("mary");
-      Task task = processEngine.getTaskService().createTaskQuery().processInstanceId(pi.getId()).singleResult();
-      processEngine.getTaskService().createComment(null, pi.getId(), "I cannot approve this invoice: the amount is missing.\n\n Could you please provide the amount?");
-      processEngine.getTaskService().complete(task.getId(), createVariables().putValue("approved", false));
-    }
-    finally{
-      ClockUtil.reset();
-      processEngine.getIdentityService().clearAuthentication();
+      // process instance 2
+      try {
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.DAY_OF_MONTH, -14);
+        ClockUtil.setCurrentTime(calendar.getTime());
+
+        ProcessInstance pi = processEngine.getRuntimeService().startProcessInstanceById(processDefinition.getId(), createVariables()
+            .putValue("creditor", "Bobby's Office Supplies")
+            .putValue("amount", 900.00d)
+            .putValue("invoiceCategory", "Misc")
+            .putValue("invoiceNumber", "BOS-43934")
+            .putValue("invoiceDocument", fileValue("invoice.pdf")
+                .file(invoiceInputStream)
+                .mimeType("application/pdf")
+                .create()));
+
+        calendar.add(Calendar.DAY_OF_MONTH, 14);
+        ClockUtil.setCurrentTime(calendar.getTime());
+
+        processEngine.getIdentityService().setAuthentication("demo", Arrays.asList(Groups.CAMUNDA_ADMIN));
+        Task task = processEngine.getTaskService().createTaskQuery().processInstanceId(pi.getId()).singleResult();
+        processEngine.getTaskService().claim(task.getId(), "demo");
+        processEngine.getTaskService().complete(task.getId(), createVariables().putValue("approved", true));
+      }
+      finally{
+        ClockUtil.reset();
+        processEngine.getIdentityService().clearAuthentication();
+      }
+
+      IoUtil.closeSilently(invoiceInputStream);
+      invoiceInputStream = InvoiceProcessApplication.class.getClassLoader().getResourceAsStream("invoice.pdf");
+
+      // process instance 3
+      try {
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.DAY_OF_MONTH, -5);
+        ClockUtil.setCurrentTime(calendar.getTime());
+
+        ProcessInstance pi = processEngine.getRuntimeService().startProcessInstanceById(processDefinition.getId(), createVariables()
+            .putValue("creditor", "Papa Steve's all you can eat")
+            .putValue("amount", 10.99d)
+            .putValue("invoiceCategory", "Travel Expenses")
+            .putValue("invoiceNumber", "PSACE-5342")
+            .putValue("invoiceDocument", fileValue("invoice.pdf")
+                .file(invoiceInputStream)
+                .mimeType("application/pdf")
+                .create()));
+
+        calendar.add(Calendar.DAY_OF_MONTH, 5);
+        ClockUtil.setCurrentTime(calendar.getTime());
+
+        processEngine.getIdentityService().setAuthenticatedUserId("mary");
+        Task task = processEngine.getTaskService().createTaskQuery().processInstanceId(pi.getId()).singleResult();
+        processEngine.getTaskService().createComment(null, pi.getId(), "I cannot approve this invoice: the amount is missing.\n\n Could you please provide the amount?");
+        processEngine.getTaskService().complete(task.getId(), createVariables().putValue("approved", false));
+      }
+      finally{
+        ClockUtil.reset();
+        processEngine.getIdentityService().clearAuthentication();
+      }
+    } else {
+      LOGGER.info("No new instances of " + processDefinition.getName() 
+          + " version " + processDefinition.getVersion() 
+          + " started, there are " + numberOfRunningProcessInstances + " instances running");
     }
   }
 


### PR DESCRIPTION
To avoid the flood of process instances with the same variables after each engine start, supress the start if there are still some instances running.