### PR TITLE
CAM-6791: Cleanup temp. dirs used for ApacheDS ldap server.

### DIFF
--- a/engine-plugins/identity-ldap/pom.xml
+++ b/engine-plugins/identity-ldap/pom.xml
@@ -31,6 +31,13 @@
       </exclusions>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <!-- required for LdapTestEnvironment -->
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
+++ b/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
@@ -372,7 +372,7 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
   public List<Group> findGroupByQueryCriteria(LdapGroupQuery query) {
     ensureContextInitialized();
 
-    String groupBaseDn = composeDn(ldapConfiguration.getGroupSearchBase(),ldapConfiguration.getBaseDn());
+    String groupBaseDn = composeDn(ldapConfiguration.getGroupSearchBase(), ldapConfiguration.getBaseDn());
 
     if(ldapConfiguration.isSortControlSupported()) {
       applyRequestControls(query);
@@ -513,8 +513,7 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
     return group;
   }
 
-  @SuppressWarnings("rawtypes")
-  protected void applyRequestControls(AbstractQuery query) {
+  protected void applyRequestControls(AbstractQuery<?, ?> query) {
 
     try {
       List<Control> controls = new ArrayList<Control>();

--- a/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapEnableSortControlSupportTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapEnableSortControlSupportTest.java
@@ -20,7 +20,6 @@ import java.util.Comparator;
 import java.util.List;
 import org.camunda.bpm.engine.identity.User;
 import org.camunda.bpm.engine.impl.test.ResourceProcessEngineTestCase;
-import static junit.framework.TestCase.assertEquals;
 
 /**
  * Represents a test case where the sortControlSupport property is enabled.

--- a/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/posix/LdapPosixTestEnvironment.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/posix/LdapPosixTestEnvironment.java
@@ -36,13 +36,13 @@ public class LdapPosixTestEnvironment extends LdapTestEnvironment {
 
   public LdapPosixTestEnvironment() {
     super();
+    // overwrite the name of the directory to use
+    workingDirectory = new File(System.getProperty("java.io.tmpdir") + "/ldap-posix-work");
   }
 
   @Override
   public void init() throws Exception {
-    File workingDir = new File(System.getProperty("java.io.tmpdir") + "/ldap-posix-work");
-    workingDir.mkdirs();
-    initializeDirectory(workingDir);
+    initializeDirectory();
 
     // Enable POSIX groups in ApacheDS
     Dn nis = new Dn("cn=nis,ou=schema");
@@ -56,14 +56,14 @@ public class LdapPosixTestEnvironment extends LdapTestEnvironment {
         modifications.add(new DefaultModification(ModificationOperation.REPLACE_ATTRIBUTE, nisDisabled));
         service.getAdminSession().modify(nis, modifications);
         service.shutdown();
-        initializeDirectory(workingDir); // Note: This instantiates service again for schema modifications to take effect.
+        initializeDirectory(); // Note: This instantiates service again for schema modifications to take effect.
       }
     }
 
     startServer();
 
     createGroup("office-berlin");
-    String dnDaniel = createUserUid("daniel", "office-berlin", "Daniel", "Meyer", "daniel@camunda.org");
+    createUserUid("daniel", "office-berlin", "Daniel", "Meyer", "daniel@camunda.org");
 
     createGroup("people");
     createUserUid("ruecker", "people", "Bernd", "Ruecker", "ruecker@camunda.org");
@@ -86,7 +86,6 @@ public class LdapPosixTestEnvironment extends LdapTestEnvironment {
         entry.add("memberUid", memberUid);
       }
       service.getAdminSession().add(entry);
-      System.out.println("created entry: " + dn.getNormName());
     }
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/test/AbstractProcessEngineTestCase.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/test/AbstractProcessEngineTestCase.java
@@ -355,14 +355,6 @@ public abstract class AbstractProcessEngineTestCase extends PvmTestCase {
     return false;
   }
 
-  @Deprecated
-  private static class InteruptTask extends InterruptTask {
-    public InteruptTask(Thread thread) {
-      super(thread);
-    }
-  }
-
-
   private static class InterruptTask extends TimerTask {
     protected boolean timeLimitExceeded = false;
     protected Thread thread;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -446,7 +446,7 @@
       <dependency>
         <groupId>org.apache.directory.server</groupId>
         <artifactId>apacheds-all</artifactId>
-        <version>2.0.0-M22</version>
+        <version>2.0.0-M23</version>
       </dependency>
 
       <dependency>
@@ -632,3 +632,5 @@
   <url>http://www.camunda.org</url>
 
 </project>
+
+

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -446,7 +446,7 @@
       <dependency>
         <groupId>org.apache.directory.server</groupId>
         <artifactId>apacheds-all</artifactId>
-        <version>2.0.0-M21</version>
+        <version>2.0.0-M22</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Changes:
- remove directories used for ApacheDS ldap server (ldap-posix-work, server-work) after shutdown
- using org.apache.common.io.FileUtils.deleteDirectory to delete the directories recursivly
- upgrade ApacheDS version to latest milestone (2.0.0-M22)
- cosmetic changes to get rid of a couple of warnings (generic types, unused code)
