### PR TITLE
fix(engine): improved signalling of long polling

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessEngineImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessEngineImpl.java
@@ -13,8 +13,6 @@
 package org.camunda.bpm.engine.impl;
 
 import java.util.Map;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.ReentrantLock;
 
 import org.camunda.bpm.engine.*;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -25,14 +23,15 @@ import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 import org.camunda.bpm.engine.impl.interceptor.SessionFactory;
 import org.camunda.bpm.engine.impl.jobexecutor.JobExecutor;
 import org.camunda.bpm.engine.impl.metrics.reporter.DbMetricsReporter;
+import org.camunda.bpm.engine.impl.util.CompositeCondition;
 
 /**
  * @author Tom Baeyens
  */
 public class ProcessEngineImpl implements ProcessEngine {
 
-  public static final ReentrantLock LOCK_MONITOR = new ReentrantLock(false);
-  public static final Condition IS_EXTERNAL_TASK_AVAILABLE = LOCK_MONITOR.newCondition();
+  /** external task conditions used to signal long polling in rest API */
+  public static final CompositeCondition EXT_TASK_CONDITIONS = new CompositeCondition();
 
   private final static ProcessEngineLogger LOG = ProcessEngineLogger.INSTANCE;
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExternalTaskManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExternalTaskManager.java
@@ -154,13 +154,7 @@ public class ExternalTaskManager extends AbstractManager {
       .addTransactionListener(TransactionState.COMMITTED, new TransactionListener() {
         @Override
         public void execute(CommandContext commandContext) {
-          ProcessEngineImpl.LOCK_MONITOR.lock();
-          try {
-            ProcessEngineImpl.IS_EXTERNAL_TASK_AVAILABLE.signal();
-          }
-          finally {
-            ProcessEngineImpl.LOCK_MONITOR.unlock();
-          }
+          ProcessEngineImpl.EXT_TASK_CONDITIONS.signalAll();
         }
       });
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/CompositeCondition.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/CompositeCondition.java
@@ -1,0 +1,38 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.util;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Composite Condition implementation which allows multiple consumers
+ * to subscribe to signals with their own {@link SingleConsumerCondition}.
+ */
+public class CompositeCondition {
+
+  protected CopyOnWriteArrayList<SingleConsumerCondition> conditions = new CopyOnWriteArrayList<SingleConsumerCondition>();
+
+  public void addConsumer(SingleConsumerCondition condition) {
+    conditions.add(condition);
+  }
+
+  public void removeConsumer(SingleConsumerCondition condition) {
+    conditions.remove(condition);
+  }
+
+  public void signalAll() {
+    for (SingleConsumerCondition condition : conditions) {
+      condition.signal();
+    }
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/SingleConsumerCondition.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/SingleConsumerCondition.java
@@ -1,0 +1,55 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.util;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * MPSC Condition implementation.
+ * <p>
+ * Implementation Notes:
+ * <ul>
+ * <li>{@link #await(long)} may spuriously return before the deadline is reached.</li>
+ * <li>if {@link #signal()} is called before the consumer thread calls {@link #await(long)},
+ * the next call to {@link #await(long)} returns immediately.</li>
+ * </ul>
+ */
+public class SingleConsumerCondition {
+
+  // note: making this private & final because it cannot be subclassed
+  // and replaced in a meaningful way without breaking the implementation
+  private final Thread consumer;
+
+  public SingleConsumerCondition(Thread consumer) {
+    if (consumer == null) {
+      throw new IllegalArgumentException("Consumer thread cannot be null");
+    }
+
+    this.consumer = consumer;
+  }
+
+  public void signal() {
+    LockSupport.unpark(consumer);
+  }
+
+  public void await(long millis) {
+    if (Thread.currentThread() != consumer) {
+      throw new RuntimeException("Wrong usage of SingleConsumerCondition: can only await in consumer thread.");
+    }
+
+    // NOTE: may spuriously return before deadline
+    LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(millis));
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskConditionsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskConditionsTest.java
@@ -1,0 +1,98 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.api.externaltask;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.camunda.bpm.engine.impl.ProcessEngineImpl;
+import org.camunda.bpm.engine.impl.util.SingleConsumerCondition;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests the signalling of external task conditions
+ */
+public class ExternalTaskConditionsTest {
+
+  @Rule
+  public ProcessEngineRule rule = new ProvidedProcessEngineRule();
+
+  @Mock
+  public SingleConsumerCondition condition;
+
+  private String deploymentId;
+
+  private final BpmnModelInstance testProcess = Bpmn.createExecutableProcess("theProcess")
+    .startEvent()
+    .serviceTask("theTask")
+        .camundaExternalTask("theTopic")
+    .done();
+
+  @Before
+  public void setUp() {
+
+    MockitoAnnotations.initMocks(this);
+
+    ProcessEngineImpl.EXT_TASK_CONDITIONS.addConsumer(condition);
+
+    deploymentId = rule.getRepositoryService()
+        .createDeployment()
+        .addModelInstance("process.bpmn", testProcess)
+        .deploy()
+        .getId();
+  }
+
+  @After
+  public void tearDown() {
+
+    ProcessEngineImpl.EXT_TASK_CONDITIONS.removeConsumer(condition);
+
+    if (deploymentId != null) {
+      rule.getRepositoryService().deleteDeployment(deploymentId, true);
+    }
+  }
+
+  @Test
+  public void shouldSignalConditionOnTaskCreate() {
+
+    // when
+    rule.getRuntimeService()
+      .startProcessInstanceByKey("theProcess");
+
+    // then
+    verify(condition, times(1)).signal();
+  }
+
+  @Test
+  public void shouldSignalConditionOnTaskCreateMultipleTimes() {
+
+    // when
+    rule.getRuntimeService()
+      .startProcessInstanceByKey("theProcess");
+    rule.getRuntimeService()
+      .startProcessInstanceByKey("theProcess");
+
+    // then
+    verify(condition, times(2)).signal();
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/util/SingleConsumerConditionTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/util/SingleConsumerConditionTest.java
@@ -1,0 +1,110 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.util;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.camunda.bpm.engine.impl.util.SingleConsumerCondition;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SingleConsumerConditionTest {
+
+  @Test(timeout=10000)
+  public void shouldNotBlockIfSignalAvailable() {
+    SingleConsumerCondition condition = new SingleConsumerCondition(Thread.currentThread());
+
+    // given
+    condition.signal();
+
+    // then
+    condition.await(100000);
+  }
+
+  @Test(timeout=10000)
+  public void shouldNotBlockIfSignalAvailableDifferentThread() throws InterruptedException {
+
+    final SingleConsumerCondition condition = new SingleConsumerCondition(Thread.currentThread());
+
+    Thread consumer = new Thread() {
+      @Override
+      public void run() {
+        condition.signal();
+      }
+    };
+
+    consumer.start();
+    consumer.join();
+
+    // then
+    condition.await(100000);
+  }
+
+  @Test
+  public void cannotAwaitFromDifferentThread() {
+    // given
+    SingleConsumerCondition condition = new SingleConsumerCondition(new Thread());
+
+    // when then
+    try {
+      condition.await(0);
+      Assert.fail("expected exception");
+    }
+    catch (RuntimeException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void cannotCreateWithNull() {
+    try {
+      new SingleConsumerCondition(null);
+      Assert.fail("expected exception");
+    }
+    catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  @Test(timeout = 10000)
+  public void conditionStressTest() throws InterruptedException {
+
+    final SingleConsumerCondition condition = new SingleConsumerCondition(Thread.currentThread());
+
+    final AtomicInteger signalCounter = new AtomicInteger();
+
+    Thread consumer = new Thread() {
+      @Override
+      public void run() {
+        for (int i = 0; i < 500000; i++) {
+
+          condition.signal();
+
+          while (signalCounter.get() == i) {
+            Thread.yield();
+          }
+        }
+      }
+    };
+
+    consumer.start();
+
+    for (int i = 0; i < 500000; i++) {
+      condition.await(100000);
+      signalCounter.set(i + 1);
+    }
+
+    consumer.join();
+  }
+
+}


### PR DESCRIPTION
Improved implementation of long polling which fixes
a race condition where long polling requests are not
notified if a task is created between the moment in
time where the acquisition thread checks for lockable
tasks and acquires the lock to await a signal.

The improved implementation provides a MPSC condition
implementation based on LockSupport.park()
and LockSupport.unpark(). A call to park() immediateley
returns when "the permit is available" meaning that
unpark() was called since the last time park() returned.
Note that the permit does not accumulate which is what
we want. Also note that the call to park() may spuriously
return which is not a problem in our usecase since
we will just poll for tasks and then continue to wait.

This fixes the race condition: if signal() is called before
the acquisition thread calls await(), the call to await()
will immediately return.

The MPSC condition is wrapped by the Composite condition
which provides a signalAll() method, signalling all
conditions that are currently registered. This effectively
allows multiple acquisition threads to "subscribe" to the
signals. Could be necessary if the users deploys multiple
rest apis on the same engine classpath.

Another advantage of this implementation is that it does
not use locks

Also adds test verifying that a condition is signalled
when external task is created.

related to #CAM-9196