### PR TITLE
Patch for the wildlfy subsystem for WF 14 (possibly 12 and 13)

### DIFF
--- a/distro/wildfly/subsystem/pom.xml
+++ b/distro/wildfly/subsystem/pom.xml
@@ -11,7 +11,7 @@
   <packaging>jar</packaging>
 
   <name>camunda BPM - Wildfly Subsystem</name>
-
+  
   <dependencies>
 
     <dependency>
@@ -157,6 +157,33 @@
         </dependency>
       </dependencies>
     </profile>
-  </profiles>
+    <profile>
+      <id>wildfly14</id>
+      <properties>
+        <version.wildfly14>14.0.0.Final</version.wildfly14>
+        <version.wildfly14.core>5.0.0.Final</version.wildfly14.core>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.wildfly</groupId>
+          <artifactId>wildfly-web-common</artifactId>
+          <version>${version.wildfly14}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.wildfly</groupId>
+          <artifactId>wildfly-ejb3</artifactId>
+          <version>${version.wildfly14}</version>
+          <scope>provided</scope>
+        </dependency>
 
+        <dependency>
+          <groupId>org.wildfly.core</groupId>
+          <artifactId>wildfly-subsystem-test-framework</artifactId>
+          <version>${version.wildfly14.core}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/distro/wildfly/subsystem/src/main/java/org/camunda/bpm/container/impl/jboss/extension/SubsystemAttributeDefinitons.java
+++ b/distro/wildfly/subsystem/src/main/java/org/camunda/bpm/container/impl/jboss/extension/SubsystemAttributeDefinitons.java
@@ -10,88 +10,101 @@ import org.jboss.dmr.ModelType;
 
 public class SubsystemAttributeDefinitons {
 
-  public static final String DEFAULT_DATASOURCE = "java:jboss/datasources/ExampleDS";
-  public static final String DEFAULT_HISTORY_LEVEL = "audit";
-  public static final String DEFAULT_PROCESS_ENGINE_CONFIGURATION_CLASS = ManagedJtaProcessEngineConfiguration.class.getName();
-  public static final String DEFAULT_ACQUISITION_STRATEGY = "SEQUENTIAL";
-  public static final String DEFAULT_JOB_EXECUTOR_THREADPOOL_NAME = "job-executor-tp";
-  public static final int DEFAULT_CORE_THREADS = 3;
-  public static final int DEFAULT_MAX_THREADS = 5;
-  public static final int DEFAULT_QUEUE_LENGTH = 10;
-  public static final int DEFAULT_KEEPALIVE_TIME = 10;
-  public static final boolean DEFAULT_ALLOW_CORE_TIMEOUT = true;
+    public static final String DEFAULT_DATASOURCE = "java:jboss/datasources/ExampleDS";
+    public static final String DEFAULT_HISTORY_LEVEL = "audit";
+    public static final String DEFAULT_PROCESS_ENGINE_CONFIGURATION_CLASS =
+            ManagedJtaProcessEngineConfiguration.class.getName();
+    public static final String DEFAULT_ACQUISITION_STRATEGY = "SEQUENTIAL";
+    public static final String DEFAULT_JOB_EXECUTOR_THREADPOOL_NAME = "job-executor-tp";
+    public static final int DEFAULT_CORE_THREADS = 3;
+    public static final int DEFAULT_MAX_THREADS = 5;
+    public static final int DEFAULT_QUEUE_LENGTH = 10;
+    public static final int DEFAULT_KEEPALIVE_TIME = 10;
+    public static final boolean DEFAULT_ALLOW_CORE_TIMEOUT = true;
 
-  // general
-  public static final SimpleAttributeDefinition NAME = new SimpleAttributeDefinition(ModelConstants.NAME, new ModelNode("default"), ModelType.STRING, false, AttributeAccess.Flag.RESTART_ALL_SERVICES);
-  public static final SimpleMapAttributeDefinition PROPERTIES = new SimpleMapAttributeDefinition.Builder(ModelConstants.PROPERTIES, true)
-    .setAttributeMarshaller(CustomMarshaller.PROPERTIES_MARSHALLER)
-    .setRestartAllServices()
-    .build();
+    // general
+    public static final SimpleAttributeDefinition NAME =
+            new SimpleAttributeDefinitionBuilder(ModelConstants.NAME, ModelType.STRING, false)
+                    .setDefaultValue(new ModelNode("default")).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .build();
+    public static final SimpleMapAttributeDefinition PROPERTIES =
+            new SimpleMapAttributeDefinition.Builder(ModelConstants.PROPERTIES, true)
+                    .setAttributeMarshaller(CustomMarshaller.PROPERTIES_MARSHALLER).setRestartAllServices().build();
 
-  // process engine
-  public static final SimpleAttributeDefinition DEFAULT = new SimpleAttributeDefinition(ModelConstants.DEFAULT, new ModelNode(false), ModelType.BOOLEAN, true, AttributeAccess.Flag.RESTART_ALL_SERVICES);
-  public static final SimpleAttributeDefinition DATASOURCE = new SimpleAttributeDefinition(ModelConstants.DATASOURCE, new ModelNode(DEFAULT_DATASOURCE), ModelType.STRING, false, AttributeAccess.Flag.RESTART_ALL_SERVICES);
-  public static final SimpleAttributeDefinition HISTORY_LEVEL = new SimpleAttributeDefinition(ModelConstants.HISTORY_LEVEL, new ModelNode(DEFAULT_HISTORY_LEVEL), ModelType.STRING, true, AttributeAccess.Flag.RESTART_ALL_SERVICES);
-  public static final SimpleAttributeDefinition CONFIGURATION = new SimpleAttributeDefinition(ModelConstants.CONFIGURATION, new ModelNode(DEFAULT_PROCESS_ENGINE_CONFIGURATION_CLASS), ModelType.STRING, true, AttributeAccess.Flag.RESTART_ALL_SERVICES);
+    // process engine
+    public static final SimpleAttributeDefinition DEFAULT =
+            new SimpleAttributeDefinitionBuilder(ModelConstants.DEFAULT, ModelType.BOOLEAN, true)
+                    .setDefaultValue(new ModelNode(false)).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
+    public static final AttributeDefinition DATASOURCE =
+            new SimpleAttributeDefinitionBuilder(ModelConstants.DATASOURCE, ModelType.STRING, false)
+                    .setDefaultValue(new ModelNode(DEFAULT_DATASOURCE))
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
+    public static final AttributeDefinition HISTORY_LEVEL =
+            new SimpleAttributeDefinitionBuilder(ModelConstants.HISTORY_LEVEL, ModelType.STRING, true)
+                    .setDefaultValue(new ModelNode(DEFAULT_HISTORY_LEVEL))
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
+    public static final AttributeDefinition CONFIGURATION =
+            new SimpleAttributeDefinitionBuilder(ModelConstants.CONFIGURATION, ModelType.STRING, true)
+                    .setDefaultValue(new ModelNode(DEFAULT_PROCESS_ENGINE_CONFIGURATION_CLASS))
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
 
-  // job executor
-  @Deprecated
-  public static final SimpleAttributeDefinition THREAD_POOL_NAME = new SimpleAttributeDefinition(ModelConstants.THREAD_POOL_NAME, new ModelNode(DEFAULT_JOB_EXECUTOR_THREADPOOL_NAME), ModelType.STRING, true, AttributeAccess.Flag.RESTART_ALL_SERVICES);
-  public static final SimpleAttributeDefinition CORE_THREADS = new SimpleAttributeDefinition(ModelConstants.CORE_THREADS, new ModelNode(DEFAULT_CORE_THREADS), ModelType.INT, false, AttributeAccess.Flag.RESTART_ALL_SERVICES);
-  public static final SimpleAttributeDefinition MAX_THREADS = new SimpleAttributeDefinition(ModelConstants.MAX_THREADS, new ModelNode(DEFAULT_MAX_THREADS), ModelType.INT, false, AttributeAccess.Flag.RESTART_ALL_SERVICES);
-  public static final SimpleAttributeDefinition QUEUE_LENGTH = new SimpleAttributeDefinition(ModelConstants.QUEUE_LENGTH, new ModelNode(DEFAULT_QUEUE_LENGTH), ModelType.INT, false, AttributeAccess.Flag.RESTART_ALL_SERVICES);
-  public static final SimpleAttributeDefinition KEEPALIVE_TIME = new SimpleAttributeDefinition(ModelConstants.KEEPALIVE_TIME, new ModelNode(DEFAULT_KEEPALIVE_TIME), ModelType.INT, true, AttributeAccess.Flag.RESTART_ALL_SERVICES);
-  public static final SimpleAttributeDefinition ALLOW_CORE_TIMEOUT = new SimpleAttributeDefinition(ModelConstants.ALLOW_CORE_TIMEOUT, new ModelNode(DEFAULT_ALLOW_CORE_TIMEOUT), ModelType.BOOLEAN, true, AttributeAccess.Flag.RESTART_ALL_SERVICES);
-  @Deprecated
-  public static final SimpleAttributeDefinition ACQUISITION_STRATEGY = new SimpleAttributeDefinition(ModelConstants.ACQUISITION_STRATEGY, new ModelNode(DEFAULT_ACQUISITION_STRATEGY), ModelType.STRING, true, AttributeAccess.Flag.RESTART_ALL_SERVICES);
+    // job executor
+    @Deprecated
+    public static final AttributeDefinition THREAD_POOL_NAME =
+            new SimpleAttributeDefinitionBuilder(ModelConstants.THREAD_POOL_NAME, ModelType.STRING, true)
+                    .setDefaultValue(new ModelNode(DEFAULT_JOB_EXECUTOR_THREADPOOL_NAME))
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
+    public static final AttributeDefinition CORE_THREADS =
+            new SimpleAttributeDefinitionBuilder(ModelConstants.CORE_THREADS, ModelType.INT, false)
+                    .setDefaultValue(new ModelNode(DEFAULT_CORE_THREADS))
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
+    public static final AttributeDefinition MAX_THREADS =
+            new SimpleAttributeDefinitionBuilder(ModelConstants.MAX_THREADS, ModelType.INT, false)
+                    .setDefaultValue(new ModelNode(DEFAULT_MAX_THREADS))
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
+    public static final AttributeDefinition QUEUE_LENGTH =
+            new SimpleAttributeDefinitionBuilder(ModelConstants.QUEUE_LENGTH, ModelType.INT, false)
+                    .setDefaultValue(new ModelNode(DEFAULT_QUEUE_LENGTH))
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
 
-  public static final SimpleAttributeDefinition PLUGIN_CLASS = SimpleAttributeDefinitionBuilder.create(ModelConstants.PLUGIN_CLASS, ModelType.STRING, true)
-      .setAttributeMarshaller(CustomMarshaller.ATTRIBUTE_AS_ELEMENT)
-      .build();
+                    .build();
+    public static final AttributeDefinition KEEPALIVE_TIME =
+            new SimpleAttributeDefinitionBuilder(ModelConstants.KEEPALIVE_TIME, ModelType.INT, true)
+                    .setDefaultValue(new ModelNode(DEFAULT_KEEPALIVE_TIME))
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
+    public static final AttributeDefinition ALLOW_CORE_TIMEOUT =
+            new SimpleAttributeDefinitionBuilder(ModelConstants.ALLOW_CORE_TIMEOUT, ModelType.BOOLEAN, true)
+                    .setDefaultValue(new ModelNode(DEFAULT_ALLOW_CORE_TIMEOUT))
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
+    @Deprecated
+    public static final AttributeDefinition ACQUISITION_STRATEGY =
+            new SimpleAttributeDefinitionBuilder(ModelConstants.ACQUISITION_STRATEGY, ModelType.STRING, true)
+                    .setDefaultValue(new ModelNode(true)).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
 
-  public static final AttributeDefinition[] PLUGIN_ATTRIBUTES = new AttributeDefinition[] {
-      PLUGIN_CLASS,
-      PROPERTIES
-  };
 
-  public static final FixedObjectTypeAttributeDefinition PLUGIN = FixedObjectTypeAttributeDefinition.Builder.of(ModelConstants.PLUGIN, PLUGIN_ATTRIBUTES)
-      .setAttributeMarshaller(CustomMarshaller.OBJECT_AS_ELEMENT)
-      .setAttributeParser(AttributeParser.LIST)
-      .setRequires(ModelConstants.PLUGIN_CLASS)
-      .setAllowNull(true)
-      .setRestartAllServices()
-      .build();
+    public static final SimpleAttributeDefinition PLUGIN_CLASS =
+            SimpleAttributeDefinitionBuilder.create(ModelConstants.PLUGIN_CLASS, ModelType.STRING, true)
+                    .setAttributeMarshaller(CustomMarshaller.ATTRIBUTE_AS_ELEMENT).build();
 
-  public static final ObjectListAttributeDefinition PLUGINS = ObjectListAttributeDefinition.Builder.of(ModelConstants.PLUGINS, PLUGIN)
-      .setAttributeMarshaller(CustomMarshaller.OBJECT_LIST)
-      .setAllowNull(true)
-      .setAllowExpression(true)
-      .setRestartAllServices()
-      .build();
+    public static final AttributeDefinition[] PLUGIN_ATTRIBUTES =
+            new AttributeDefinition[] { PLUGIN_CLASS, PROPERTIES };
 
-  public static final AttributeDefinition[] JOB_EXECUTOR_ATTRIBUTES = new AttributeDefinition[] {
-      THREAD_POOL_NAME,
-      CORE_THREADS,
-      MAX_THREADS,
-      QUEUE_LENGTH,
-      KEEPALIVE_TIME,
-      ALLOW_CORE_TIMEOUT
-  };
+    public static final FixedObjectTypeAttributeDefinition PLUGIN = FixedObjectTypeAttributeDefinition.Builder
+            .of(ModelConstants.PLUGIN, PLUGIN_ATTRIBUTES).setAttributeMarshaller(CustomMarshaller.OBJECT_AS_ELEMENT)
+            .setAttributeParser(AttributeParser.OBJECT_LIST_PARSER).setRequires(ModelConstants.PLUGIN_CLASS)
+            .setAllowNull(true).setRestartAllServices().build();
 
-  public static final AttributeDefinition[] JOB_ACQUISITION_ATTRIBUTES = new AttributeDefinition[] {
-      NAME,
-      ACQUISITION_STRATEGY,
-      PROPERTIES
-  };
+    public static final ObjectListAttributeDefinition PLUGINS = ObjectListAttributeDefinition.Builder
+            .of(ModelConstants.PLUGINS, PLUGIN).setAttributeMarshaller(CustomMarshaller.OBJECT_LIST).setAllowNull(true)
+            .setAllowExpression(true).setRestartAllServices().build();
 
-  public static final AttributeDefinition[] PROCESS_ENGINE_ATTRIBUTES = new AttributeDefinition[] {
-      NAME,
-      DEFAULT,
-      DATASOURCE,
-      HISTORY_LEVEL,
-      CONFIGURATION,
-      PROPERTIES,
-      PLUGINS
-  };
+    public static final AttributeDefinition[] JOB_EXECUTOR_ATTRIBUTES = new AttributeDefinition[] { THREAD_POOL_NAME,
+            CORE_THREADS, MAX_THREADS, QUEUE_LENGTH, KEEPALIVE_TIME, ALLOW_CORE_TIMEOUT };
+
+    public static final AttributeDefinition[] JOB_ACQUISITION_ATTRIBUTES =
+            new AttributeDefinition[] { NAME, ACQUISITION_STRATEGY, PROPERTIES };
+
+    public static final AttributeDefinition[] PROCESS_ENGINE_ATTRIBUTES =
+            new AttributeDefinition[] { NAME, DEFAULT, DATASOURCE, HISTORY_LEVEL, CONFIGURATION, PROPERTIES, PLUGINS };
 
 }

