### PR TITLE
Patch Of VariableListenerInvocationListener.java To Address CAM-7145

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/core/variable/scope/VariableListenerInvocationListener.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/core/variable/scope/VariableListenerInvocationListener.java
@@ -51,14 +51,16 @@ public class VariableListenerInvocationListener implements VariableInstanceLifec
 
     if (sourceScope instanceof ExecutionEntity) {
       addEventToScopeExecution((ExecutionEntity) sourceScope, event);
-    } else if (sourceScope instanceof TaskEntity) {
-      TaskEntity task = (TaskEntity) sourceScope;
-      ExecutionEntity execution = task.getExecution();
-      if (execution != null) {
-        addEventToScopeExecution(execution, event);
-      }
     } else {
-      throw new ProcessEngineException("BPMN execution scope expected");
+      if(sourceScope.getParentVariableScope() instanceof ExecutionEntity) {
+    	  ExecutionEntity execution = (ExecutionEntity)sourceScope.getParentVariableScope();
+    	  if (execution != null) {
+    	        addEventToScopeExecution(execution, event);
+    	  }
+      }
+      else {
+    	  throw new ProcessEngineException("BPMN execution scope expected");
+      }
     }
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/core/variable/scope/VariableListenerInvocationListener.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/core/variable/scope/VariableListenerInvocationListener.java
@@ -21,6 +21,7 @@ import org.camunda.bpm.engine.impl.persistence.entity.VariableInstanceEntity;
 
 /**
  * @author Thorben Lindhauer
+ * @author Ryan Johnston
  *
  */
 public class VariableListenerInvocationListener implements VariableInstanceLifecycleListener<VariableInstanceEntity> {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/core/variable/scope/VariableListenerInvocationListener.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/core/variable/scope/VariableListenerInvocationListener.java
@@ -52,16 +52,19 @@ public class VariableListenerInvocationListener implements VariableInstanceLifec
 
     if (sourceScope instanceof ExecutionEntity) {
       addEventToScopeExecution((ExecutionEntity) sourceScope, event);
-    } else {
-      if(sourceScope.getParentVariableScope() instanceof ExecutionEntity) {
-    	  ExecutionEntity execution = (ExecutionEntity)sourceScope.getParentVariableScope();
-    	  if (execution != null) {
-    	        addEventToScopeExecution(execution, event);
-    	  }
+    }
+    else if (sourceScope instanceof TaskEntity) {
+      TaskEntity task = (TaskEntity) sourceScope;
+      ExecutionEntity execution = task.getExecution();
+      if (execution != null) {
+        addEventToScopeExecution(execution, event);
       }
-      else {
-    	  throw new ProcessEngineException("BPMN execution scope expected");
-      }
+    }
+    else if(sourceScope.getParentVariableScope() instanceof ExecutionEntity) {
+      addEventToScopeExecution((ExecutionEntity)sourceScope.getParentVariableScope(), event);
+    }
+    else {
+      throw new ProcessEngineException("BPMN execution scope expected");
     }
   }
 


### PR DESCRIPTION
Per the subject line, I'm requesting a pull of these modifications, which address CAM-7145 and the inability to set variables on ConnectorVariableScope objects in 7.6.x.

I'm attaching an Eclipse project with the change and with a full unit test illustrating that the new method code works for ConnectorVariableScope, TaskEntity (regression test), and ExecutionEntity (regression test) objects.

-Ryan Johnston
ryan.johnston@camunda.com

[connector-execscopeissue-7.6.tar.gz](https://github.com/camunda/camunda-bpm-platform/files/669473/connector-execscopeissue-7.6.tar.gz)
