### PR TITLE
enforce singleton behavior

### DIFF
--- a/engine-spring/src/main/java/org/camunda/bpm/engine/spring/ProcessEngineFactoryBean.java
+++ b/engine-spring/src/main/java/org/camunda/bpm/engine/spring/ProcessEngineFactoryBean.java
@@ -45,10 +45,12 @@ public class ProcessEngineFactoryBean implements FactoryBean<ProcessEngine>, Dis
   }
 
   public ProcessEngine getObject() throws Exception {
-    initializeExpressionManager();
-    initializeTransactionExternallyManaged();
+    if (processEngine == null) {
+      initializeExpressionManager();
+      initializeTransactionExternallyManaged();
     
-    processEngine = (ProcessEngineImpl) processEngineConfiguration.buildProcessEngine();
+      processEngine = (ProcessEngineImpl) processEngineConfiguration.buildProcessEngine();
+    }
 
     return processEngine;
   }


### PR DESCRIPTION
so far multiple calls to getObject tried to create a new instance although isSingleton and destroy() clearly suggest otherwise.