### PR TITLE
Added whitespace in BPMNParse messages.

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
@@ -4226,7 +4226,7 @@ public class BpmnParse extends Parse {
                                                           // lane, but it might
                                                           // still reference
                                                           // 'something'
-            addError("Invalid reference in 'bpmnElement' attribute, activity " + bpmnElement + "not found", bpmnShapeElement);
+            addError("Invalid reference in 'bpmnElement' attribute, activity " + bpmnElement + " not found", bpmnShapeElement);
           }
         }
       }


### PR DESCRIPTION
Added whitespace after bpmnElement variable for better readability when showing parse errors.