### PR TITLE
Fix history level auto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ faces-config.NavData
 **/overlays
 
 *.DS_Store
+.java-version

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessEngineImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessEngineImpl.java
@@ -90,7 +90,7 @@ public class ProcessEngineImpl implements ProcessEngine {
     this.databaseSchemaUpdate = processEngineConfiguration.getDatabaseSchemaUpdate();
     this.jobExecutor = processEngineConfiguration.getJobExecutor();
     this.commandExecutor = processEngineConfiguration.getCommandExecutorTxRequired();
-    commandExecutorSchemaOperations = processEngineConfiguration.getCommandExecutorSchemaOperations();
+    this.commandExecutorSchemaOperations = processEngineConfiguration.getCommandExecutorSchemaOperations();
     this.sessionFactories = processEngineConfiguration.getSessionFactories();
     this.historyLevel = processEngineConfiguration.getHistoryLevel();
     this.transactionContextFactory = processEngineConfiguration.getTransactionContextFactory();
@@ -151,8 +151,8 @@ public class ProcessEngineImpl implements ProcessEngine {
   public String getName() {
     return name;
   }
-  
-  @Override  
+
+  @Override
   public ProcessEngineConfigurationImpl getProcessEngineConfiguration() {
     return processEngineConfiguration;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/SchemaOperationsProcessEngineBuild.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/SchemaOperationsProcessEngineBuild.java
@@ -15,6 +15,9 @@ package org.camunda.bpm.engine.impl;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.SchemaOperationsCommand;
+import org.camunda.bpm.engine.impl.bpmn.deployer.BpmnDeployer;
+import org.camunda.bpm.engine.impl.bpmn.parser.BpmnParseListener;
+import org.camunda.bpm.engine.impl.bpmn.parser.BpmnParser;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.cmd.DetermineHistoryLevelCmd;
 import org.camunda.bpm.engine.impl.context.Context;
@@ -22,9 +25,12 @@ import org.camunda.bpm.engine.impl.db.EnginePersistenceLogger;
 import org.camunda.bpm.engine.impl.db.PersistenceSession;
 import org.camunda.bpm.engine.impl.db.entitymanager.DbEntityManager;
 import org.camunda.bpm.engine.impl.history.HistoryLevel;
-import org.camunda.bpm.engine.impl.interceptor.Command;
+import org.camunda.bpm.engine.impl.history.parser.HistoryParseListener;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.persistence.deploy.Deployer;
 import org.camunda.bpm.engine.impl.persistence.entity.PropertyEntity;
+
+import java.util.List;
 
 /**
  * @author Tom Baeyens
@@ -36,6 +42,7 @@ public final class SchemaOperationsProcessEngineBuild implements SchemaOperation
 
   private final static EnginePersistenceLogger LOG = ProcessEngineLogger.PERSISTENCE_LOGGER;
 
+  @Override
   public Void execute(CommandContext commandContext) {
     String databaseSchemaUpdate = Context.getProcessEngineConfiguration().getDatabaseSchemaUpdate();
     PersistenceSession persistenceSession = commandContext.getSession(PersistenceSession.class);
@@ -46,7 +53,7 @@ public final class SchemaOperationsProcessEngineBuild implements SchemaOperation
         // ignore
       }
     }
-    if ( ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP.equals(databaseSchemaUpdate)
+    if (ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP.equals(databaseSchemaUpdate)
       || ProcessEngineConfigurationImpl.DB_SCHEMA_UPDATE_DROP_CREATE.equals(databaseSchemaUpdate)
       || ProcessEngineConfigurationImpl.DB_SCHEMA_UPDATE_CREATE.equals(databaseSchemaUpdate)
       ) {
@@ -68,13 +75,18 @@ public final class SchemaOperationsProcessEngineBuild implements SchemaOperation
   public static void dbCreateHistoryLevel(DbEntityManager entityManager) {
     ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
     HistoryLevel configuredHistoryLevel = processEngineConfiguration.getHistoryLevel();
-    PropertyEntity property = new PropertyEntity("historyLevel", Integer.toString(configuredHistoryLevel.getId()));
-    entityManager.insert(property);
-    LOG.creatingHistoryLevelPropertyInDatabase(configuredHistoryLevel);
+
+    insertHistoryLevel(entityManager, configuredHistoryLevel);
   }
 
+  public static void insertHistoryLevel(DbEntityManager entityManager, HistoryLevel historyLevel) {
+    PropertyEntity property = new PropertyEntity("historyLevel", Integer.toString(historyLevel.getId()));
+    entityManager.insert(property);
+    LOG.creatingHistoryLevelPropertyInDatabase(historyLevel);
+  }
+
+
   /**
-   *
    * @param entityManager entoty manager for db query
    * @return Integer value representing the history level or <code>null</code> if none found
    */
@@ -83,8 +95,7 @@ public final class SchemaOperationsProcessEngineBuild implements SchemaOperation
     try {
       PropertyEntity historyLevelProperty = entityManager.selectById(PropertyEntity.class, "historyLevel");
       return historyLevelProperty != null ? new Integer(historyLevelProperty.getValue()) : null;
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       LOG.couldNotSelectHistoryLevel(e.getMessage());
       return null;
     }
@@ -92,14 +103,14 @@ public final class SchemaOperationsProcessEngineBuild implements SchemaOperation
   }
 
   public void checkHistoryLevel(DbEntityManager entityManager) {
-    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    ProcessEngineConfigurationImpl engineConfiguration = Context.getProcessEngineConfiguration();
 
 
-    HistoryLevel databaseHistoryLevel = new DetermineHistoryLevelCmd(processEngineConfiguration.getHistoryLevels())
+    HistoryLevel databaseHistoryLevel = new DetermineHistoryLevelCmd(engineConfiguration.getHistoryLevels())
       .execute(Context.getCommandContext());
-    determineAutoHistoryLevel(processEngineConfiguration, databaseHistoryLevel);
+    determineAutoHistoryLevel(engineConfiguration, databaseHistoryLevel);
 
-    HistoryLevel configuredHistoryLevel = processEngineConfiguration.getHistoryLevel();
+    HistoryLevel configuredHistoryLevel = engineConfiguration.getHistoryLevel();
 
     if (databaseHistoryLevel == null) {
       LOG.noHistoryLevelPropertyFound();
@@ -107,25 +118,50 @@ public final class SchemaOperationsProcessEngineBuild implements SchemaOperation
     } else {
       if (!((Integer) configuredHistoryLevel.getId()).equals(databaseHistoryLevel.getId())) {
         throw new ProcessEngineException("historyLevel mismatch: configuration says " + configuredHistoryLevel
-            + " and database says " + databaseHistoryLevel);
+          + " and database says " + databaseHistoryLevel);
       }
     }
+
+
+    // add ParseListener depending on history level
+    for (Deployer deployer : engineConfiguration.getDeployers()) {
+      if (deployer instanceof BpmnDeployer) {
+        BpmnParser parser = ((BpmnDeployer) deployer).getBpmnParser();
+        BpmnParseListener historyParseListener = findHistoryParseListener(parser.getParseListeners());
+        if (historyParseListener == null) {
+          parser.getParseListeners().add(new HistoryParseListener(engineConfiguration.getHistoryLevel(), engineConfiguration.getHistoryEventProducer()));
+        }
+      }
+    }
+
+    // init dmn engine again for historyLevel
+    engineConfiguration.setDmnEngine(null);
+    engineConfiguration.initDmnEngine();
   }
 
   protected void determineAutoHistoryLevel(ProcessEngineConfigurationImpl engineConfiguration, HistoryLevel databaseHistoryLevel) {
     HistoryLevel configuredHistoryLevel = engineConfiguration.getHistoryLevel();
 
     if (configuredHistoryLevel == null
-        && ProcessEngineConfiguration.HISTORY_AUTO.equals(engineConfiguration.getHistory())) {
+      && ProcessEngineConfiguration.HISTORY_AUTO.equals(engineConfiguration.getHistory())) {
 
       // automatically determine history level or use default AUDIT
       if (databaseHistoryLevel != null) {
         engineConfiguration.setHistoryLevel(databaseHistoryLevel);
-      }
-      else {
+      } else {
         engineConfiguration.setHistoryLevel(engineConfiguration.getDefaultHistoryLevel());
       }
     }
+
+  }
+
+  private static BpmnParseListener findHistoryParseListener(List<BpmnParseListener> parseListeners) {
+    for (BpmnParseListener listener : parseListeners) {
+      if (listener instanceof HistoryParseListener) {
+        return listener;
+      }
+    }
+    return null;
   }
 
   public void checkDeploymentLockExists(DbEntityManager entityManager) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -1391,7 +1391,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected List<BpmnParseListener> getDefaultBPMNParseListeners() {
     List<BpmnParseListener> defaultListeners = new ArrayList<BpmnParseListener>();
-    if (!HistoryLevel.HISTORY_LEVEL_NONE.equals(historyLevel)) {
+    // do not add if history==none or history==auto
+    if (!HistoryLevel.HISTORY_LEVEL_NONE.equals(historyLevel) && !ProcessEngineConfiguration.HISTORY_AUTO.equals(history)) {
       defaultListeners.add(new HistoryParseListener(historyLevel, historyEventProducer));
     }
     if (isMetricsEnabled) {
@@ -1782,7 +1783,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
   }
 
-  protected void initDmnEngine() {
+  public void initDmnEngine() {
     if (dmnEngine == null) {
 
       if (dmnEngineConfiguration == null) {
@@ -3314,6 +3315,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   public boolean isBpmnStacktraceVerbose() {
     return this.isBpmnStacktraceVerbose;
   }
+
+
 
   public boolean isForceCloseMybatisConnectionPool() {
     return forceCloseMybatisConnectionPool;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/configuration/DmnEngineConfigurationBuilder.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/configuration/DmnEngineConfigurationBuilder.java
@@ -13,10 +13,6 @@
 
 package org.camunda.bpm.engine.impl.dmn.configuration;
 
-import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
-
-import java.util.List;
-
 import org.camunda.bpm.dmn.engine.delegate.DmnDecisionEvaluationListener;
 import org.camunda.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
 import org.camunda.bpm.dmn.engine.impl.spi.el.DmnScriptEngineResolver;
@@ -31,6 +27,10 @@ import org.camunda.bpm.engine.impl.history.producer.DmnHistoryEventProducer;
 import org.camunda.bpm.engine.impl.metrics.dmn.MetricsDecisionEvaluationListener;
 import org.camunda.bpm.model.dmn.instance.Decision;
 import org.camunda.bpm.model.dmn.instance.Definitions;
+
+import java.util.List;
+
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
  * Modify the given DMN engine configuration so that the DMN engine can be used
@@ -114,14 +114,15 @@ public class DmnEngineConfigurationBuilder {
 
   protected List<DmnDecisionEvaluationListener> createCustomPostDecisionEvaluationListeners() {
     ensureNotNull("dmnHistoryEventProducer", dmnHistoryEventProducer);
-    // note that the history level may be null - see CAM-5165
-
-    HistoryDecisionEvaluationListener historyDecisionEvaluationListener = new HistoryDecisionEvaluationListener(dmnHistoryEventProducer, historyLevel);
 
     List<DmnDecisionEvaluationListener> customPostDecisionEvaluationListeners = dmnEngineConfiguration
-        .getCustomPostDecisionEvaluationListeners();
+      .getCustomPostDecisionEvaluationListeners();
     customPostDecisionEvaluationListeners.add(new MetricsDecisionEvaluationListener());
-    customPostDecisionEvaluationListeners.add(historyDecisionEvaluationListener);
+
+    // note that the history level may be null - see CAM-5165
+    if (historyLevel != null) {
+      customPostDecisionEvaluationListeners.add(new HistoryDecisionEvaluationListener(dmnHistoryEventProducer, historyLevel));
+    }
 
     return customPostDecisionEvaluationListeners;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/history/parser/HistoryDecisionEvaluationListener.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/history/parser/HistoryDecisionEvaluationListener.java
@@ -27,16 +27,21 @@ import org.camunda.bpm.engine.impl.history.producer.DmnHistoryEventProducer;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.camunda.bpm.engine.repository.DecisionDefinition;
 
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
+
 public class HistoryDecisionEvaluationListener implements DmnDecisionEvaluationListener {
 
   protected DmnHistoryEventProducer eventProducer;
   protected HistoryLevel historyLevel;
 
   public HistoryDecisionEvaluationListener(DmnHistoryEventProducer historyEventProducer, HistoryLevel historyLevel) {
+    ensureNotNull("historyLevel", historyLevel);
+    ensureNotNull("historyEventProducer", historyEventProducer);
     this.eventProducer = historyEventProducer;
     this.historyLevel = historyLevel;
   }
 
+  @Override
   public void notify(DmnDecisionEvaluationEvent evaluationEvent) {
    HistoryEvent historyEvent = createHistoryEvent(evaluationEvent);
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/history/parser/HistoryParseListener.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/history/parser/HistoryParseListener.java
@@ -29,8 +29,11 @@ import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
 import org.camunda.bpm.engine.impl.pvm.process.ScopeImpl;
 import org.camunda.bpm.engine.impl.pvm.process.TransitionImpl;
 import org.camunda.bpm.engine.impl.task.TaskDefinition;
+import org.camunda.bpm.engine.impl.util.EnsureUtil;
 import org.camunda.bpm.engine.impl.util.xml.Element;
 import org.camunda.bpm.engine.impl.variable.VariableDeclaration;
+
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
  * <p>This class is responsible for wiring history as execution listeners into process execution.
@@ -67,7 +70,10 @@ public class HistoryParseListener implements BpmnParseListener {
   protected HistoryLevel historyLevel;
 
   public HistoryParseListener(HistoryLevel historyLevel, HistoryEventProducer historyEventProducer) {
+    ensureNotNull("historyLevel", historyLevel);
+    ensureNotNull("historyEventProducer", historyEventProducer);
     this.historyLevel = historyLevel;
+
     initExecutionListeners(historyEventProducer, historyLevel);
   }
 


### PR DESCRIPTION
I manually add the historicParseListeners that could not be initialized correctly due to the late resolve of the auto history level after schema creation.

This fixes CAM-5164 and CAM-5165
