### PR TITLE
feat(engine): enable querying on task created/endtime for history api

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricTaskInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricTaskInstanceQueryDto.java
@@ -125,6 +125,11 @@ public class HistoricTaskInstanceQueryDto extends AbstractQueryDto<HistoricTaskI
   protected Date taskFollowUpDateAfter;
   private List<String> tenantIds;
 
+  protected Date startedBefore;
+  protected Date startedAfter;
+  protected Date finishedBefore;
+  protected Date finishedAfter;
+
   protected String caseDefinitionId;
   protected String caseDefinitionKey;
   protected String caseDefinitionName;
@@ -380,6 +385,26 @@ public class HistoricTaskInstanceQueryDto extends AbstractQueryDto<HistoricTaskI
     this.withoutCandidateGroups = withoutCandidateGroups;
   }
 
+  @CamundaQueryParam(value="startedBefore", converter=DateConverter.class)
+  public void setStartedBefore(Date startedBefore) {
+    this.startedBefore = startedBefore;
+  }
+
+  @CamundaQueryParam(value="startedAfter", converter=DateConverter.class)
+  public void setStartedAfter(Date startedAfter) {
+    this.startedAfter = startedAfter;
+  }
+
+  @CamundaQueryParam(value="finishedBefore", converter=DateConverter.class)
+  public void setFinishedBefore(Date finishedBefore) {
+    this.finishedBefore = finishedBefore;
+  }
+
+  @CamundaQueryParam(value="finishedAfter", converter=DateConverter.class)
+  public void setFinishedAfter(Date finishedAfter) {
+    this.finishedAfter = finishedAfter;
+  }
+
   @Override
   protected boolean isValidSortByValue(String value) {
     return VALID_SORT_BY_VALUES.contains(value);
@@ -527,6 +552,23 @@ public class HistoricTaskInstanceQueryDto extends AbstractQueryDto<HistoricTaskI
     if (withoutCandidateGroups != null) {
       query.withoutCandidateGroups();
     }
+
+    if (finishedAfter != null) {
+      query.finishedAfter(finishedAfter);
+    }
+
+    if (finishedBefore != null) {
+      query.finishedBefore(finishedBefore);
+    }
+
+    if (startedAfter != null) {
+      query.startedAfter(startedAfter);
+    }
+
+    if (startedBefore != null) {
+      query.startedBefore(startedBefore);
+    }
+
     if (taskVariables != null) {
       for (VariableQueryParameterDto variableQueryParam : taskVariables) {
         String variableName = variableQueryParam.getName();

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricTaskInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricTaskInstanceRestServiceQueryTest.java
@@ -1528,6 +1528,141 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     verify(mockedQuery).taskFollowUpAfter(DateTimeUtil.parseDate(followUp));
   }
 
+    @Test
+    public void testQueryByStartedBefore() {
+
+        String startedBefore = MockProvider.EXAMPLE_HISTORIC_TASK_INST_START_TIME;
+
+        given()
+                .queryParam("startedBefore", startedBefore)
+                .then().expect().statusCode(Status.OK.getStatusCode())
+                .when().get(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
+
+        verify(mockedQuery).startedBefore(DateTimeUtil.parseDate(startedBefore));
+
+
+    }
+
+    @Test
+    public void testQueryByStartedBeforeAsPost() {
+
+        String startedBefore = MockProvider.EXAMPLE_HISTORIC_TASK_INST_START_TIME;
+
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("startedBefore", DateTimeUtil.parseDate(startedBefore));
+
+        given()
+                .contentType(POST_JSON_CONTENT_TYPE)
+                .body(params)
+                .then().expect().statusCode(Status.OK.getStatusCode())
+                .when().post(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
+
+        verify(mockedQuery).startedBefore(DateTimeUtil.parseDate(startedBefore));
+
+    }
+
+
+    @Test
+    public void testQueryByStartedAfter() {
+
+        String startedAfter = MockProvider.EXAMPLE_HISTORIC_TASK_INST_START_TIME;
+
+        given()
+                .queryParam("startedAfter", startedAfter)
+                .then().expect().statusCode(Status.OK.getStatusCode())
+                .when().get(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
+
+        verify(mockedQuery).startedAfter(DateTimeUtil.parseDate(startedAfter));
+
+    }
+
+    @Test
+    public void testQueryByStartedAfterAsPost() {
+
+        String startedAfter = MockProvider.EXAMPLE_HISTORIC_TASK_INST_START_TIME;
+
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("startedAfter", DateTimeUtil.parseDate(startedAfter));
+
+        given()
+                .contentType(POST_JSON_CONTENT_TYPE)
+                .body(params)
+                .then().expect().statusCode(Status.OK.getStatusCode())
+                .when().post(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
+
+        verify(mockedQuery).startedAfter(DateTimeUtil.parseDate(startedAfter));
+
+    }
+
+
+    @Test
+    public void testQueryByFinishedBefore() {
+
+        String finishedBefore = MockProvider.EXAMPLE_HISTORIC_TASK_INST_END_TIME;
+
+        given()
+                .queryParam("finishedBefore", finishedBefore)
+                .then().expect().statusCode(Status.OK.getStatusCode())
+                .when().get(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
+
+        verify(mockedQuery).finishedBefore(DateTimeUtil.parseDate(finishedBefore));
+
+    }
+
+    @Test
+    public void testQueryByFinishedBeforeAsPost() {
+
+        String finishedBefore = MockProvider.EXAMPLE_HISTORIC_TASK_INST_END_TIME;
+
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("finishedBefore", DateTimeUtil.parseDate(finishedBefore));
+
+        given()
+                .contentType(POST_JSON_CONTENT_TYPE)
+                .body(params)
+                .then().expect().statusCode(Status.OK.getStatusCode())
+                .when().post(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
+
+        verify(mockedQuery).finishedBefore(DateTimeUtil.parseDate(finishedBefore));
+
+    }
+
+
+    @Test
+    public void testQueryByFinishedAfter() {
+
+        String finishedAfter = MockProvider.EXAMPLE_HISTORIC_TASK_INST_END_TIME;
+
+        given()
+                .queryParam("finishedAfter", finishedAfter)
+                .then().expect().statusCode(Status.OK.getStatusCode())
+                .when().get(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
+
+        verify(mockedQuery).finishedAfter(DateTimeUtil.parseDate(finishedAfter));
+
+
+    }
+
+    @Test
+    public void testQueryByFinishedAfterAsPost() {
+
+        String finishedAfter = MockProvider.EXAMPLE_HISTORIC_TASK_INST_END_TIME;
+
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("finishedAfter", DateTimeUtil.parseDate(finishedAfter));
+
+        given()
+                .contentType(POST_JSON_CONTENT_TYPE)
+                .body(params)
+                .then().expect().statusCode(Status.OK.getStatusCode())
+                .when().post(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
+
+        verify(mockedQuery).finishedAfter(DateTimeUtil.parseDate(finishedAfter));
+
+    }
+
+
+
   @Test
   public void testQueryByTaskVariable() {
     String variableName = "varName";

--- a/engine/src/main/java/org/camunda/bpm/engine/history/HistoricTaskInstanceQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/history/HistoricTaskInstanceQuery.java
@@ -350,9 +350,14 @@ public interface HistoricTaskInstanceQuery  extends Query<HistoricTaskInstanceQu
   HistoricTaskInstanceQuery finishedBefore(Date date);
 
   /**
-   * Only select tasks where created after given date
+   * Only select tasks where started after given date
    */
-  HistoricTaskInstanceQuery createdAfter(Date date);
+  HistoricTaskInstanceQuery startedAfter(Date date);
+
+  /**
+   * Only select tasks where started before given date
+   */
+  HistoricTaskInstanceQuery startedBefore(Date date);
 
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/history/HistoricTaskInstanceQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/history/HistoricTaskInstanceQuery.java
@@ -338,4 +338,21 @@ public interface HistoricTaskInstanceQuery  extends Query<HistoricTaskInstanceQu
 
   /** Order by case execution id (needs to be followed by {@link #asc()} or {@link #desc()}). */
   HistoricTaskInstanceQuery orderByCaseExecutionId();
+
+  /**
+   * Only select tasks where end time is after given date
+   */
+  HistoricTaskInstanceQuery finishedAfter(Date date);
+
+  /**
+   * Only select tasks where end time is before given date
+   */
+  HistoricTaskInstanceQuery finishedBefore(Date date);
+
+  /**
+   * Only select tasks where created after given date
+   */
+  HistoricTaskInstanceQuery createdAfter(Date date);
+
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -82,6 +82,10 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
   protected String caseInstanceId;
   protected String caseExecutionId;
 
+  protected Date finishedAfter;
+  protected Date finishedBefore;
+  protected Date createdAfter;
+
   public HistoricTaskInstanceQueryImpl() {
   }
 
@@ -356,6 +360,8 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
     return super.hasExcludingConditions()
       || (finished && unfinished)
       ||(processFinished && processUnfinished)
+      || CompareUtil.areNotInAscendingOrder(createdAfter)
+      || CompareUtil.areNotInAscendingOrder(finishedAfter, finishedBefore)
       || CompareUtil.areNotInAscendingOrder(dueAfter, dueDate, dueBefore)
       || CompareUtil.areNotInAscendingOrder(followUpAfter, followUpDate, followUpBefore);
   }
@@ -461,6 +467,27 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
     orderBy(HistoricTaskInstanceQueryProperty.CASE_EXECUTION_ID);
     return this;
   }
+
+  @Override
+  public HistoricTaskInstanceQuery finishedAfter(Date date) {
+    finished = true;
+    this.finishedAfter = date;
+    return this;
+  }
+
+  @Override
+  public HistoricTaskInstanceQuery finishedBefore(Date date) {
+    finished = true;
+    this.finishedBefore = date;
+    return this;
+  }
+
+  @Override
+  public HistoricTaskInstanceQuery createdAfter(Date date) {
+    this.createdAfter = date;
+    return this;
+  }
+
 
   public HistoricTaskInstanceQuery orderByTenantId() {
     return orderBy(HistoricTaskInstanceQueryProperty.TENANT_ID);
@@ -582,6 +609,18 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
 
   public String getCaseExecutionId() {
     return caseExecutionId;
+  }
+
+  public Date getFinishedAfter() {
+    return finishedAfter;
+  }
+
+  public Date getFinishedBefore() {
+    return finishedBefore;
+  }
+
+  public Date getCreatedAfter() {
+    return createdAfter;
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -84,7 +84,8 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
 
   protected Date finishedAfter;
   protected Date finishedBefore;
-  protected Date createdAfter;
+  protected Date startedAfter;
+  protected Date startedBefore;
 
   public HistoricTaskInstanceQueryImpl() {
   }
@@ -360,7 +361,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
     return super.hasExcludingConditions()
       || (finished && unfinished)
       ||(processFinished && processUnfinished)
-      || CompareUtil.areNotInAscendingOrder(createdAfter)
+      || CompareUtil.areNotInAscendingOrder(startedAfter, startedBefore)
       || CompareUtil.areNotInAscendingOrder(finishedAfter, finishedBefore)
       || CompareUtil.areNotInAscendingOrder(dueAfter, dueDate, dueBefore)
       || CompareUtil.areNotInAscendingOrder(followUpAfter, followUpDate, followUpBefore);
@@ -483,8 +484,14 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
   }
 
   @Override
-  public HistoricTaskInstanceQuery createdAfter(Date date) {
-    this.createdAfter = date;
+  public HistoricTaskInstanceQuery startedAfter(Date date) {
+    this.startedAfter = date;
+    return this;
+  }
+
+  @Override
+  public HistoricTaskInstanceQuery startedBefore(Date date) {
+    this.startedBefore = date;
     return this;
   }
 
@@ -619,8 +626,11 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
     return finishedBefore;
   }
 
-  public Date getCreatedAfter() {
-    return createdAfter;
+  public Date getStartedAfter() {
+    return startedAfter;
   }
 
+  public Date getStartedBefore() {
+    return startedBefore;
+  }
 }

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
@@ -358,14 +358,17 @@
       <if test="processUnfinished">
         and HPI.END_TIME_ is null
       </if>
-      <if test="createdAfter != null">
-        and RES.START_TIME_ > #{createdAfter}
+      <if test="startedAfter != null">
+        and RES.START_TIME_ &gt;= #{startedAfter}
+      </if>
+      <if test="startedBefore != null">
+        and RES.START_TIME_ &lt;= #{startedBefore}
       </if>
       <if test="finishedBefore != null">
         and RES.END_TIME_ &lt;= #{finishedBefore}
       </if>
       <if test="finishedAfter != null">
-        and RES.END_TIME_ >= #{finishedAfter}
+        and RES.END_TIME_ &gt;= #{finishedAfter}
       </if>
       <if test="dueDate != null">
         and RES.DUE_DATE_ = #{dueDate}

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
@@ -358,6 +358,15 @@
       <if test="processUnfinished">
         and HPI.END_TIME_ is null
       </if>
+      <if test="createdAfter != null">
+        and RES.START_TIME_ > #{createdAfter}
+      </if>
+      <if test="finishedBefore != null">
+        and RES.END_TIME_ &lt;= #{finishedBefore}
+      </if>
+      <if test="finishedAfter != null">
+        and RES.END_TIME_ >= #{finishedAfter}
+      </if>
       <if test="dueDate != null">
         and RES.DUE_DATE_ = #{dueDate}
       </if>

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricTaskInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricTaskInstanceTest.java
@@ -225,6 +225,22 @@ public class HistoricTaskInstanceTest extends PluggableProcessEngineTestCase {
     assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDueDate(dueDate).taskDueAfter(anHourLater.getTime()).count());
     assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDueBefore(anHourAgo.getTime()).taskDueAfter(anHourLater.getTime()).count());
 
+
+    //End time before
+    assertEquals(1, historyService.createHistoricTaskInstanceQuery().finishedBefore(Calendar.getInstance().getTime()).count());
+
+    //End time after
+    assertEquals(0, historyService.createHistoricTaskInstanceQuery().finishedAfter(Calendar.getInstance().getTime()).count());
+
+    //Tasks completed in the last 7 days
+    Calendar sevenDaysAgo = Calendar.getInstance();
+    sevenDaysAgo.add(Calendar.DAY_OF_MONTH, -7);
+    assertEquals(1, historyService.createHistoricTaskInstanceQuery()
+            .createdAfter(sevenDaysAgo.getTime())
+            .finishedBefore(Calendar.getInstance().getTime()).count());
+
+
+
     // Finished and Unfinished - Add anther other instance that has a running task (unfinished)
     runtimeService.startProcessInstanceByKey("HistoricTaskQueryTest");
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricTaskInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricTaskInstanceTest.java
@@ -226,19 +226,21 @@ public class HistoricTaskInstanceTest extends PluggableProcessEngineTestCase {
     assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskDueBefore(anHourAgo.getTime()).taskDueAfter(anHourLater.getTime()).count());
 
 
-    //End time before
-    assertEquals(1, historyService.createHistoricTaskInstanceQuery().finishedBefore(Calendar.getInstance().getTime()).count());
+    Calendar hourAgo = Calendar.getInstance();
+    hourAgo.add(Calendar.HOUR_OF_DAY, -1);
+    Calendar hourFromNow = Calendar.getInstance();
+    hourFromNow.add(Calendar.HOUR_OF_DAY, 1);
 
-    //End time after
-    assertEquals(0, historyService.createHistoricTaskInstanceQuery().finishedAfter(Calendar.getInstance().getTime()).count());
-
-    //Tasks completed in the last 7 days
-    Calendar sevenDaysAgo = Calendar.getInstance();
-    sevenDaysAgo.add(Calendar.DAY_OF_MONTH, -7);
-    assertEquals(1, historyService.createHistoricTaskInstanceQuery()
-            .createdAfter(sevenDaysAgo.getTime())
-            .finishedBefore(Calendar.getInstance().getTime()).count());
-
+    // Start/end dates
+    assertEquals(0, historyService.createHistoricTaskInstanceQuery().finishedBefore(hourAgo.getTime()).count());
+    assertEquals(1, historyService.createHistoricTaskInstanceQuery().finishedBefore(hourFromNow.getTime()).count());
+    assertEquals(1, historyService.createHistoricTaskInstanceQuery().finishedAfter(hourAgo.getTime()).count());
+    assertEquals(0, historyService.createHistoricTaskInstanceQuery().finishedAfter(hourFromNow.getTime()).count());
+    assertEquals(1, historyService.createHistoricTaskInstanceQuery().startedBefore(hourFromNow.getTime()).count());
+    assertEquals(0, historyService.createHistoricTaskInstanceQuery().startedBefore(hourAgo.getTime()).count());
+    assertEquals(1, historyService.createHistoricTaskInstanceQuery().startedAfter(hourAgo.getTime()).count());
+    assertEquals(0, historyService.createHistoricTaskInstanceQuery().startedAfter(hourFromNow.getTime()).count());
+    assertEquals(0, historyService.createHistoricTaskInstanceQuery().startedAfter(hourFromNow.getTime()).startedBefore(hourAgo.getTime()).count());
 
 
     // Finished and Unfinished - Add anther other instance that has a running task (unfinished)

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryTest.java
@@ -12,6 +12,7 @@
  */
 package org.camunda.bpm.engine.test.standalone.history;
 
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
 
@@ -319,6 +320,51 @@ public class HistoricTaskInstanceQueryTest extends PluggableProcessEngineTestCas
     taskService.deleteTask("taskOne",true);
     taskService.deleteTask("taskTwo",true);
     taskService.deleteTask("taskThree",true);
+  }
+
+
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+  @Deployment(resources = { "org/camunda/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
+  public void testTaskReturnedBeforeEndTime() {
+    // given
+    Task taskOne = taskService.newTask("taskOne");
+
+    // when
+    taskOne.setAssignee("aUserId");
+    taskService.saveTask(taskOne);
+    taskService.complete(taskOne.getId());
+
+
+    List<HistoricTaskInstance> list = historyService.createHistoricTaskInstanceQuery()
+            .finishedBefore(Calendar.getInstance().getTime()).list();
+
+    // then
+    assertEquals(list.size(), 1);
+
+    // cleanup
+    taskService.deleteTask("taskOne",true);
+  }
+
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+  @Deployment(resources = { "org/camunda/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
+  public void testTaskReturnedAfterEndTime() {
+    // given
+    Task taskOne = taskService.newTask("taskOne");
+
+    // when
+    taskOne.setAssignee("aUserId");
+    taskService.saveTask(taskOne);
+    taskService.complete(taskOne.getId());
+
+
+    List<HistoricTaskInstance> list = historyService.createHistoricTaskInstanceQuery()
+            .finishedAfter(Calendar.getInstance().getTime()).list();
+
+    // then
+    assertEquals(list.size(), 0);
+
+    // cleanup
+    taskService.deleteTask("taskOne",true);
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryTest.java
@@ -20,6 +20,7 @@ import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.history.HistoricTaskInstance;
 import org.camunda.bpm.engine.history.HistoricTaskInstanceQuery;
 import org.camunda.bpm.engine.impl.test.PluggableProcessEngineTestCase;
+import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.RequiredHistoryLevel;
@@ -332,28 +333,40 @@ public class HistoricTaskInstanceQueryTest extends PluggableProcessEngineTestCas
     // when
     taskOne.setAssignee("aUserId");
     taskService.saveTask(taskOne);
+
+    Calendar hourAgo = Calendar.getInstance();
+    hourAgo.add(Calendar.HOUR_OF_DAY, -1);
+    ClockUtil.setCurrentTime(hourAgo.getTime());
+
+
     taskService.complete(taskOne.getId());
 
 
     List<HistoricTaskInstance> list = historyService.createHistoricTaskInstanceQuery()
-            .finishedBefore(Calendar.getInstance().getTime()).list();
+            .finishedBefore(hourAgo.getTime()).list();
 
     // then
-    assertEquals(list.size(), 1);
+    assertEquals(1, list.size());
 
     // cleanup
     taskService.deleteTask("taskOne",true);
+    ClockUtil.reset();
   }
 
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
   @Deployment(resources = { "org/camunda/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
-  public void testTaskReturnedAfterEndTime() {
+  public void testTaskNotReturnedAfterEndTime() {
     // given
     Task taskOne = taskService.newTask("taskOne");
 
     // when
     taskOne.setAssignee("aUserId");
     taskService.saveTask(taskOne);
+
+    Calendar hourAgo = Calendar.getInstance();
+    hourAgo.add(Calendar.HOUR_OF_DAY, -1);
+    ClockUtil.setCurrentTime(hourAgo.getTime());
+
     taskService.complete(taskOne.getId());
 
 
@@ -361,10 +374,13 @@ public class HistoricTaskInstanceQueryTest extends PluggableProcessEngineTestCas
             .finishedAfter(Calendar.getInstance().getTime()).list();
 
     // then
-    assertEquals(list.size(), 0);
+    assertEquals(0, list.size());
 
     // cleanup
     taskService.deleteTask("taskOne",true);
+
+    ClockUtil.reset();
   }
+
 
 }


### PR DESCRIPTION
change historictaskinstancequery to include:
finishedAfter(date)
finishedBefore(date)
createdAfter(date)

enable filtering of tasks based on start and end time.