### PR TITLE
feat(pom): Refactor webjar to be more webjarry

### DIFF
--- a/distro/webjar/pom.xml
+++ b/distro/webjar/pom.xml
@@ -50,7 +50,7 @@
                   <version>${project.parent.version}</version>
                   <type>war</type>
                   <overWrite>true</overWrite>
-                  <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                  <outputDirectory>${project.build.outputDirectory}/META-INF/resources</outputDirectory>
                   <excludes>META-INF/**</excludes>
                 </artifactItem>
               </artifactItems>
@@ -67,8 +67,8 @@
             <phase>generate-resources</phase>
             <configuration>
               <target>
-                <move file="${project.build.outputDirectory}/WEB-INF/securityFilterRules.json" todir="${project.build.outputDirectory}" />
-                <delete dir="${project.build.outputDirectory}/WEB-INF" />
+                <move file="${project.build.outputDirectory}/META-INF/resources/WEB-INF/securityFilterRules.json" todir="${project.build.outputDirectory}/META-INF/resources/" />
+                <delete dir="${project.build.outputDirectory}/META-INF/resources/WEB-INF" />
               </target>
             </configuration>
             <goals>


### PR DESCRIPTION
Web resources are now in /META-INF/resources so that the webjar follows typical webjars.org structure and can be accessed out of the box when used as dependency.

Closes: #5835