### PR TITLE
feat(engine):enable process definition business keys in query

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/repository/ProcessDefinitionQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/repository/ProcessDefinitionQueryDto.java
@@ -79,6 +79,7 @@ public class ProcessDefinitionQueryDto extends AbstractQueryDto<ProcessDefinitio
   private Boolean includeDefinitionsWithoutTenantId;
   private String versionTag;
   private String versionTagLike;
+  private List<String> keys;
 
   public ProcessDefinitionQueryDto() {
 
@@ -126,6 +127,12 @@ public class ProcessDefinitionQueryDto extends AbstractQueryDto<ProcessDefinitio
   @CamundaQueryParam("key")
   public void setKey(String key) {
     this.key = key;
+  }
+
+
+  @CamundaQueryParam(value = "keysIn", converter = StringListConverter.class)
+  public void setKeysIn(List<String> keys) {
+    this.keys = keys;
   }
 
   @CamundaQueryParam("keyLike")
@@ -269,6 +276,10 @@ public class ProcessDefinitionQueryDto extends AbstractQueryDto<ProcessDefinitio
     }
     if (keyLike != null) {
       query.processDefinitionKeyLike(keyLike);
+    }
+
+    if (keys != null && !keys.isEmpty()) {
+      query.processDefinitionKeysIn(keys.toArray(new String[keys.size()]));
     }
     if (version != null) {
       query.processDefinitionVersion(version);

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ProcessDefinitionRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ProcessDefinitionRestServiceQueryTest.java
@@ -349,6 +349,35 @@ public class ProcessDefinitionRestServiceQueryTest extends AbstractRestServiceTe
   }
 
   @Test
+  public void testProcessDefinitionKeysList() {
+    List<ProcessDefinition> processDefinitions = Arrays.asList(
+            MockProvider.mockDefinition().key(MockProvider.EXAMPLE_PROCESS_DEFINITION_KEY).build(),
+            MockProvider.mockDefinition().key(MockProvider.ANOTHER_EXAMPLE_PROCESS_DEFINITION_KEY).build());
+    mockedQuery = setUpMockDefinitionQuery(processDefinitions);
+
+    Response response = given()
+            .queryParam("keysIn", MockProvider.EXAMPLE_KEY_LIST)
+            .then().expect()
+            .statusCode(Status.OK.getStatusCode())
+            .when()
+            .get(PROCESS_DEFINITION_QUERY_URL);
+
+    verify(mockedQuery).processDefinitionKeysIn(MockProvider.EXAMPLE_PROCESS_DEFINITION_KEY,
+            MockProvider.ANOTHER_EXAMPLE_PROCESS_DEFINITION_KEY);
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(2);
+
+    String returnedKey1 = from(content).getString("[0].key");
+    String returnedKey2 = from(content).getString("[1].key");
+
+    assertThat(returnedKey1).isEqualTo(MockProvider.EXAMPLE_PROCESS_DEFINITION_KEY);
+    assertThat(returnedKey2).isEqualTo(MockProvider.ANOTHER_EXAMPLE_PROCESS_DEFINITION_KEY);
+  }
+
+  @Test
   public void testProcessDefinitionWithoutTenantId() {
     Response response = given()
       .queryParam("withoutTenantId", true)

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
@@ -254,6 +254,9 @@ public abstract class MockProvider {
   public static final String EXAMPLE_PROCESS_DEFINITION_NAME = "aName";
   public static final String EXAMPLE_PROCESS_DEFINITION_NAME_LIKE = "aNameLike";
   public static final String EXAMPLE_PROCESS_DEFINITION_KEY = "aKey";
+  public static final String ANOTHER_EXAMPLE_PROCESS_DEFINITION_KEY="anotherProcessDefinitionKey";
+  public static final String EXAMPLE_KEY_LIST = EXAMPLE_PROCESS_DEFINITION_KEY + "," + ANOTHER_EXAMPLE_PROCESS_DEFINITION_KEY;
+
   public static final String NON_EXISTING_PROCESS_DEFINITION_KEY = "aNonExistingKey";
   public static final String EXAMPLE_PROCESS_DEFINITION_CATEGORY = "aCategory";
   public static final String EXAMPLE_PROCESS_DEFINITION_DESCRIPTION = "aDescription";

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessDefinitionQueryImpl.java
@@ -54,6 +54,7 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
   protected String nameLike;
   protected String deploymentId;
   protected String key;
+  protected String[] keys;
   protected String keyLike;
   protected String resourceName;
   protected String resourceNameLike;
@@ -127,6 +128,11 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
   public ProcessDefinitionQueryImpl processDefinitionKey(String key) {
     ensureNotNull("key", key);
     this.key = key;
+    return this;
+  }
+
+  public ProcessDefinitionQueryImpl processDefinitionKeysIn(String... keys) {
+    this.keys = keys;
     return this;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/repository/ProcessDefinitionQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/repository/ProcessDefinitionQuery.java
@@ -14,6 +14,7 @@
 package org.camunda.bpm.engine.repository;
 
 import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.impl.ProcessDefinitionQueryImpl;
 import org.camunda.bpm.engine.query.Query;
 
 /**
@@ -60,6 +61,11 @@ public interface ProcessDefinitionQuery extends Query<ProcessDefinitionQuery, Pr
    * Only select process definition with the given key.
    */
   ProcessDefinitionQuery processDefinitionKey(String processDefinitionKey);
+
+  /**
+   * Only select process definitions with the given keys
+   */
+  ProcessDefinitionQueryImpl processDefinitionKeysIn(String... processDefinitionKeys);
 
   /**
    * Only select process definitions where the key matches the given parameter.

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ProcessDefinition.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ProcessDefinition.xml
@@ -229,6 +229,13 @@
           #{item}
         </foreach>
       </if>
+      <if test="keys != null &amp;&amp; keys.length > 0">
+        and RES.KEY_ in
+        <foreach item="item" index="index" collection="keys"
+                 open="(" separator="," close=")">
+          #{item}
+        </foreach>
+      </if>
       <if test="category != null">
         and RES.CATEGORY_ = #{category}
       </if>

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
@@ -154,6 +154,35 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
     verifyQueryResults(query, 1);
   }
 
+  public void testQueryByKeys() {
+
+    // empty list
+    assertTrue(repositoryService.createProcessDefinitionQuery().processDefinitionKeysIn("a", "b").list().isEmpty());
+
+
+    // collect all definition keys
+    List<ProcessDefinition> list = repositoryService.createProcessDefinitionQuery().list();
+    String[] processDefinitionKeys = new String[list.size()];
+    for (int i = 0; i < processDefinitionKeys.length; i++) {
+      processDefinitionKeys[i] = list.get(i).getKey();
+    }
+
+    List<ProcessDefinition> keyInList = repositoryService.createProcessDefinitionQuery().processDefinitionKeysIn(processDefinitionKeys).list();
+    for (ProcessDefinition processDefinition : keyInList) {
+      boolean found = false;
+      for (ProcessDefinition otherProcessDefinition : list) {
+        if(otherProcessDefinition.getKey().equals(processDefinition.getKey())) {
+          found = true; break;
+        }
+      }
+      if(!found) {
+        fail("Expected to find process definition "+processDefinition);
+      }
+    }
+
+    assertEquals(0, repositoryService.createProcessDefinitionQuery().processDefinitionKey("dummyKey").processDefinitionKeysIn(processDefinitionKeys).count());
+  }
+
   public void testQueryByInvalidKey() {
     ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionKey("invalid");
     verifyQueryResults(query, 0);


### PR DESCRIPTION
Enable the querying of process definition keys as well as definition ids. 