--- a/distro/wildfly/subsystem/src/main/java/org/camunda/bpm/container/impl/jboss/extension/handler/BpmPlatformSubsystemAdd.java
+++ b/distro/wildfly/subsystem/src/main/java/org/camunda/bpm/container/impl/jboss/extension/handler/BpmPlatformSubsystemAdd.java
@@ -24,7 +24,6 @@ import org.camunda.bpm.container.impl.plugin.BpmPlatformPlugins;
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.server.deployment.Phase;
@@ -50,8 +49,7 @@ public class BpmPlatformSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
   /** {@inheritDoc} */
   @Override
-  protected void performBoottime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler,
-          List<ServiceController< ? >> newControllers) throws OperationFailedException {
+  protected void performBoottime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
 
     // add deployment processors
     context.addStep(new AbstractDeploymentChainStep() {
@@ -69,11 +67,8 @@ public class BpmPlatformSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
     final ServiceController<MscRuntimeContainerDelegate> controller = context.getServiceTarget()
             .addService(ServiceNames.forMscRuntimeContainerDelegate(), processEngineService)
-            .addListener(verificationHandler)
             .setInitialMode(Mode.ACTIVE)
             .install();
-
-    newControllers.add(controller);
 
     // discover and register bpm platform plugins
     BpmPlatformPlugins plugins = BpmPlatformPlugins.load(getClass().getClassLoader());
@@ -81,11 +76,8 @@ public class BpmPlatformSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
     ServiceController<BpmPlatformPlugins> serviceController = context.getServiceTarget()
       .addService(ServiceNames.forBpmPlatformPlugins(), managedPlugins)
-      .addListener(verificationHandler)
       .setInitialMode(Mode.ACTIVE)
       .install();
-
-    newControllers.add(serviceController);
   }
 
 }

--- a/distro/wildfly/subsystem/src/main/java/org/camunda/bpm/container/impl/jboss/extension/handler/JobAcquisitionAdd.java
+++ b/distro/wildfly/subsystem/src/main/java/org/camunda/bpm/container/impl/jboss/extension/handler/JobAcquisitionAdd.java
@@ -44,9 +44,7 @@ public class JobAcquisitionAdd extends AbstractAddStepHandler {
   }
 
   @Override
-  protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model,
-          ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers)
-          throws OperationFailedException {
+  protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
 
     String acquisitionName = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.ADDRESS)).getLastElement().getValue();
 
