### PR TITLE
Attach activity behavior and execution listeners before running parse listeners

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
@@ -1543,13 +1543,14 @@ public class BpmnParse extends Parse {
       activityBehavior = new IntermediateThrowNoneEventActivityBehavior();
     }
 
-    for (BpmnParseListener parseListener : parseListeners) {
-      parseListener.parseIntermediateThrowEvent(intermediateEventElement, scopeElement, nestedActivityImpl);
-    }
-
+    // CAM-9300 attach activity behaviour and execution listeners before executing parseListeners
     nestedActivityImpl.setActivityBehavior(activityBehavior);
 
     parseExecutionListenersOnScope(intermediateEventElement, nestedActivityImpl);
+
+    for (BpmnParseListener parseListener : parseListeners) {
+      parseListener.parseIntermediateThrowEvent(intermediateEventElement, scopeElement, nestedActivityImpl);
+    }
 
     return nestedActivityImpl;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
@@ -854,10 +854,12 @@ public class BpmnParse extends Parse {
 
       ensureNoIoMappingDefined(startEventElement);
 
+      parseExecutionListenersOnScope(startEventElement, startEventActivity);
+
       for (BpmnParseListener parseListener : parseListeners) {
         parseListener.parseStartEvent(startEventElement, scope, startEventActivity);
       }
-      parseExecutionListenersOnScope(startEventElement, startEventActivity);
+
     }
 
     if (scope instanceof ProcessDefinitionEntity) {
@@ -1433,11 +1435,11 @@ public class BpmnParse extends Parse {
       addError("Unsupported intermediate catch event type", intermediateEventElement);
     }
 
+    parseExecutionListenersOnScope(intermediateEventElement, nestedActivity);
+
     for (BpmnParseListener parseListener : parseListeners) {
       parseListener.parseIntermediateCatchEvent(intermediateEventElement, scopeElement, nestedActivity);
     }
-
-    parseExecutionListenersOnScope(intermediateEventElement, nestedActivity);
 
     return nestedActivity;
   }
@@ -2934,11 +2936,12 @@ public class BpmnParse extends Parse {
 
       parseAsynchronousContinuationForActivity(endEventElement, activity);
 
+      parseExecutionListenersOnScope(endEventElement, activity);
+
       for (BpmnParseListener parseListener : parseListeners) {
         parseListener.parseEndEvent(endEventElement, scope, activity);
       }
 
-      parseExecutionListenersOnScope(endEventElement, activity);
     }
   }
 
@@ -3056,13 +3059,14 @@ public class BpmnParse extends Parse {
 
       ensureNoIoMappingDefined(boundaryEventElement);
 
+      boundaryEventActivity.setActivityBehavior(behavior);
+
+      parseExecutionListenersOnScope(boundaryEventElement, boundaryEventActivity);
+
       for (BpmnParseListener parseListener : parseListeners) {
         parseListener.parseBoundaryEvent(boundaryEventElement, flowScope, boundaryEventActivity);
       }
 
-      boundaryEventActivity.setActivityBehavior(behavior);
-
-      parseExecutionListenersOnScope(boundaryEventElement, boundaryEventActivity);
     }
 
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/deploy/BPMNParseListenerTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/deploy/BPMNParseListenerTest.java
@@ -13,24 +13,48 @@
 
 package org.camunda.bpm.engine.test.standalone.deploy;
 
-
+import org.camunda.bpm.engine.impl.persistence.entity.ProcessInstanceWithVariablesImpl;
+import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
+import org.camunda.bpm.engine.impl.pvm.process.ProcessDefinitionImpl;
 import org.camunda.bpm.engine.impl.test.ResourceProcessEngineTestCase;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.test.Deployment;
