### PR TITLE
Invoice example: output name is equal to the decision id

### DIFF
--- a/examples/invoice/src/main/resources/invoiceBusinessDecisions.dmn
+++ b/examples/invoice/src/main/resources/invoiceBusinessDecisions.dmn
@@ -1,63 +1,82 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/1.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="invoiceBusinessDecisions" name="Invoice Business Decisions" namespace="http://camunda.org/schema/1.0/dmn">
-  <decision id="invoice-classification" name="Invoice Classification">
+  <decision id="invoiceClassification" name="Invoice Classification">
     <extensionElements>
       <biodi:bounds x="393" y="325" width="100" height="55" />
     </extensionElements>
-    <decisionTable id="decisionTable" hitPolicy="UNIQUE">
+    <decisionTable id="decisionTable">
       <input id="clause1" label="Invoice Amount" camunda:inputVariable="">
-        <inputExpression id="inputExpression1" typeRef="double">        <text>amount</text>
-</inputExpression>
+        <inputExpression id="inputExpression1" typeRef="double">
+          <text>amount</text>
+        </inputExpression>
       </input>
       <input id="InputClause_15qmk0v" label="Invoice Category" camunda:inputVariable="">
-        <inputExpression id="LiteralExpression_1oi86cw" typeRef="string">        <text>invoiceCategory</text>
-</inputExpression>
-        <inputValues id="UnaryTests_0kisa67">        <text><![CDATA["Travel Expenses","Misc","Software License Costs"]]></text>
-</inputValues>
+        <inputExpression id="LiteralExpression_1oi86cw" typeRef="string">
+          <text>invoiceCategory</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_0kisa67">
+          <text>"Travel Expenses","Misc","Software License Costs"</text>
+        </inputValues>
       </input>
       <output id="clause3" label="Classification" name="invoiceClassification" typeRef="string">
-        <outputValues id="UnaryTests_08dl8wf">        <text><![CDATA["day-to-day expense","budget","exceptional"]]></text>
-</outputValues>
+        <outputValues id="UnaryTests_08dl8wf">
+          <text>"day-to-day expense","budget","exceptional"</text>
+        </outputValues>
       </output>
       <rule id="DecisionRule_1of5a87">
-        <inputEntry id="LiteralExpression_0yrqmtg">        <text><![CDATA[< 250]]></text>
-</inputEntry>
-        <inputEntry id="UnaryTests_06edsin">        <text><![CDATA["Misc"]]></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_046antl">        <text><![CDATA["day-to-day expense"]]></text>
-</outputEntry>
+        <inputEntry id="LiteralExpression_0yrqmtg">
+          <text>&lt; 250</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06edsin">
+          <text>"Misc"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_046antl">
+          <text>"day-to-day expense"</text>
+        </outputEntry>
       </rule>
       <rule id="DecisionRule_1ak4z14">
-        <inputEntry id="LiteralExpression_0qmsef6">        <text>[250..1000]</text>
-</inputEntry>
-        <inputEntry id="UnaryTests_09b743h">        <text><![CDATA["Misc"]]></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_05xxvip">        <text><![CDATA["budget"]]></text>
-</outputEntry>
+        <inputEntry id="LiteralExpression_0qmsef6">
+          <text>[250..1000]</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09b743h">
+          <text>"Misc"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_05xxvip">
+          <text>"budget"</text>
+        </outputEntry>
       </rule>
       <rule id="row-49839158-4">
-        <inputEntry id="UnaryTests_0le0gl8">        <text><![CDATA[> 1000]]></text>
-</inputEntry>
-        <inputEntry id="UnaryTests_0pukamj">        <text><![CDATA["Misc"]]></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_1e76ugx">        <text><![CDATA["exceptional"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_0le0gl8">
+          <text>&gt; 1000</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pukamj">
+          <text>"Misc"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1e76ugx">
+          <text>"exceptional"</text>
+        </outputEntry>
       </rule>
       <rule id="DecisionRule_0cuxolz">
