### PR TITLE
feat(engine): log activity name of multiInstanceBody activities

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
@@ -1629,7 +1629,8 @@ public class BpmnParse extends Parse {
       id = getIdForMiBody(id);
       ActivityImpl miBodyScope = scope.createActivity(id);
       setActivityAsyncDelegates(miBodyScope);
-      miBodyScope.setProperty(PROPERTYNAME_TYPE, ActivityTypes.MULTI_INSTANCE_BODY);
+      miBodyScope.setProperty("name", activityElement.attribute("name"));
+      miBodyScope.getProperties().set(BpmnProperties.TYPE, ActivityTypes.MULTI_INSTANCE_BODY);
       miBodyScope.setScope(true);
 
       boolean isSequential = parseBooleanAttribute(miLoopCharacteristics.attribute("isSequential"), false);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricActivityInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricActivityInstanceTest.java
@@ -13,15 +13,6 @@
 
 package org.camunda.bpm.engine.test.history;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.history.HistoricActivityInstance;
@@ -31,15 +22,16 @@ import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.history.event.HistoricActivityInstanceEventEntity;
 import org.camunda.bpm.engine.impl.test.PluggableProcessEngineTestCase;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
-import org.camunda.bpm.engine.runtime.EventSubscriptionQuery;
-import org.camunda.bpm.engine.runtime.Execution;
-import org.camunda.bpm.engine.runtime.Job;
-import org.camunda.bpm.engine.runtime.JobQuery;
-import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.runtime.*;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.task.TaskQuery;
 import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.RequiredHistoryLevel;
+
+import java.util.*;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 /**
  * @author Tom Baeyens
@@ -754,6 +746,7 @@ public class HistoricActivityInstanceTest extends PluggableProcessEngineTestCase
     HistoricActivityInstanceQuery query = historyService.createHistoricActivityInstanceQuery();
 
     HistoricActivityInstance miBodyInstance = query.activityId("userTask#multiInstanceBody").singleResult();
+    assertEquals("multiInstanceUserTask", miBodyInstance.getActivityName());
 
     query.activityId("userTask");
     assertEquals(5, query.count());
@@ -779,6 +772,7 @@ public class HistoricActivityInstanceTest extends PluggableProcessEngineTestCase
 
     HistoricActivityInstanceQuery query = historyService.createHistoricActivityInstanceQuery();
     HistoricActivityInstance miBodyInstance = query.activityId("receiveTask#multiInstanceBody").singleResult();
+    assertEquals("multiInstanceUserTask", miBodyInstance.getActivityName());
 
     query.activityId("receiveTask");
     assertEquals(5, query.count());

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceTest.testMultiInstanceReceiveActivity.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceTest.testMultiInstanceReceiveActivity.bpmn20.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions id="definitions" 
+<definitions id="definitions"
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
   targetNamespace="Examples">
@@ -12,7 +12,7 @@
 
     <sequenceFlow sourceRef="start" targetRef="receiveTask" />
 
-    <receiveTask id="receiveTask" messageRef="messageId">
+    <receiveTask id="receiveTask" name="multiInstanceUserTask" messageRef="messageId">
       <multiInstanceLoopCharacteristics>
         <loopCardinality>5</loopCardinality>
       </multiInstanceLoopCharacteristics>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceTest.testMultiInstanceScopeActivity.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/history/HistoricActivityInstanceTest.testMultiInstanceScopeActivity.bpmn20.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions id="definitions" 
+<definitions id="definitions"
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
   targetNamespace="Examples">
@@ -12,7 +12,7 @@
 
     <sequenceFlow sourceRef="start" targetRef="userTask" />
 
-    <userTask id="userTask">
+    <userTask id="userTask" name="multiInstanceUserTask">
       <multiInstanceLoopCharacteristics>
         <loopCardinality>5</loopCardinality>
       </multiInstanceLoopCharacteristics>


### PR DESCRIPTION
This is meant to add the activities name of a multiInstanceBody activity to the act_hi_actinst table as discussed in [CAM-7059](https://app.camunda.com/jira/browse/CAM-7059). 

I was only to test this via the test suite but not with my application yet, though I thought it may be worth to push this upstream.