### PR TITLE
chore(engine): do not return JSONObject.NULL in Map or List

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/JsonUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/JsonUtil.java
@@ -47,13 +47,13 @@ public final class JsonUtil {
       Iterator keys = jsonObject.keys();
       while (keys.hasNext()) {
         String key = (String) keys.next();
-        if (jsonObject.optJSONObject(key) != null) {
-          map.put(key, jsonObjectAsMap(jsonObject.getJSONObject(key)));
-        } else if (jsonObject.optJSONArray(key) != null) {
-          map.put(key, jsonArrayAsList(jsonObject.getJSONArray(key)));
-        } else {
-          map.put(key, jsonObject.get(key));
+        Object value = optJavaNull(jsonObject.get(key));
+        if (JSONObject.class.isInstance(value)) {
+          value = jsonObjectAsMap(JSONObject.class.cast(value));
+        } else if (JSONArray.class.isInstance(value)) {
+          value = jsonArrayAsList(JSONArray.class.cast(value));
         }
+        map.put(key, value);
       }
       return map;
     }
@@ -73,16 +73,33 @@ public final class JsonUtil {
     else {
       List<Object> list = new ArrayList<Object>();
       for (int i = 0; i < jsonArray.length(); i++) {
-        if (jsonArray.optJSONObject(i) != null) {
-          list.add(jsonObjectAsMap(jsonArray.getJSONObject(i)));
-        } else if (jsonArray.optJSONArray(i) != null) {
-          list.add(jsonArrayAsList(jsonArray.getJSONArray(i)));
-        } else {
-          list.add(jsonArray.get(i));
+        Object value = optJavaNull(jsonArray.get(i));
+        if (JSONObject.class.isInstance(value)) {
+          value = jsonObjectAsMap(JSONObject.class.cast(value));
+        } else if (JSONArray.class.isInstance(value)) {
+          value = jsonArrayAsList(JSONArray.class.cast(value));
         }
+        list.add(value);
       }
       return list;
     }
+  }
+
+  /**
+   * Converts a {@link JSONObject#NULL} to a standard Java <code>null</code>.
+   *
+   * In any other case it just returns the object as provided.
+   *
+   * @param value the object to convert
+   *
+   * @return the object as provided or <code>null</code> in case the special
+   * marker instance {@link JSONObject#NULL} is provided
+   */
+  public static Object optJavaNull(Object value) {
+      if (JSONObject.NULL == value) {
+          return null;
+      }
+      return value;
   }
 
   public static void addField(JSONObject json, String name, Object value) {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/util/JsonUtilTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/util/JsonUtilTest.java
@@ -51,9 +51,10 @@ public class JsonUtilTest {
     jsonObject.put("list", Collections.singletonList("test"));
     jsonObject.put("map", Collections.singletonMap("test", "test"));
     jsonObject.put("date", new Date(0));
+    jsonObject.put("null", JSONObject.NULL);
 
     map = jsonObjectAsMap(jsonObject);
-    assertEquals(8, map.size());
+    assertEquals(9, map.size());
 
     assertEquals(true, map.get("boolean"));
     assertEquals(12, map.get("int"));
@@ -72,6 +73,9 @@ public class JsonUtilTest {
 
     Date embeddedDate = (Date) map.get("date");
     assertEquals(new Date(0), embeddedDate);
+
+    assertTrue(map.containsKey("null"));
+    assertNull(map.get("null"));
   }
 
   @Test
@@ -92,9 +96,10 @@ public class JsonUtilTest {
     jsonArray.put(Collections.singletonList("test"));
     jsonArray.put(Collections.singletonMap("test", "test"));
     jsonArray.put(new Date(0));
+    jsonArray.put(JSONObject.NULL);
 
     list = jsonArrayAsList(jsonArray);
-    assertEquals(8, list.size());
+    assertEquals(9, list.size());
 
     assertEquals(true, list.get(0));
     assertEquals(12, list.get(1));
@@ -113,6 +118,35 @@ public class JsonUtilTest {
 
     Date embeddedDate = (Date) list.get(7);
     assertEquals(new Date(0), embeddedDate);
+
+    Object null_ = list.get(8);
+    assertNull(null_);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testJsonObjectNullRetained() {
+    String json = "{\"key\":null}";
+
+    JSONObject object = new JSONObject(json);
+    assertTrue(object.has("key"));
+
+    Map<String, Object> map = jsonObjectAsMap(object);
+    assertTrue(map.containsKey("key"));
+    assertNull(map.get("key"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testJsonArrayNullRetained() {
+    String json = "[null]";
+
+    JSONArray array = new JSONArray(json);
+    assertEquals(1, array.length());
+
+    List<Object> list = jsonArrayAsList(array);
+    assertEquals(1, list.size());
+    assertNull(list.get(0));
   }
 
 }


### PR DESCRIPTION
I've encountered the following problem:

Whenever a `JSONObject` or `JSONArray` is created using the input string method or by parsing some input and the JSON contains members with value `null`, the `Map`'s and `List`'s produced by the `JsonUtil` static utility methods contain the special internal marker object `JSONObject.NULL`.

When using the result of that as a process variable value results into a process incident with a stacktrace like the following:

```
java.io.NotSerializableException: org.camunda.bpm.engine.impl.util.json.JSONObject$Null
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1183)
        at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:347)
        at java.util.ArrayList.writeObject(ArrayList.java:742)
        at sun.reflect.GeneratedMethodAccessor33.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at java.io.ObjectStreamClass.invokeWriteObject(ObjectStreamClass.java:1028)
        at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1495)
        at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1431)
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1177)
        at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:347)
        at java.util.HashMap.writeObject(HashMap.java:1129)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at java.io.ObjectStreamClass.invokeWriteObject(ObjectStreamClass.java:1028)
        at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1495)
        at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1431)
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1177)
        at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:347)
        at java.util.HashMap.writeObject(HashMap.java:1129)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at java.io.ObjectStreamClass.invokeWriteObject(ObjectStreamClass.java:1028)
        at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1495)
        at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1431)
        at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1177)
        at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:347)
        at org.camunda.bpm.engine.impl.variable.serializer.JavaObjectSerializer.serializeToByteArray(JavaObjectSerializer.java:68)
        at org.camunda.bpm.engine.impl.variable.serializer.AbstractSerializableValueSerializer.writeValue(AbstractSerializableValueSerializer.java:50)
        ... 70 more
```

In addition, the expectation would be the following:

1. a JSON object such as `{"key":null}` shall result in a `Map` with key "key" available and the Java `null` value
2. a JSON array such as `[null]` shall result in a `List` with 1 entry and the only entry being exactly the Java `null` value
