### PR TITLE
feat(engine): add SQL native query for historic variable instance (CAM-5327)

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/HistoryService.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/HistoryService.java
@@ -56,6 +56,7 @@ import org.camunda.bpm.engine.history.NativeHistoricCaseInstanceQuery;
 import org.camunda.bpm.engine.history.NativeHistoricDecisionInstanceQuery;
 import org.camunda.bpm.engine.history.NativeHistoricProcessInstanceQuery;
 import org.camunda.bpm.engine.history.NativeHistoricTaskInstanceQuery;
+import org.camunda.bpm.engine.history.NativeHistoricVariableInstanceQuery;
 import org.camunda.bpm.engine.history.UserOperationLogEntry;
 import org.camunda.bpm.engine.history.UserOperationLogQuery;
 import org.camunda.bpm.engine.history.HistoricDecisionInstanceStatisticsQuery;
@@ -337,6 +338,11 @@ public interface HistoryService {
    * creates a native query to search for {@link HistoricDecisionInstance}s via SQL
    */
   NativeHistoricDecisionInstanceQuery createNativeHistoricDecisionInstanceQuery();
+
+  /**
+   * creates a native query to search for {@link HistoricVariableInstance}s via SQL
+   */
+  NativeHistoricVariableInstanceQuery createNativeHistoricVariableInstanceQuery();
 
   /**
    * Creates a new programmatic query to search for {@link HistoricJobLog historic job logs}.

--- a/engine/src/main/java/org/camunda/bpm/engine/history/NativeHistoricVariableInstanceQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/history/NativeHistoricVariableInstanceQuery.java
@@ -1,0 +1,10 @@
+package org.camunda.bpm.engine.history;
+
+import org.camunda.bpm.engine.query.NativeQuery;
+
+/**
+ * Allows querying of {@link org.camunda.bpm.engine.history.HistoricVariableInstanceQuery}s via native (SQL) queries
+ * @author Ramona Koch
+ */
+public interface NativeHistoricVariableInstanceQuery extends NativeQuery<NativeHistoricVariableInstanceQuery, HistoricVariableInstance> {
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/history/NativeHistoricVariableInstanceQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/history/NativeHistoricVariableInstanceQuery.java
@@ -7,4 +7,13 @@ import org.camunda.bpm.engine.query.NativeQuery;
  * @author Ramona Koch
  */
 public interface NativeHistoricVariableInstanceQuery extends NativeQuery<NativeHistoricVariableInstanceQuery, HistoricVariableInstance> {
+
+    /**
+     * Disable deserialization of variable values that are custom objects. By default, the query
+     * will attempt to deserialize the value of these variables. By calling this method you can
+     * prevent such attempts in environments where their classes are not available.
+     * Independent of this setting, variable serialized values are accessible.
+     */
+    NativeHistoricVariableInstanceQuery disableCustomObjectDeserialization();
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoryServiceImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoryServiceImpl.java
@@ -43,6 +43,7 @@ import org.camunda.bpm.engine.history.NativeHistoricCaseInstanceQuery;
 import org.camunda.bpm.engine.history.NativeHistoricDecisionInstanceQuery;
 import org.camunda.bpm.engine.history.NativeHistoricProcessInstanceQuery;
 import org.camunda.bpm.engine.history.NativeHistoricTaskInstanceQuery;
+import org.camunda.bpm.engine.history.NativeHistoricVariableInstanceQuery;
 import org.camunda.bpm.engine.history.UserOperationLogQuery;
 import org.camunda.bpm.engine.impl.batch.history.DeleteHistoricBatchCmd;
 import org.camunda.bpm.engine.impl.batch.history.HistoricBatchQueryImpl;
@@ -215,6 +216,10 @@ public class HistoryServiceImpl extends ServiceImpl implements HistoryService {
 
   public NativeHistoricDecisionInstanceQuery createNativeHistoricDecisionInstanceQuery() {
     return new NativeHistoryDecisionInstanceQueryImpl(commandExecutor);
+  }
+
+  public NativeHistoricVariableInstanceQuery createNativeHistoricVariableInstanceQuery() {
+    return new NativeHistoricVariableInstanceQueryImpl(commandExecutor);
   }
 
   public HistoricJobLogQuery createHistoricJobLogQuery() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/NativeHistoricVariableInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/NativeHistoricVariableInstanceQueryImpl.java
@@ -30,6 +30,8 @@ public class NativeHistoricVariableInstanceQueryImpl extends AbstractNativeQuery
 
   private static final long serialVersionUID = 1L;
 
+  protected boolean isCustomObjectDeserializationEnabled = true;
+
   public NativeHistoricVariableInstanceQueryImpl(CommandContext commandContext) {
     super(commandContext);
   }
@@ -41,6 +43,12 @@ public class NativeHistoricVariableInstanceQueryImpl extends AbstractNativeQuery
 
   //results ////////////////////////////////////////////////////////////////
 
+  @Override
+  public NativeHistoricVariableInstanceQuery disableCustomObjectDeserialization() {
+        this.isCustomObjectDeserializationEnabled = false;
+        return this;
+  }
+
   public List<HistoricVariableInstance> executeList(CommandContext commandContext, Map<String, Object> parameterMap, int firstResult, int maxResults) {
     List<HistoricVariableInstance> historicVariableInstances = commandContext
             .getHistoricVariableInstanceManager()
@@ -51,7 +59,7 @@ public class NativeHistoricVariableInstanceQueryImpl extends AbstractNativeQuery
 
         HistoricVariableInstanceEntity variableInstanceEntity = (HistoricVariableInstanceEntity) historicVariableInstance;
           try {
-            variableInstanceEntity.getTypedValue(true);
+            variableInstanceEntity.getTypedValue(isCustomObjectDeserializationEnabled);
           } catch(Exception t) {
             // do not fail if one of the variables fails to load
             LOG.exceptionWhileGettingValueForVariable(t);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/NativeHistoricVariableInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/NativeHistoricVariableInstanceQueryImpl.java
@@ -1,0 +1,70 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl;
+
+import org.camunda.bpm.engine.history.HistoricVariableInstance;
+import org.camunda.bpm.engine.history.NativeHistoricVariableInstanceQuery;
+import org.camunda.bpm.engine.impl.cmd.CommandLogger;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
+
+import java.util.List;
+import java.util.Map;
+
+
+public class NativeHistoricVariableInstanceQueryImpl extends AbstractNativeQuery<NativeHistoricVariableInstanceQuery, HistoricVariableInstance>
+        implements NativeHistoricVariableInstanceQuery {
+
+  private final static CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
+
+  private static final long serialVersionUID = 1L;
+
+  public NativeHistoricVariableInstanceQueryImpl(CommandContext commandContext) {
+    super(commandContext);
+  }
+
+  public NativeHistoricVariableInstanceQueryImpl(CommandExecutor commandExecutor) {
+    super(commandExecutor);
+  }
+
+
+  //results ////////////////////////////////////////////////////////////////
+
+  public List<HistoricVariableInstance> executeList(CommandContext commandContext, Map<String, Object> parameterMap, int firstResult, int maxResults) {
+    List<HistoricVariableInstance> historicVariableInstances = commandContext
+            .getHistoricVariableInstanceManager()
+            .findHistoricVariableInstancesByNativeQuery(parameterMap, firstResult, maxResults);
+
+    if (historicVariableInstances!=null) {
+      for (HistoricVariableInstance historicVariableInstance: historicVariableInstances) {
+
+        HistoricVariableInstanceEntity variableInstanceEntity = (HistoricVariableInstanceEntity) historicVariableInstance;
+          try {
+            variableInstanceEntity.getTypedValue(true);
+          } catch(Exception t) {
+            // do not fail if one of the variables fails to load
+            LOG.exceptionWhileGettingValueForVariable(t);
+          }
+      }
+    }
+    return historicVariableInstances;
+  }
+
+  public long executeCount(CommandContext commandContext, Map<String, Object> parameterMap) {
+    return commandContext
+      .getHistoricVariableInstanceManager()
+      .findHistoricVariableInstanceCountByNativeQuery(parameterMap);
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
@@ -294,6 +294,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     addDatabaseSpecificStatement(DB2, "selectHistoricProcessInstanceByNativeQuery", "selectHistoricProcessInstanceByNativeQuery_mssql_or_db2");
     addDatabaseSpecificStatement(DB2, "selectHistoricCaseInstanceByNativeQuery", "selectHistoricCaseInstanceByNativeQuery_mssql_or_db2");
     addDatabaseSpecificStatement(DB2, "selectHistoricTaskInstanceByNativeQuery", "selectHistoricTaskInstanceByNativeQuery_mssql_or_db2");
+    addDatabaseSpecificStatement(DB2, "selectHistoricVariableInstanceByNativeQuery", "selectHistoricVariableInstanceByNativeQuery_mssql_or_db2");
     addDatabaseSpecificStatement(DB2, "selectTaskByNativeQuery", "selectTaskByNativeQuery_mssql_or_db2");
     addDatabaseSpecificStatement(DB2, "selectUserByNativeQuery", "selectUserByNativeQuery_mssql_or_db2");
     addDatabaseSpecificStatement(DB2, "selectHistoricDecisionInstancesByNativeQuery", "selectHistoricDecisionInstancesByNativeQuery_mssql_or_db2");
@@ -341,6 +342,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     addDatabaseSpecificStatement(MSSQL, "selectHistoricProcessInstanceByNativeQuery", "selectHistoricProcessInstanceByNativeQuery_mssql_or_db2");
     addDatabaseSpecificStatement(MSSQL, "selectHistoricCaseInstanceByNativeQuery", "selectHistoricCaseInstanceByNativeQuery_mssql_or_db2");
     addDatabaseSpecificStatement(MSSQL, "selectHistoricTaskInstanceByNativeQuery", "selectHistoricTaskInstanceByNativeQuery_mssql_or_db2");
+    addDatabaseSpecificStatement(MSSQL, "selectHistoricVariableInstanceByNativeQuery", "selectHistoricVariableInstanceByNativeQuery_mssql_or_db2");
     addDatabaseSpecificStatement(MSSQL, "selectTaskByNativeQuery", "selectTaskByNativeQuery_mssql_or_db2");
     addDatabaseSpecificStatement(MSSQL, "selectUserByNativeQuery", "selectUserByNativeQuery_mssql_or_db2");
     addDatabaseSpecificStatement(MSSQL, "lockDeploymentLockProperty", "lockDeploymentLockProperty_mssql");

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricVariableInstanceManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricVariableInstanceManager.java
@@ -122,6 +122,16 @@ public class HistoricVariableInstanceManager extends AbstractHistoricManager {
     }
   }
 
+  @SuppressWarnings("unchecked")
+  public List<HistoricVariableInstance> findHistoricVariableInstancesByNativeQuery(Map<String, Object> parameterMap, int firstResult, int
+          maxResults) {
+    return getDbEntityManager().selectListWithRawParameter("selectHistoricVariableInstanceByNativeQuery", parameterMap, firstResult, maxResults);
+  }
+
+  public long findHistoricVariableInstanceCountByNativeQuery(Map<String, Object> parameterMap) {
+    return (Long) getDbEntityManager().selectOne("selectHistoricVariableInstanceCountByNativeQuery", parameterMap);
+  }
+
   protected void configureQuery(HistoricVariableInstanceQueryImpl query) {
     getAuthorizationManager().configureHistoricVariableInstanceQuery(query);
     getTenantManager().configureQuery(query);

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricVariableInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricVariableInstance.xml
@@ -402,4 +402,28 @@
     </if>
   </sql>
 
+  <select id="selectHistoricVariableInstanceByNativeQuery" parameterType="java.util.Map" resultMap="historicVariableInstanceResultMap">
+    <if test="resultType == 'LIST_PAGE'">
+      ${limitBefore}
+    </if>
+    ${sql}
+    <if test="resultType == 'LIST_PAGE'">
+      ${limitAfter}
+    </if>
+  </select>
+
+  <select id="selectHistoricVariableInstanceByNativeQuery_mssql_or_db2" parameterType="java.util.Map" resultMap="historicVariableInstanceResultMap">
+    <if test="resultType == 'LIST_PAGE'">
+      ${limitBeforeNativeQuery}
+    </if>
+    ${sql}
+    <if test="resultType == 'LIST_PAGE'">
+      ${limitAfter}
+    </if>
+  </select>
+
+  <select id="selectHistoricVariableInstanceCountByNativeQuery" parameterType="java.util.Map" resultType="long">
+    ${sql}
+  </select>
+
 </mapper>

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/HistoryServiceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/HistoryServiceTest.java
@@ -18,6 +18,7 @@ import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
 import org.camunda.bpm.engine.history.HistoricProcessInstanceQuery;
+import org.camunda.bpm.engine.history.HistoricVariableInstance;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.test.PluggableProcessEngineTestCase;
 import org.camunda.bpm.engine.impl.util.CollectionUtil;
@@ -447,6 +448,26 @@ public class HistoryServiceTest extends PluggableProcessEngineTestCase {
     assertEquals(1, historyService.createNativeHistoricActivityInstanceQuery().sql("SELECT count(*) FROM " + managementService.getTableName(HistoricProcessInstance.class)).count());
     assertEquals(1, historyService.createNativeHistoricActivityInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class)).list().size());
     assertEquals(1, historyService.createNativeHistoricActivityInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricProcessInstance.class)).listPage(0, 1).size());
+  }
+
+  @Deployment(resources = {"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void testNativeHistoricVariableInstanceTest() {
+    Date date = Calendar.getInstance().getTime();
+    Map<String, Object> vars = new HashMap<String, Object>();
+    vars.put("stringVar", "abcdef");
+    vars.put("dateVar", date);
+    runtimeService.startProcessInstanceByKey(ONE_TASK_PROCESS, vars);
+
+    assertEquals(2, historyService.createNativeHistoricVariableInstanceQuery().sql("SELECT count(*) FROM " + managementService.getTableName(HistoricVariableInstance.class)).count());
+    assertEquals(1, historyService.createNativeHistoricVariableInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricVariableInstance.class)).listPage(0, 1).size());
+
+    List<HistoricVariableInstance> variables = historyService.createNativeHistoricVariableInstanceQuery().sql("SELECT * FROM " + managementService.getTableName(HistoricVariableInstance.class)).list();
+    assertEquals(2, variables.size());
+    for (HistoricVariableInstance variable : variables) {
+      assertTrue(vars.containsKey(variable.getName()));
+      assertEquals(vars.get(variable.getName()), variable.getValue());
+      vars.remove(variable.getName());
+    }
   }
 
   @Deployment(resources = "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")


### PR DESCRIPTION
This pull request introduces native queries to historic variable instances.
It would be nice to have this to be able to do more complex queries on historic variables.

I'm not sure, if this closes the issue as there might be cases I did not thought of, but it might be a good point to start with.

see: https://app.camunda.com/jira/browse/CAM-5327