### PR TITLE
Update WildFly 14 to latest version.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -41,8 +41,8 @@
     <version.wildfly12.core>4.0.0.Final</version.wildfly12.core>
     <version.wildfly13>13.0.0.Final</version.wildfly13>
     <version.wildfly13.core>5.0.0.Final</version.wildfly13.core>
-    <version.wildfly14>14.0.0.Final</version.wildfly14>
-    <version.wildfly14.core>5.0.0.Final</version.wildfly14.core>
+    <version.wildfly14>14.0.1.Final</version.wildfly14>
+    <version.wildfly14.core>6.0.2.Final</version.wildfly14.core>
 
     <version.glassfish>3.1.2</version.glassfish>
     <version.tomcat>9.0.5</version.tomcat>

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,7 @@
         <module>distro/wildfly11</module>
         <module>distro/wildfly12</module>
         <module>distro/wildfly13</module>
+        <module>distro/wildfly14</module>
       </modules>
     </profile>
 


### PR DESCRIPTION
Latest WildFly version is 14.0.1.Final based on WildFly-Core 6.0.2.Final.

Change the version properties and enable build of Wildfly 14 distro.