### PR TITLE
Exposing deployChangedOnly property in SpringTransactionsProcessEngineConfiguration

### DIFF
--- a/engine-spring/src/main/java/org/camunda/bpm/engine/spring/SpringTransactionsProcessEngineConfiguration.java
+++ b/engine-spring/src/main/java/org/camunda/bpm/engine/spring/SpringTransactionsProcessEngineConfiguration.java
@@ -52,6 +52,7 @@ public class SpringTransactionsProcessEngineConfiguration extends ProcessEngineC
   protected String deploymentName = "SpringAutoDeployment";
   protected Resource[] deploymentResources = new Resource[0];
   protected String deploymentTenantId;
+  protected boolean deployChangedOnly;
 
   public SpringTransactionsProcessEngineConfiguration() {
     transactionsExternallyManaged = true;
@@ -110,7 +111,7 @@ public class SpringTransactionsProcessEngineConfiguration extends ProcessEngineC
 
       DeploymentBuilder deploymentBuilder = repositoryService
         .createDeployment()
-        .enableDuplicateFiltering(false)
+        .enableDuplicateFiltering(deployChangedOnly)
         .name(deploymentName)
         .tenantId(deploymentTenantId);
 
@@ -189,6 +190,14 @@ public class SpringTransactionsProcessEngineConfiguration extends ProcessEngineC
 
   public void setDeploymentTenantId(String deploymentTenantId) {
     this.deploymentTenantId = deploymentTenantId;
+  }
+
+  public boolean isDeployChangedOnly() {
+    return deployChangedOnly;
+  }
+
+  public void setDeployChangedOnly(boolean deployChangedOnly) {
+    this.deployChangedOnly = deployChangedOnly;
   }
 
 }


### PR DESCRIPTION
Currently the `SpringTransactionsProcessEngineConfiguration` disables `deployChangedOnly` option in `autoDeployResources` method by setting it to `false`.

By exposing it we get a configuration property that can be used to minimize the scope of Camunda process deployment. Handy if you have many different process definitions that change infrequently.

Can you please advise how this change should be tested? I haven't found existing unit tests for `SpringTransactionsProcessEngineConfiguration` or child classes.