### PR TITLE
fix(engine/test): Increase Timeout value for SingleConsumerConditionTest

### DIFF
--- a/engine/src/test/java/org/camunda/bpm/engine/test/util/SingleConsumerConditionTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/util/SingleConsumerConditionTest.java
@@ -76,7 +76,7 @@ public class SingleConsumerConditionTest {
     }
   }
 
-  @Test(timeout = 10000)
+  @Test(timeout = 100000)
   public void conditionStressTest() throws InterruptedException {
 
     final SingleConsumerCondition condition = new SingleConsumerCondition(Thread.currentThread());


### PR DESCRIPTION
Given Timeout value of 10s is not sufficient to do the work on old / slow machines.

As it is only a timeout which comes into account when the Test does not finish at all, it can be increased significantly to 100s without any drawback.
