### PR TITLE
Upgrade spin version to 1.4.0-SNAPSHOT

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -37,7 +37,7 @@
     <version.uuid-generator>3.1.2</version.uuid-generator>
     <version.camunda.commons>1.4.0</version.camunda.commons>
     <version.camunda.connect>1.0.4</version.camunda.connect>
-    <version.camunda.spin>1.3.1</version.camunda.spin>
+    <version.camunda.spin>1.4.0-SNAPSHOT</version.camunda.spin>
     <version.camunda.template-engines>1.0.1</version.camunda.template-engines>
     <version.camunda.ee.xslt-plugin>1.0.2</version.camunda.ee.xslt-plugin>
   </properties>

--- a/distro/jbossas7/modules/src/main/modules/com/jayway/jsonpath/json-path/main/module.xml
+++ b/distro/jbossas7/modules/src/main/modules/com/jayway/jsonpath/json-path/main/module.xml
@@ -1,6 +1,6 @@
 <module xmlns="urn:jboss:module:1.0" name="com.jayway.jsonpath.json-path">
   <resources>
-    <resource-root path="json-path-0.9.1.jar" />
+    <resource-root path="json-path-2.4.0.jar" />
   </resources>
 
   <dependencies>
@@ -8,6 +8,7 @@
     <module name="javax.api" />
     <module name="com.fasterxml.jackson.core.jackson-databind" />
     <module name="org.slf4j" />
+    <module name="net.minidev.json-smart" />
 
   </dependencies>
 </module>

--- a/distro/jbossas7/modules/src/main/modules/net/minidev/accessors-smart/main/module.xml
+++ b/distro/jbossas7/modules/src/main/modules/net/minidev/accessors-smart/main/module.xml
@@ -1,0 +1,9 @@
+<module xmlns="urn:jboss:module:1.0" name="com.jayway.jsonpath.json-path">
+  <resources>
+    <resource-root path="accessors-smart-1.2.jar" />
+  </resources>
+
+  <dependencies>
+    <module name="org.ow2.asm.asm" />
+  </dependencies>
+</module>

--- a/distro/jbossas7/modules/src/main/modules/net/minidev/accessors-smart/main/module.xml
+++ b/distro/jbossas7/modules/src/main/modules/net/minidev/accessors-smart/main/module.xml
@@ -1,4 +1,4 @@
-<module xmlns="urn:jboss:module:1.0" name="com.jayway.jsonpath.json-path">
+<module xmlns="urn:jboss:module:1.0" name="net.minidev.accessors-smart">
   <resources>
     <resource-root path="accessors-smart-1.2.jar" />
   </resources>

--- a/distro/jbossas7/modules/src/main/modules/net/minidev/json-smart/main/module.xml
+++ b/distro/jbossas7/modules/src/main/modules/net/minidev/json-smart/main/module.xml
@@ -1,4 +1,4 @@
-<module xmlns="urn:jboss:module:1.0" name="com.jayway.jsonpath.json-path">
+<module xmlns="urn:jboss:module:1.0" name="net.minidev.json-smart">
   <resources>
     <resource-root path="json-smart-2.3.jar" />
   </resources>

--- a/distro/jbossas7/modules/src/main/modules/net/minidev/json-smart/main/module.xml
+++ b/distro/jbossas7/modules/src/main/modules/net/minidev/json-smart/main/module.xml
@@ -1,0 +1,9 @@
+<module xmlns="urn:jboss:module:1.0" name="com.jayway.jsonpath.json-path">
+  <resources>
+    <resource-root path="json-smart-2.3.jar" />
+  </resources>
+
+  <dependencies>
+    <module name="org.minidev.accessors-smart" />
+  </dependencies>
+</module>

--- a/distro/jbossas7/modules/src/main/modules/org/ow2/asm/asm/main/module.xml
+++ b/distro/jbossas7/modules/src/main/modules/org/ow2/asm/asm/main/module.xml
@@ -1,0 +1,5 @@
+<module xmlns="urn:jboss:module:1.0" name="com.jayway.jsonpath.json-path">
+  <resources>
+    <resource-root path="asm-5.0.4.jar" />
+  </resources>
+</module>