-
 
 /**
  * @author Frederik Heremans
  */
 public class BPMNParseListenerTest extends ResourceProcessEngineTestCase {
 
-  public BPMNParseListenerTest() {
-    super("org/camunda/bpm/engine/test/standalone/deploy/bpmn.parse.listener.camunda.cfg.xml");
-  }
+    public BPMNParseListenerTest() {
+        super("org/camunda/bpm/engine/test/standalone/deploy/bpmn.parse.listener.camunda.cfg.xml");
+    }
 
-  @Deployment
-  public void testAlterProcessDefinitionKeyWhenDeploying() throws Exception {
-    // Check if process-definition has different key
-    assertEquals(0, repositoryService.createProcessDefinitionQuery().processDefinitionKey("oneTaskProcess").count());
-    assertEquals(1, repositoryService.createProcessDefinitionQuery().processDefinitionKey("oneTaskProcess-modified").count());
-  }
+    @Deployment
+    public void testAlterProcessDefinitionKeyWhenDeploying() throws Exception {
+        // Check if process-definition has different key
+        assertEquals(0, repositoryService.createProcessDefinitionQuery()
+                .processDefinitionKey("oneTaskProcess").count());
+        assertEquals(1, repositoryService.createProcessDefinitionQuery()
+                .processDefinitionKey("oneTaskProcess-modified").count());
+    }
+
+    @Deployment
+    public void testAlterActivityBehaviors() throws Exception {
+
+        ProcessInstance processInstance = runtimeService
+                .startProcessInstanceByKey("oneTaskWithIntermediateThrowEvent-modified");
+        ProcessDefinitionImpl processDefinition = ((ProcessInstanceWithVariablesImpl) processInstance)
+                .getExecutionEntity().getProcessDefinition();
+        ActivityImpl cancelThrowEvent = processDefinition.findActivity("CancelthrowEvent");
+        assertTrue(cancelThrowEvent
+                .getActivityBehavior() instanceof TestBPMNParseListener.TestCompensationEventActivityBehavior);
+
+        ActivityImpl startEvent = processDefinition.findActivity("theStart");
+        assertTrue(startEvent
+                .getActivityBehavior() instanceof TestBPMNParseListener.TestNoneStartEventActivityBehavior);
+
+        ActivityImpl endEvent = processDefinition.findActivity("theEnd");
+        assertTrue(endEvent
+                .getActivityBehavior() instanceof TestBPMNParseListener.TestNoneEndEventActivityBehavior);
+    }
 }

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/standalone/deploy/BPMNParseListenerTest.testAlterActivityBehaviors.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/standalone/deploy/BPMNParseListenerTest.testAlterActivityBehaviors.bpmn20.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.6.0">
+    <bpmn:process id="oneTaskWithIntermediateThrowEvent" name="oneTaskWithIntermediateThrowEvent" isExecutable="true">
+        <bpmn:startEvent id="theStart" name="theStart">
+            <bpmn:outgoing>flow1</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:sequenceFlow id="flow1" name="flow1" sourceRef="theStart" targetRef="theTask" />
+        <bpmn:endEvent id="theEnd" name="theEnd">
+            <bpmn:incoming>flow8</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:boundaryEvent id="BoundaryEvent_1qkuihx" attachedToRef="theTask">
+            <bpmn:compensateEventDefinition />
+        </bpmn:boundaryEvent>
+        <bpmn:task id="CompensateMyTask" name="CompensateMyTask" isForCompensation="true" />
+        <bpmn:userTask id="theTask" name="theTask">
+            <bpmn:incoming>flow1</bpmn:incoming>
+            <bpmn:outgoing>flow2</bpmn:outgoing>
+        </bpmn:userTask>
+        <bpmn:sequenceFlow id="flow2" name="flow2" sourceRef="theTask" targetRef="ExclusiveGateway_1qlu2p1" />
+        <bpmn:sequenceFlow id="flow5" name="flow5" sourceRef="ExclusiveGateway_1qlu2p1" targetRef="CancelthrowEvent" />
+        <bpmn:intermediateThrowEvent id="CancelthrowEvent" name="CancelthrowEvent">
+            <bpmn:incoming>flow5</bpmn:incoming>
+            <bpmn:outgoing>flow6</bpmn:outgoing>
+            <bpmn:compensateEventDefinition activityRef="theTask" />
+        </bpmn:intermediateThrowEvent>
+        <bpmn:sequenceFlow id="flow7" name="flow7" sourceRef="ExclusiveGateway_1qlu2p1" targetRef="ExclusiveGateway_0t2xd5m" />
+        <bpmn:sequenceFlow id="flow6" name="flow6" sourceRef="CancelthrowEvent" targetRef="ExclusiveGateway_0t2xd5m" />
+        <bpmn:sequenceFlow id="flow8" name="flow8" sourceRef="ExclusiveGateway_0t2xd5m" targetRef="theEnd" />
+        <bpmn:inclusiveGateway id="ExclusiveGateway_1qlu2p1">
+            <bpmn:incoming>flow2</bpmn:incoming>
+            <bpmn:outgoing>flow5</bpmn:outgoing>
+            <bpmn:outgoing>flow7</bpmn:outgoing>
+        </bpmn:inclusiveGateway>
+        <bpmn:inclusiveGateway id="ExclusiveGateway_0t2xd5m">
+            <bpmn:incoming>flow7</bpmn:incoming>
+            <bpmn:incoming>flow6</bpmn:incoming>
+            <bpmn:outgoing>flow8</bpmn:outgoing>
+        </bpmn:inclusiveGateway>
+        <bpmn:association id="Association1" associationDirection="One" sourceRef="BoundaryEvent_1qkuihx" targetRef="CompensateMyTask" />
+    </bpmn:process>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+        <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="oneTaskWithIntermediateThrowEvent">
+            <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="theStart">
+                <dc:Bounds x="202" y="282" width="36" height="36" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="201" y="318" width="38" height="12" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="SequenceFlow_0ztqexv_di" bpmnElement="flow1">
+                <di:waypoint xsi:type="dc:Point" x="238" y="300" />
+                <di:waypoint xsi:type="dc:Point" x="345" y="300" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="279" y="285" width="25" height="12" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="EndEvent_0krnw5w_di" bpmnElement="theEnd">
+                <dc:Bounds x="803" y="282" width="36" height="36" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="804" y="318" width="34" height="12" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="BoundaryEvent_0k875o3_di" bpmnElement="BoundaryEvent_1qkuihx">
+                <dc:Bounds x="387" y="322" width="36" height="36" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="405" y="358" width="0" height="0" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Task_115he4b_di" bpmnElement="CompensateMyTask">
+                <dc:Bounds x="466" y="386" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Association_1b6mdcj_di" bpmnElement="Association1">
+                <di:waypoint xsi:type="dc:Point" x="405" y="358" />
+                <di:waypoint xsi:type="dc:Point" x="405" y="426" />
+                <di:waypoint xsi:type="dc:Point" x="466" y="426" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="UserTask_052abl8_di" bpmnElement="theTask">
+                <dc:Bounds x="345" y="260" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="SequenceFlow_1c3lpbx_di" bpmnElement="flow2">
+                <di:waypoint xsi:type="dc:Point" x="445" y="300" />
+                <di:waypoint xsi:type="dc:Point" x="549" y="300" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="484" y="285" width="25" height="12" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="SequenceFlow_1754ahi_di" bpmnElement="flow5">
+                <di:waypoint xsi:type="dc:Point" x="574" y="275" />
+                <di:waypoint xsi:type="dc:Point" x="574" y="173" />
+                <di:waypoint xsi:type="dc:Point" x="642" y="173" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="576" y="224" width="25" height="12" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="IntermediateThrowEvent_0hx1jyn_di" bpmnElement="CancelthrowEvent">
+                <dc:Bounds x="642" y="155" width="36" height="36" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="615" y="191" width="89" height="12" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="SequenceFlow_0srd10y_di" bpmnElement="flow7">
+                <di:waypoint xsi:type="dc:Point" x="599" y="300" />
+                <di:waypoint xsi:type="dc:Point" x="714" y="300" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="644" y="285" width="25" height="12" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="SequenceFlow_137risc_di" bpmnElement="flow6">
+                <di:waypoint xsi:type="dc:Point" x="678" y="173" />
+                <di:waypoint xsi:type="dc:Point" x="739" y="173" />
+                <di:waypoint xsi:type="dc:Point" x="739" y="275" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="696" y="158" width="25" height="12" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="SequenceFlow_0kvwroo_di" bpmnElement="flow8">
+                <di:waypoint xsi:type="dc:Point" x="764" y="300" />
+                <di:waypoint xsi:type="dc:Point" x="803" y="300" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="771" y="275" width="25" height="12" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="InclusiveGateway_03rmcae_di" bpmnElement="ExclusiveGateway_1qlu2p1">
+                <dc:Bounds x="549" y="275" width="50" height="50" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="574" y="325" width="0" height="0" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="InclusiveGateway_16epf33_di" bpmnElement="ExclusiveGateway_0t2xd5m">
+                <dc:Bounds x="714" y="275" width="50" height="50" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="739" y="325" width="0" height="0" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
In BpmnParse.java, while parsing intermediate throw event, the activity behavior and execution listeners are attached post running bpmnParseListeners.

There are two issues with current implementation
1. Its inconsistent with the parsing logic for rest of the BPMN activities like service task, user task, manual task etc.
2. It block extending camunda activity behavior for intermediate via bpmnParseListeners for advanced use-cases.

https://app.camunda.com/jira/browse/CAM-9300 