### PR TITLE
fix(engine): add jdbcType Integer to bind-value

### DIFF
--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricBatch.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricBatch.xml
@@ -174,7 +174,7 @@
     FROM ${prefix}ACT_HI_BATCH RES
     WHERE
     <foreach index="key" item="value" collection="parameter.map" open="(" separator="OR" close=")">
-      <bind name="days" value="'#{value}'"/>
+      <bind name="days" value="'#{value, jdbcType=INTEGER}'"/>
       RES.TYPE_ = #{key} and ${dayComparator}
     </foreach>
     AND RES.END_TIME_ is not null


### PR DESCRIPTION
Add the jdbcType Integer explicitly to the bind-variable.

Variable bound is of type int.
Latest version of IBM Informix JDBC-Driver does not map int values to Intgeger automatically. Explicit TypeMapping is required in this case.
Should work with all other databases as well. Tested with H2.