### PR TITLE
made authenticated user check case insensitive

### DIFF
--- a/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
+++ b/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
@@ -592,7 +592,7 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
     if(user.getId() == null) {
       return false;
     }
-    return user.getId().equals(org.camunda.bpm.engine.impl.context.Context.getCommandContext().getAuthenticatedUserId());
+    return user.getId().equalsIgnoreCase(org.camunda.bpm.engine.impl.context.Context.getCommandContext().getAuthenticatedUserId());
   }
 
   protected boolean isAuthorized(Permission permission, Resource resource, String resourceId) {

--- a/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapLoginTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapLoginTest.java
@@ -22,6 +22,10 @@ public class LdapLoginTest extends LdapIdentityProviderTest {
     assertTrue(identityService.checkPassword("roman", "roman"));
   }
   
+  public void testLdapLoginCapitalization() {
+    assertTrue(identityService.checkPassword("Roman", "roman"));
+  }
+  
   public void testLdapLoginFailure() {
     assertFalse(identityService.checkPassword("roman", "ro"));
     assertFalse(identityService.checkPassword("r", "roman"));

--- a/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapUserQueryTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapUserQueryTest.java
@@ -68,6 +68,25 @@ public class LdapUserQueryTest extends LdapIdentityProviderTest {
     assertNotNull(users);
     assertEquals(3, users.size());
   }
+  
+  public void testFilterByUserIdWithCapitalization() {
+	try {
+	  processEngineConfiguration.setAuthorizationEnabled(true);
+	  identityService.setAuthenticatedUserId("Oscar");
+	  User user = identityService.createUserQuery().userId("Oscar").singleResult();
+	  assertNotNull(user);
+
+	  // validate user
+	  assertEquals("oscar", user.getId());
+	  assertEquals("Oscar", user.getFirstName());
+	  assertEquals("The Crouch", user.getLastName());
+	  assertEquals("oscar@camunda.org", user.getEmail());
+	}
+	finally {
+      processEngineConfiguration.setAuthorizationEnabled(false);
+	  identityService.clearAuthentication();
+	}
+  }
 
   public void testFilterByFirstname() {
     User user = identityService.createUserQuery().userFirstName("Oscar").singleResult();


### PR DESCRIPTION
LDAP login is not case sensitive, so a user may successfully login but cannot be identified when user id in LDAP differs. As a result the user is logged in, but has no profile information (like mail address) and is not assigned to any LDAP groups. Therefore the check has to be case insentive too.