### PR TITLE
VersionTag for decision tables.

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/repository/DecisionDefinitionDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/repository/DecisionDefinitionDto.java
@@ -27,7 +27,8 @@ public class DecisionDefinitionDto {
   protected String decisionRequirementsDefinitionId;
   protected String decisionRequirementsDefinitionKey;
   protected Integer historyTimeToLive;
-
+  protected String versionTag;
+  
   public String getId() {
     return id;
   }
@@ -71,7 +72,11 @@ public class DecisionDefinitionDto {
   public Integer getHistoryTimeToLive() {
     return historyTimeToLive;
   }
-
+  
+  public String getVersionTag(){
+    return versionTag;
+  }
+  
   public static DecisionDefinitionDto fromDecisionDefinition(DecisionDefinition definition) {
     DecisionDefinitionDto dto = new DecisionDefinitionDto();
 
@@ -86,6 +91,7 @@ public class DecisionDefinitionDto {
     dto.decisionRequirementsDefinitionKey = definition.getDecisionRequirementsDefinitionKey();
     dto.tenantId = definition.getTenantId();
     dto.historyTimeToLive = definition.getHistoryTimeToLive();
+    dto.versionTag = definition.getVersionTag();
 
     return dto;
   }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/repository/DecisionDefinitionQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/repository/DecisionDefinitionQueryDto.java
@@ -39,7 +39,8 @@ public class DecisionDefinitionQueryDto extends AbstractQueryDto<DecisionDefinit
   private static final String SORT_BY_DEPLOYMENT_ID_VALUE = "deploymentId";
   private static final String SORT_BY_CATEGORY_VALUE = "category";
   private static final String SORT_BY_TENANT_ID = "tenantId";
-
+  private static final String SORT_BY_VERSION_TAG = "versionTag";
+  
   private static final List<String> VALID_SORT_BY_VALUES;
 
   static {
@@ -52,7 +53,7 @@ public class DecisionDefinitionQueryDto extends AbstractQueryDto<DecisionDefinit
     VALID_SORT_BY_VALUES.add(SORT_BY_VERSION_VALUE);
     VALID_SORT_BY_VALUES.add(SORT_BY_DEPLOYMENT_ID_VALUE);
     VALID_SORT_BY_VALUES.add(SORT_BY_TENANT_ID);
-
+    VALID_SORT_BY_VALUES.add(SORT_BY_VERSION_TAG);
   }
 
   protected String decisionDefinitionId;
@@ -74,7 +75,9 @@ public class DecisionDefinitionQueryDto extends AbstractQueryDto<DecisionDefinit
   protected List<String> tenantIds;
   protected Boolean withoutTenantId;
   protected Boolean includeDefinitionsWithoutTenantId;
-
+  private String versionTag;
+  private String versionTagLike;
+  
   public DecisionDefinitionQueryDto() {}
 
   public DecisionDefinitionQueryDto(ObjectMapper objectMapper, MultivaluedMap<String, String> queryParameters) {
@@ -175,6 +178,16 @@ public class DecisionDefinitionQueryDto extends AbstractQueryDto<DecisionDefinit
   public void setIncludeDecisionDefinitionsWithoutTenantId(Boolean includeDefinitionsWithoutTenantId) {
     this.includeDefinitionsWithoutTenantId = includeDefinitionsWithoutTenantId;
   }
+  
+  @CamundaQueryParam(value = "versionTag")
+  public void setVersionTag(String versionTag) {
+    this.versionTag = versionTag;
+  }
+
+  @CamundaQueryParam(value = "versionTagLike")
+  public void setVersionTagLike(String versionTagLike) {
+    this.versionTagLike = versionTagLike;
+  }
 
   @Override
   protected boolean isValidSortByValue(String value) {
@@ -245,6 +258,12 @@ public class DecisionDefinitionQueryDto extends AbstractQueryDto<DecisionDefinit
     if (TRUE.equals(includeDefinitionsWithoutTenantId)) {
       query.includeDecisionDefinitionsWithoutTenantId();
     }
+    if( versionTag != null) {
+      query.versionTag(versionTag);
+    }
+    if( versionTagLike != null) {
+      query.versionTagLike(versionTagLike);
+    }
   }
 
   @Override
@@ -263,6 +282,8 @@ public class DecisionDefinitionQueryDto extends AbstractQueryDto<DecisionDefinit
       query.orderByDeploymentId();
     } else if (sortBy.equals(SORT_BY_TENANT_ID)) {
       query.orderByTenantId();
+    } else if (sortBy.equals(SORT_BY_VERSION_TAG)) {
+      query.orderByVersionTag();
     }
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/DecisionDefinitionRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/DecisionDefinitionRestServiceQueryTest.java
@@ -226,6 +226,16 @@ public class DecisionDefinitionRestServiceQueryTest extends AbstractRestServiceT
     executeAndVerifySorting("tenantId", "desc", Status.OK);
     inOrder.verify(mockedQuery).orderByTenantId();
     inOrder.verify(mockedQuery).desc();
+    
+    inOrder = Mockito.inOrder(mockedQuery);
+    executeAndVerifySorting("versionTag", "asc", Status.OK);
+    inOrder.verify(mockedQuery).orderByVersionTag();
+    inOrder.verify(mockedQuery).asc();
+
+    inOrder = Mockito.inOrder(mockedQuery);
+    executeAndVerifySorting("versionTag", "desc", Status.OK);
+    inOrder.verify(mockedQuery).orderByVersionTag();
+    inOrder.verify(mockedQuery).asc();
   }
 
   @Test
@@ -391,6 +401,8 @@ public class DecisionDefinitionRestServiceQueryTest extends AbstractRestServiceT
     verify(mockedQuery).decisionDefinitionResourceNameLike(queryParameters.get("resourceNameLike"));
     verify(mockedQuery).decisionRequirementsDefinitionId(queryParameters.get("decisionRequirementsDefinitionId"));
     verify(mockedQuery).decisionRequirementsDefinitionKey(queryParameters.get("decisionRequirementsDefinitionKey"));
+    verify(mockedQuery).versionTag(queryParameters.get("versionTag"));
+    verify(mockedQuery).versionTagLike(queryParameters.get("versionTagLike"));
     verify(mockedQuery).withoutDecisionRequirementsDefinition();
     verify(mockedQuery).list();
   }
@@ -481,6 +493,24 @@ public class DecisionDefinitionRestServiceQueryTest extends AbstractRestServiceT
 
     verify(mockedQuery).count();
   }
