### PR TITLE
(chore) Enhance ClockUtil with clock functionality

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -182,8 +182,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.exparity</groupId>
-      <artifactId>hamcrest-date</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -182,6 +182,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.exparity</groupId>
+      <artifactId>hamcrest-date</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/ClockUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/ClockUtil.java
@@ -12,9 +12,8 @@
  */
 package org.camunda.bpm.engine.impl.util;
 
-import java.time.Clock;
-import java.time.Duration;
-import java.time.ZoneId;
+import org.joda.time.DateTimeUtils;
+
 import java.util.Date;
 
 
@@ -23,10 +22,8 @@ import java.util.Date;
  */
 public class ClockUtil {
 
-  private static Clock clock = Clock.system(ZoneId.systemDefault());
-
   public static void setCurrentTime(Date currentTime) {
-    clock = Clock.fixed(currentTime.toInstant(), ZoneId.systemDefault());
+    DateTimeUtils.setCurrentMillisFixed(currentTime.getTime());
   }
 
   public static void reset() {
@@ -38,16 +35,16 @@ public class ClockUtil {
   }
 
   public static Date now() {
-    return Date.from(clock.instant());
+    return new Date(DateTimeUtils.currentTimeMillis());
   }
 
-  public static Date offset(Duration duration) {
-    clock = Clock.offset(clock, duration);
-    return Date.from(clock.instant());
+  public static Date offset(Long offsetInMillis) {
+    DateTimeUtils.setCurrentMillisOffset(offsetInMillis);
+    return new Date(DateTimeUtils.currentTimeMillis());
   }
 
   public static Date resetClock() {
-    clock = Clock.system(ZoneId.of("CET"));
-    return Date.from(clock.instant());
+    DateTimeUtils.setCurrentMillisSystem();
+    return new Date(DateTimeUtils.currentTimeMillis());
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/ClockUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/ClockUtil.java
@@ -12,6 +12,9 @@
  */
 package org.camunda.bpm.engine.impl.util;
 
+import java.time.Clock;
+import java.time.Duration;
+import java.time.ZoneId;
 import java.util.Date;
 
 
@@ -20,21 +23,31 @@ import java.util.Date;
  */
 public class ClockUtil {
 
-  private volatile static Date CURRENT_TIME = null;
+  private static Clock clock = Clock.system(ZoneId.systemDefault());
 
   public static void setCurrentTime(Date currentTime) {
-    ClockUtil.CURRENT_TIME = currentTime;
+    offset(Duration.between(now().toInstant(), currentTime.toInstant()));
   }
 
   public static void reset() {
-    ClockUtil.CURRENT_TIME = null;
+    resetClock();
   }
 
   public static Date getCurrentTime() {
-    if (CURRENT_TIME != null) {
-      return CURRENT_TIME;
-    }
-    return new Date();
+    return now();
   }
 
+  public static Date now() {
+    return Date.from(clock.instant());
+  }
+
+  public static Date offset(Duration duration) {
+    clock = Clock.offset(clock, duration);
+    return Date.from(clock.instant());
+  }
+
+  public static Date resetClock() {
+    clock = Clock.system(ZoneId.of("CET"));
+    return Date.from(clock.instant());
+  }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/ClockUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/ClockUtil.java
@@ -26,7 +26,7 @@ public class ClockUtil {
   private static Clock clock = Clock.system(ZoneId.systemDefault());
 
   public static void setCurrentTime(Date currentTime) {
-    offset(Duration.between(now().toInstant(), currentTime.toInstant()));
+    clock = Clock.fixed(currentTime.toInstant(), ZoneId.systemDefault());
   }
 
   public static void reset() {

--- a/engine/src/test/java/org/camunda/bpm/engine/impl/util/ClockUtilTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/impl/util/ClockUtilTest.java
@@ -1,20 +1,19 @@
 package org.camunda.bpm.engine.impl.util;
 
 import org.joda.time.Duration;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Date;
 
-import static org.exparity.hamcrest.date.DateMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /*
  * Copyright © 2013-2019 camunda services GmbH and various authors (info@camunda.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * You may obtain a copy of the License atØ
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -26,14 +25,21 @@ import static org.hamcrest.core.Is.is;
  */
 public class ClockUtilTest {
 
+    private static final long ONE_SECOND = 1000L;
+
+    @Before
+    public void setUp() throws Exception {
+        ClockUtil.resetClock();
+    }
+
     @Test
     public void now_should_return_current_time() {
-        assertThat(ClockUtil.now(), sameSecondOfMinute(new Date()));
+        assertThat(ClockUtil.now()).isCloseTo(new Date(), ONE_SECOND);
     }
 
     @Test
     public void getCurrentTime_should_return_same_value_as_now() {
-        assertThat(ClockUtil.getCurrentTime(), is(ClockUtil.now()));
+        assertThat(ClockUtil.getCurrentTime()).isCloseTo(ClockUtil.now(), 1000);
     }
 
     @Test
@@ -43,7 +49,7 @@ public class ClockUtilTest {
 
         ClockUtil.offset(duration.getMillis());
 
-        assertTimesAreInSameSecond(ClockUtil.now(), target);
+        assertThat(ClockUtil.now()).isCloseTo(target, ONE_SECOND);
     }
 
     @Test
@@ -53,7 +59,7 @@ public class ClockUtilTest {
 
         ClockUtil.setCurrentTime(target);
 
-        assertTimesAreInSameSecond(ClockUtil.now(), target);
+        assertThat(ClockUtil.now()).isCloseTo(target, ONE_SECOND);
     }
 
     @Test
@@ -63,10 +69,10 @@ public class ClockUtilTest {
 
         ClockUtil.offset(duration.getMillis());
 
-        assertTimesAreInSameSecond(ClockUtil.now(), target);
+        assertThat(ClockUtil.now()).isCloseTo(target, ONE_SECOND);
 
-        assertTimesAreInSameSecond(ClockUtil.resetClock(), new Date());
-        assertTimesAreInSameSecond(ClockUtil.getCurrentTime(), new Date());
+        assertThat(ClockUtil.resetClock()).isCloseTo(new Date(), ONE_SECOND);
+        assertThat(ClockUtil.getCurrentTime()).isCloseTo(new Date(), ONE_SECOND);
     }
 
     @Test
@@ -76,11 +82,11 @@ public class ClockUtilTest {
 
         ClockUtil.offset(duration.getMillis());
 
-        assertTimesAreInSameSecond(ClockUtil.now(), target);
+        assertThat(ClockUtil.now()).isCloseTo(target, ONE_SECOND);
 
         ClockUtil.reset();
 
-        assertTimesAreInSameSecond(ClockUtil.getCurrentTime(), new Date());
+        assertThat(ClockUtil.now()).isCloseTo(new Date(), ONE_SECOND);
     }
 
     @Test
@@ -91,11 +97,11 @@ public class ClockUtilTest {
 
         ClockUtil.offset(duration.getMillis());
 
-        assertTimesAreInSameSecond(ClockUtil.now(), target);
+        assertThat(ClockUtil.now()).isCloseTo(target, ONE_SECOND);
 
         Thread.sleep(10000);
 
-        assertTimesAreInSameSecond(ClockUtil.now(), new Date(target.getTime() + Duration.standardSeconds(10).getMillis()));
+        assertThat(ClockUtil.now()).isCloseTo(new Date(target.getTime() + Duration.standardSeconds(10).getMillis()), ONE_SECOND);
     }
 
     @Test
@@ -107,15 +113,6 @@ public class ClockUtilTest {
 
         Thread.sleep(10000);
 
-        assertTimesAreInSameSecond(ClockUtil.now(), target);
-    }
-
-    private static void assertTimesAreInSameSecond(Date first, Date second) {
-        assertThat(first, sameSecondOfMinute(second));
-        assertThat(first, sameMinuteOfHour(second));
-        assertThat(first, sameHourOfDay(second));
-        assertThat(first, sameDayOfMonth(second));
-        assertThat(first, sameMonthOfYear(second));
-        assertThat(first, sameMonthOfYear(second));
+        assertThat(ClockUtil.now()).isCloseTo(target, ONE_SECOND);
     }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/impl/util/ClockUtilTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/impl/util/ClockUtilTest.java
@@ -5,10 +5,25 @@ import org.junit.Test;
 
 import java.util.Date;
 
-import static org.exparity.hamcrest.date.DateMatchers.sameSecondOfMinute;
+import static org.exparity.hamcrest.date.DateMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
+/*
+ * Copyright © 2013-2019 camunda services GmbH and various authors (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 public class ClockUtilTest {
 
     @Test
@@ -28,7 +43,7 @@ public class ClockUtilTest {
 
         ClockUtil.offset(duration.getMillis());
 
-        assertThat(ClockUtil.now(), sameSecondOfMinute(target));
+        assertTimesAreInSameSecond(ClockUtil.now(), target);
     }
 
     @Test
@@ -38,7 +53,7 @@ public class ClockUtilTest {
 
         ClockUtil.setCurrentTime(target);
 
-        assertThat(ClockUtil.now(), sameSecondOfMinute(target));
+        assertTimesAreInSameSecond(ClockUtil.now(), target);
     }
 
     @Test
@@ -48,10 +63,10 @@ public class ClockUtilTest {
 
         ClockUtil.offset(duration.getMillis());
 
-        assertThat(ClockUtil.now(), sameSecondOfMinute(target));
+        assertTimesAreInSameSecond(ClockUtil.now(), target);
 
-        assertThat(ClockUtil.resetClock(), sameSecondOfMinute(new Date()));
-        assertThat(ClockUtil.getCurrentTime(), sameSecondOfMinute(new Date()));
+        assertTimesAreInSameSecond(ClockUtil.resetClock(), new Date());
+        assertTimesAreInSameSecond(ClockUtil.getCurrentTime(), new Date());
     }
 
     @Test
@@ -61,11 +76,11 @@ public class ClockUtilTest {
 
         ClockUtil.offset(duration.getMillis());
 
-        assertThat(ClockUtil.now(), sameSecondOfMinute(target));
+        assertTimesAreInSameSecond(ClockUtil.now(), target);
 
         ClockUtil.reset();
 
-        assertThat(ClockUtil.getCurrentTime(), sameSecondOfMinute(new Date()));
+        assertTimesAreInSameSecond(ClockUtil.getCurrentTime(), new Date());
     }
 
     @Test
@@ -76,11 +91,11 @@ public class ClockUtilTest {
 
         ClockUtil.offset(duration.getMillis());
 
-        assertThat(ClockUtil.now(), sameSecondOfMinute(target));
+        assertTimesAreInSameSecond(ClockUtil.now(), target);
 
         Thread.sleep(10000);
 
-        assertThat(ClockUtil.now(), sameSecondOfMinute(new Date(target.getTime() + Duration.standardSeconds(10).getMillis())));
+        assertTimesAreInSameSecond(ClockUtil.now(), new Date(target.getTime() + Duration.standardSeconds(10).getMillis()));
     }
 
     @Test
@@ -90,9 +105,17 @@ public class ClockUtilTest {
         Date target = new Date(now.getTime() + duration.getMillis());
         ClockUtil.setCurrentTime(target);
 
-
         Thread.sleep(10000);
 
-        assertThat(ClockUtil.now(), sameSecondOfMinute(target));
+        assertTimesAreInSameSecond(ClockUtil.now(), target);
+    }
+
+    private static void assertTimesAreInSameSecond(Date first, Date second) {
+        assertThat(first, sameSecondOfMinute(second));
+        assertThat(first, sameMinuteOfHour(second));
+        assertThat(first, sameHourOfDay(second));
+        assertThat(first, sameDayOfMonth(second));
+        assertThat(first, sameMonthOfYear(second));
+        assertThat(first, sameMonthOfYear(second));
     }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/impl/util/ClockUtilTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/impl/util/ClockUtilTest.java
@@ -33,7 +33,7 @@ public class ClockUtilTest {
     }
 
     @Test
-    public void setCurrentTime_should_travel_in_time() {
+    public void setCurrentTime_should_freeze_time() {
         Instant target = Instant.now().plus(2L, ChronoUnit.DAYS);
 
         ClockUtil.setCurrentTime(Date.from(target));
@@ -77,5 +77,16 @@ public class ClockUtilTest {
         Thread.sleep(10000);
 
         assertThat(ClockUtil.now(), sameSecondOfMinute(Date.from(target.plusMillis(10000))));
+    }
+
+    @Test
+    public void time_should_freeze_with_setCurrentTime() throws InterruptedException {
+        Instant target = Instant.now().plus(2L, ChronoUnit.DAYS);
+
+        ClockUtil.setCurrentTime(Date.from(target));
+
+        Thread.sleep(10000);
+
+        assertThat(ClockUtil.now(), sameSecondOfMinute(Date.from(target)));
     }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/impl/util/ClockUtilTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/impl/util/ClockUtilTest.java
@@ -1,0 +1,81 @@
+package org.camunda.bpm.engine.impl.util;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import static org.exparity.hamcrest.date.DateMatchers.sameSecondOfMinute;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class ClockUtilTest {
+
+    @Test
+    public void now_should_return_current_time() {
+        assertThat(ClockUtil.now(), sameSecondOfMinute(new Date()));
+    }
+
+    @Test
+    public void getCurrentTime_should_return_same_value_as_now() {
+        assertThat(ClockUtil.getCurrentTime(), is(ClockUtil.now()));
+    }
+
+    @Test
+    public void offset_should_travel_in_time() {
+        Instant target = Instant.now().plus(2L, ChronoUnit.DAYS);
+
+        ClockUtil.offset(Duration.between(Instant.now(), target));
+
+        assertThat(ClockUtil.now(), sameSecondOfMinute(Date.from(target)));
+    }
+
+    @Test
+    public void setCurrentTime_should_travel_in_time() {
+        Instant target = Instant.now().plus(2L, ChronoUnit.DAYS);
+
+        ClockUtil.setCurrentTime(Date.from(target));
+
+        assertThat(ClockUtil.now(), sameSecondOfMinute(Date.from(target)));
+    }
+
+    @Test
+    public void resetClock_should_reset_to_current_time() {
+        Instant target = Instant.now().plus(2L, ChronoUnit.DAYS);
+
+        ClockUtil.offset(Duration.between(Instant.now(), target));
+
+        assertThat(ClockUtil.now(), sameSecondOfMinute(Date.from(target)));
+
+        assertThat(ClockUtil.resetClock(), sameSecondOfMinute(new Date()));
+        assertThat(ClockUtil.getCurrentTime(), sameSecondOfMinute(new Date()));
+    }
+
+    @Test
+    public void reset_should_reset_to_current_time() {
+        Instant target = Instant.now().plus(2L, ChronoUnit.DAYS);
+
+        ClockUtil.offset(Duration.between(Instant.now(), target));
+
+        assertThat(ClockUtil.now(), sameSecondOfMinute(Date.from(target)));
+
+        ClockUtil.reset();
+
+        assertThat(ClockUtil.getCurrentTime(), sameSecondOfMinute(new Date()));
+    }
+
+    @Test
+    public void time_should_move_on_after_travel() throws InterruptedException {
+        Instant target = Instant.now().plus(2L, ChronoUnit.DAYS);
+
+        ClockUtil.offset(Duration.between(Instant.now(), target));
+
+        assertThat(ClockUtil.now(), sameSecondOfMinute(Date.from(target)));
+
+        Thread.sleep(10000);
+
+        assertThat(ClockUtil.now(), sameSecondOfMinute(Date.from(target.plusMillis(10000))));
+    }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/impl/util/ClockUtilTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/impl/util/ClockUtilTest.java
@@ -1,10 +1,8 @@
 package org.camunda.bpm.engine.impl.util;
 
+import org.joda.time.Duration;
 import org.junit.Test;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
 import static org.exparity.hamcrest.date.DateMatchers.sameSecondOfMinute;
@@ -25,29 +23,32 @@ public class ClockUtilTest {
 
     @Test
     public void offset_should_travel_in_time() {
-        Instant target = Instant.now().plus(2L, ChronoUnit.DAYS);
+        Duration duration = Duration.standardDays(2);
+        Date target = new Date(new Date().getTime() + duration.getMillis());
 
-        ClockUtil.offset(Duration.between(Instant.now(), target));
+        ClockUtil.offset(duration.getMillis());
 
-        assertThat(ClockUtil.now(), sameSecondOfMinute(Date.from(target)));
+        assertThat(ClockUtil.now(), sameSecondOfMinute(target));
     }
 
     @Test
     public void setCurrentTime_should_freeze_time() {
-        Instant target = Instant.now().plus(2L, ChronoUnit.DAYS);
+        Duration duration = Duration.standardDays(2);
+        Date target = new Date(new Date().getTime() + duration.getMillis());
 
-        ClockUtil.setCurrentTime(Date.from(target));
+        ClockUtil.setCurrentTime(target);
 
-        assertThat(ClockUtil.now(), sameSecondOfMinute(Date.from(target)));
+        assertThat(ClockUtil.now(), sameSecondOfMinute(target));
     }
 
     @Test
     public void resetClock_should_reset_to_current_time() {
-        Instant target = Instant.now().plus(2L, ChronoUnit.DAYS);
+        Duration duration = Duration.standardDays(2);
+        Date target = new Date(new Date().getTime() + duration.getMillis());
 
-        ClockUtil.offset(Duration.between(Instant.now(), target));
+        ClockUtil.offset(duration.getMillis());
 
-        assertThat(ClockUtil.now(), sameSecondOfMinute(Date.from(target)));
+        assertThat(ClockUtil.now(), sameSecondOfMinute(target));
 
         assertThat(ClockUtil.resetClock(), sameSecondOfMinute(new Date()));
         assertThat(ClockUtil.getCurrentTime(), sameSecondOfMinute(new Date()));
@@ -55,11 +56,12 @@ public class ClockUtilTest {
 
     @Test
     public void reset_should_reset_to_current_time() {
-        Instant target = Instant.now().plus(2L, ChronoUnit.DAYS);
+        Duration duration = Duration.standardDays(2);
+        Date target = new Date(new Date().getTime() + duration.getMillis());
 
-        ClockUtil.offset(Duration.between(Instant.now(), target));
+        ClockUtil.offset(duration.getMillis());
 
-        assertThat(ClockUtil.now(), sameSecondOfMinute(Date.from(target)));
+        assertThat(ClockUtil.now(), sameSecondOfMinute(target));
 
         ClockUtil.reset();
 
@@ -68,25 +70,29 @@ public class ClockUtilTest {
 
     @Test
     public void time_should_move_on_after_travel() throws InterruptedException {
-        Instant target = Instant.now().plus(2L, ChronoUnit.DAYS);
+        Date now = new Date();
+        Duration duration = Duration.standardDays(2);
+        Date target = new Date(now.getTime() + duration.getMillis());
 
-        ClockUtil.offset(Duration.between(Instant.now(), target));
+        ClockUtil.offset(duration.getMillis());
 
-        assertThat(ClockUtil.now(), sameSecondOfMinute(Date.from(target)));
+        assertThat(ClockUtil.now(), sameSecondOfMinute(target));
 
         Thread.sleep(10000);
 
-        assertThat(ClockUtil.now(), sameSecondOfMinute(Date.from(target.plusMillis(10000))));
+        assertThat(ClockUtil.now(), sameSecondOfMinute(new Date(target.getTime() + Duration.standardSeconds(10).getMillis())));
     }
 
     @Test
     public void time_should_freeze_with_setCurrentTime() throws InterruptedException {
-        Instant target = Instant.now().plus(2L, ChronoUnit.DAYS);
+        Date now = new Date();
+        Duration duration = Duration.standardDays(2);
+        Date target = new Date(now.getTime() + duration.getMillis());
+        ClockUtil.setCurrentTime(target);
 
-        ClockUtil.setCurrentTime(Date.from(target));
 
         Thread.sleep(10000);
 
-        assertThat(ClockUtil.now(), sameSecondOfMinute(Date.from(target)));
+        assertThat(ClockUtil.now(), sameSecondOfMinute(target));
     }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -222,6 +222,11 @@
         <scope>test</scope>
         <version>1.3</version>
       </dependency>
+      <dependency>
+        <groupId>org.exparity</groupId>
+        <artifactId>hamcrest-date</artifactId>
+        <version>2.0.4</version>
+      </dependency>
 
       <dependency>
         <groupId>org.mule.modules</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -222,11 +222,6 @@
         <scope>test</scope>
         <version>1.3</version>
       </dependency>
-      <dependency>
-        <groupId>org.exparity</groupId>
-        <artifactId>hamcrest-date</artifactId>
-        <version>2.0.4</version>
-      </dependency>
 
       <dependency>
         <groupId>org.mule.modules</groupId>


### PR DESCRIPTION
I folks, 

I made a few changes to ClockUtil. 

Short story: Instead of freezing it to a fixed time with setCurrentTime, it now contains a Clock, which is shifted by an offset. Advantage: After time travelling, the time moves on, which is especially useful when testing jobs (use case: travel to the future, schedule a job and it will magically be executed, because time is not frozen anymore).

The old API still exists and is delegated to the new clock.

Let me know what you think about this pull request, feedback is welcome!