### PR TITLE
CAM-6454 use toString to log process engine plugins

### DIFF
--- a/engine-spring/src/main/java/org/camunda/bpm/engine/spring/SpringProcessEnginePlugin.java
+++ b/engine-spring/src/main/java/org/camunda/bpm/engine/spring/SpringProcessEnginePlugin.java
@@ -1,0 +1,23 @@
+package org.camunda.bpm.engine.spring;
+
+import org.camunda.bpm.engine.impl.cfg.AbstractProcessEnginePlugin;
+import org.springframework.beans.factory.BeanNameAware;
+
+/**
+ * This is bean-name-aware extension of the {@link AbstractProcessEnginePlugin} allowing anonymous
+ * classes get logged correctly when processed.
+ */
+public class SpringProcessEnginePlugin extends AbstractProcessEnginePlugin implements BeanNameAware {
+
+  protected String beanName;
+
+  @Override
+  public void setBeanName(String beanName) {
+    this.beanName = beanName;
+  }
+
+  @Override
+  public String toString() {
+    return beanName;
+  }
+}

--- a/engine-spring/src/test/java/org/camunda/bpm/engine/spring/SpringProcessEnginePluginTest.java
+++ b/engine-spring/src/test/java/org/camunda/bpm/engine/spring/SpringProcessEnginePluginTest.java
@@ -1,0 +1,30 @@
+package org.camunda.bpm.engine.spring;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = SpringProcessEnginePluginTest.TestConfig.class)
+public class SpringProcessEnginePluginTest {
+
+  public static class TestConfig {
+
+    @Bean
+    public SpringProcessEnginePlugin theBeanName() {
+      return new SpringProcessEnginePlugin(){};
+    }
+  }
+
+  @Autowired
+  private SpringProcessEnginePlugin plugin;
+
+  @Test
+  public void verifyToString() throws Exception {
+    Assert.assertEquals(plugin.toString(), "theBeanName");
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/AbstractProcessEnginePlugin.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/AbstractProcessEnginePlugin.java
@@ -34,4 +34,8 @@ public class AbstractProcessEnginePlugin implements ProcessEnginePlugin {
 
   }
 
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -673,7 +673,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void invokePreInit() {
     for (ProcessEnginePlugin plugin : processEnginePlugins) {
-      LOG.pluginActivated(plugin.getClass().getSimpleName(), getProcessEngineName());
+      LOG.pluginActivated(plugin.toString(), getProcessEngineName());
       plugin.preInit(this);
     }
   }


### PR DESCRIPTION
see https://app.camunda.com/jira/browse/CAM-6454

Motivation: when using anonymous classes as plugins (either by using a Spring Bean or just adding a "new ProcessEnginePlugin" the ConfigurationLogger still tried to use the getClass.getSimpleName for the output, which resulted in st. like "cglibSpringEnhanced#72687643... was applied to engine  ...".
Now simpleName is still the default, but it can be changed by either overwriting  toString() or extending teh Spring ProcessEnginePlugin which is beanNameAware.