+  
+  @Test
+  public void testDecisionDefinitionVersionTag() {
+    List<DecisionDefinition> decisionDefinitions = Arrays.asList(
+      MockProvider.mockDecisionDefinition().versionTag(MockProvider.EXAMPLE_VERSION_TAG).build(),
+      MockProvider.mockDecisionDefinition().id(MockProvider.ANOTHER_EXAMPLE_DECISION_DEFINITION_ID).versionTag(MockProvider.ANOTHER_EXAMPLE_VERSION_TAG).build());
+    mockedQuery = createMockDecisionDefinitionQuery(decisionDefinitions);
+
+    given()
+      .queryParam("versionTag", MockProvider.EXAMPLE_VERSION_TAG)
+      .then().expect()
+      .statusCode(Status.OK.getStatusCode())
+      .when()
+      .get(DECISION_DEFINITION_QUERY_URL);
+
+    verify(mockedQuery).versionTag(MockProvider.EXAMPLE_VERSION_TAG);
+    verify(mockedQuery).list();
+  }
 
   private Map<String, String> getCompleteQueryParameters() {
     Map<String, String> parameters = new HashMap<String, String>();
@@ -500,7 +530,9 @@ public class DecisionDefinitionRestServiceQueryTest extends AbstractRestServiceT
     parameters.put("decisionRequirementsDefinitionId", MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID);
     parameters.put("decisionRequirementsDefinitionKey", MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_KEY);
     parameters.put("withoutDecisionRequirementsDefinition", "true");
-
+    parameters.put("versionTag", "semVer");
+    parameters.put("versionTagLike", "semVerLike");
+    
     return parameters;
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockDecisionDefinitionBuilder.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockDecisionDefinitionBuilder.java
@@ -30,6 +30,7 @@ public class MockDecisionDefinitionBuilder {
   private String tenantId = null;
   private String decisionRequirementsDefinitionId = null;
   private String decisionRequirementsDefinitionKey = null;
+  private String versionTag = null;
 
   public MockDecisionDefinitionBuilder id(String id) {
     this.id = id;
@@ -86,6 +87,11 @@ public class MockDecisionDefinitionBuilder {
     return this;
   }
 
+  public MockDecisionDefinitionBuilder versionTag(String versionTag) {
+    this.versionTag = versionTag;
+	return this;
+  }
+  
   public DecisionDefinition build() {
     DecisionDefinition mockDefinition = mock(DecisionDefinition.class);
 
@@ -100,6 +106,7 @@ public class MockDecisionDefinitionBuilder {
     when(mockDefinition.getTenantId()).thenReturn(tenantId);
     when(mockDefinition.getDecisionRequirementsDefinitionId()).thenReturn(decisionRequirementsDefinitionId);
     when(mockDefinition.getDecisionRequirementsDefinitionKey()).thenReturn(decisionRequirementsDefinitionKey);
+    when(mockDefinition.getVersionTag()).thenReturn(versionTag);
 
     return mockDefinition;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/entity/repository/DecisionDefinitionEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/entity/repository/DecisionDefinitionEntity.java
@@ -53,6 +53,7 @@ public class DecisionDefinitionEntity extends DmnDecisionImpl implements Decisio
   protected String previousDecisionDefinitionId;
 
   protected Integer historyTimeToLive;
+  protected String versionTag;
 
   public DecisionDefinitionEntity() {
 
@@ -265,6 +266,15 @@ public class DecisionDefinitionEntity extends DmnDecisionImpl implements Decisio
   public void setHistoryTimeToLive(Integer historyTimeToLive) {
     this.historyTimeToLive = historyTimeToLive;
   }
+  
+  @Override
+  public String getVersionTag() {
+    return versionTag;
+  }
+
+  public void setVersionTag(String versionTag) {
+    this.versionTag = versionTag;
+  }
 
   @Override
   public String toString() {
@@ -274,6 +284,7 @@ public class DecisionDefinitionEntity extends DmnDecisionImpl implements Decisio
       ", category='" + category + '\'' +
       ", key='" + key + '\'' +
       ", version=" + version +
+      ", versionTag=" + versionTag +
       ", decisionRequirementsDefinitionId='" + decisionRequirementsDefinitionId + '\'' +
       ", decisionRequirementsDefinitionKey='" + decisionRequirementsDefinitionKey + '\'' +
       ", deploymentId='" + deploymentId + '\'' +

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/entity/repository/DecisionDefinitionQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/entity/repository/DecisionDefinitionQueryImpl.java
@@ -154,7 +154,7 @@ public class DecisionDefinitionQueryImpl extends AbstractQuery<DecisionDefinitio
   
   @Override
   public DecisionDefinitionQuery versionTag(String versionTag) {
-	ensureNotNull(NotValidException.class, "versionTag", versionTag);
+    ensureNotNull(NotValidException.class, "versionTag", versionTag);
 	this.versionTag = versionTag;
   	return this;
   }
@@ -225,7 +225,7 @@ public class DecisionDefinitionQueryImpl extends AbstractQuery<DecisionDefinitio
 
   @Override
   public DecisionDefinitionQuery orderByVersionTag() {
-	  return orderBy(DecisionDefinitionQueryProperty.VERSION_TAG);
+    return orderBy(DecisionDefinitionQueryProperty.VERSION_TAG);
   }
   
   //results ////////////////////////////////////////////
@@ -307,11 +307,11 @@ public class DecisionDefinitionQueryImpl extends AbstractQuery<DecisionDefinitio
   }
   
   public String getVersionTag() {
-	 return versionTag;
+    return versionTag;
   }
   
   public String getVersionTagLike() {
-	 return versionTagLike;
+    return versionTagLike;
   }
   
   public boolean isLatest() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/entity/repository/DecisionDefinitionQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/entity/repository/DecisionDefinitionQueryImpl.java
@@ -51,6 +51,9 @@ public class DecisionDefinitionQueryImpl extends AbstractQuery<DecisionDefinitio
   protected String[] tenantIds;
   protected boolean includeDefinitionsWithoutTenantId = false;
 
+  protected String versionTag;
+  protected String versionTagLike;
+  
   public DecisionDefinitionQueryImpl() {
   }
 
@@ -148,6 +151,20 @@ public class DecisionDefinitionQueryImpl extends AbstractQuery<DecisionDefinitio
     this.decisionRequirementsDefinitionKey = decisionRequirementsDefinitionKey;
     return this;
   }
+  
+  @Override
+  public DecisionDefinitionQuery versionTag(String versionTag) {
+	ensureNotNull(NotValidException.class, "versionTag", versionTag);
+	this.versionTag = versionTag;
+  	return this;
+  }
+
+  @Override
+  public DecisionDefinitionQuery versionTagLike(String versionTagLike) {
+	ensureNotNull(NotValidException.class, "versionTagLike", versionTagLike);
+	this.versionTagLike = versionTagLike;
+  	return this;
+  }
 
   public DecisionDefinitionQuery withoutDecisionRequirementsDefinition() {
     withoutDecisionRequirementsDefinition = true;
@@ -206,6 +223,11 @@ public class DecisionDefinitionQueryImpl extends AbstractQuery<DecisionDefinitio
     return orderBy(DecisionDefinitionQueryProperty.TENANT_ID);
   }
 
+  @Override
+  public DecisionDefinitionQuery orderByVersionTag() {
+	  return orderBy(DecisionDefinitionQueryProperty.VERSION_TAG);
+  }
+  
   //results ////////////////////////////////////////////
 
   @Override
@@ -283,9 +305,16 @@ public class DecisionDefinitionQueryImpl extends AbstractQuery<DecisionDefinitio
   public Integer getVersion() {
     return version;
   }
-
+  
+  public String getVersionTag() {
+	 return versionTag;
+  }
+  
+  public String getVersionTagLike() {
+	 return versionTagLike;
+  }
+  
   public boolean isLatest() {
     return latest;
   }
-
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/entity/repository/DecisionDefinitionQueryProperty.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/entity/repository/DecisionDefinitionQueryProperty.java
@@ -27,5 +27,5 @@ public interface DecisionDefinitionQueryProperty {
   public static final QueryProperty DECISION_DEFINITION_CATEGORY = new QueryPropertyImpl("CATEGORY_");
   public static final QueryProperty DEPLOYMENT_ID = new QueryPropertyImpl("DEPLOYMENT_ID_");
   public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
-
+  public static final QueryProperty VERSION_TAG = new QueryPropertyImpl("VERSION_TAG_");
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/transformer/DecisionDefinitionHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/transformer/DecisionDefinitionHandler.java
@@ -37,7 +37,8 @@ public class DecisionDefinitionHandler extends DmnDecisionTransformHandler {
     final Integer historyTimeToLive = decision.getCamundaHistoryTimeToLive();
     validateHistoryTimeToLive(historyTimeToLive);
     decisionDefinition.setHistoryTimeToLive(historyTimeToLive);
-
+    decisionDefinition.setVersionTag(decision.getVersionTag());
+    
     return decisionDefinition;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/repository/DecisionDefinition.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/repository/DecisionDefinition.java
@@ -33,4 +33,7 @@ public interface DecisionDefinition extends ResourceDefinition {
    */
   String getDecisionRequirementsDefinitionKey();
 
+  /** Version tag of the decision definition. */
+  String getVersionTag();
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/repository/DecisionDefinitionQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/repository/DecisionDefinitionQuery.java
@@ -148,6 +148,16 @@ public interface DecisionDefinitionQuery extends Query<DecisionDefinitionQuery, 
    * combination with {@link #tenantIdIn(String...)}.
    */
   DecisionDefinitionQuery includeDecisionDefinitionsWithoutTenantId();
+  
+  /**
+   * Only selects decision definitions with a specific version tag
+   */
+  DecisionDefinitionQuery versionTag(String versionTag);
+
+  /**
+   * Only selects decision definitions with a version tag like the given
+   */
+  DecisionDefinitionQuery versionTagLike(String versionTagLike);
 
   // ordering ////////////////////////////////////////////////////////////
 
@@ -178,5 +188,14 @@ public interface DecisionDefinitionQuery extends Query<DecisionDefinitionQuery, 
   /** Order by tenant id (needs to be followed by {@link #asc()} or {@link #desc()}).
    * Note that the ordering of decision definitions without tenant id is database-specific. */
   DecisionDefinitionQuery orderByTenantId();
+  
+  /**
+   * Order by version tag (needs to be followed by {@link #asc()} or {@link #desc()}).
+   *
+   * <strong>Note:</strong> sorting by versionTag is a string based sort.
+   * There is no interpretation of the version which can lead to a sorting like:
+   * v0.1.0 v0.10.0 v0.2.0.
+   */
+  DecisionDefinitionQuery orderByVersionTag();
 
 }

--- a/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.db2.create.decision.engine.sql
+++ b/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.db2.create.decision.engine.sql
@@ -13,6 +13,7 @@ create table ACT_RE_DECISION_DEF (
     DEC_REQ_KEY_ varchar(255),
     TENANT_ID_ varchar(64),
     HISTORY_TTL_ integer,
+    VERSION_TAG_ varchar(64),    
     primary key (ID_)
 );
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.h2.create.decision.engine.sql
+++ b/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.h2.create.decision.engine.sql
@@ -13,6 +13,7 @@ create table ACT_RE_DECISION_DEF (
     DEC_REQ_KEY_ varchar(255),
     TENANT_ID_ varchar(64),
     HISTORY_TTL_ integer,
+    VERSION_TAG_ varchar(64),    
     primary key (ID_)
 );
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.mariadb.create.decision.engine.sql
+++ b/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.mariadb.create.decision.engine.sql
@@ -13,6 +13,7 @@ create table ACT_RE_DECISION_DEF (
     DEC_REQ_KEY_ varchar(255),
     TENANT_ID_ varchar(64),
     HISTORY_TTL_ integer,
+    VERSION_TAG_ varchar(64),    
     primary key (ID_)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_bin;
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.mssql.create.decision.engine.sql
+++ b/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.mssql.create.decision.engine.sql
@@ -13,6 +13,7 @@ create table ACT_RE_DECISION_DEF (
     DEC_REQ_KEY_ nvarchar(255),
     TENANT_ID_ nvarchar(64),
     HISTORY_TTL_ int,
+    VERSION_TAG_ varchar(64),    
     primary key (ID_)
 );
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.mssql.create.decision.engine.sql
+++ b/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.mssql.create.decision.engine.sql
@@ -13,7 +13,7 @@ create table ACT_RE_DECISION_DEF (
     DEC_REQ_KEY_ nvarchar(255),
     TENANT_ID_ nvarchar(64),
     HISTORY_TTL_ int,
-    VERSION_TAG_ varchar(64),    
+    VERSION_TAG_ nvarchar(64),    
     primary key (ID_)
 );
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.mysql.create.decision.engine.sql
+++ b/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.mysql.create.decision.engine.sql
@@ -13,6 +13,7 @@ create table ACT_RE_DECISION_DEF (
     DEC_REQ_KEY_ varchar(255),
     TENANT_ID_ varchar(64),
     HISTORY_TTL_ integer,
+    VERSION_TAG_ varchar(64),
     primary key (ID_)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_bin;
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.oracle.create.decision.engine.sql
+++ b/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.oracle.create.decision.engine.sql
@@ -13,7 +13,7 @@ create table ACT_RE_DECISION_DEF (
     DEC_REQ_KEY_ NVARCHAR2(255),
     TENANT_ID_ NVARCHAR2(64),
     HISTORY_TTL_ integer,
-    VERSION_TAG_ varchar(64),
+    VERSION_TAG_ NVARCHAR2(64),
     primary key (ID_)
 );
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.oracle.create.decision.engine.sql
+++ b/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.oracle.create.decision.engine.sql
@@ -13,6 +13,7 @@ create table ACT_RE_DECISION_DEF (
     DEC_REQ_KEY_ NVARCHAR2(255),
     TENANT_ID_ NVARCHAR2(64),
     HISTORY_TTL_ integer,
+    VERSION_TAG_ varchar(64),
     primary key (ID_)
 );
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.postgres.create.decision.engine.sql
+++ b/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.postgres.create.decision.engine.sql
@@ -13,6 +13,7 @@ create table ACT_RE_DECISION_DEF (
     DEC_REQ_KEY_ varchar(255),
     TENANT_ID_ varchar(64),
     HISTORY_TTL_ integer,
+    VERSION_TAG_ varchar(64),
     primary key (ID_)
 );
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/DecisionDefinition.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/DecisionDefinition.xml
@@ -20,6 +20,7 @@
       DEC_REQ_KEY_,
       TENANT_ID_,
       HISTORY_TTL_,
+      VERSION_TAG_,
       REV_)
     values (#{id, jdbcType=VARCHAR},
             #{category, jdbcType=VARCHAR},
@@ -33,6 +34,7 @@
             #{decisionRequirementsDefinitionKey, jdbcType=VARCHAR},
             #{tenantId, jdbcType=VARCHAR},
             #{historyTimeToLive, jdbcType=INTEGER},
+            #{versionTag, jdbcType=VARCHAR},
             1
            )
   </insert>
@@ -69,6 +71,7 @@
     <result property="decisionRequirementsDefinitionKey" column="DEC_REQ_KEY_" jdbcType="VARCHAR"/>
     <result property="tenantId" column="TENANT_ID_" jdbcType="VARCHAR"/>
     <result property="historyTimeToLive" column="HISTORY_TTL_" jdbcType="INTEGER" />
+    <result property="versionTag" column="VERSION_TAG_" jdbcType="VARCHAR" />
   </resultMap>
 
   <!-- DECISIONDEFINITION SELECT -->

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/DecisionDefinition.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/DecisionDefinition.xml
@@ -248,6 +248,12 @@
       <if test="name != null">
         and RES.NAME_ = #{name}
       </if>
+      <if test="versionTag != null">
+        and RES.VERSION_TAG_ = #{versionTag}
+      </if>
+      <if test="versionTagLike != null">
+        and RES.VERSION_TAG_ like #{versionTagLike} ESCAPE #{escapeChar}
+      </if>
       <if test="nameLike != null">
         and RES.NAME_ like #{nameLike} ESCAPE #{escapeChar}
       </if>

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/DecisionDefinitionQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/DecisionDefinitionQueryTest.java
@@ -614,46 +614,45 @@ public class DecisionDefinitionQueryTest {
     assertEquals(expectedCount, query.list().size());
   }
   
-	@Deployment(resources = { 
-			"org/camunda/bpm/engine/test/api/repository/versionTag.dmn",
-			"org/camunda/bpm/engine/test/api/repository/versionTagHigher.dmn" })
-	@Test
-	public void testQueryOrderByVersionTag() {
-		List<DecisionDefinition> decisionDefinitionList = repositoryService
-															.createDecisionDefinitionQuery()
-															.versionTagLike("1%")
-															.orderByVersionTag()
-															.asc()
-															.list();
+  @Deployment(resources = { 
+    "org/camunda/bpm/engine/test/api/repository/versionTag.dmn",
+	"org/camunda/bpm/engine/test/api/repository/versionTagHigher.dmn" })
+  @Test
+  public void testQueryOrderByVersionTag() {
+    List<DecisionDefinition> decisionDefinitionList = repositoryService
+	  .createDecisionDefinitionQuery()
+	  .versionTagLike("1%")
+	  .orderByVersionTag()
+	  .asc()
+	  .list();
 
-		assertEquals("1.1.0", decisionDefinitionList.get(1).getVersionTag());
-	}
+	assertEquals("1.1.0", decisionDefinitionList.get(1).getVersionTag());
+  }
 	
-	@Deployment(resources = { 
-			"org/camunda/bpm/engine/test/api/repository/versionTag.dmn",
-			"org/camunda/bpm/engine/test/api/repository/versionTagHigher.dmn" })
-	@Test
-	public void testQueryByVersionTag() {
-		DecisionDefinition decisionDefinition = repositoryService
-															.createDecisionDefinitionQuery()
-															.versionTag("1.0.0")
-															.singleResult();
-
-		assertEquals("versionTag", decisionDefinition.getKey());
-		assertEquals("1.0.0", decisionDefinition.getVersionTag());
-	}
+  @Deployment(resources = { 
+    "org/camunda/bpm/engine/test/api/repository/versionTag.dmn",
+    "org/camunda/bpm/engine/test/api/repository/versionTagHigher.dmn" })
+  @Test
+  public void testQueryByVersionTag() {
+    DecisionDefinition decisionDefinition = repositoryService
+	  .createDecisionDefinitionQuery()
+      .versionTag("1.0.0")
+	   .singleResult();
+  
+    assertEquals("versionTag", decisionDefinition.getKey());
+	assertEquals("1.0.0", decisionDefinition.getVersionTag());
+  }
 	
-	@Deployment(resources = { 
-			"org/camunda/bpm/engine/test/api/repository/versionTag.dmn",
-			"org/camunda/bpm/engine/test/api/repository/versionTagHigher.dmn" })
-	@Test
-	public void testQueryByVersionTagLike() {
-		List<DecisionDefinition> decisionDefinitionList = repositoryService
-															.createDecisionDefinitionQuery()
-															.versionTagLike("1%")
-															.list();
+  @Deployment(resources = { 
+    "org/camunda/bpm/engine/test/api/repository/versionTag.dmn",
+	"org/camunda/bpm/engine/test/api/repository/versionTagHigher.dmn" })
+  @Test
+  public void testQueryByVersionTagLike() {
+    List<DecisionDefinition> decisionDefinitionList = repositoryService
+	  .createDecisionDefinitionQuery()
+	  .versionTagLike("1%")
+	  .list();
 
-		assertEquals(2, decisionDefinitionList.size());
-	}
-
+    assertEquals(2, decisionDefinitionList.size());
+  }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/DecisionDefinitionQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/DecisionDefinitionQueryTest.java
@@ -24,6 +24,7 @@ import org.camunda.bpm.engine.exception.NotValidException;
 import org.camunda.bpm.engine.repository.DecisionDefinition;
 import org.camunda.bpm.engine.repository.DecisionDefinitionQuery;
 import org.camunda.bpm.engine.repository.DecisionRequirementsDefinition;
+import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
 import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
@@ -612,5 +613,47 @@ public class DecisionDefinitionQueryTest {
     assertEquals(expectedCount, query.count());
     assertEquals(expectedCount, query.list().size());
   }
+  
+	@Deployment(resources = { 
+			"org/camunda/bpm/engine/test/api/repository/versionTag.dmn",
+			"org/camunda/bpm/engine/test/api/repository/versionTagHigher.dmn" })
+	@Test
+	public void testQueryOrderByVersionTag() {
+		List<DecisionDefinition> decisionDefinitionList = repositoryService
+															.createDecisionDefinitionQuery()
+															.versionTagLike("1%")
+															.orderByVersionTag()
+															.asc()
+															.list();
+
+		assertEquals("1.1.0", decisionDefinitionList.get(1).getVersionTag());
+	}
+	
+	@Deployment(resources = { 
+			"org/camunda/bpm/engine/test/api/repository/versionTag.dmn",
+			"org/camunda/bpm/engine/test/api/repository/versionTagHigher.dmn" })
+	@Test
+	public void testQueryByVersionTag() {
+		DecisionDefinition decisionDefinition = repositoryService
+															.createDecisionDefinitionQuery()
+															.versionTag("1.0.0")
+															.singleResult();
+
+		assertEquals("versionTag", decisionDefinition.getKey());
+		assertEquals("1.0.0", decisionDefinition.getVersionTag());
+	}
+	
+	@Deployment(resources = { 
+			"org/camunda/bpm/engine/test/api/repository/versionTag.dmn",
+			"org/camunda/bpm/engine/test/api/repository/versionTagHigher.dmn" })
+	@Test
+	public void testQueryByVersionTagLike() {
+		List<DecisionDefinition> decisionDefinitionList = repositoryService
+															.createDecisionDefinitionQuery()
+															.versionTagLike("1%")
+															.list();
+
+		assertEquals(2, decisionDefinitionList.size());
+	}
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/VersionTagTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/VersionTagTest.java
@@ -46,22 +46,22 @@ public class VersionTagTest extends PluggableProcessEngineTestCase {
   
   @Deployment(resources={"org/camunda/bpm/engine/test/api/repository/versionTag.dmn"})
   public void testParsingVersionTagDecisionDefinition() {
-	  DecisionDefinition decision = repositoryService
-		      .createDecisionDefinitionQuery()
-		      .orderByDecisionDefinitionVersion()
-		      .asc()
-		      .singleResult();
+    DecisionDefinition decision = repositoryService
+	  .createDecisionDefinitionQuery()
+	  .orderByDecisionDefinitionVersion()
+	  .asc()
+	  .singleResult();
 
     assertEquals("1.0.0", decision.getVersionTag());
   }
 
   @Deployment(resources={"org/camunda/bpm/engine/test/api/repository/noVersionTag.dmn"})
   public void testParsingNullVersionTagDecisionDefinition() {
-	  DecisionDefinition decision = repositoryService
-		      .createDecisionDefinitionQuery()
-		      .orderByDecisionDefinitionVersion()
-		      .asc()
-		      .singleResult();
+    DecisionDefinition decision = repositoryService
+      .createDecisionDefinitionQuery()
+	  .orderByDecisionDefinitionVersion()
+	  .asc()
+	  .singleResult();
 
     assertEquals(null, decision.getVersionTag());
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/VersionTagTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/VersionTagTest.java
@@ -13,6 +13,7 @@
 package org.camunda.bpm.engine.test.api.repository;
 
 import org.camunda.bpm.engine.impl.test.PluggableProcessEngineTestCase;
+import org.camunda.bpm.engine.repository.DecisionDefinition;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.camunda.bpm.engine.test.Deployment;
 
@@ -41,5 +42,27 @@ public class VersionTagTest extends PluggableProcessEngineTestCase {
       .singleResult();
 
     assertEquals(null, process.getVersionTag());
+  }
+  
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/repository/versionTag.dmn"})
+  public void testParsingVersionTagDecisionDefinition() {
+	  DecisionDefinition decision = repositoryService
+		      .createDecisionDefinitionQuery()
+		      .orderByDecisionDefinitionVersion()
+		      .asc()
+		      .singleResult();
+
+    assertEquals("1.0.0", decision.getVersionTag());
+  }
+
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/repository/noVersionTag.dmn"})
+  public void testParsingNullVersionTagDecisionDefinition() {
+	  DecisionDefinition decision = repositoryService
+		      .createDecisionDefinitionQuery()
+		      .orderByDecisionDefinitionVersion()
+		      .asc()
+		      .singleResult();
+
+    assertEquals(null, decision.getVersionTag());
   }
 }

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/repository/noVersionTag.dmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/repository/noVersionTag.dmn
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+             xmlns:camunda="http://camunda.org/schema/1.0/dmn"
+             id="definitions"
+             name="definitions"
+             namespace="http://camunda.org/schema/1.0/dmn">  
+  <decision id="decision" name="VersionTag DMN">
+    <decisionTable id="decisionTable">
+      <input id="input1" label="">
+        <inputExpression id="inputExpression1" typeRef="string">        <text></text>
+</inputExpression>
+      </input>
+      <output id="output1" label="" name="" typeRef="string" />
+    </decisionTable>
+  </decision>
+</definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/repository/versionTag.dmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/repository/versionTag.dmn
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+             xmlns:camunda="http://camunda.org/schema/1.0/dmn"
+             id="definitions"
+             name="definitions"
+             namespace="http://camunda.org/schema/1.0/dmn">  
+  <decision id="decision" name="VersionTag DMN" camunda:versionTag="1.0.0">
+    <decisionTable id="decisionTable">
+      <input id="input1" label="">
+        <inputExpression id="inputExpression1" typeRef="string">        <text></text>
+</inputExpression>
+      </input>
+      <output id="output1" label="" name="" typeRef="string" />
+    </decisionTable>
+  </decision>
+</definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/repository/versionTag.dmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/repository/versionTag.dmn
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
-             xmlns:camunda="http://camunda.org/schema/1.0/dmn"
-             id="definitions"
-             name="definitions"
-             namespace="http://camunda.org/schema/1.0/dmn">  
-  <decision id="decision" name="VersionTag DMN" camunda:versionTag="1.0.0">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="versionTag" name="VersionTag DMN" camunda:versionTag="1.0.0">
     <decisionTable id="decisionTable">
       <input id="input1" label="">
         <inputExpression id="inputExpression1" typeRef="string">        <text></text>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/repository/versionTagHigher.dmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/repository/versionTagHigher.dmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
-  <decision id="noVersionTag" name="VersionTag DMN">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="versionTagHigher" name="VersionTag DMN" camunda:versionTag="1.1.0">
     <decisionTable id="decisionTable">
       <input id="input1" label="">
         <inputExpression id="inputExpression1" typeRef="string">        <text></text>


### PR DESCRIPTION
Hi,

I forked the camunda-bpm-platform and added semantic for versionTag to DecisionDefinition.
It is now able to save the versionTag in database, get them from DecisionDefinition and query and order it with DecisionDefinitionQuery.

I added a few tests for these features equal to tests for versionTag in ProcessDefinition.

The related jira ticket is 
https://app.camunda.com/jira/browse/CAM-7852

Also important to know is that already a pull request for camunda-dmn-model exists which is necessary: https://github.com/camunda/camunda-dmn-model/pull/33

See also related forum discussion : https://forum.camunda.org/t/version-tag-for-decision-tables/3579/

Best regards, 

Markus