-        <inputEntry id="LiteralExpression_05lyjk7">        <text></text>
-</inputEntry>
-        <inputEntry id="UnaryTests_0ve4z34">        <text><![CDATA["Travel Expenses"]]></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_1bq8m03">        <text><![CDATA["day-to-day expense"]]></text>
-</outputEntry>
+        <inputEntry id="LiteralExpression_05lyjk7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ve4z34">
+          <text>"Travel Expenses"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1bq8m03">
+          <text>"day-to-day expense"</text>
+        </outputEntry>
       </rule>
       <rule id="row-49839158-2">
-        <inputEntry id="UnaryTests_1nssdlk">        <text></text>
-</inputEntry>
-        <inputEntry id="UnaryTests_01ppb4l">        <text><![CDATA["Software License Costs"]]></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_0y00iih">        <text><![CDATA["budget"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_1nssdlk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01ppb4l">
+          <text>"Software License Costs"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0y00iih">
+          <text>"budget"</text>
+        </outputEntry>
       </rule>
     </decisionTable>
   </decision>
@@ -68,42 +87,51 @@
         <biodi:waypoints x="460" y="325" />
         <biodi:waypoints x="506" y="249" />
       </biodi:edge>
-      <biodi:edge source="invoice-classification">
+      <biodi:edge source="invoiceClassification">
         <biodi:waypoints x="458" y="325" />
         <biodi:waypoints x="498" y="249" />
       </biodi:edge>
     </extensionElements>
     <informationRequirement>
-      <requiredDecision href="#invoice-classification" />
+      <requiredDecision href="#invoiceClassification" />
     </informationRequirement>
     <decisionTable id="DecisionTable_16o85h8" hitPolicy="COLLECT">
       <input id="InputClause_0og2hn3" label="Invoice Classification" camunda:inputVariable="">
-        <inputExpression id="LiteralExpression_1vywt5q" typeRef="string">        <text>invoiceClassification</text>
-</inputExpression>
-        <inputValues id="UnaryTests_0by7qiy">        <text><![CDATA["day-to-day expense","budget","exceptional"]]></text>
-</inputValues>
+        <inputExpression id="LiteralExpression_1vywt5q" typeRef="string">
+          <text>invoiceClassification</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_0by7qiy">
+          <text>"day-to-day expense","budget","exceptional"</text>
+        </inputValues>
       </input>
       <output id="OutputClause_1cthd0w" label="Approver Group" name="result" typeRef="string">
-        <outputValues id="UnaryTests_1ulmk9p">        <text><![CDATA["management","accounting","sales"]]></text>
-</outputValues>
+        <outputValues id="UnaryTests_1ulmk9p">
+          <text>"management","accounting","sales"</text>
+        </outputValues>
       </output>
       <rule id="row-49839158-1">
-        <inputEntry id="UnaryTests_18ifczd">        <text><![CDATA["day-to-day expense"]]></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_0sgxulk">        <text><![CDATA["accounting"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_18ifczd">
+          <text>"day-to-day expense"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0sgxulk">
+          <text>"accounting"</text>
+        </outputEntry>
       </rule>
       <rule id="row-49839158-6">
-        <inputEntry id="UnaryTests_0kfae8g">        <text><![CDATA["day-to-day expense"]]></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_1iksrro">        <text><![CDATA["sales"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_0kfae8g">
+          <text>"day-to-day expense"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1iksrro">
+          <text>"sales"</text>
+        </outputEntry>
       </rule>
       <rule id="row-49839158-5">
-        <inputEntry id="UnaryTests_08cevwi">        <text><![CDATA["budget", "exceptional"]]></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_0c7hz8g">        <text><![CDATA["management"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_08cevwi">
+          <text>"budget", "exceptional"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c7hz8g">
+          <text>"management"</text>
+        </outputEntry>
       </rule>
     </decisionTable>
   </decision>


### PR DESCRIPTION
In the invoice example, change the decision id to 'invoiceClassification' so that it is equal
to the output name.

This follows the recommendation of the DMN spec that the output name of a decision table should be equal to the decision id if the decision table has only one output.