### PR TITLE
[CAM-9262] suspensionState is always null

### DIFF
--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
@@ -593,7 +593,7 @@
               )
             </foreach>
             <if test="query.suspensionState != null">
-              <if test="suspensionState.stateCode == 1">
+              <if test="query.suspensionState.stateCode == 1">
                 ${queryType} RES.SUSPENSION_STATE_ = 1
               </if>
               <if test="query.suspensionState.stateCode == 2">

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryTest.java
@@ -985,6 +985,21 @@ public class TaskQueryTest extends PluggableProcessEngineTestCase {
   }
 
   @Deployment
+  public void testQueryBySuspensionState() throws Exception {
+
+    // Start 2 process-instance and leave them active
+    ProcessInstance activeProcessInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    ProcessInstance activeProcessInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+
+    // Start 1 process-instance and suspend it
+    ProcessInstance suspendedProcessInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    runtimeService.suspendProcessInstanceById(suspendedProcessInstance.getProcessInstanceId());
+
+    assertEquals(2, taskService.createTaskQuery().taskDefinitionKey("testQuerySuspensionStateTask").active().count());
+    assertEquals(1, taskService.createTaskQuery().taskDefinitionKey("testQuerySuspensionStateTask").suspended().count());
+  }
+
+  @Deployment
   public void testProcessVariableValueEquals() throws Exception {
     Map<String, Object> variables = new HashMap<String, Object>();
     variables.put("longVar", 928374L);

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/task/TaskQueryTest.testQueryBySuspensionState.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/task/TaskQueryTest.testQueryBySuspensionState.bpmn20.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  targetNamespace="Examples">
+
+  <process id="oneTaskProcess" name="The One Task Process" isExecutable="true">
+
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="testQuerySuspensionStateTask" />
+    <userTask id="testQuerySuspensionStateTask" name="my task" />
+    <sequenceFlow id="flow2" sourceRef="testQuerySuspensionStateTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>


### PR DESCRIPTION
I found that execution of query:
 `.or().active().processVariableValueEquals("FOO", 0).endOr().list()`

thows a OgnlException:
`org.apache.ibatis.ognl.OgnlException: source is null for getProperty(null, "stateCode")`

I suppose I fixed a bug in this pull request