### PR TITLE
catch and handle exceptions in OutputParameter.execute()

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/core/variable/mapping/OutputParameter.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/core/variable/mapping/OutputParameter.java
@@ -38,14 +38,15 @@ public class OutputParameter extends IoParameter {
   }
 
   protected void execute(AbstractVariableScope innerScope, AbstractVariableScope outerScope) {
-
-    // get value from inner scope
-    Object value = valueProvider.getValue(innerScope);
-
-    LOG.debugMappingValuefromInnerScopeToOuterScope(value, innerScope, name, outerScope);
-
-    // set variable in outer scope
-    outerScope.setVariable(name, value);
+    try {
+      // get value from inner scope
+      Object value = valueProvider.getValue(innerScope);
+      LOG.debugMappingValuefromInnerScopeToOuterScope(value, innerScope, name, outerScope);
+      // set variable in outer scope
+      outerScope.setVariable(name, value);
+    }catch (Exception e){
+      outerScope.setVariable(name, null);
+    }
   }
 
 }


### PR DESCRIPTION
## Scenario

- ExternalTask maps "${result.outputs.metrics.level}" to "level" 
- result.outputs.metrics.level will be created on completion (POST /external-task/{id}/complete)
- timeout on task execution causes incident

## Error

- Process-Instance cannot be stopped because OutputParameter.execute() can't read not existing result.outputs.metrics.level

## Fix 
catch exception and whrite null to result.outputs.metrics.level