### PR TITLE
CAM-6763 make schema operation plugable

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/ProcessEngineConfiguration.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/ProcessEngineConfiguration.java
@@ -19,6 +19,7 @@ import javax.sql.DataSource;
 
 import org.camunda.bpm.engine.authorization.Authorization;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.camunda.bpm.engine.impl.SchemaOperationsProcessEngineBuild;
 import org.camunda.bpm.engine.impl.cfg.BeansConfigurationHelper;
 import org.camunda.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
 import org.camunda.bpm.engine.impl.cfg.StandaloneProcessEngineConfiguration;
@@ -209,6 +210,7 @@ public abstract class ProcessEngineConfiguration {
   protected String jdbcPingQuery = null;
   protected int jdbcPingConnectionNotUsedFor;
   protected DataSource dataSource;
+  protected SchemaOperationsCommand schemaOperationsCommand = new SchemaOperationsProcessEngineBuild();
   protected boolean transactionsExternallyManaged = false;
   /** the number of seconds the jdbc driver will wait for a response from the database */
   protected Integer jdbcStatementTimeout;
@@ -419,6 +421,14 @@ public abstract class ProcessEngineConfiguration {
   public ProcessEngineConfiguration setDataSource(DataSource dataSource) {
     this.dataSource = dataSource;
     return this;
+  }
+
+  public SchemaOperationsCommand getSchemaOperationsCommand() {
+    return schemaOperationsCommand;
+  }
+
+  public void setSchemaOperationsCommand(SchemaOperationsCommand schemaOperationsCommand) {
+    this.schemaOperationsCommand = schemaOperationsCommand;
   }
 
   public String getJdbcDriver() {

--- a/engine/src/main/java/org/camunda/bpm/engine/SchemaOperationsCommand.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/SchemaOperationsCommand.java
@@ -1,5 +1,17 @@
-package org.camunda.bpm.engine;
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+package org.camunda.bpm.engine;
 
 import org.camunda.bpm.engine.impl.interceptor.Command;
 

--- a/engine/src/main/java/org/camunda/bpm/engine/SchemaOperationsCommand.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/SchemaOperationsCommand.java
@@ -1,0 +1,7 @@
+package org.camunda.bpm.engine;
+
+
+import org.camunda.bpm.engine.impl.interceptor.Command;
+
+public interface SchemaOperationsCommand extends Command<Void> {
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessEngineImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessEngineImpl.java
@@ -123,7 +123,7 @@ public class ProcessEngineImpl implements ProcessEngine {
   }
 
   protected void executeSchemaOperations() {
-    commandExecutorSchemaOperations.execute(new SchemaOperationsProcessEngineBuild());
+    commandExecutorSchemaOperations.execute(processEngineConfiguration.getSchemaOperationsCommand());
   }
 
   @Override

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/SchemaOperationsProcessEngineBuild.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/SchemaOperationsProcessEngineBuild.java
@@ -14,6 +14,7 @@ package org.camunda.bpm.engine.impl;
 
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.SchemaOperationsCommand;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.cmd.DetermineHistoryLevelCmd;
 import org.camunda.bpm.engine.impl.context.Context;
@@ -31,7 +32,7 @@ import org.camunda.bpm.engine.impl.persistence.entity.PropertyEntity;
  * @author Sebastian Menski
  * @author Daniel Meyer
  */
-public final class SchemaOperationsProcessEngineBuild implements Command<Void> {
+public final class SchemaOperationsProcessEngineBuild implements SchemaOperationsCommand {
 
   private final static EnginePersistenceLogger LOG = ProcessEngineLogger.PERSISTENCE_LOGGER;
 


### PR DESCRIPTION
see https://app.camunda.com/jira/browse/CAM-6763

This prepares schema operations to be replaced by something custom like a flyway or liquibase by using the configuration-impl. So far it does nothing else than before and the tests are green.
I extracted an extra interface for this so its clear that you cannot just register any "Command<Void>" but a SchemaOperationsCommand.

If you like this, we could discuss how to go on ... we could use optional dependencies to provide basic liquibase and flyway stuff ore just leave like it is and let extensions based on 7.6 deal with the concrete implementation.  Personally ... I tend to leave concrete db migration out of the core, so accepting this PR would just allow to exchange the db setup. Opinions?