@@ -63,12 +61,8 @@ public class JobAcquisitionAdd extends AbstractAddStepHandler {
     ServiceController<RuntimeContainerJobExecutor> serviceController = context.getServiceTarget().addService(ServiceNames.forMscRuntimeContainerJobExecutorService(acquisitionName), mscRuntimeContainerJobExecutor)
       .addDependency(ServiceNames.forMscRuntimeContainerDelegate())
       .addDependency(ServiceNames.forMscExecutorService())
-      .addListener(verificationHandler)
       .setInitialMode(Mode.ACTIVE)
       .install();
-
-    newControllers.add(serviceController);
-
   }
 
 }

--- a/distro/wildfly/subsystem/src/main/java/org/camunda/bpm/container/impl/jboss/extension/handler/JobExecutorAdd.java
+++ b/distro/wildfly/subsystem/src/main/java/org/camunda/bpm/container/impl/jboss/extension/handler/JobExecutorAdd.java
@@ -1,17 +1,10 @@
 /**
- * Copyright (C) 2011, 2012 camunda services GmbH
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (C) 2011, 2012 camunda services GmbH Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and limitations under the
+ * License.
  */
 package org.camunda.bpm.container.impl.jboss.extension.handler;
 
@@ -21,7 +14,6 @@ import org.camunda.bpm.container.impl.jboss.service.ServiceNames;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.threads.BoundedQueueThreadPoolService;
 import org.jboss.as.threads.ManagedQueueExecutorService;
 import org.jboss.as.threads.ThreadFactoryService;