--- a/distro/jbossas7/modules/src/main/modules/org/ow2/asm/asm/main/module.xml
+++ b/distro/jbossas7/modules/src/main/modules/org/ow2/asm/asm/main/module.xml
@@ -1,4 +1,4 @@
-<module xmlns="urn:jboss:module:1.0" name="com.jayway.jsonpath.json-path">
+<module xmlns="urn:jboss:module:1.0" name="org.ow2.asm.asm">
   <resources>
     <resource-root path="asm-5.0.4.jar" />
   </resources>

--- a/distro/wildfly/modules/src/main/modules/com/jayway/jsonpath/json-path/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/com/jayway/jsonpath/json-path/main/module.xml
@@ -1,6 +1,6 @@
 <module xmlns="urn:jboss:module:1.0" name="com.jayway.jsonpath.json-path">
   <resources>
-    <resource-root path="json-path-0.9.1.jar" />
+    <resource-root path="json-path-2.4.0.jar" />
   </resources>
 
   <dependencies>
@@ -8,6 +8,7 @@
     <module name="javax.api" />
     <module name="com.fasterxml.jackson.core.jackson-databind" />
     <module name="org.slf4j" />
+    <module name="net.minidev.json-smart" />
 
   </dependencies>
 </module>

--- a/distro/wildfly/modules/src/main/modules/net/minidev/accessors-smart/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/net/minidev/accessors-smart/main/module.xml
@@ -1,0 +1,9 @@
+<module xmlns="urn:jboss:module:1.0" name="com.jayway.jsonpath.json-path">
+  <resources>
+    <resource-root path="accessors-smart-1.2.jar" />
+  </resources>
+
+  <dependencies>
+    <module name="org.ow2.asm.asm" />
+  </dependencies>
+</module>

--- a/distro/wildfly/modules/src/main/modules/net/minidev/accessors-smart/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/net/minidev/accessors-smart/main/module.xml
@@ -1,4 +1,4 @@
-<module xmlns="urn:jboss:module:1.0" name="com.jayway.jsonpath.json-path">
+<module xmlns="urn:jboss:module:1.0" name="net.minidev.accessors-smart">
   <resources>
     <resource-root path="accessors-smart-1.2.jar" />
   </resources>

--- a/distro/wildfly/modules/src/main/modules/net/minidev/json-smart/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/net/minidev/json-smart/main/module.xml
@@ -1,4 +1,4 @@
-<module xmlns="urn:jboss:module:1.0" name="com.jayway.jsonpath.json-path">
+<module xmlns="urn:jboss:module:1.0" name="net.minidev.json-smart">
   <resources>
     <resource-root path="json-smart-2.3.jar" />
   </resources>

--- a/distro/wildfly/modules/src/main/modules/net/minidev/json-smart/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/net/minidev/json-smart/main/module.xml
@@ -1,0 +1,9 @@
+<module xmlns="urn:jboss:module:1.0" name="com.jayway.jsonpath.json-path">
+  <resources>
+    <resource-root path="json-smart-2.3.jar" />
+  </resources>
+
+  <dependencies>
+    <module name="org.minidev.accessors-smart" />
+  </dependencies>
+</module>

--- a/distro/wildfly/modules/src/main/modules/org/ow2/asm/asm/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/ow2/asm/asm/main/module.xml
@@ -1,4 +1,4 @@
-<module xmlns="urn:jboss:module:1.0" name="com.jayway.jsonpath.json-path">
+<module xmlns="urn:jboss:module:1.0" name="org.ow2.awm.awm">
   <resources>
     <resource-root path="asm-5.0.4.jar" />
   </resources>

--- a/distro/wildfly/modules/src/main/modules/org/ow2/asm/asm/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/ow2/asm/asm/main/module.xml
@@ -1,0 +1,5 @@
+<module xmlns="urn:jboss:module:1.0" name="com.jayway.jsonpath.json-path">
+  <resources>
+    <resource-root path="asm-5.0.4.jar" />
+  </resources>
+</module>


### PR DESCRIPTION
Version 1.4.0.SNAPSHOT of camunda-spin will utilise the latest version of json-path. This PR updates the spin version and adds JBoss modules for new dependencies required by json-path 2.4.0

cf. https://github.com/camunda/camunda-spin/pull/15