### PR TITLE
filter historic process instances regarding the incident status

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricProcessInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricProcessInstanceQueryDto.java
@@ -69,6 +69,7 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
   private Boolean finished;
   private Boolean unfinished;
   private Boolean withIncidents;
+  private String incidentStatus;
   private String incidentMessage;
   private String incidentMessageLike;
   private Date startedBefore;
@@ -149,6 +150,11 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
   @CamundaQueryParam(value = "withIncidents", converter = BooleanConverter.class)
   public void setWithIncidents(Boolean withIncidents) {
     this.withIncidents = withIncidents;
+  }
+
+  @CamundaQueryParam(value = "incidentStatus")
+  public void setIncidentStatus(String status) {
+    this.incidentStatus = status;
   }
 
   @CamundaQueryParam(value = "incidentMessage")
@@ -269,6 +275,9 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
     }
     if (withIncidents != null && withIncidents) {
       query.withIncidents();
+    }
+    if (incidentStatus != null) {
+      query.incidentStatus(incidentStatus);
     }
     if(incidentMessage != null) {
       query.incidentMessage(incidentMessage);

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricProcessInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricProcessInstanceRestServiceQueryTest.java
@@ -772,6 +772,58 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
   }
 
   @Test
+  public void testQueryWithIncidentStatusOpen() {
+    given()
+      .queryParam("incidentStatus", "open")
+      .then()
+      .expect()
+      .statusCode(Status.OK.getStatusCode())
+      .when()
+      .get(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
+
+    InOrder inOrder = inOrder(mockedQuery);
+    inOrder.verify(mockedQuery).incidentStatus("open");
+    inOrder.verify(mockedQuery).list();
+  }
+
+  @Test
+  public void testQueryWithIncidentStatusOpenAsPost() {
+    Map<String, String> body = new HashMap<String, String>();
+    body.put("incidentStatus", "open");
+
+    given()
+      .contentType(POST_JSON_CONTENT_TYPE)
+      .body(body)
+      .then()
+      .expect()
+      .statusCode(Status.OK.getStatusCode())
+      .when()
+      .post(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
+
+    InOrder inOrder = inOrder(mockedQuery);
+    inOrder.verify(mockedQuery).incidentStatus("open");
+    inOrder.verify(mockedQuery).list();
+  }
+  
+  @Test
+  public void testQueryCountIncidentStatusOpenForPost() {
+    Map<String,String> body = new HashMap<String, String>();
+    body.put("incidentStatus", "open");
+    given()
+      .contentType(POST_JSON_CONTENT_TYPE)
+      .body(body)
+    .then()
+      .expect()
+        .body("count", equalTo(1))
+      .when()
+        .post(HISTORIC_PROCESS_INSTANCE_COUNT_RESOURCE_URL);
+
+    verify(mockedQuery).count();
+    verify(mockedQuery).incidentStatus("open");
+  }
+
+
+  @Test
   public void testQueryIncidentMessage() {
     given()
       .queryParam("incidentMessage", MockProvider.EXAMPLE_INCIDENT_MESSAGE)

--- a/engine/src/main/java/org/camunda/bpm/engine/history/HistoricProcessInstanceQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/history/HistoricProcessInstanceQuery.java
@@ -86,6 +86,15 @@ public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInsta
    */
   HistoricProcessInstanceQuery withIncidents();
 
+  /** Only select historic process instances with incident status either 'open' or 'resolved'.
+   * To get all process instances with incidents, use {@link HistoricProcessInstanceQuery#withIncidents()} 
+   * as query parameter.
+   *  
+   * @param incident status either 'open' or 'resolved'
+   * @return {@link HistoricProcessInstanceQuery}
+   */
+  HistoricProcessInstanceQuery incidentStatus(String status);
+
   /**
    * Only select historic process instances with the given incident message.
    *

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -46,6 +46,7 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   protected boolean finished = false;
   protected boolean unfinished = false;
   protected boolean withIncidents = false;
+  protected String incidentStatus;
   protected String incidentMessage;
   protected String incidentMessageLike;
   protected String startedBy;
@@ -125,6 +126,12 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   public HistoricProcessInstanceQuery withIncidents() {
     this.withIncidents = true;
 
+    return this;
+  }
+
+  @Override
+  public HistoricProcessInstanceQuery incidentStatus(String status) {
+    this.incidentStatus = status;
     return this;
   }
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
@@ -159,7 +159,7 @@
       inner join ${prefix}ACT_RE_PROCDEF DEF on RES.PROC_DEF_ID_ = DEF.ID_
     </if>
 
-    <if test="withIncidents || incidentMessage != null || incidentMessageLike != null">
+    <if test="withIncidents || incidentStatus != null || incidentMessage != null || incidentMessageLike != null">
       inner join ${prefix}ACT_HI_INCIDENT INC on RES.PROC_INST_ID_ = INC.PROC_INST_ID_
     </if>
     <where>
@@ -244,6 +244,14 @@
 
       <if test="incidentMessageLike != null">
         and INC.INCIDENT_MSG_ like #{incidentMessageLike}
+      </if>
+      
+      <if test="incidentStatus == 'open'">
+        and INC.END_TIME_ is null
+      </if>
+      
+      <if test="incidentStatus == 'resolved'">
+        and INC.END_TIME_ is not null
       </if>
 
       <if test="startedBy != null">

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricProcessInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricProcessInstanceTest.java
@@ -18,7 +18,9 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang.time.DateUtils;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
@@ -31,6 +33,7 @@ import org.camunda.bpm.engine.impl.history.event.HistoricProcessInstanceEventEnt
 import org.camunda.bpm.engine.impl.test.PluggableProcessEngineTestCase;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.engine.runtime.Job;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.Deployment;
@@ -259,6 +262,48 @@ public class HistoricProcessInstanceTest extends PluggableProcessEngineTestCase 
 
     assertEquals(0, historyService.createHistoricProcessInstanceQuery().incidentMessage("Unknown message").count());
     assertEquals(0, historyService.createHistoricProcessInstanceQuery().incidentMessage("Unknown message").list().size());
+  }
+
+  @Deployment(resources = {"org/camunda/bpm/engine/test/api/mgmt/IncidentTest.testShouldDeleteIncidentAfterJobWasSuccessfully.bpmn"})
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+  public void testHistoricProcessInstanceQueryIncidentStatusOpen() {
+    Map<String, Object> parameters = new HashMap<String, Object>();
+    parameters.put("fail", true);
+    ProcessInstance pi1 = runtimeService.startProcessInstanceByKey("failingProcessWithUserTask", parameters);
+    runtimeService.startProcessInstanceByKey("failingProcessWithUserTask", parameters);
+    
+    executeAvailableJobs();
+    
+    assertEquals(2, historyService.createHistoricProcessInstanceQuery().incidentStatus("open").count());
+    assertEquals(2, historyService.createHistoricProcessInstanceQuery().incidentStatus("open").list().size());
+    
+    // set execution variable from "true" to "false"
+    runtimeService.setVariable(pi1.getId(), "fail", new Boolean(false));
+    Job jobToResolve = managementService.createJobQuery().processInstanceId(pi1.getId()).singleResult();
+    managementService.setJobRetries(jobToResolve.getId(), 1);
+    executeAvailableJobs();
+    
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().incidentStatus("open").count());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().incidentStatus("open").list().size());
+  }
+
+  @Deployment(resources = {"org/camunda/bpm/engine/test/api/mgmt/IncidentTest.testShouldDeleteIncidentAfterJobWasSuccessfully.bpmn"})
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+  public void testHistoricProcessInstanceQueryIncidentStatusResolved() {
+    Map<String, Object> parameters = new HashMap<String, Object>();
+    parameters.put("fail", true);
+    ProcessInstance pi = runtimeService.startProcessInstanceByKey("failingProcessWithUserTask", parameters);
+    
+    executeAvailableJobs();
+    
+    // set execution variable from "true" to "false"
+    runtimeService.setVariable(pi.getId(), "fail", new Boolean(false));
+    Job jobToResolve = managementService.createJobQuery().processInstanceId(pi.getId()).singleResult();
+    managementService.setJobRetries(jobToResolve.getId(), 1);
+    executeAvailableJobs();
+    
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().incidentStatus("resolved").count());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().incidentStatus("resolved").list().size());
   }
 
   public void testHistoricProcessInstanceQueryWithIncidentMessageNull() {


### PR DESCRIPTION
server side implementation to solve CAM-6166. Add new query filter incidentStatus=open to the historicProcessInstanceQuery (Java and REST)