### PR TITLE
make beanName protected

### DIFF
--- a/engine-spring/src/main/java/org/camunda/bpm/engine/spring/application/SpringProcessApplication.java
+++ b/engine-spring/src/main/java/org/camunda/bpm/engine/spring/application/SpringProcessApplication.java
@@ -49,7 +49,7 @@ public class SpringProcessApplication extends AbstractProcessApplication impleme
 
   protected Map<String, String> properties = new HashMap<String, String>();
   protected ApplicationContext applicationContext;
-  private String beanName;
+  protected String beanName;
 
   @Override
   protected String autodetectProcessApplicationName() {


### PR DESCRIPTION
so it can be accessed from classes extending it