### PR TITLE
fix(test): Set Locale for tests to en_US.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -471,7 +471,7 @@
             <systemPropertyVariables>
               <myWorkingDir>${project.build.directory}</myWorkingDir>
             </systemPropertyVariables>
-            <argLine>-XX:MaxPermSize=160m -Xmx968m</argLine>
+            <argLine>-XX:MaxPermSize=384m -Xmx1536m -Duser.language=en -Duser.region=US</argLine>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Set language / region to en / US to avoid failure of BpmnParseTest on non-English systems.

On my German Windows 10 System I got this test failure:
`[ERROR] Tests run: 72, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.879 s <<< FAILURE! - in org.camunda.bpm.engine.test.bpmn.parse.BpmnParseTest
[ERROR] testXmlParsingErrors(org.camunda.bpm.engine.test.bpmn.parse.BpmnParseTest)  Time elapsed: 0.063 s  <<< FAILURE!
junit.framework.AssertionFailedError: expected presence of [The end-tag for element type "bpmndi:BPMNLabel" must end with a '>' delimiter], but was [ENGINE-09003 Could not parse 'org/camunda/bpm/engine/test/bpmn/parse/BpmnParseTest.testXMLParsingErrors.bpmn'. Endtag fⁿr Elementtyp "bpmndi:BPMNLabel" muss mit einem ">"-Begrenzungszeichen enden.]
	at org.camunda.bpm.engine.impl.test.PvmTestCase.assertTextPresent(PvmTestCase.java:35)
	at org.camunda.bpm.engine.test.bpmn.parse.BpmnParseTest.testXmlParsingErrors(BpmnParseTest.java:219)
`

Additionally I had to increase the memory limits to avoid PermGen and OutOfMemory errors.
