### PR TITLE
Add test where assignee equals candidate user

### DIFF
--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/usertask/UserTaskTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/usertask/UserTaskTest.java
@@ -132,4 +132,10 @@ public class UserTaskTest extends PluggableProcessEngineTestCase {
 
     assertProcessEnded(processInstance.getId());
   }
+  
+  @Deployment
+  public void testAssigneeEqualsCandidateUser() {
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    assertEquals(1, taskService.createTaskQuery().processInstanceId(processInstance.getId()).list().size());
+  }
 }

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/usertask/UserTaskTest.testAssigneeEqualsCandidateUser.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/usertask/UserTaskTest.testAssigneeEqualsCandidateUser.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="taskAssigneeExample" 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  targetNamespace="Examples">
+  
+  <process id="oneTaskProcess" isExecutable="true">
+  
+    <startEvent id="start"/>
+    
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="theTask" />
+
+    <userTask id="theTask" name="my task" camunda:assignee="kermit"
+              camunda:candidateUsers="kermit">
+      <documentation>Very important</documentation>
+    </userTask>            
+    
+    <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
+    
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>


### PR DESCRIPTION
During a workshop, I received a bug report from a customer:
A User Task where the assignee equals the candidate user leads to a unique constraint violation in the authorization table. I couldn't reproduce it on H2, but I think, the customer is using Oracle. Would you be willing to accept this test case to run it through QA?