### PR TITLE
heavy concurrent process start from more server with one database cause deadlock exception

### DIFF
--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Property.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Property.xml
@@ -50,7 +50,7 @@
   </select>
 
   <select id="selectProperty" parameterType="string" resultMap="propertyResultMap">
-    select * from ${prefix}ACT_GE_PROPERTY where NAME_ = #{name}
+    select * from ${prefix}ACT_GE_PROPERTY where NAME_ = #{name} FOR UPDATE
   </select>
   
   <select id="selectProperties" resultMap="propertyResultMap">


### PR DESCRIPTION
When start lot of process instance simultaneously (more then 100) from more application which use camunda as workflow engine it cause deadlock exception.
The problem is, the table row not locked when read and update next.dbid in the ACT_GE_PROPERTY table.

I was test this modification only MariaDB 10.1.19 on Fedora 24.
I don't know it causes problem on other SQL servers.

You can test is it with this demo: https://github.com/zsoltii/workflow-demo

The original exception: 

> 2016-12-07 17:21:11,774 [Thread-20] ERROR h.z.w.cuncurrent.WorkflowThread: Error executing workflow.
> org.camunda.bpm.engine.ProcessEngineException: ENGINE-03004 Exception while executing Database Operation 'UPDATE PropertyEntity[next.dbid]' with message '
> ### Error updating database.  Cause: java.sql.SQLTransactionRollbackException: (conn:2561) Deadlock found when trying to get lock; try restarting transaction
> Query is: update ACT_GE_PROPERTY
>      SET REV_ = ?,
>       VALUE_ = ? 
>     where NAME_ = ?
>       and REV_ = ?, parameters [6540,'653901','next.dbid',6539]
> ### The error may involve org.camunda.bpm.engine.impl.persistence.entity.PropertyEntity.updateProperty-Inline
> ### The error occurred while setting parameters
> ### SQL: update ACT_GE_PROPERTY      SET REV_ = ?,       VALUE_ = ?      where NAME_ = ?       and REV_ = ?
> ### Cause: java.sql.SQLTransactionRollbackException: (conn:2561) Deadlock found when trying to get lock; try restarting transaction
> Query is: update ACT_GE_PROPERTY
>      SET REV_ = ?,
>       VALUE_ = ? 
>     where NAME_ = ?
>       and REV_ = ?, parameters [6540,'653901','next.dbid',6539]'. Flush summary: 
>  [
>   UPDATE PropertyEntity[next.dbid]
> ]
> 	at org.camunda.bpm.engine.impl.db.EnginePersistenceLogger.flushDbOperationException(EnginePersistenceLogger.java:115)
> 	at org.camunda.bpm.engine.impl.db.entitymanager.DbEntityManager.flushDbOperationManager(DbEntityManager.java:292)
> 	at org.camunda.bpm.engine.impl.db.entitymanager.DbEntityManager.flush(DbEntityManager.java:278)
> 	at org.camunda.bpm.engine.impl.interceptor.CommandContext.flushSessions(CommandContext.java:247)
> 	at org.camunda.bpm.engine.impl.interceptor.CommandContext.close(CommandContext.java:176)
> 	at org.camunda.bpm.engine.impl.interceptor.CommandContextInterceptor.execute(CommandContextInterceptor.java:113)
> 	at org.camunda.bpm.engine.spring.SpringTransactionInterceptor$1.doInTransaction(SpringTransactionInterceptor.java:42)
> 	at org.springframework.transaction.support.TransactionTemplate.execute(TransactionTemplate.java:133)
> 	at org.camunda.bpm.engine.spring.SpringTransactionInterceptor.execute(SpringTransactionInterceptor.java:40)
> 	at org.camunda.bpm.engine.impl.interceptor.ProcessApplicationContextInterceptor.execute(ProcessApplicationContextInterceptor.java:66)
> 	at org.camunda.bpm.engine.impl.interceptor.LogInterceptor.execute(LogInterceptor.java:30)
> 	at org.camunda.bpm.engine.impl.db.DbIdGenerator.getNewBlock(DbIdGenerator.java:46)
> 	at org.camunda.bpm.engine.impl.db.DbIdGenerator.getNextId(DbIdGenerator.java:38)
> 	at org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity.generateActivityInstanceId(ExecutionEntity.java:844)
> 	at org.camunda.bpm.engine.impl.pvm.runtime.PvmExecutionImpl.enterActivityInstance(PvmExecutionImpl.java:1181)
> 	at org.camunda.bpm.engine.impl.pvm.runtime.operation.PvmAtomicOperationActivityInstanceStart.eventNotificationsStarted(PvmAtomicOperationActivityInstanceStart.java:37)
> 	at org.camunda.bpm.engine.impl.pvm.runtime.operation.PvmAtomicOperationActivityInstanceStart.eventNotificationsStarted(PvmAtomicOperationActivityInstanceStart.java:31)
> 	at org.camunda.bpm.engine.impl.core.operation.AbstractEventAtomicOperation.execute(AbstractEventAtomicOperation.java:41)
> 	at org.camunda.bpm.engine.impl.interceptor.AtomicOperationInvocation.execute(AtomicOperationInvocation.java:89)
> 	at org.camunda.bpm.engine.impl.interceptor.CommandInvocationContext.invokeNext(CommandInvocationContext.java:125)
> 	at org.camunda.bpm.engine.impl.interceptor.CommandInvocationContext.performNext(CommandInvocationContext.java:104)
> 	at org.camunda.bpm.engine.impl.interceptor.CommandInvocationContext.performOperation(CommandInvocationContext.java:79)
> 	at org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity.performOperation(ExecutionEntity.java:613)
> 	at org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity.performOperation(ExecutionEntity.java:587)
> 	at org.camunda.bpm.engine.impl.pvm.runtime.operation.PvmAtomicOperationTransitionCreateScope.scopeCreated(PvmAtomicOperationTransitionCreateScope.java:34)
> 	at org.camunda.bpm.engine.impl.pvm.runtime.operation.PvmAtomicOperationCreateScope.execute(PvmAtomicOperationCreateScope.java:50)
> 	at org.camunda.bpm.engine.impl.pvm.runtime.operation.PvmAtomicOperationCreateScope.execute(PvmAtomicOperationCreateScope.java:24)
> 	at org.camunda.bpm.engine.impl.interceptor.AtomicOperationInvocation.execute(AtomicOperationInvocation.java:89)
> 	at org.camunda.bpm.engine.impl.interceptor.CommandInvocationContext.invokeNext(CommandInvocationContext.java:125)
> 	at org.camunda.bpm.engine.impl.interceptor.CommandInvocationContext.performNext(CommandInvocationContext.java:112)
> 	at org.camunda.bpm.engine.impl.interceptor.CommandInvocationContext.performOperation(CommandInvocationContext.java:79)
> 	at org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity.performOperation(ExecutionEntity.java:613)
> 	at org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity.performOperation(ExecutionEntity.java:587)
> 	at org.camunda.bpm.engine.impl.pvm.runtime.PvmExecutionImpl.start(PvmExecutionImpl.java:231)
> 	at org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity.start(ExecutionEntity.java:432)
> 	at org.camunda.bpm.engine.impl.cmd.StartProcessInstanceCmd.execute(StartProcessInstanceCmd.java:55)
> 	at org.camunda.bpm.engine.impl.cmd.StartProcessInstanceCmd.execute(StartProcessInstanceCmd.java:31)
> 	at org.camunda.bpm.engine.impl.interceptor.CommandExecutorImpl.execute(CommandExecutorImpl.java:24)
> 	at org.camunda.bpm.engine.impl.interceptor.CommandContextInterceptor.execute(CommandContextInterceptor.java:104)
> 	at org.camunda.bpm.engine.spring.SpringTransactionInterceptor$1.doInTransaction(SpringTransactionInterceptor.java:42)
> 	at org.springframework.transaction.support.TransactionTemplate.execute(TransactionTemplate.java:133)
> 	at org.camunda.bpm.engine.spring.SpringTransactionInterceptor.execute(SpringTransactionInterceptor.java:40)
> 	at org.camunda.bpm.engine.impl.interceptor.ProcessApplicationContextInterceptor.execute(ProcessApplicationContextInterceptor.java:66)
> 	at org.camunda.bpm.engine.impl.interceptor.LogInterceptor.execute(LogInterceptor.java:30)
> 	at org.camunda.bpm.engine.impl.ProcessInstantiationBuilderImpl.executeWithVariablesInReturn(ProcessInstantiationBuilderImpl.java:156)
> 	at org.camunda.bpm.engine.impl.ProcessInstantiationBuilderImpl.execute(ProcessInstantiationBuilderImpl.java:122)
> 	at org.camunda.bpm.engine.impl.ProcessInstantiationBuilderImpl.execute(ProcessInstantiationBuilderImpl.java:118)
> 	at org.camunda.bpm.engine.impl.RuntimeServiceImpl.startProcessInstanceByKey(RuntimeServiceImpl.java:100)
> 	at hu.zsoltii.workflow.CamundaWorkflowService.start(CamundaWorkflowService.java:229)
> 	at hu.zsoltii.workflow.CamundaWorkflowService.start(CamundaWorkflowService.java:223)
> 	at hu.zsoltii.workflow.cuncurrent.WorkflowThread.run(WorkflowThread.java:32)
> 	at java.lang.Thread.run(Thread.java:745)
> Caused by: org.apache.ibatis.exceptions.PersistenceException: 
> ### Error updating database.  Cause: java.sql.SQLTransactionRollbackException: (conn:2561) Deadlock found when trying to get lock; try restarting transaction
> Query is: update ACT_GE_PROPERTY
>      SET REV_ = ?,
>       VALUE_ = ? 
>     where NAME_ = ?
>       and REV_ = ?, parameters [6540,'653901','next.dbid',6539]
> ### The error may involve org.camunda.bpm.engine.impl.persistence.entity.PropertyEntity.updateProperty-Inline
> ### The error occurred while setting parameters
> ### SQL: update ACT_GE_PROPERTY      SET REV_ = ?,       VALUE_ = ?      where NAME_ = ?       and REV_ = ?
> ### Cause: java.sql.SQLTransactionRollbackException: (conn:2561) Deadlock found when trying to get lock; try restarting transaction
> Query is: update ACT_GE_PROPERTY
>      SET REV_ = ?,
>       VALUE_ = ? 
>     where NAME_ = ?
>       and REV_ = ?, parameters [6540,'653901','next.dbid',6539]
> 	at org.apache.ibatis.exceptions.ExceptionFactory.wrapException(ExceptionFactory.java:26)
> 	at org.apache.ibatis.session.defaults.DefaultSqlSession.update(DefaultSqlSession.java:154)
> 	at org.camunda.bpm.engine.impl.db.sql.DbSqlSession.executeUpdate(DbSqlSession.java:237)
> 	at org.camunda.bpm.engine.impl.db.sql.DbSqlSession.updateEntity(DbSqlSession.java:217)
> 	at org.camunda.bpm.engine.impl.db.AbstractPersistenceSession.executeDbOperation(AbstractPersistenceSession.java:52)
> 	at org.camunda.bpm.engine.impl.db.entitymanager.DbEntityManager.flushDbOperationManager(DbEntityManager.java:289)
> 	... 50 common frames omitted
> Caused by: java.sql.SQLTransactionRollbackException: (conn:2561) Deadlock found when trying to get lock; try restarting transaction
> Query is: update ACT_GE_PROPERTY
>      SET REV_ = ?,
>       VALUE_ = ? 
>     where NAME_ = ?
>       and REV_ = ?, parameters [6540,'653901','next.dbid',6539]
> 	at org.mariadb.jdbc.internal.util.ExceptionMapper.get(ExceptionMapper.java:136)
> 	at org.mariadb.jdbc.internal.util.ExceptionMapper.getException(ExceptionMapper.java:101)
> 	at org.mariadb.jdbc.internal.util.ExceptionMapper.throwAndLogException(ExceptionMapper.java:77)
> 	at org.mariadb.jdbc.MariaDbStatement.executeQueryEpilog(MariaDbStatement.java:224)
> 	at org.mariadb.jdbc.MariaDbServerPreparedStatement.executeInternal(MariaDbServerPreparedStatement.java:411)
> 	at org.mariadb.jdbc.MariaDbServerPreparedStatement.execute(MariaDbServerPreparedStatement.java:359)
> 	at org.apache.ibatis.executor.statement.PreparedStatementHandler.update(PreparedStatementHandler.java:44)
> 	at org.apache.ibatis.executor.statement.RoutingStatementHandler.update(RoutingStatementHandler.java:69)
> 	at org.apache.ibatis.executor.SimpleExecutor.doUpdate(SimpleExecutor.java:48)
> 	at org.apache.ibatis.executor.BaseExecutor.update(BaseExecutor.java:105)
> 	at org.apache.ibatis.executor.CachingExecutor.update(CachingExecutor.java:71)
> 	at org.apache.ibatis.session.defaults.DefaultSqlSession.update(DefaultSqlSession.java:152)
> 	... 54 common frames omitted
> Caused by: org.mariadb.jdbc.internal.util.dao.QueryException: Deadlock found when trying to get lock; try restarting transaction
> Query is: update ACT_GE_PROPERTY
>      SET REV_ = ?,
>       VALUE_ = ? 
>     where NAME_ = ?
>       and REV_ = ?, parameters [6540,'653901','next.dbid',6539]
> 	at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.getResult(AbstractQueryProtocol.java:1114)
> 	at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.executePreparedQuery(AbstractQueryProtocol.java:602)
> 	at org.mariadb.jdbc.MariaDbServerPreparedStatement.executeInternal(MariaDbServerPreparedStatement.java:398)
> 	... 61 common frames omitted