### PR TITLE
H2 database version upgrade to 1.4.193: JIRA CAM-3311

### DIFF
--- a/database/pom.xml
+++ b/database/pom.xml
@@ -18,7 +18,7 @@
   <properties>
 
     <!-- database driver versions -->
-    <version.h2>1.3.168</version.h2>
+    <version.h2>1.4.193</version.h2>
     <version.oracle-12>12.1.0.2</version.oracle-12>
     <version.oracle-11>11.2.0.4</version.oracle-11>
     <version.oracle-10>10.2.0.5</version.oracle-10>


### PR DESCRIPTION
Upgraded the database driver version to: 1.4.193
This change will effect the h2 db file name . 

OLD: process-engine.h2.db
NEW: process-engine.mv.db

Reason for the request is that h2 has since moved to a new data-store naming/format convention. And, attempting to download and build the older version, something easily compatible with the engine's current (h2-1.3.168.jar) is a little tedious... And, attempting to simply connect the h2 v1.4.x server with Camunda's DB has a few pitfalls/annoyances - though correctable.

In context to the JBoss/Wildfly platform - upgrading to h2 v1.4.x and switching Camunad's DB integration to a shared, tcp connection is straightforward. This approach then provides access to DB tools (such as eclipse, dbVisualizer, etc) while Camunda is running - avoiding the error, "db is locked by...". And, though there are other ways around shared access without using the TCP/shared approach, not all the DB tools are copacetic.