@@ -45,76 +37,56 @@ import java.util.concurrent.TimeUnit;
  */
 public class JobExecutorAdd extends AbstractAddStepHandler {
 
-  public static final String THREAD_POOL_GRP_NAME = "Camunda BPM ";
+    public static final String THREAD_POOL_GRP_NAME = "Camunda BPM ";
 
-  public static final JobExecutorAdd INSTANCE = new JobExecutorAdd();
+    public static final JobExecutorAdd INSTANCE = new JobExecutorAdd();
 
-  private JobExecutorAdd() {
-    super(SubsystemAttributeDefinitons.JOB_EXECUTOR_ATTRIBUTES);
-  }
-
-  @Override
-  protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model,
-          ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers)
-          throws OperationFailedException {
-
-    String jobExecutorThreadPoolName = SubsystemAttributeDefinitons.THREAD_POOL_NAME.resolveModelAttribute(context, model).asString();
-    ServiceName jobExecutorThreadPoolServiceName = ServiceNames.forManagedThreadPool(jobExecutorThreadPoolName);
-
-    performRuntimeThreadPool(context, model, jobExecutorThreadPoolName, jobExecutorThreadPoolServiceName, verificationHandler, newControllers);
-
-    MscExecutorService service = new MscExecutorService();
-    ServiceController<MscExecutorService> serviceController = context.getServiceTarget().addService(ServiceNames.forMscExecutorService(), service)
-        .addDependency(jobExecutorThreadPoolServiceName, ManagedQueueExecutorService.class, service.getManagedQueueInjector())
-        .addListener(verificationHandler)
-        .setInitialMode(Mode.ACTIVE)
-        .install();
-
-    newControllers.add(serviceController);
-
-  }
-
-  protected void performRuntimeThreadPool(OperationContext context, ModelNode model, String name, ServiceName jobExecutorThreadPoolServiceName,
-      ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers)
-      throws OperationFailedException {
-
-    ServiceTarget serviceTarget = context.getServiceTarget();
-
-    ThreadFactoryService threadFactory = new ThreadFactoryService();
-    threadFactory.setThreadGroupName(THREAD_POOL_GRP_NAME + name);
-
-    ServiceName threadFactoryServiceName = ServiceNames.forThreadFactoryService(name);
-
-    ServiceBuilder<ThreadFactory> factoryBuilder = serviceTarget.addService(threadFactoryServiceName, threadFactory);
-    if (verificationHandler != null) {
-      factoryBuilder.addListener(verificationHandler);
-    }
-    if (newControllers != null) {
-      newControllers.add(factoryBuilder.install());
-    } else {
-      factoryBuilder.install();
+    private JobExecutorAdd() {
+        super(SubsystemAttributeDefinitons.JOB_EXECUTOR_ATTRIBUTES);
     }
 
-    final BoundedQueueThreadPoolService threadPoolService = new BoundedQueueThreadPoolService(
-        SubsystemAttributeDefinitons.CORE_THREADS.resolveModelAttribute(context, model).asInt(),
-        SubsystemAttributeDefinitons.MAX_THREADS.resolveModelAttribute(context, model).asInt(),
-        SubsystemAttributeDefinitons.QUEUE_LENGTH.resolveModelAttribute(context, model).asInt(),
-        false,
-        new TimeSpec(TimeUnit.SECONDS, SubsystemAttributeDefinitons.KEEPALIVE_TIME.resolveModelAttribute(context,model).asInt()),
-        SubsystemAttributeDefinitons.ALLOW_CORE_TIMEOUT.resolveModelAttribute(context, model).asBoolean()
-    );
+    @Override
+    protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model)
+            throws OperationFailedException {
 
-    ServiceBuilder<ManagedQueueExecutorService> builder = serviceTarget.addService(jobExecutorThreadPoolServiceName, threadPoolService)
-        .addDependency(threadFactoryServiceName, ThreadFactory.class, threadPoolService.getThreadFactoryInjector())
-        .setInitialMode(ServiceController.Mode.ACTIVE);
-    if (verificationHandler != null) {
-      builder.addListener(verificationHandler);
+        String jobExecutorThreadPoolName =
+                SubsystemAttributeDefinitons.THREAD_POOL_NAME.resolveModelAttribute(context, model).asString();
+        ServiceName jobExecutorThreadPoolServiceName = ServiceNames.forManagedThreadPool(jobExecutorThreadPoolName);
+
+        performRuntimeThreadPool(context, model, jobExecutorThreadPoolName, jobExecutorThreadPoolServiceName);
+
+        MscExecutorService service = new MscExecutorService();
+        ServiceController<MscExecutorService> serviceController =
+                context.getServiceTarget().addService(ServiceNames.forMscExecutorService(), service)
+                        .addDependency(jobExecutorThreadPoolServiceName, ManagedQueueExecutorService.class,
+                                service.getManagedQueueInjector())
+                        .setInitialMode(Mode.ACTIVE).install();
     }
-    if (newControllers != null) {
-      newControllers.add(builder.install());
-    } else {
-      builder.install();
+
+    protected void performRuntimeThreadPool(OperationContext context, ModelNode model, String name,
+            ServiceName jobExecutorThreadPoolServiceName) throws OperationFailedException {
+
+        ServiceTarget serviceTarget = context.getServiceTarget();
+
+        ThreadFactoryService threadFactory = new ThreadFactoryService();
+        threadFactory.setThreadGroupName(THREAD_POOL_GRP_NAME + name);
+
+        ServiceName threadFactoryServiceName = ServiceNames.forThreadFactoryService(name);
+
+        serviceTarget.addService(threadFactoryServiceName, threadFactory).install();
+
+        final BoundedQueueThreadPoolService threadPoolService = new BoundedQueueThreadPoolService(
+                SubsystemAttributeDefinitons.CORE_THREADS.resolveModelAttribute(context, model).asInt(),
+                SubsystemAttributeDefinitons.MAX_THREADS.resolveModelAttribute(context, model).asInt(),
+                SubsystemAttributeDefinitons.QUEUE_LENGTH.resolveModelAttribute(context, model).asInt(), false,
+                new TimeSpec(TimeUnit.SECONDS,
+                        SubsystemAttributeDefinitons.KEEPALIVE_TIME.resolveModelAttribute(context, model).asInt()),
+                SubsystemAttributeDefinitons.ALLOW_CORE_TIMEOUT.resolveModelAttribute(context, model).asBoolean());
+
+        serviceTarget.addService(jobExecutorThreadPoolServiceName, threadPoolService)
+                .addDependency(threadFactoryServiceName, ThreadFactory.class,
+                        threadPoolService.getThreadFactoryInjector())
+                .setInitialMode(ServiceController.Mode.ACTIVE).install();
     }
-  }
 
 }

--- a/distro/wildfly/subsystem/src/main/java/org/camunda/bpm/container/impl/jboss/extension/handler/ProcessEngineAdd.java
+++ b/distro/wildfly/subsystem/src/main/java/org/camunda/bpm/container/impl/jboss/extension/handler/ProcessEngineAdd.java
@@ -51,20 +51,16 @@ public class ProcessEngineAdd extends AbstractAddStepHandler {
   }
 
   @Override
-  protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model,
-          ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers)
-          throws OperationFailedException {
+  protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
 
     String engineName = PathAddress.pathAddress(operation.get(ADDRESS)).getLastElement().getValue();
 
     ManagedProcessEngineMetadata processEngineConfiguration = transformConfiguration(context, engineName, model);
 
-    ServiceController<ProcessEngine> controller = installService(context, verificationHandler, processEngineConfiguration);
-
-    newControllers.add(controller);
+    ServiceController<ProcessEngine> controller = installService(context, processEngineConfiguration);
   }
 
-  protected ServiceController<ProcessEngine> installService(OperationContext context, ServiceVerificationHandler verificationHandler,
+  protected ServiceController<ProcessEngine> installService(OperationContext context, 
       ManagedProcessEngineMetadata processEngineConfiguration) {
 
     MscManagedProcessEngineController service = new MscManagedProcessEngineController(processEngineConfiguration);
@@ -74,7 +70,6 @@ public class ProcessEngineAdd extends AbstractAddStepHandler {
 
     MscManagedProcessEngineController.initializeServiceBuilder(processEngineConfiguration, service, serviceBuilder, processEngineConfiguration.getJobExecutorAcquisitionName());
 
-    serviceBuilder.addListener(verificationHandler);
     return serviceBuilder.install();
   }
 


### PR DESCRIPTION
The changes allow to build and run the Camunda BPM for a current Wildfly version.
The actual wildfly subsystem won't compile with Wildfy 14 (probably 12 & 13 too), due to changes in the configuration model. This adresses CAM-8934 (https://app.camunda.com/jira/browse/CAM-8934)

I assume the best way would be to have 2 wildfly subsystems, one covering the current supported versions and a second one for the newer Wildfly versions, but this would need more work to be spent in the current maven setup of the project - which I'm not sure if I understood it correctly. 

I've built and tested this with Wildfly 14 successfully.
 