### PR TITLE
feat(engine): Implemented OR queries for ProcessInstanceQuery, HistoricProcessInstanceQuery and HistoricTaskInstanceQuery

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricTaskInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricTaskInstanceQueryDto.java
@@ -25,6 +25,7 @@ import javax.ws.rs.core.Response.Status;
 
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.history.HistoricTaskInstanceQuery;
+import org.camunda.bpm.engine.impl.HistoricTaskInstanceQueryImpl;
 import org.camunda.bpm.engine.rest.dto.AbstractQueryDto;
 import org.camunda.bpm.engine.rest.dto.CamundaQueryParam;
 import org.camunda.bpm.engine.rest.dto.VariableQueryParameterDto;
@@ -150,10 +151,17 @@ public class HistoricTaskInstanceQueryDto extends AbstractQueryDto<HistoricTaskI
   protected List<VariableQueryParameterDto> taskVariables;
   protected List<VariableQueryParameterDto> processVariables;
 
+  private List<HistoricTaskInstanceQueryDto> orQueries;
+
   public HistoricTaskInstanceQueryDto() {}
 
   public HistoricTaskInstanceQueryDto(ObjectMapper objectMapper, MultivaluedMap<String, String> queryParameters) {
     super(objectMapper, queryParameters);
+  }
+
+  @CamundaQueryParam("orQueries")
+  public void setOrQueries(List<HistoricTaskInstanceQueryDto> orQueries) {
+    this.orQueries = orQueries;
   }
 
   @CamundaQueryParam("taskId")
@@ -436,8 +444,20 @@ public class HistoricTaskInstanceQueryDto extends AbstractQueryDto<HistoricTaskI
     return engine.getHistoryService().createHistoricTaskInstanceQuery();
   }
 
+  public List<HistoricTaskInstanceQueryDto> getOrQueries() {
+    return orQueries;
+  }
+
   @Override
   protected void applyFilters(HistoricTaskInstanceQuery query) {
+    if (orQueries != null) {
+      for (HistoricTaskInstanceQueryDto orQueryDto: orQueries) {
+        HistoricTaskInstanceQueryImpl orQuery = new HistoricTaskInstanceQueryImpl();
+        orQuery.setOrQueryActive();
+        orQueryDto.applyFilters(orQuery);
+        ((HistoricTaskInstanceQueryImpl) query).addOrQuery(orQuery);
+      }
+    }
     if (taskId != null) {
       query.taskId(taskId);
     }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/runtime/ProcessInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/runtime/ProcessInstanceQueryDto.java
@@ -26,6 +26,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response.Status;
 
 import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.impl.ProcessInstanceQueryImpl;
 import org.camunda.bpm.engine.rest.dto.AbstractQueryDto;
 import org.camunda.bpm.engine.rest.dto.CamundaQueryParam;
 import org.camunda.bpm.engine.rest.dto.VariableQueryParameterDto;
@@ -80,12 +81,18 @@ public class ProcessInstanceQueryDto extends AbstractQueryDto<ProcessInstanceQue
 
   private List<VariableQueryParameterDto> variables;
 
-  public ProcessInstanceQueryDto() {
+  private List<ProcessInstanceQueryDto> orQueries;
 
+  public ProcessInstanceQueryDto() {
   }
 
   public ProcessInstanceQueryDto(ObjectMapper objectMapper, MultivaluedMap<String, String> queryParameters) {
     super(objectMapper, queryParameters);
+  }
+
+  @CamundaQueryParam("orQueries")
+  public void setOrQueries(List<ProcessInstanceQueryDto> orQueries) {
+    this.orQueries = orQueries;
   }
 
   public Set<String> getProcessInstanceIds() {
@@ -296,9 +303,20 @@ public class ProcessInstanceQueryDto extends AbstractQueryDto<ProcessInstanceQue
     return engine.getRuntimeService().createProcessInstanceQuery();
   }
 
+  public List<ProcessInstanceQueryDto> getOrQueries() {
+    return orQueries;
+  }
+
   @Override
   protected void applyFilters(ProcessInstanceQuery query) {
-
+    if (orQueries != null) {
+      for (ProcessInstanceQueryDto orQueryDto: orQueries) {
+        ProcessInstanceQueryImpl orQuery = new ProcessInstanceQueryImpl();
+        orQuery.setOrQueryActive();
+        orQueryDto.applyFilters(orQuery);
+        ((ProcessInstanceQueryImpl) query).addOrQuery(orQuery);
+      }
+    }
     if (processInstanceIds != null) {
       query.processInstanceIds(processInstanceIds);
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/history/HistoricProcessInstanceQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/history/HistoricProcessInstanceQuery.java
@@ -19,7 +19,9 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.query.Query;
 import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
 
@@ -29,6 +31,7 @@ import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
  * @author Tom Baeyens
  * @author Joram Barrez
  * @author Falko Menge
+ * @author Fabian Bahle
  */
 public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInstanceQuery, HistoricProcessInstance> {
 
@@ -330,4 +333,31 @@ public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInsta
 
   /** Only select historic process instances that are internallyTerminated. */
   HistoricProcessInstanceQuery internallyTerminated();
+
+  /**
+   * <p>After calling or(), a chain of several filter criteria could follow. Each filter criterion that follows or()
+   * will be linked together with an OR expression until the OR query is terminated. To terminate the OR query right
+   * after the last filter criterion was applied, {@link #endOr()} must be invoked.</p>
+   *
+   * @return an object of the type {@link HistoricProcessInstanceQuery} on which an arbitrary amount of filter criteria could be applied.
+   * The several filter criteria will be linked together by an OR expression.
+   *
+   * @throws ProcessEngineException when or() has been invoked directly after or() or after or() and trailing filter
+   * criteria. To prevent throwing this exception, {@link #endOr()} must be invoked after a chain of filter criteria to
+   * mark the end of the OR query.
+   * */
+  HistoricProcessInstanceQuery or() throws ProcessEngineException;
+
+  /**
+   * <p>endOr() terminates an OR query on which an arbitrary amount of filter criteria were applied. To terminate the
+   * OR query which has been started by invoking {@link #or()}, endOr() must be invoked. Filter criteria which are
+   * applied after calling endOr() are linked together by an AND expression.</p>
+   *
+   * @return an object of the type {@link HistoricProcessInstanceQuery} on which an arbitrary amount of filter criteria could be applied.
+   * The filter criteria will be linked together by an AND expression.
+   *
+   * @throws ProcessEngineException when endOr() has been invoked before {@link #or()} was invoked. To prevent throwing
+   * this exception, {@link #or()} must be invoked first.
+   * */
+  HistoricProcessInstanceQuery endOr() throws ProcessEngineException;
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/history/HistoricTaskInstanceQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/history/HistoricTaskInstanceQuery.java
@@ -17,6 +17,7 @@ package org.camunda.bpm.engine.history;
 
 import java.util.Date;
 
+import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.query.Query;
 import org.camunda.bpm.engine.task.Task;
 
@@ -411,5 +412,32 @@ public interface HistoricTaskInstanceQuery  extends Query<HistoricTaskInstanceQu
 
   /** Order by case execution id (needs to be followed by {@link #asc()} or {@link #desc()}). */
   HistoricTaskInstanceQuery orderByCaseExecutionId();
+
+  /**
+   * <p>After calling or(), a chain of several filter criteria could follow. Each filter criterion that follows or()
+   * will be linked together with an OR expression until the OR query is terminated. To terminate the OR query right
+   * after the last filter criterion was applied, {@link #endOr()} must be invoked.</p>
+   *
+   * @return an object of the type {@link HistoricTaskInstanceQuery} on which an arbitrary amount of filter criteria could be applied.
+   * The several filter criteria will be linked together by an OR expression.
+   *
+   * @throws ProcessEngineException when or() has been invoked directly after or() or after or() and trailing filter
+   * criteria. To prevent throwing this exception, {@link #endOr()} must be invoked after a chain of filter criteria to
+   * mark the end of the OR query.
+   * */
+  HistoricTaskInstanceQuery or() throws ProcessEngineException;
+
+  /**
+   * <p>endOr() terminates an OR query on which an arbitrary amount of filter criteria were applied. To terminate the
+   * OR query which has been started by invoking {@link #or()}, endOr() must be invoked. Filter criteria which are
+   * applied after calling endOr() are linked together by an AND expression.</p>
+   *
+   * @return an object of the type {@link HistoricTaskInstanceQuery} on which an arbitrary amount of filter criteria could be applied.
+   * The filter criteria will be linked together by an AND expression.
+   *
+   * @throws ProcessEngineException when endOr() has been invoked before {@link #or()} was invoked. To prevent throwing
+   * this exception, {@link #or()} must be invoked first.
+   * */
+  HistoricTaskInstanceQuery endOr() throws ProcessEngineException;
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -18,6 +18,7 @@ package org.camunda.bpm.engine.impl;
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -79,7 +80,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
   protected Date dueBefore;
   protected Date followUpDate;
   protected Date followUpBefore;
-
+  protected boolean followUpNullAccepted=false;
   protected Date followUpAfter;
   protected String[] tenantIds;
   protected String caseDefinitionId;
@@ -93,6 +94,9 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
   protected Date startedAfter;
   protected Date startedBefore;
 
+  protected List<HistoricTaskInstanceQueryImpl> queries = new ArrayList<HistoricTaskInstanceQueryImpl>(Arrays.asList(this));
+  protected boolean isOrQueryActive = false;
+
   public HistoricTaskInstanceQueryImpl() {
   }
 
@@ -102,8 +106,10 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
 
   @Override
   public long executeCount(CommandContext commandContext) {
+    ensureOrExpressionsEvaluated();
     ensureVariablesInitialized();
     checkQueryOk();
+
     return commandContext
       .getHistoricTaskInstanceManager()
       .findHistoricTaskInstanceCountByQueryCriteria(this);
@@ -111,13 +117,14 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
 
   @Override
   public List<HistoricTaskInstance> executeList(CommandContext commandContext, Page page) {
+    ensureOrExpressionsEvaluated();
     ensureVariablesInitialized();
     checkQueryOk();
+
     return commandContext
       .getHistoricTaskInstanceManager()
       .findHistoricTaskInstancesByQueryCriteria(this, page);
   }
-
 
   public HistoricTaskInstanceQueryImpl processInstanceId(String processInstanceId) {
     this.processInstanceId = processInstanceId;
@@ -172,6 +179,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
     this.taskId = taskId;
     return this;
   }
+
   public HistoricTaskInstanceQueryImpl taskName(String taskName) {
     this.taskName = taskName;
     return this;
@@ -358,11 +366,19 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
   }
 
   public HistoricTaskInstanceQuery withCandidateGroups() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set withCandidateGroups() within 'or' query");
+    }
+
     this.withCandidateGroups = true;
     return this;
   }
 
   public HistoricTaskInstanceQuery withoutCandidateGroups() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set withoutCandidateGroups() within 'or' query");
+    }
+
     this.withoutCandidateGroups = true;
     return this;
   }
@@ -372,10 +388,28 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
     return this;
   }
 
+  protected void ensureOrExpressionsEvaluated() {
+    // skips first query as it has already been evaluated
+    for (int i = 1; i < queries.size(); i++) {
+      queries.get(i).validate();
+      queries.get(i).evaluateExpressions();
+    }
+  }
+
   protected void ensureVariablesInitialized() {
-    VariableSerializers types = Context.getProcessEngineConfiguration().getVariableSerializers();
-    for(QueryVariableValue var : variables) {
-      var.initialize(types);
+    VariableSerializers variableSerializers = Context.getProcessEngineConfiguration().getVariableSerializers();
+    if (!variables.isEmpty()) {
+      for(QueryVariableValue queryVariableValue : variables) {
+        queryVariableValue.initialize(variableSerializers);
+      }
+    }
+
+    if (!queries.isEmpty()) {
+      for (HistoricTaskInstanceQueryImpl orQuery: queries) {
+        for (QueryVariableValue var : orQuery.variables) {
+          var.initialize(variableSerializers);
+        }
+      }
     }
   }
 
@@ -435,7 +469,12 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
 
   public HistoricTaskInstanceQuery taskFollowUpBefore(Date followUpBefore) {
     this.followUpBefore = followUpBefore;
+    this.followUpNullAccepted = false;
     return this;
+  }
+
+  public void setFollowUpNullAccepted(boolean followUpNullAccepted) {
+    this.followUpNullAccepted = followUpNullAccepted;
   }
 
   public HistoricTaskInstanceQuery taskFollowUpAfter(Date followUpAfter) {
@@ -490,106 +529,190 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
   // ordering /////////////////////////////////////////////////////////////////
 
   public HistoricTaskInstanceQueryImpl orderByTaskId() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByTaskId() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.HISTORIC_TASK_INSTANCE_ID);
     return this;
   }
 
   public HistoricTaskInstanceQueryImpl orderByHistoricActivityInstanceId() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByHistoricActivityInstanceId() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.ACTIVITY_INSTANCE_ID);
     return this;
   }
 
   public HistoricTaskInstanceQueryImpl orderByProcessDefinitionId() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByProcessDefinitionId() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.PROCESS_DEFINITION_ID);
     return this;
   }
 
   public HistoricTaskInstanceQueryImpl orderByProcessInstanceId() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByProcessInstanceId() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.PROCESS_INSTANCE_ID);
     return this;
   }
 
   public HistoricTaskInstanceQueryImpl orderByExecutionId() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByExecutionId() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.EXECUTION_ID);
     return this;
   }
 
   public HistoricTaskInstanceQueryImpl orderByHistoricTaskInstanceDuration() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByHistoricTaskInstanceDuration() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.DURATION);
     return this;
   }
 
   public HistoricTaskInstanceQueryImpl orderByHistoricTaskInstanceEndTime() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByHistoricTaskInstanceEndTime() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.END);
     return this;
   }
 
   public HistoricTaskInstanceQueryImpl orderByHistoricActivityInstanceStartTime() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByHistoricActivityInstanceStartTime() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.START);
     return this;
   }
 
   public HistoricTaskInstanceQueryImpl orderByTaskName() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByTaskName() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.TASK_NAME);
     return this;
   }
 
   public HistoricTaskInstanceQueryImpl orderByTaskDescription() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByTaskDescription() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.TASK_DESCRIPTION);
     return this;
   }
 
   public HistoricTaskInstanceQuery orderByTaskAssignee() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByTaskAssignee() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.TASK_ASSIGNEE);
     return this;
   }
 
   public HistoricTaskInstanceQuery orderByTaskOwner() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByTaskOwner() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.TASK_OWNER);
     return this;
   }
 
   public HistoricTaskInstanceQuery orderByTaskDueDate() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByTaskDueDate() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.TASK_DUE_DATE);
     return this;
   }
 
   public HistoricTaskInstanceQuery orderByTaskFollowUpDate() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByTaskFollowUpDate() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.TASK_FOLLOW_UP_DATE);
     return this;
   }
 
   public HistoricTaskInstanceQueryImpl orderByDeleteReason() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByDeleteReason() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.DELETE_REASON);
     return this;
   }
 
   public HistoricTaskInstanceQuery orderByTaskDefinitionKey() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByTaskDefinitionKey() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.TASK_DEFINITION_KEY);
     return this;
   }
 
   public HistoricTaskInstanceQuery orderByTaskPriority() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByTaskPriority() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.TASK_PRIORITY);
     return this;
   }
 
   public HistoricTaskInstanceQuery orderByCaseDefinitionId() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByCaseDefinitionId() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.CASE_DEFINITION_ID);
     return this;
   }
 
   public HistoricTaskInstanceQuery orderByCaseInstanceId() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByCaseInstanceId() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.CASE_INSTANCE_ID);
     return this;
   }
 
   public HistoricTaskInstanceQuery orderByCaseExecutionId() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByCaseExecutionId() within 'or' query");
+    }
+
     orderBy(HistoricTaskInstanceQueryProperty.CASE_EXECUTION_ID);
     return this;
   }
 
   public HistoricTaskInstanceQuery orderByTenantId() {
+    if (isOrQueryActive) {
+      throw new ProcessEngineException("Invalid query usage: cannot set orderByTenantId() within 'or' query");
+    }
+
     return orderBy(HistoricTaskInstanceQueryProperty.TENANT_ID);
   }
 
@@ -609,6 +732,14 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
 
   public String getProcessInstanceBusinessKeyLike() {
     return processInstanceBusinessKeyLike;
+  }
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public String getProcessDefinitionName() {
+    return processDefinitionName;
   }
 
   public String getExecutionId() {
@@ -643,8 +774,44 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
     return finished;
   }
 
+  public boolean isProcessFinished() {
+    return processFinished;
+  }
+
   public boolean isUnfinished() {
     return unfinished;
+  }
+
+  public boolean isProcessUnfinished() {
+    return processUnfinished;
+  }
+
+  public boolean isFollowUpNullAccepted() {
+    return followUpNullAccepted;
+  }
+
+  public Date getDueDate() {
+    return dueDate;
+  }
+
+  public Date getDueBefore() {
+    return dueBefore;
+  }
+
+  public Date getDueAfter() {
+    return dueAfter;
+  }
+
+  public Date getFollowUpDate() {
+    return followUpDate;
+  }
+
+  public Date getFollowUpBefore() {
+    return followUpBefore;
+  }
+
+  public Date getFollowUpAfter() {
+    return followUpAfter;
   }
 
   public String getTaskName() {
@@ -683,6 +850,22 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
     return taskId;
   }
 
+  public String getTaskInvolvedGroup() {
+    return taskInvolvedGroup;
+  }
+
+  public String getTaskInvolvedUser() {
+    return taskInvolvedUser;
+  }
+
+  public String getTaskHadCandidateGroup() {
+    return taskHadCandidateGroup;
+  }
+
+  public String getTaskHadCandidateUser() {
+    return taskHadCandidateUser;
+  }
+
   public String[] getTaskDefinitionKeys() {
     return taskDefinitionKeys;
   }
@@ -699,8 +882,16 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
     return taskOwner;
   }
 
+  public Integer getTaskPriority() {
+    return taskPriority;
+  }
+
   public String getTaskParentTaskId() {
     return taskParentTaskId;
+  }
+
+  public String[] getTenantIds() {
+    return tenantIds;
   }
 
   public String getCaseDefinitionId() {
@@ -737,5 +928,44 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
 
   public Date getStartedBefore() {
     return startedBefore;
+  }
+
+  public List<HistoricTaskInstanceQueryImpl> getQueries() {
+    return queries;
+  }
+
+  public boolean isOrQueryActive() {
+    return isOrQueryActive;
+  }
+
+  public void addOrQuery(HistoricTaskInstanceQueryImpl orQuery) {
+    orQuery.isOrQueryActive = true;
+    this.queries.add(orQuery);
+  }
+
+  public void setOrQueryActive() {
+    isOrQueryActive = true;
+  }
+
+  @Override
+  public HistoricTaskInstanceQuery or() {
+    if (this != queries.get(0)) {
+      throw new ProcessEngineException("Invalid query usage: cannot set or() within 'or' query");
+    }
+
+    HistoricTaskInstanceQueryImpl orQuery = new HistoricTaskInstanceQueryImpl();
+    orQuery.isOrQueryActive = true;
+    orQuery.queries = queries;
+    queries.add(orQuery);
+    return orQuery;
+  }
+
+  @Override
+  public HistoricTaskInstanceQuery endOr() {
+    if (!queries.isEmpty() && this != queries.get(queries.size()-1)) {
+      throw new ProcessEngineException("Invalid query usage: cannot set endOr() before or()");
+    }
+
+    return queries.get(0);
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/runtime/ProcessInstanceQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/runtime/ProcessInstanceQuery.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.Set;
 
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.query.Query;
 
 /**
@@ -27,6 +28,7 @@ import org.camunda.bpm.engine.query.Query;
  * @author Joram Barrez
  * @author Frederik Heremans
  * @author Falko Menge
+ * @author Fabian Bahle
  */
 public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, ProcessInstance> {
 
@@ -242,4 +244,31 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
 
   /** Order by the business key (needs to be followed by {@link #asc()} or {@link #desc()}). */
   ProcessInstanceQuery orderByBusinessKey();
+
+  /**
+   * <p>After calling or(), a chain of several filter criteria could follow. Each filter criterion that follows or()
+   * will be linked together with an OR expression until the OR query is terminated. To terminate the OR query right
+   * after the last filter criterion was applied, {@link #endOr()} must be invoked.</p>
+   *
+   * @return an object of the type {@link ProcessInstanceQuery} on which an arbitrary amount of filter criteria could be applied.
+   * The several filter criteria will be linked together by an OR expression.
+   *
+   * @throws ProcessEngineException when or() has been invoked directly after or() or after or() and trailing filter
+   * criteria. To prevent throwing this exception, {@link #endOr()} must be invoked after a chain of filter criteria to
+   * mark the end of the OR query.
+   * */
+  ProcessInstanceQuery or() throws ProcessEngineException;
+
+  /**
+   * <p>endOr() terminates an OR query on which an arbitrary amount of filter criteria were applied. To terminate the
+   * OR query which has been started by invoking {@link #or()}, endOr() must be invoked. Filter criteria which are
+   * applied after calling endOr() are linked together by an AND expression.</p>
+   *
+   * @return an object of the type {@link ProcessInstanceQuery} on which an arbitrary amount of filter criteria could be applied.
+   * The filter criteria will be linked together by an AND expression.
+   *
+   * @throws ProcessEngineException when endOr() has been invoked before {@link #or()} was invoked. To prevent throwing
+   * this exception, {@link #or()} must be invoked first.
+   * */
+  ProcessInstanceQuery endOr() throws ProcessEngineException;
 }

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Execution.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Execution.xml
@@ -220,10 +220,22 @@
   <sql id="selectProcessInstanceByQueryCriteriaSql">
 
     from ${prefix}ACT_RU_EXECUTION RES
-    <if test="incidentType != null || incidentId != null || incidentMessage != null || incidentMessageLike != null">
+    <bind name="INC_JOIN" value="false" />
+    <bind name="EXE_JOIN" value="false" />
+
+    <foreach collection="queries" item="query">
+      <if test="query != null &amp;&amp; (query.incidentType != null || query.incidentId != null || query.incidentMessage != null || query.incidentMessageLike != null)">
+        <bind name="INC_JOIN" value="true" />
+      </if>
+      <if test="query != null &amp;&amp; (query.activityIds != null &amp;&amp; query.activityIds.length > 0)">
+        <bind name="EXE_JOIN" value="true" />
+      </if>
+    </foreach>
+
+    <if test="INC_JOIN">
       inner join ${prefix}ACT_RU_INCIDENT INC on RES.ID_ = INC.PROC_INST_ID_
     </if>
-    <if test="activityIds != null &amp;&amp; activityIds.length > 0">
+    <if test="EXE_JOIN">
       left join ${prefix}ACT_RU_EXECUTION EXE on RES.ID_ = EXE.PROC_INST_ID_
     </if>
     inner join ${prefix}ACT_RE_PROCDEF P on RES.PROC_DEF_ID_ = P.ID_
@@ -232,116 +244,132 @@
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" /> 
       AUTH ON (AUTH.RESOURCE_ID_ in (RES.ID_, P.KEY_, '*'))
     </if>
-    
+
     <where>
-      RES.PARENT_ID_ is null
-      <if test="processDefinitionId != null">
-        and P.ID_ = #{processDefinitionId}
-      </if>
-      <if test="processDefinitionKey != null">
-        and P.KEY_ = #{processDefinitionKey}
-      </if>
-      <if test="deploymentId != null">
-        and P.DEPLOYMENT_ID_ = #{deploymentId}
-      </if>
-      <if test="processInstanceId != null">
-        and RES.PROC_INST_ID_ = #{processInstanceId}
-      </if>
-      <if test="processInstanceIds != null and !processInstanceIds.isEmpty()">
-        and
-        <bind name="listOfIds" value="processInstanceIds" />
-        <bind name="fieldName" value="'RES.PROC_INST_ID_'" />
-        <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.applyInForPaginatedCollection" />
-      </if>
-      <if test="businessKey != null">
-        and RES.BUSINESS_KEY_ = #{businessKey}
-      </if>
-      <if test="businessKeyLike != null">
-        and RES.BUSINESS_KEY_ like #{businessKeyLike} ESCAPE ${escapeChar}
-      </if>
-      <if test="superProcessInstanceId != null">
-        <!-- A sub process instance is stored under a certain *execution*, potentially nested.
-             A sub process instance is NOT stored under the process instance, hence the following: -->
-        and RES.SUPER_EXEC_ IN (select ID_ from ${prefix}ACT_RU_EXECUTION where PROC_INST_ID_ = #{superProcessInstanceId})
-      </if>
-      <if test="isRootProcessInstances == true">
-        and RES.SUPER_EXEC_ is null
-      </if>
-      <if test="subProcessInstanceId != null">
-        and RES.ID_ = (select PROC_INST_ID_ from ${prefix}ACT_RU_EXECUTION where ID_ = (select SUPER_EXEC_ from ${prefix}ACT_RU_EXECUTION where ID_ = #{subProcessInstanceId}))
-      </if>
-      <if test="suspensionState != null">
-        and RES.SUSPENSION_STATE_ = #{suspensionState.stateCode}
-      </if>
-      <if test="caseInstanceId != null">
-        and RES.CASE_INST_ID_ = #{caseInstanceId}
-      </if>
-      <if test="superCaseInstanceId != null">
-        and RES.SUPER_CASE_EXEC_ IN (select ID_ from ${prefix}ACT_RU_CASE_EXECUTION where CASE_INST_ID_ = #{superCaseInstanceId})
-      </if>
-      <if test="subCaseInstanceId != null">
-        and RES.ID_ = (select PROC_INST_ID_ from ${prefix}ACT_RU_EXECUTION where ID_ = (select SUPER_EXEC_ from ${prefix}ACT_RU_CASE_EXECUTION where ID_ = #{subCaseInstanceId}))
-      </if>
-      <!-- PLEASE NOTE: If you change anything have a look into the HistoricVariableInstance & HistoricProcessInstance, the same query object is used there! -->
-      <foreach collection="queryVariableValues" index="index" item="queryVariableValue">
-        and EXISTS (
-          select
-            ID_
-          from
-            ${prefix}ACT_RU_VARIABLE
-          WHERE
-            NAME_= #{queryVariableValue.name}
-            
+      <foreach collection="queries" item="query" index="i">
         <choose>
-          <when test="queryVariableValue.local">
-            and RES.ID_ = EXECUTION_ID_
+          <when test="i == 0">
+            <bind name="queryType" value="'and'" />
           </when>
           <otherwise>
-            <!-- When process instance or case instance variable is queried for, taskId should be null -->
-            and TASK_ID_ is null and RES.PROC_INST_ID_ = PROC_INST_ID_
+            <bind name="queryType" value="'or'" />
           </otherwise>
         </choose>
-        
-        <bind name="varTypeField" value="'TYPE_'"/>
-        <bind name="varPrefix" value="''"/>
-        <if test="queryVariableValue.valueConditions != null">
-          and 
-          <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.variableValueConditions"/>
-        </if>
-      )
+        and (
+        <trim suffixOverrides="and">
+          RES.PARENT_ID_ is null and
+          <trim prefix="(" prefixOverrides="or|and" suffix=")">
+            <if test="query.processDefinitionId != null">
+              ${queryType} P.ID_ = #{query.processDefinitionId}
+            </if>
+            <if test="query.processDefinitionKey != null">
+              ${queryType} P.KEY_ = #{query.processDefinitionKey}
+            </if>
+            <if test="query.deploymentId != null">
+              ${queryType} P.DEPLOYMENT_ID_ = #{query.deploymentId}
+            </if>
+            <if test="query.processInstanceId != null">
+              ${queryType} RES.PROC_INST_ID_ = #{query.processInstanceId}
+            </if>
+            <if test="query.processInstanceIds != null &amp;&amp; !query.processInstanceIds.isEmpty()">
+              ${queryType}
+              <bind name="listOfIds" value="query.processInstanceIds" />
+              <bind name="fieldName" value="'RES.PROC_INST_ID_'" />
+              <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.applyInForPaginatedCollection" />
+            </if>
+            <if test="query.businessKey != null">
+              ${queryType} RES.BUSINESS_KEY_ = #{query.businessKey}
+            </if>
+            <if test="query.businessKeyLike != null">
+              ${queryType} RES.BUSINESS_KEY_ like #{query.businessKeyLike} ESCAPE ${escapeChar}
+            </if>
+            <if test="query.superProcessInstanceId != null">
+              <!-- A sub process instance is stored under a certain *execution*, potentially nested.
+              A sub process instance is NOT stored under the process instance, hence the following: -->
+              ${queryType} RES.SUPER_EXEC_ IN (select ID_ from ${prefix}ACT_RU_EXECUTION where PROC_INST_ID_ = #{query.superProcessInstanceId})
+            </if>
+            <if test="query.isRootProcessInstances == true">
+              ${queryType} RES.SUPER_EXEC_ is null
+            </if>
+            <if test="query.subProcessInstanceId != null">
+              ${queryType} RES.ID_ = (select PROC_INST_ID_ from ${prefix}ACT_RU_EXECUTION where ID_ = (select SUPER_EXEC_ from ${prefix}ACT_RU_EXECUTION where ID_ = #{query.subProcessInstanceId}))
+            </if>
+            <if test="query.suspensionState != null">
+              ${queryType} RES.SUSPENSION_STATE_ = #{query.suspensionState.stateCode}
+            </if>
+            <if test="query.caseInstanceId != null">
+              ${queryType} RES.CASE_INST_ID_ = #{query.caseInstanceId}
+            </if>
+            <if test="query.superCaseInstanceId != null">
+              ${queryType} RES.SUPER_CASE_EXEC_ IN (select ID_ from ${prefix}ACT_RU_CASE_EXECUTION where CASE_INST_ID_ = #{query.superCaseInstanceId})
+            </if>
+            <if test="query.subCaseInstanceId != null">
+              ${queryType} RES.ID_ = (select PROC_INST_ID_ from ${prefix}ACT_RU_EXECUTION where ID_ = (select SUPER_EXEC_ from ${prefix}ACT_RU_CASE_EXECUTION where ID_ = #{query.subCaseInstanceId}))
+            </if>
+            <!-- PLEASE NOTE: If you change anything have a look into the HistoricVariableInstance & HistoricProcessInstance, the same query object is used there! -->
+            <foreach collection="query.queryVariableValues" index="index" item="queryVariableValue">
+              ${queryType} EXISTS (
+              select
+              ID_
+              from
+              ${prefix}ACT_RU_VARIABLE
+              WHERE
+              NAME_= #{queryVariableValue.name}
+
+              <choose>
+                <when test="queryVariableValue.local">
+                  and RES.ID_ = EXECUTION_ID_
+                </when>
+                <otherwise>
+                  <!-- When process instance or case instance variable is queried for, taskId should be null -->
+                  and TASK_ID_ is null and RES.PROC_INST_ID_ = PROC_INST_ID_
+                </otherwise>
+              </choose>
+
+              <bind name="varTypeField" value="'TYPE_'"/>
+              <bind name="varPrefix" value="''"/>
+              <if test="queryVariableValue.valueConditions != null">
+                and
+                <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.variableValueConditions"/>
+              </if>
+              )
+            </foreach>
+            <if test="query.incidentType != null">
+              ${queryType} INC.INCIDENT_TYPE_ = #{query.incidentType}
+            </if>
+            <if test="query.incidentId != null">
+              ${queryType} INC.ID_ = #{query.incidentId}
+            </if>
+            <if test="query.incidentMessage != null">
+              ${queryType} INC.INCIDENT_MSG_ = #{query.incidentMessage}
+            </if>
+            <if test="query.incidentMessageLike != null">
+              ${queryType} INC.INCIDENT_MSG_ like #{query.incidentMessageLike} ESCAPE ${escapeChar}
+            </if>
+            <if test="query.isTenantIdSet">
+              <if test="query.tenantIds != null &amp;&amp; query.tenantIds.length > 0">
+                ${queryType} RES.TENANT_ID_ in
+                <foreach item="tenantId" index="index" collection="query.tenantIds"
+                                 open="(" separator="," close=")">
+                  #{tenantId}
+                </foreach>
+              </if>
+              <if test="query.tenantIds == null">
+                ${queryType} RES.TENANT_ID_ is null
+              </if>
+            </if>
+            <if test="query.activityIds != null &amp;&amp; query.activityIds.length > 0">
+              ${queryType} (EXE.IS_EVENT_SCOPE_ = ${falseConstant} and EXE.ACT_ID_ in
+              <foreach item="activityId" index="index" collection="query.activityIds"
+                             open="(" separator="," close=")">
+                #{activityId}
+              </foreach>
+              )
+            </if>
+          </trim>
+        </trim>
+        )
       </foreach>
-      <if test="incidentType != null">
-        and INC.INCIDENT_TYPE_ = #{incidentType}
-      </if>
-      <if test="incidentId != null">
-        and INC.ID_ = #{incidentId}
-      </if>
-      <if test="incidentMessage != null">
-        and INC.INCIDENT_MSG_ = #{incidentMessage}
-      </if>
-      <if test="incidentMessageLike != null">
-        and INC.INCIDENT_MSG_ like #{incidentMessageLike} ESCAPE ${escapeChar}
-      </if>
-      <if test="isTenantIdSet">
-        <if test="tenantIds != null &amp;&amp; tenantIds.length > 0">
-          and RES.TENANT_ID_ in
-          <foreach item="tenantId" index="index" collection="tenantIds"
-                   open="(" separator="," close=")">
-            #{tenantId}
-          </foreach>
-        </if>
-        <if test="tenantIds == null">
-          and RES.TENANT_ID_ is null
-        </if>
-      </if>
-      <if test="activityIds != null &amp;&amp; activityIds.length > 0">
-        and EXE.IS_EVENT_SCOPE_ = ${falseConstant}
-        and EXE.ACT_ID_ in
-        <foreach item="activityId" index="index" collection="activityIds"
-                 open="(" separator="," close=")">
-          #{activityId}
-        </foreach>
-      </if>
 
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.queryAuthorizationCheck" />
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.TenantEntity.queryTenantCheck" />

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
@@ -248,234 +248,258 @@
     LEFT JOIN ${prefix}ACT_RE_PROCDEF DEF
     ON SELF.PROC_DEF_ID_ = DEF.ID_
 
-
     <if test="authCheck.isAuthorizationCheckEnabled &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause"/>
         AUTH ON (AUTH.RESOURCE_ID_ in (SELF.PROC_DEF_KEY_, '*'))
     </if>
 
+    <bind name="INC_JOIN" value="false" />
+    <bind name="HAI_JOIN" value="false" />
 
-    <if test="withIncidents || withRootIncidents || incidentStatus != null || incidentMessage != null || incidentMessageLike != null || incidentType != null">
-        inner join ${prefix}ACT_HI_INCIDENT INC on SELF.PROC_INST_ID_ = INC.PROC_INST_ID_
+    <foreach collection="queries" item="query">
+      <if test="query != null &amp;&amp; (query.withIncidents || query.withRootIncidents || query.incidentStatus != null || query.incidentMessage != null || query.incidentMessageLike != null || query.incidentType != null)">
+        <bind name="INC_JOIN" value="true" />
+      </if>
+      <if test="query != null &amp;&amp; (query.executedActivityIds != null &amp;&amp; query.executedActivityIds.length > 0) || (query.activeActivityIds != null &amp;&amp; query.activeActivityIds.length > 0)">
+        <bind name="HAI_JOIN" value="true" />
+      </if>
+    </foreach>
+
+    <if test="INC_JOIN">
+      inner join ${prefix}ACT_HI_INCIDENT INC on SELF.PROC_INST_ID_ = INC.PROC_INST_ID_
     </if>
-
-    <if test="(executedActivityIds != null and executedActivityIds.length > 0) || (activeActivityIds != null and activeActivityIds.length > 0)">
-      LEFT JOIN ${prefix}ACT_HI_ACTINST HAI
-      ON HAI.PROC_INST_ID_ = SELF.ID_
+    <if test="HAI_JOIN">
+      LEFT JOIN ${prefix}ACT_HI_ACTINST HAI ON HAI.PROC_INST_ID_ = SELF.ID_
     </if>
 
     <where>
-      <if test="processInstanceId != null">
-        SELF.PROC_INST_ID_ = #{processInstanceId}
-      </if>
-      <if test="processInstanceIds != null and !processInstanceIds.isEmpty()">
-        and SELF.PROC_INST_ID_ in
-        <foreach item="item" index="index" collection="processInstanceIds" open="(" separator="," close=")">
-            #{item, jdbcType=VARCHAR}
-        </foreach>
-      </if>
-      <if test="caseInstanceId != null">
-        and SELF.CASE_INST_ID_ = #{caseInstanceId}
-      </if>
-      <if test="processDefinitionId != null">
-        and SELF.PROC_DEF_ID_ = #{processDefinitionId}
-      </if>
-      <if test="processDefinitionKey != null">
-        and DEF.KEY_ = #{processDefinitionKey}
-      </if>
-      <if test="processDefinitionName != null">
-        and DEF.NAME_ = #{processDefinitionName}
-      </if>
-      <if test="processDefinitionNameLike != null">
-        and DEF.NAME_ like #{processDefinitionNameLike} ESCAPE ${escapeChar}
-      </if>
-      <if test="businessKey != null">
-        and SELF.BUSINESS_KEY_ = #{businessKey}
-      </if>
-      <if test="businessKeyLike != null">
-        and SELF.BUSINESS_KEY_ like #{businessKeyLike} ESCAPE ${escapeChar}
-      </if>
+      <foreach collection="queries" item="query" index="i">
+        <choose>
+          <when test="i == 0">
+            <bind name="queryType" value="'and'" />
+          </when>
+          <otherwise>
+            <bind name="queryType" value="'or'" />
+          </otherwise>
+        </choose>
+        and (
+        <trim suffixOverrides="and">
+          1 = 1 and
+          <trim prefixOverrides="or|and">
+            <if test="query.processInstanceId != null">
+              ${queryType} SELF.PROC_INST_ID_ = #{query.processInstanceId}
+            </if>
+            <if test="query.processInstanceIds != null &amp;&amp; !query.processInstanceIds.isEmpty()">
+              ${queryType} SELF.PROC_INST_ID_ in
+              <foreach item="item" index="index" collection="query.processInstanceIds" open="(" separator="," close=")">
+                  #{item, jdbcType=VARCHAR}
+              </foreach>
+            </if>
+            <if test="query.caseInstanceId != null">
+              ${queryType} SELF.CASE_INST_ID_ = #{query.caseInstanceId}
+            </if>
+            <if test="query.processDefinitionId != null">
+              ${queryType} SELF.PROC_DEF_ID_ = #{query.processDefinitionId}
+            </if>
+            <if test="query.processDefinitionKey != null">
+              ${queryType} DEF.KEY_ = #{query.processDefinitionKey}
+            </if>
+            <if test="query.processDefinitionName != null">
+              ${queryType} DEF.NAME_ = #{query.processDefinitionName}
+            </if>
+            <if test="query.processDefinitionNameLike != null">
+              ${queryType} DEF.NAME_ like #{query.processDefinitionNameLike} ESCAPE ${escapeChar}
+            </if>
+            <if test="query.businessKey != null">
+              ${queryType} SELF.BUSINESS_KEY_ = #{query.businessKey}
+            </if>
+            <if test="query.businessKeyLike != null">
+              ${queryType} SELF.BUSINESS_KEY_ like #{query.businessKeyLike} ESCAPE ${escapeChar}
+            </if>
 
-      <if test="startedBefore != null">
-        and SELF.START_TIME_ &lt;= #{startedBefore}
-      </if>
-      <if test="startedAfter != null">
-        and SELF.START_TIME_ &gt;= #{startedAfter}
-      </if>
-      <if test="finishedBefore != null">
-        and SELF.END_TIME_ &lt;= #{finishedBefore}
-      </if>
-      <if test="finishedAfter != null">
-        and SELF.END_TIME_ &gt;= #{finishedAfter}
-      </if>
-      <if test="processKeyNotIn != null">
-        <foreach collection="processKeyNotIn" index="index" item="procDefKey">
-          and DEF.KEY_ not like #{procDefKey} ESCAPE ${escapeChar}
-        </foreach>
-      </if>
-      <if test="state != null">
-        and STATE_ = #{state}
-      </if>
-      
+            <if test="query.startedBefore != null">
+              ${queryType} SELF.START_TIME_ &lt;= #{query.startedBefore}
+            </if>
+            <if test="query.startedAfter != null">
+              ${queryType} SELF.START_TIME_ &gt;= #{query.startedAfter}
+            </if>
+            <if test="query.finishedBefore != null">
+              ${queryType} SELF.END_TIME_ &lt;= #{query.finishedBefore}
+            </if>
+            <if test="query.finishedAfter != null">
+              ${queryType} SELF.END_TIME_ &gt;= #{query.finishedAfter}
+            </if>
+            <if test="query.processKeyNotIn != null">
+              ${queryType}
+              <foreach collection="query.processKeyNotIn" index="index" item="procDefKey"
+                       open="(" separator=" and " close=")">
+                DEF.KEY_ not like #{procDefKey} ESCAPE ${escapeChar}
+              </foreach>
+            </if>
+            <if test="query.state != null">
+              ${queryType} STATE_ = #{query.state}
+            </if>
 
-      <!-- DEPRECATED : TO BE REMOVED IN 5.11 -->
-      <if test="startDateOn">
-        and SELF.START_TIME_ &gt;= #{startDateOnBegin}
-        and SELF.START_TIME_ &lt;= #{startDateOnEnd}
-      </if>
-      <!-- DEPRECATED : TO BE REMOVED IN 5.11 -->
-      <if test="finishDateOn">
-        and SELF.END_TIME_ &gt;= #{finishDateOnBegin}
-        and SELF.END_TIME_ &lt;= #{finishDateOnEnd}
-      </if>
-      <!-- DEPRECATED : TO BE REMOVED IN 5.11 -->
-      <if test="finishDateBy">
-        and SELF.END_TIME_ &lt;= #{finishDateBy}
-      </if>
-      <!-- DEPRECATED : TO BE REMOVED IN 5.11 -->
-      <if test="startDateBy">
-        and SELF.START_TIME_ &gt;= #{startDateBy}
-      </if>
 
-      <if test="unfinished">
-        and SELF.END_TIME_ IS NULL
-      </if>
-      <if test="finished">
-        and SELF.END_TIME_ is not NULL
-      </if>
+            <!-- DEPRECATED : TO BE REMOVED IN 5.11 -->
+            <if test="query.startDateOn">
+              ${queryType} (SELF.START_TIME_ &gt;= #{query.startDateOnBegin} and SELF.START_TIME_ &lt;= #{query.startDateOnEnd})
+            </if>
+            <!-- DEPRECATED : TO BE REMOVED IN 5.11 -->
+            <if test="query.finishDateOn">
+              ${queryType} (SELF.END_TIME_ &gt;= #{query.finishDateOnBegin} and SELF.END_TIME_ &lt;= #{query.finishDateOnEnd})
+            </if>
+            <!-- DEPRECATED : TO BE REMOVED IN 5.11 -->
+            <if test="query.finishDateBy">
+              ${queryType} SELF.END_TIME_ &lt;= #{query.finishDateBy}
+            </if>
+            <!-- DEPRECATED : TO BE REMOVED IN 5.11 -->
+            <if test="query.startDateBy">
+              ${queryType} SELF.START_TIME_ &gt;= #{query.startDateBy}
+            </if>
 
-      <if test="incidentType != null">
-        and INC.INCIDENT_TYPE_ = #{incidentType}
-      </if>
-      <if test="incidentMessage != null">
-        and INC.INCIDENT_MSG_ = #{incidentMessage}
-      </if>
+            <if test="query.unfinished">
+              ${queryType} SELF.END_TIME_ IS NULL
+            </if>
+            <if test="query.finished">
+              ${queryType} SELF.END_TIME_ is not NULL
+            </if>
 
-      <if test="incidentMessageLike != null">
-        and INC.INCIDENT_MSG_ like #{incidentMessageLike} ESCAPE ${escapeChar}
-      </if>
+            <if test="query.incidentType != null">
+              ${queryType} INC.INCIDENT_TYPE_ = #{query.incidentType}
+            </if>
+            <if test="query.incidentMessage != null">
+              ${queryType} INC.INCIDENT_MSG_ = #{query.incidentMessage}
+            </if>
 
-      <if test="incidentStatus == 'open'">
-        and INC.END_TIME_ is null
-      </if>
+            <if test="query.incidentMessageLike != null">
+              ${queryType} INC.INCIDENT_MSG_ like #{query.incidentMessageLike} ESCAPE ${escapeChar}
+            </if>
 
-      <if test="incidentStatus == 'resolved'">
-        and INC.END_TIME_ is not null
-      </if>
+            <if test="query.incidentStatus == 'open'">
+              ${queryType} INC.END_TIME_ is null
+            </if>
 
-	  <if test="withRootIncidents">
-        and INC.ID_ = INC.ROOT_CAUSE_INCIDENT_ID_
-	  </if>
-      <if test="startedBy != null">
-        and SELF.START_USER_ID_ = #{startedBy}
-      </if>
+            <if test="query.incidentStatus == 'resolved'">
+              ${queryType} INC.END_TIME_ is not null
+            </if>
 
-      <if test="isRootProcessInstances">
-        and SELF.SUPER_PROCESS_INSTANCE_ID_ is null
-      </if>
-      <if test="superProcessInstanceId != null">
-        and SELF.SUPER_PROCESS_INSTANCE_ID_ = #{superProcessInstanceId}
-      </if>
-      <if test="subProcessInstanceId != null">
-        and SELF.PROC_INST_ID_ = (select SUPER_PROCESS_INSTANCE_ID_ from ${prefix}ACT_HI_PROCINST where
-        PROC_INST_ID_ = #{subProcessInstanceId})
-      </if>
-      <if test="superCaseInstanceId != null">
-        and SELF.SUPER_CASE_INSTANCE_ID_ = #{superCaseInstanceId}
-      </if>
-      <if test="subCaseInstanceId != null">
-        and SELF.PROC_INST_ID_ = (select SUPER_PROCESS_INSTANCE_ID_ from ${prefix}ACT_HI_CASEINST where
-        CASE_INST_ID_ = #{subCaseInstanceId})
-      </if>
-      <foreach collection="queryVariableValues" index="index" item="queryVariableValue">
-        and EXISTS (
-        select
-        ID_
-        from
-        ${prefix}ACT_HI_VARINST
-        WHERE
-        NAME_= #{queryVariableValue.name}
-        AND PROC_INST_ID_ = SELF.PROC_INST_ID_
+            <if test="query.withRootIncidents">
+              ${queryType} INC.ID_ = INC.ROOT_CAUSE_INCIDENT_ID_
+            </if>
+            <if test="query.startedBy != null">
+              ${queryType} SELF.START_USER_ID_ = #{query.startedBy}
+            </if>
 
-        <bind name="varTypeField" value="'VAR_TYPE_'"/>
-        <bind name="varPrefix" value="''"/>
-        <if test="queryVariableValue.valueConditions != null">
-          and <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.variableValueConditions"/>
-        </if>
+            <if test="query.isRootProcessInstances">
+              ${queryType} SELF.SUPER_PROCESS_INSTANCE_ID_ is null
+            </if>
+            <if test="query.superProcessInstanceId != null">
+              ${queryType} SELF.SUPER_PROCESS_INSTANCE_ID_ = #{query.superProcessInstanceId}
+            </if>
+            <if test="query.subProcessInstanceId != null">
+              ${queryType} SELF.PROC_INST_ID_ = (select SUPER_PROCESS_INSTANCE_ID_ from ${prefix}ACT_HI_PROCINST where
+              PROC_INST_ID_ = #{query.subProcessInstanceId})
+            </if>
+            <if test="query.superCaseInstanceId != null">
+              ${queryType} SELF.SUPER_CASE_INSTANCE_ID_ = #{query.superCaseInstanceId}
+            </if>
+            <if test="query.subCaseInstanceId != null">
+              ${queryType} SELF.PROC_INST_ID_ = (select SUPER_PROCESS_INSTANCE_ID_ from ${prefix}ACT_HI_CASEINST where
+              CASE_INST_ID_ = #{query.subCaseInstanceId})
+            </if>
+            <foreach collection="query.queryVariableValues" index="index" item="queryVariableValue">
+              ${queryType} EXISTS (
+              select
+              ID_
+              from
+              ${prefix}ACT_HI_VARINST
+              WHERE
+              NAME_= #{queryVariableValue.name}
+              AND PROC_INST_ID_ = SELF.PROC_INST_ID_
+
+              <bind name="varTypeField" value="'VAR_TYPE_'"/>
+              <bind name="varPrefix" value="''"/>
+              <if test="queryVariableValue.valueConditions != null">
+                and <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.variableValueConditions"/>
+              </if>
+              )
+            </foreach>
+
+            <if test="query.executedActivityAfter != null || query.executedActivityBefore != null">
+              ${queryType} EXISTS (
+                SELECT *
+                FROM ${prefix}ACT_HI_ACTINST
+                <where>
+                  PROC_INST_ID_ = SELF.ID_
+                  <if test="query.executedActivityAfter != null">
+                    AND (START_TIME_ &gt;= #{query.executedActivityAfter} OR END_TIME_ &gt;= #{query.executedActivityAfter})
+                  </if>
+                  <if test="query.executedActivityBefore != null">
+                    AND (START_TIME_ &lt;= #{query.executedActivityBefore} OR END_TIME_ &lt;= #{query.executedActivityBefore})
+                  </if>
+                </where>
+                )
+            </if>
+
+            <if test="query.executedActivityIds != null &amp;&amp; query.executedActivityIds.length > 0">
+              ${queryType} (HAI.END_TIME_ IS NOT NULL AND HAI.ACT_ID_ IN
+              <foreach item="activityId" index="index" collection="query.executedActivityIds" open="(" separator="," close=")">
+                #{activityId}
+              </foreach>
+              )
+            </if>
+
+            <if test="query.activeActivityIds != null &amp;&amp; query.activeActivityIds.length > 0">
+              ${queryType} (HAI.END_TIME_ IS NULL AND HAI.ACT_ID_ IN
+              <foreach item="activityId" index="index" collection="query.activeActivityIds" open="(" separator="," close=")">
+                #{activityId}
+              </foreach>
+              )
+            </if>
+
+            <if test="query.executedJobAfter != null || query.executedJobBefore != null">
+              ${queryType} EXISTS (
+              SELECT *
+              FROM ${prefix}ACT_HI_JOB_LOG
+              <where>
+                PROCESS_INSTANCE_ID_ = SELF.ID_
+                <if test="query.executedJobAfter != null">
+                  AND TIMESTAMP_ &gt;= #{query.executedJobAfter}
+                </if>
+                <if test="query.executedJobBefore != null">
+                  AND TIMESTAMP_ &lt;= #{query.executedJobBefore}
+                </if>
+              </where>
+              )
+            </if>
+
+            <if test="query.isTenantIdSet">
+              <if test="query.tenantIds != null &amp;&amp; query.tenantIds.length > 0">
+                ${queryType} SELF.TENANT_ID_ in
+                <foreach item="tenantId" index="index" collection="query.tenantIds"
+                         open="(" separator="," close=")">
+                  #{tenantId}
+                </foreach>
+              </if>
+              <if test="query.tenantIds == null">
+                ${queryType} SELF.TENANT_ID_ is null
+              </if>
+            </if>
+
+            <if test="query.authCheck.isAuthorizationCheckEnabled &amp;&amp; query.authCheck.authUserId != null">
+              ${queryType} (
+              (SELF.PROC_DEF_KEY_ is not null
+              <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.queryAuthorizationCheck"/>
+              ) or SELF.PROC_DEF_KEY_ is null
+              )
+            </if>
+
+            <include refid="org.camunda.bpm.engine.impl.persistence.entity.TenantEntity.queryTenantCheckWithSelfPrefix"/>
+          </trim>
+        </trim>
         )
       </foreach>
-
-      <if test="executedActivityAfter != null || executedActivityBefore != null">
-        AND EXISTS (
-          SELECT *
-          FROM ${prefix}ACT_HI_ACTINST
-          <where>
-            PROC_INST_ID_ = SELF.ID_
-            <if test="executedActivityAfter != null">
-              AND (START_TIME_ &gt;= #{executedActivityAfter} OR END_TIME_ &gt;= #{executedActivityAfter})
-            </if>
-            <if test="executedActivityBefore != null">
-              AND (START_TIME_ &lt;= #{executedActivityBefore} OR END_TIME_ &lt;= #{executedActivityBefore})
-            </if>
-          </where>
-          )
-      </if>
-
-      <if test="executedActivityIds != null and executedActivityIds.length > 0">
-        AND HAI.END_TIME_ IS NOT NULL
-        AND HAI.ACT_ID_ IN
-        <foreach item="activityId" index="index" collection="executedActivityIds" open="(" separator="," close=")">
-          #{activityId}
-        </foreach>
-      </if>
-
-      <if test="activeActivityIds != null and activeActivityIds.length > 0">
-        AND HAI.END_TIME_ IS NULL
-        AND HAI.ACT_ID_ IN
-        <foreach item="activityId" index="index" collection="activeActivityIds" open="(" separator="," close=")">
-          #{activityId}
-        </foreach>
-      </if>
-
-      <if test="executedJobAfter != null || executedJobBefore != null">
-        AND EXISTS (
-        SELECT *
-        FROM ${prefix}ACT_HI_JOB_LOG
-        <where>
-          PROCESS_INSTANCE_ID_ = SELF.ID_
-          <if test="executedJobAfter != null">
-            AND TIMESTAMP_ &gt;= #{executedJobAfter}
-          </if>
-          <if test="executedJobBefore != null">
-            AND TIMESTAMP_ &lt;= #{executedJobBefore}
-          </if>
-        </where>
-        )
-      </if>
-
-      <if test="isTenantIdSet">
-        <if test="tenantIds != null &amp;&amp; tenantIds.length > 0">
-          and SELF.TENANT_ID_ in
-          <foreach item="tenantId" index="index" collection="tenantIds"
-                   open="(" separator="," close=")">
-            #{tenantId}
-          </foreach>
-        </if>
-        <if test="tenantIds == null">
-          and SELF.TENANT_ID_ is null
-        </if>
-      </if>
-
-      <if test="authCheck.isAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
-        and (
-        (SELF.PROC_DEF_KEY_ is not null
-        <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.queryAuthorizationCheck"/>
-        ) or SELF.PROC_DEF_KEY_ is null
-        )
-      </if>
-
-      <include refid="org.camunda.bpm.engine.impl.persistence.entity.TenantEntity.queryTenantCheckWithSelfPrefix"/>
-
     </where>
 
     ) RES

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
@@ -254,245 +254,290 @@
       AUTH ON (AUTH.RESOURCE_ID_ in (RES.PROC_DEF_KEY_, '*'))
     </if>
 
-    <if test="processFinished || processUnfinished || processInstanceBusinessKey != null || processInstanceBusinessKeyLike != null ||
-              (processInstanceBusinessKeys != null &amp;&amp; processInstanceBusinessKeys.length > 0)">
+    <bind name="HPI_JOIN" value="false" />
+    <bind name="D_JOIN" value="false" />
+    <bind name="CD_JOIN" value="false" />
+
+    <foreach collection="queries" item="query">
+      <if test="query != null &amp;&amp; (query.processFinished || query.processUnfinished || query.processInstanceBusinessKey != null || query.processInstanceBusinessKeyLike != null ||
+              (query.processInstanceBusinessKeys != null &amp;&amp; query.processInstanceBusinessKeys.length > 0))">
+        <bind name="HPI_JOIN" value="true" />
+      </if>
+      <if test="query != null &amp;&amp; (query.processDefinitionKey != null || query.processDefinitionName != null)">
+        <bind name="D_JOIN" value="true" />
+      </if>
+      <if test="query != null &amp;&amp; (query.caseDefinitionKey != null || query.caseDefinitionName != null)">
+        <bind name="CD_JOIN" value="true" />
+      </if>
+    </foreach>
+
+    <if test="HPI_JOIN">
       inner join ${prefix}ACT_HI_PROCINST HPI ON RES.PROC_INST_ID_ = HPI.ID_
     </if>
-    <if test="processDefinitionKey != null || processDefinitionName != null">
+    <if test="D_JOIN">
       inner join ${prefix}ACT_RE_PROCDEF D on RES.PROC_DEF_ID_ = D.ID_
     </if>
-    <if test="caseDefinitionKey != null || caseDefinitionName != null">
+    <if test="CD_JOIN">
       inner join ${prefix}ACT_RE_CASE_DEF CD on RES.CASE_DEF_ID_ = CD.ID_
     </if>
+
     <where>
+      <foreach collection="queries" item="query" index="i">
+        <choose>
+          <when test="i == 0">
+            <bind name="queryType" value="'and'" />
+          </when>
+          <otherwise>
+            <bind name="queryType" value="'or'" />
+          </otherwise>
+        </choose>
+        and (
+        <trim suffixOverrides="and">
+          1 = 1 and
+          <trim prefixOverrides="or|and">
+            <if test="query.taskInvolvedUser != null || query.taskInvolvedGroup != null || query.taskHadCandidateUser != null || query.taskHadCandidateGroup != null || query.withCandidateGroups">
+                ${queryType} RES.ID_ in (select TASK_ID_ from ${prefix}ACT_HI_IDENTITYLINK HIL
+                <where>
+                  <if test= "query.taskInvolvedUser != null">
+                    HIL.USER_ID_ = #{query.taskInvolvedUser}
+                  </if>
+                  <if test ="query.taskInvolvedGroup != null">
+                   and HIL.GROUP_ID_ = #{query.taskInvolvedGroup}
+                  </if>
+                  <if test="query.taskHadCandidateUser != null">
+                   and HIL.TYPE_ = 'candidate' and HIL.USER_ID_ = #{query.taskHadCandidateUser}
+                  </if>
+                  <if test="query.taskHadCandidateGroup != null">
+                    and HIL.TYPE_ = 'candidate' and HIL.GROUP_ID_ = #{query.taskHadCandidateGroup}
+                  </if>
+                  <if test="query.withCandidateGroups">
+                    and HIL.TYPE_ = 'candidate' and HIL.GROUP_ID_ is not null
+                  </if>
+               </where>
+               )
+            </if>
 
-      <if test="taskInvolvedUser != null || taskInvolvedGroup != null || taskHadCandidateUser != null || taskHadCandidateGroup != null || withCandidateGroups">
-          RES.ID_ in (select TASK_ID_ from ${prefix}ACT_HI_IDENTITYLINK HIL
-          <where>
-            <if test= "taskInvolvedUser != null">
-              HIL.USER_ID_ = #{taskInvolvedUser}
+            <if test="query.withoutCandidateGroups">
+              ${queryType} RES.ID_ not in (
+                select
+                  TASK_ID_
+                from
+                  ${prefix}ACT_HI_IDENTITYLINK HIL
+                <where>
+                  HIL.TYPE_ = 'candidate' and HIL.GROUP_ID_ is not null
+                </where>
+              )
             </if>
-            <if test ="taskInvolvedGroup != null">
-             and HIL.GROUP_ID_ = #{taskInvolvedGroup}
-            </if>
-            <if test="taskHadCandidateUser != null">
-             and HIL.TYPE_ = 'candidate' and HIL.USER_ID_ = #{taskHadCandidateUser}
-            </if>
-            <if test="taskHadCandidateGroup != null">
-              and HIL.TYPE_ = 'candidate' and HIL.GROUP_ID_ = #{taskHadCandidateGroup}
-            </if>
-            <if test="withCandidateGroups">
-              and HIL.TYPE_ = 'candidate' and HIL.GROUP_ID_ is not null
-            </if>
-         </where>
-         )
-      </if>
 
-      <if test="withoutCandidateGroups">
-        RES.ID_ not in (
-          select
-            TASK_ID_
-          from
-            ${prefix}ACT_HI_IDENTITYLINK HIL
-          <where>
-            HIL.TYPE_ = 'candidate' and HIL.GROUP_ID_ is not null
-          </where>
-        )
-      </if>
+            <if test="query.taskId != null">
+              ${queryType} RES.ID_ = #{query.taskId}
+            </if>
+            <if test="query.processDefinitionId != null">
+              ${queryType} RES.PROC_DEF_ID_ = #{query.processDefinitionId}
+            </if>
+            <if test="query.processDefinitionKey != null">
+              ${queryType} D.KEY_ = #{query.processDefinitionKey}
+            </if>
+            <if test="query.processDefinitionName != null">
+              ${queryType} D.NAME_ = #{query.processDefinitionName}
+            </if>
+            <if test="query.processInstanceId != null">
+              ${queryType} RES.PROC_INST_ID_ = #{query.processInstanceId}
+            </if>
+            <if test="query.processInstanceBusinessKey != null">
+              ${queryType} HPI.BUSINESS_KEY_ = #{query.processInstanceBusinessKey}
+            </if>
+            <if test="query.processInstanceBusinessKeys != null &amp;&amp; query.processInstanceBusinessKeys.length > 0">
+              ${queryType} HPI.BUSINESS_KEY_ in
+              <foreach item="item" index="index" collection="query.processInstanceBusinessKeys"
+                       open="(" separator="," close=")">
+                #{item}
+              </foreach>
+            </if>
+            <if test="query.processInstanceBusinessKeyLike != null">
+              ${queryType} HPI.BUSINESS_KEY_ like #{query.processInstanceBusinessKeyLike} ESCAPE ${escapeChar}
+            </if>
+            <if test="query.taskDefinitionKeys != null &amp;&amp; query.taskDefinitionKeys.length > 0">
+              ${queryType} RES.TASK_DEF_KEY_ in
+              <foreach item="taskDefinitionKey" index="index" collection="query.taskDefinitionKeys"
+                       open="(" separator="," close=")">
+                #{taskDefinitionKey}
+              </foreach>
+            </if>
+            <if test="query.executionId != null">
+              ${queryType} RES.EXECUTION_ID_ = #{query.executionId}
+            </if>
+            <if test="query.activityInstanceIds != null &amp;&amp; query.activityInstanceIds.length > 0">
+              ${queryType} RES.ACT_INST_ID_ in
+              <foreach item="item" index="index" collection="query.activityInstanceIds"
+                       open="(" separator="," close=")">
+                #{item}
+              </foreach>
+            </if>
+            <if test="query.caseDefinitionId != null">
+              ${queryType} RES.CASE_DEF_ID_ = #{query.caseDefinitionId}
+            </if>
+            <if test="query.caseDefinitionKey != null">
+              ${queryType} CD.KEY_ = #{query.caseDefinitionKey}
+            </if>
+            <if test="query.caseDefinitionName != null">
+              ${queryType} CD.NAME_ = #{query.caseDefinitionName}
+            </if>
+            <if test="query.caseInstanceId != null">
+              ${queryType} RES.CASE_INST_ID_ = #{query.caseInstanceId}
+            </if>
+            <if test="query.caseExecutionId != null">
+              ${queryType} RES.CASE_EXECUTION_ID_ = #{query.caseExecutionId}
+            </if>
+            <if test="query.taskName != null">
+              ${queryType} RES.NAME_ = #{query.taskName}
+            </if>
+            <if test="query.taskNameLike != null">
+              ${queryType} RES.NAME_ like #{query.taskNameLike} ESCAPE ${escapeChar}
+            </if>
+            <if test="query.taskParentTaskId != null">
+              ${queryType} RES.PARENT_TASK_ID_ = #{query.taskParentTaskId}
+            </if>
+            <if test="query.taskDescription != null">
+              ${queryType} RES.DESCRIPTION_ = #{query.taskDescription}
+            </if>
+            <if test="query.taskDescriptionLike != null">
+              ${queryType} RES.DESCRIPTION_ like #{query.taskDescriptionLike} ESCAPE ${escapeChar}
+            </if>
+            <if test="query.taskDeleteReason != null">
+              ${queryType} RES.DELETE_REASON_ = #{query.taskDeleteReason}
+            </if>
+            <if test="query.taskDeleteReasonLike != null">
+              ${queryType} RES.DELETE_REASON_ like #{query.taskDeleteReasonLike} ESCAPE ${escapeChar}
+            </if>
+            <if test="query.taskOwner != null">
+              ${queryType} RES.OWNER_ = #{query.taskOwner}
+            </if>
+            <if test="query.taskOwnerLike != null">
+              ${queryType} RES.OWNER_ like #{query.taskOwnerLike} ESCAPE ${escapeChar}
+            </if>
+            <if test="query.assigned">
+              ${queryType} RES.ASSIGNEE_ is not null
+            </if>
+            <if test="query.unassigned">
+              ${queryType} RES.ASSIGNEE_ is null
+            </if>
+            <if test="query.taskAssignee != null">
+              ${queryType} RES.ASSIGNEE_ = #{query.taskAssignee}
+            </if>
+            <if test="query.taskAssigneeLike != null">
+              ${queryType} RES.ASSIGNEE_ like #{query.taskAssigneeLike} ESCAPE ${escapeChar}
+            </if>
+            <if test="query.taskPriority != null">
+              ${queryType} RES.PRIORITY_ = #{query.taskPriority}
+            </if>
+            <if test="query.unfinished">
+              ${queryType} RES.END_TIME_ is null
+            </if>
+            <if test="query.finished">
+              ${queryType} RES.END_TIME_ is not null
+            </if>
+            <if test="query.processFinished">
+              ${queryType} HPI.END_TIME_ is not null
+            </if>
+            <if test="query.processUnfinished">
+              ${queryType} HPI.END_TIME_ is null
+            </if>
+            <if test="query.startedAfter != null">
+              ${queryType} RES.START_TIME_ &gt;= #{query.startedAfter}
+            </if>
+            <if test="query.startedBefore != null">
+              ${queryType} RES.START_TIME_ &lt;= #{query.startedBefore}
+            </if>
+            <if test="query.finishedBefore != null">
+              ${queryType} RES.END_TIME_ &lt;= #{query.finishedBefore}
+            </if>
+            <if test="query.finishedAfter != null">
+              ${queryType} RES.END_TIME_ &gt;= #{query.finishedAfter}
+            </if>
+            <if test="query.dueDate != null || query.dueBefore != null || query.dueAfter != null">
+              ${queryType}
+              <trim prefix="(" suffix=")" prefixOverrides="and|or">
+                <if test="query.dueDate != null">
+                  ${queryType} RES.DUE_DATE_ = #{query.dueDate}
+                </if>
+                <if test="query.dueBefore != null">
+                  ${queryType} RES.DUE_DATE_ &lt; #{query.dueBefore}
+                </if>
+                <if test="query.dueAfter != null">
+                  ${queryType} RES.DUE_DATE_ &gt; #{query.dueAfter}
+                </if>
 
-      <if test="taskId != null">
-        RES.ID_ = #{taskId}
-      </if>
-      <if test="processDefinitionId != null">
-        and RES.PROC_DEF_ID_ = #{processDefinitionId}
-      </if>
-      <if test="processDefinitionKey != null">
-        and D.KEY_ = #{processDefinitionKey}
-      </if>
-      <if test="processDefinitionName != null">
-        and D.NAME_ = #{processDefinitionName}
-      </if>
-      <if test="processInstanceId != null">
-        and RES.PROC_INST_ID_ = #{processInstanceId}
-      </if>
-      <if test="processInstanceBusinessKey != null">
-        and HPI.BUSINESS_KEY_ = #{processInstanceBusinessKey}
-      </if>
-      <if test="processInstanceBusinessKeys != null &amp;&amp; processInstanceBusinessKeys.length > 0">
-        and HPI.BUSINESS_KEY_ in
-        <foreach item="item" index="index" collection="processInstanceBusinessKeys"
-                 open="(" separator="," close=")">
-          #{item}
-        </foreach>
-      </if>
-      <if test="processInstanceBusinessKeyLike != null">
-        HPI.BUSINESS_KEY_ like #{processInstanceBusinessKeyLike} ESCAPE ${escapeChar}
-      </if>
-      <if test="taskDefinitionKeys != null &amp;&amp; taskDefinitionKeys.length > 0">
-        and RES.TASK_DEF_KEY_ in
-        <foreach item="taskDefinitionKey" index="index" collection="taskDefinitionKeys"
-                 open="(" separator="," close=")">
-          #{taskDefinitionKey}
-        </foreach>
-      </if>
-      <if test="executionId != null">
-        and RES.EXECUTION_ID_ = #{executionId}
-      </if>
-      <if test="activityInstanceIds != null &amp;&amp; activityInstanceIds.length > 0">
-        and RES.ACT_INST_ID_ in
-        <foreach item="item" index="index" collection="activityInstanceIds"
-                 open="(" separator="," close=")">
-          #{item}
-        </foreach>
-      </if>
-      <if test="caseDefinitionId != null">
-        and RES.CASE_DEF_ID_ = #{caseDefinitionId}
-      </if>
-      <if test="caseDefinitionKey != null">
-        and CD.KEY_ = #{caseDefinitionKey}
-      </if>
-      <if test="caseDefinitionName != null">
-        and CD.NAME_ = #{caseDefinitionName}
-      </if>
-      <if test="caseInstanceId != null">
-        and RES.CASE_INST_ID_ = #{caseInstanceId}
-      </if>
-      <if test="caseExecutionId != null">
-        and RES.CASE_EXECUTION_ID_ = #{caseExecutionId}
-      </if>
-      <if test="taskName != null">
-        and RES.NAME_ = #{taskName}
-      </if>
-      <if test="taskNameLike != null">
-        and RES.NAME_ like #{taskNameLike} ESCAPE ${escapeChar}
-      </if>
-      <if test="taskParentTaskId != null">
-        and RES.PARENT_TASK_ID_ = #{taskParentTaskId}
-      </if>
-      <if test="taskDescription != null">
-        and RES.DESCRIPTION_ = #{taskDescription}
-      </if>
-      <if test="taskDescriptionLike != null">
-        and RES.DESCRIPTION_ like #{taskDescriptionLike} ESCAPE ${escapeChar}
-      </if>
-      <if test="taskDeleteReason != null">
-        and RES.DELETE_REASON_ = #{taskDeleteReason}
-      </if>
-      <if test="taskDeleteReasonLike != null">
-        and RES.DELETE_REASON_ like #{taskDeleteReasonLike} ESCAPE ${escapeChar}
-      </if>
-      <if test="taskOwner != null">
-        and RES.OWNER_ = #{taskOwner}
-      </if>
-      <if test="taskOwnerLike != null">
-        and RES.OWNER_ like #{taskOwnerLike} ESCAPE ${escapeChar}
-      </if>
-      <if test="assigned">
-        and RES.ASSIGNEE_ is not null
-      </if>
-      <if test="unassigned">
-        and RES.ASSIGNEE_ is null
-      </if>
-      <if test="taskAssignee != null">
-        and RES.ASSIGNEE_ = #{taskAssignee}
-      </if>
-      <if test="taskAssigneeLike != null">
-        and RES.ASSIGNEE_ like #{taskAssigneeLike} ESCAPE ${escapeChar}
-      </if>
-      <if test="taskPriority != null">
-        and RES.PRIORITY_ = #{taskPriority}
-      </if>
-      <if test="unfinished">
-        and RES.END_TIME_ is null
-      </if>
-      <if test="finished">
-        and RES.END_TIME_ is not null
-      </if>
-      <if test="processFinished">
-        and HPI.END_TIME_ is not null
-      </if>
-      <if test="processUnfinished">
-        and HPI.END_TIME_ is null
-      </if>
-      <if test="startedAfter != null">
-        and RES.START_TIME_ &gt;= #{startedAfter}
-      </if>
-      <if test="startedBefore != null">
-        and RES.START_TIME_ &lt;= #{startedBefore}
-      </if>
-      <if test="finishedBefore != null">
-        and RES.END_TIME_ &lt;= #{finishedBefore}
-      </if>
-      <if test="finishedAfter != null">
-        and RES.END_TIME_ &gt;= #{finishedAfter}
-      </if>
-      <if test="dueDate != null">
-        and RES.DUE_DATE_ = #{dueDate}
-      </if>
-      <if test="dueBefore != null">
-        and RES.DUE_DATE_ &lt; #{dueBefore}
-      </if>
-      <if test="dueAfter != null">
-        and RES.DUE_DATE_ &gt; #{dueAfter}
-      </if>
-      <if test="dueDate != null || dueBefore != null || dueAfter != null">
-        and RES.DUE_DATE_ is not null
-      </if>
-      <if test="followUpDate != null">
-        and RES.FOLLOW_UP_DATE_ = #{followUpDate}
-      </if>
-      <if test="followUpBefore != null">
-        and RES.FOLLOW_UP_DATE_ &lt; #{followUpBefore}
-      </if>
-      <if test="followUpAfter != null">
-        and RES.FOLLOW_UP_DATE_ &gt; #{followUpAfter}
-      </if>
-      <if test="followUpDate != null || followUpBefore != null || followUpAfter != null">
-        and RES.FOLLOW_UP_DATE_ is not null
-      </if>
-      <if test="tenantIds != null &amp;&amp; tenantIds.length > 0">
-        and RES.TENANT_ID_ in
-        <foreach item="tenantId" index="index" collection="tenantIds"
-                 open="(" separator="," close=")">
-          #{tenantId}
-        </foreach>
-      </if>
-      <foreach collection="variables" index="index" item="queryVariableValue">
-        and exists (
-          select
-            ID_
-          from
-            ${prefix}ACT_HI_VARINST VAR
-          WHERE
-            NAME_= #{queryVariableValue.name}
-          <choose>
-            <when test="queryVariableValue.local">
-              and TASK_ID_ = RES.ID_
-            </when>
-            <otherwise>
-              and PROC_INST_ID_ = RES.PROC_INST_ID_ and TASK_ID_ is null
-            </otherwise>
-          </choose>
+                and RES.DUE_DATE_ is not null
+              </trim>
+            </if>
+            <if test="query.followUpDate != null || query.followUpBefore != null || query.followUpAfter != null">
+              ${queryType}
+              <trim prefix="(" suffix=")" prefixOverrides="and|or">
+                <if test="query.followUpDate != null">
+                  ${queryType} RES.FOLLOW_UP_DATE_ = #{query.followUpDate}
+                </if>
+                <if test="query.followUpBefore != null &amp;&amp; !query.followUpNullAccepted">
+                  ${queryType} RES.FOLLOW_UP_DATE_ &lt; #{query.followUpBefore}
+                </if>
+                <if test="query.followUpBefore != null &amp;&amp; query.followUpNullAccepted">
+                  ${queryType} (RES.FOLLOW_UP_DATE_ IS NULL OR RES.FOLLOW_UP_DATE_ &lt; #{query.followUpBefore})
+                </if>
+                <if test="query.followUpAfter != null">
+                  ${queryType} RES.FOLLOW_UP_DATE_ &gt; #{query.followUpAfter}
+                </if>
 
-          <bind name="varTypeField" value="'VAR_TYPE_'"/>
-          <bind name="varPrefix" value="''"/>
-          <if test="queryVariableValue.valueConditions != null">
-            and
-            <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.variableValueConditions"/>
-          </if>
+                <if test="!query.followUpNullAccepted">
+                  and RES.FOLLOW_UP_DATE_ is not null
+                </if>
+              </trim>
+            </if>
+            <if test="query.tenantIds != null &amp;&amp; query.tenantIds.length > 0">
+              ${queryType} RES.TENANT_ID_ in
+              <foreach item="tenantId" index="index" collection="query.tenantIds"
+                       open="(" separator="," close=")">
+                #{tenantId}
+              </foreach>
+            </if>
+            <foreach collection="query.variables" index="index" item="queryVariableValue">
+              ${queryType} exists (
+                select
+                  ID_
+                from
+                  ${prefix}ACT_HI_VARINST VAR
+                WHERE
+                  NAME_= #{queryVariableValue.name}
+                <choose>
+                  <when test="queryVariableValue.local">
+                    and TASK_ID_ = RES.ID_
+                  </when>
+                  <otherwise>
+                    and PROC_INST_ID_ = RES.PROC_INST_ID_ and TASK_ID_ is null
+                  </otherwise>
+                </choose>
+
+                <bind name="varTypeField" value="'VAR_TYPE_'"/>
+                <bind name="varPrefix" value="''"/>
+                <if test="queryVariableValue.valueConditions != null">
+                  and
+                  <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.variableValueConditions"/>
+                </if>
+              )
+            </foreach>
+
+            <if test="query.authCheck.isAuthorizationCheckEnabled &amp;&amp; query.authCheck.authUserId != null">
+              ${queryType} (
+              (RES.EXECUTION_ID_ is not null
+              <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.queryAuthorizationCheck"/>
+              ) or RES.EXECUTION_ID_ is null
+              )
+            </if>
+
+            <include refid="org.camunda.bpm.engine.impl.persistence.entity.TenantEntity.queryTenantCheck" />
+          </trim>
+        </trim>
         )
       </foreach>
-
-      <if test="authCheck.isAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
-        and (
-        (RES.EXECUTION_ID_ is not null
-        <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.queryAuthorizationCheck"/>
-        ) or RES.EXECUTION_ID_ is null
-        )
-      </if>
-
-      <include refid="org.camunda.bpm.engine.impl.persistence.entity.TenantEntity.queryTenantCheck" />
-
     </where>
   </sql>
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/ProcessInstanceQueryOrTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/ProcessInstanceQueryOrTest.java
@@ -1,0 +1,503 @@
+/*
+ * Copyright © 2012 - 2018 camunda services GmbH and various authors (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.api.runtime;
+
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.RepositoryService;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Tassilo Weidner
+ */
+public class ProcessInstanceQueryOrTest {
+
+  @Rule
+  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  protected RuntimeService runtimeService;
+  protected RepositoryService repositoryService;
+
+  @Before
+  public void init() {
+    runtimeService = processEngineRule.getRuntimeService();
+    repositoryService = processEngineRule.getRepositoryService();
+  }
+
+  @Test
+  public void shouldThrowExceptionByMissingStartOr() {
+    thrown.expect(ProcessEngineException.class);
+    thrown.expectMessage("Invalid query usage: cannot set endOr() before or()");
+
+    runtimeService.createProcessInstanceQuery()
+      .or()
+      .endOr()
+      .endOr();
+  }
+
+  @Test
+  public void shouldThrowExceptionByNesting() {
+    thrown.expect(ProcessEngineException.class);
+    thrown.expectMessage("Invalid query usage: cannot set or() within 'or' query");
+
+    runtimeService.createProcessInstanceQuery()
+      .or()
+        .or()
+        .endOr()
+      .endOr()
+      .or()
+      .endOr();
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldReturnProcInstWithEmptyOrQuery() {
+    // given
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+
+    // when
+    List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery()
+      .or()
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, processInstances.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldReturnProcInstWithVarValue1OrVarValue2() {
+    // given
+    Map<String, Object> vars = new HashMap<String, Object>();
+    vars.put("stringVar", "abcdef");
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "ghijkl");
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    // when
+    List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery()
+      .or()
+        .variableValueEquals("stringVar", "abcdef")
+        .variableValueEquals("stringVar", "ghijkl")
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, processInstances.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldReturnProcInstWithMultipleOrCriteria() {
+    // given
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+
+    Map<String, Object> vars = new HashMap<String, Object>();
+    vars.put("stringVar", "abcdef");
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+    runtimeService.setVariable(processInstance2.getProcessInstanceId(), "aVarName", "varValue");
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar2", "aaabbbaaa");
+    ProcessInstance processInstance3 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+    runtimeService.setVariable(processInstance3.getProcessInstanceId(), "bVarName", "bTestb");
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar2", "cccbbbccc");
+    ProcessInstance processInstance4 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+    runtimeService.setVariable(processInstance4.getProcessInstanceId(), "bVarName", "aTesta");
+
+    // when
+    List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery()
+      .or()
+        .variableValueEquals("stringVar", "abcdef")
+        .variableValueLike("stringVar2", "%bbb%")
+        .processInstanceId(processInstance1.getId())
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(4, processInstances.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance4.getId(), "test");
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldReturnProcInstFilteredByMultipleOrAndCriteria() {
+    // given
+    Map<String, Object> vars = new HashMap<String, Object>();
+    vars.put("stringVar", "abcdef");
+    vars.put("longVar", 12345L);
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "ghijkl");
+    vars.put("longVar", 56789L);
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "abcdef");
+    vars.put("longVar", 56789L);
+    ProcessInstance processInstance3 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "ghijkl");
+    vars.put("longVar", 12345L);
+    ProcessInstance processInstance4 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    // when
+    List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery()
+      .or()
+        .variableValueEquals("longVar", 56789L)
+        .processInstanceId(processInstance1.getId())
+      .endOr()
+      .variableValueEquals("stringVar", "abcdef")
+      .list();
+
+    // then
+    assertEquals(2, processInstances.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance4.getId(), "test");
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldReturnProcInstFilteredByMultipleOrQueries() {
+    // given
+    Map<String, Object> vars = new HashMap<String, Object>();
+    vars.put("stringVar", "abcdef");
+    vars.put("longVar", 12345L);
+    vars.put("boolVar", true);
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "ghijkl");
+    vars.put("longVar", 56789L);
+    vars.put("boolVar", true);
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "abcdef");
+    vars.put("longVar", 56789L);
+    vars.put("boolVar", true);
+    ProcessInstance processInstance3 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "ghijkl");
+    vars.put("longVar", 12345L);
+    vars.put("boolVar", true);
+    ProcessInstance processInstance4 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "ghijkl");
+    vars.put("longVar", 56789L);
+    vars.put("boolVar", false);
+    ProcessInstance processInstance5 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "abcdef");
+    vars.put("longVar", 12345L);
+    vars.put("boolVar", false);
+    ProcessInstance processInstance6 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    // when
+    List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery()
+      .or()
+        .variableValueEquals("stringVar", "abcdef")
+        .variableValueEquals("longVar", 12345L)
+      .endOr()
+      .or()
+        .variableValueEquals("boolVar", true)
+        .variableValueEquals("longVar", 12345L)
+      .endOr()
+      .or()
+        .variableValueEquals("stringVar", "ghijkl")
+        .variableValueEquals("longVar", 56789L)
+      .endOr()
+      .or()
+        .variableValueEquals("stringVar", "ghijkl")
+        .variableValueEquals("boolVar", false)
+        .variableValueEquals("longVar", 56789L)
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, processInstances.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance4.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance5.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance6.getId(), "test");
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldReturnProcInstWhereSameCriterionWasAppliedThreeTimesInOneQuery() {
+    // given
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    ProcessInstance processInstance3 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+
+    // when
+    List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery()
+      .or()
+        .processInstanceId(processInstance1.getId())
+        .processInstanceId(processInstance2.getId())
+        .processInstanceId(processInstance3.getId())
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(1, processInstances.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldReturnProcInstWithVariableValueEqualsOrVariableValueGreaterThan() {
+    // given
+    Map<String, Object> vars = new HashMap<String, Object>();
+    vars.put("longVar", 12345L);
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("longerVar", 56789L);
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("longerVar", 56789L);
+    ProcessInstance processInstance3 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    // when
+    ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery()
+      .or()
+        .variableValueEquals("longVar", 12345L)
+        .variableValueGreaterThan("longerVar", 20000L)
+      .endOr();
+
+    // then
+    assertEquals(3, query.count());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
+  }
+
+  @Test
+  public void shouldReturnProcInstWithProcessDefinitionNameOrProcessDefinitionKey() {
+    // given
+    BpmnModelInstance aProcessDefinition = Bpmn.createExecutableProcess("aProcessDefinition")
+      .name("process1")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+    repositoryService
+      .createDeployment()
+      .addModelInstance("foo.bpmn", aProcessDefinition)
+      .deploy();
+
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("aProcessDefinition");
+
+    BpmnModelInstance anotherProcessDefinition = Bpmn.createExecutableProcess("anotherProcessDefinition")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+     repositoryService
+       .createDeployment()
+       .addModelInstance("foo.bpmn", anotherProcessDefinition)
+       .deploy();
+
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("anotherProcessDefinition");
+
+    // when
+    List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery()
+      .or()
+        .processDefinitionId(processInstance1.getProcessDefinitionId())
+        .processDefinitionKey("anotherProcessDefinition")
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, processInstances.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+  }
+
+  @Test
+  public void shouldReturnProcInstWithBusinessKeyOrBusinessKeyLike() {
+    // given
+    BpmnModelInstance aProcessDefinition = Bpmn.createExecutableProcess("aProcessDefinition")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+    repositoryService
+      .createDeployment()
+      .addModelInstance("foo.bpmn", aProcessDefinition)
+      .deploy();
+
+    ProcessInstance processInstance1 = runtimeService
+      .startProcessInstanceByKey("aProcessDefinition", "aBusinessKey");
+
+    BpmnModelInstance anotherProcessDefinition = Bpmn.createExecutableProcess("anotherProcessDefinition")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+     repositoryService
+       .createDeployment()
+       .addModelInstance("foo.bpmn", anotherProcessDefinition)
+       .deploy();
+
+    ProcessInstance processInstance2 = runtimeService
+      .startProcessInstanceByKey("anotherProcessDefinition", "anotherBusinessKey");
+
+    // when
+    List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery()
+      .or()
+        .processInstanceBusinessKey("aBusinessKey")
+        .processInstanceBusinessKeyLike("anotherBusinessKey")
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, processInstances.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+  }
+
+  @Test
+  public void shouldReturnProcInstWithActivityIdInOrProcInstId() {
+    // given
+    BpmnModelInstance aProcessDefinition = Bpmn.createExecutableProcess("aProcessDefinition")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+    repositoryService
+      .createDeployment()
+      .addModelInstance("foo.bpmn", aProcessDefinition)
+      .deploy();
+
+    ProcessInstance processInstance1 = runtimeService
+      .startProcessInstanceByKey("aProcessDefinition");
+
+    String activityInstanceId = runtimeService.getActivityInstance(processInstance1.getId())
+      .getChildActivityInstances()[0].getActivityId();
+
+    ProcessInstance processInstance2 = runtimeService
+      .startProcessInstanceByKey("aProcessDefinition");
+
+    // when
+    List<ProcessInstance> processInstances = runtimeService.createProcessInstanceQuery()
+      .or()
+        .activityIdIn(activityInstanceId)
+        .processInstanceId(processInstance2.getId())
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, processInstances.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+  }
+
+  @Test
+  public void shouldReturnProcInstByVariableAndActiveProcesses() throws Exception {
+    // given
+    BpmnModelInstance aProcessDefinition = Bpmn.createExecutableProcess("oneTaskProcess")
+        .startEvent()
+          .userTask("testQuerySuspensionStateTask")
+        .endEvent()
+        .done();
+
+      repositoryService
+        .createDeployment()
+        .addModelInstance("foo.bpmn", aProcessDefinition)
+        .deploy();
+
+    // start two process instance and leave them active
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+
+    // start one process instance and suspend it
+    Map<String, Object> variables = new HashMap<String, Object>();
+    variables.put("foo", 0);
+    ProcessInstance suspendedProcessInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
+    runtimeService.suspendProcessInstanceById(suspendedProcessInstance.getProcessInstanceId());
+
+    // assume
+    assertEquals(2, runtimeService.createProcessInstanceQuery().processDefinitionKey("oneTaskProcess").active().count());
+    assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey("oneTaskProcess").suspended().count());
+
+    // then
+    assertEquals(3, runtimeService.createProcessInstanceQuery().or().active().variableValueEquals("foo", 0).endOr().list().size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+    runtimeService.deleteProcessInstance(suspendedProcessInstance.getId(), "test");
+  }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricProcessInstanceQueryOrTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricProcessInstanceQueryOrTest.java
@@ -1,0 +1,507 @@
+/*
+ * Copyright © 2012 - 2018 camunda services GmbH and various authors (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.history;
+
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.RepositoryService;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.camunda.bpm.engine.HistoryService;
+import org.camunda.bpm.engine.history.HistoricProcessInstance;
+import org.camunda.bpm.engine.history.HistoricProcessInstanceQuery;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Tassilo Weidner
+ */
+public class HistoricProcessInstanceQueryOrTest {
+
+  @Rule
+  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  protected HistoryService historyService;
+  protected RuntimeService runtimeService;
+  protected RepositoryService repositoryService;
+
+  @Before
+  public void init() {
+    historyService = processEngineRule.getHistoryService();
+    runtimeService = processEngineRule.getRuntimeService();
+    repositoryService = processEngineRule.getRepositoryService();
+  }
+
+  @Test
+  public void shouldThrowExceptionByMissingStartOr() {
+    thrown.expect(ProcessEngineException.class);
+    thrown.expectMessage("Invalid query usage: cannot set endOr() before or()");
+
+    historyService.createHistoricProcessInstanceQuery()
+      .or()
+      .endOr()
+      .endOr();
+  }
+
+  @Test
+  public void shouldThrowExceptionByNesting() {
+    thrown.expect(ProcessEngineException.class);
+    thrown.expectMessage("Invalid query usage: cannot set or() within 'or' query");
+
+    historyService.createHistoricProcessInstanceQuery()
+      .or()
+        .or()
+        .endOr()
+      .endOr()
+      .or()
+      .endOr();
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldReturnHistoricProcInstWithEmptyOrQuery() {
+    // given
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+
+    // when
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+      .or()
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, processInstances.size());
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldReturnHistoricProcInstWithVarValue1OrVarValue2() {
+    // given
+    Map<String, Object> vars = new HashMap<String, Object>();
+    vars.put("stringVar", "abcdef");
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "ghijkl");
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    // when
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+      .or()
+        .variableValueEquals("stringVar", "abcdef")
+        .variableValueEquals("stringVar", "ghijkl")
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, processInstances.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldReturnHistoricProcInstWithMultipleOrCriteria() {
+    // given
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+
+    Map<String, Object> vars = new HashMap<String, Object>();
+    vars.put("stringVar", "abcdef");
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+    runtimeService.setVariable(processInstance2.getProcessInstanceId(), "aVarName", "varValue");
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar2", "aaabbbaaa");
+    ProcessInstance processInstance3 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+    runtimeService.setVariable(processInstance3.getProcessInstanceId(), "bVarName", "bTestb");
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar2", "cccbbbccc");
+    ProcessInstance processInstance4 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+    runtimeService.setVariable(processInstance4.getProcessInstanceId(), "bVarName", "aTesta");
+
+    // when
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+      .or()
+        .variableValueEquals("stringVar", "abcdef")
+        .variableValueLike("stringVar2", "%bbb%")
+        .processInstanceId(processInstance1.getId())
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(4, processInstances.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance4.getId(), "test");
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldReturnHistoricProcInstFilteredByMultipleOrAndCriteria() {
+    // given
+    Map<String, Object> vars = new HashMap<String, Object>();
+    vars.put("stringVar", "abcdef");
+    vars.put("longVar", 12345L);
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "ghijkl");
+    vars.put("longVar", 56789L);
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "abcdef");
+    vars.put("longVar", 56789L);
+    ProcessInstance processInstance3 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "ghijkl");
+    vars.put("longVar", 12345L);
+    ProcessInstance processInstance4 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    // when
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+      .or()
+        .variableValueEquals("longVar", 56789L)
+        .processInstanceId(processInstance1.getId())
+      .endOr()
+      .variableValueEquals("stringVar", "abcdef")
+      .list();
+
+    // then
+    assertEquals(2, processInstances.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance4.getId(), "test");
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldReturnHistoricProcInstFilteredByMultipleOrQueries() {
+    // given
+    Map<String, Object> vars = new HashMap<String, Object>();
+    vars.put("stringVar", "abcdef");
+    vars.put("longVar", 12345L);
+    vars.put("boolVar", true);
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "ghijkl");
+    vars.put("longVar", 56789L);
+    vars.put("boolVar", true);
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "abcdef");
+    vars.put("longVar", 56789L);
+    vars.put("boolVar", true);
+    ProcessInstance processInstance3 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "ghijkl");
+    vars.put("longVar", 12345L);
+    vars.put("boolVar", true);
+    ProcessInstance processInstance4 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "ghijkl");
+    vars.put("longVar", 56789L);
+    vars.put("boolVar", false);
+    ProcessInstance processInstance5 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("stringVar", "abcdef");
+    vars.put("longVar", 12345L);
+    vars.put("boolVar", false);
+    ProcessInstance processInstance6 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    // when
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+      .or()
+        .variableValueEquals("stringVar", "abcdef")
+        .variableValueEquals("longVar", 12345L)
+      .endOr()
+      .or()
+        .variableValueEquals("boolVar", true)
+        .variableValueEquals("longVar", 12345L)
+      .endOr()
+      .or()
+        .variableValueEquals("stringVar", "ghijkl")
+        .variableValueEquals("longVar", 56789L)
+      .endOr()
+      .or()
+        .variableValueEquals("stringVar", "ghijkl")
+        .variableValueEquals("boolVar", false)
+        .variableValueEquals("longVar", 56789L)
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, processInstances.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance4.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance5.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance6.getId(), "test");
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldReturnHistoricProcInstWhereSameCriterionWasAppliedThreeTimesInOneQuery() {
+    // given
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    ProcessInstance processInstance3 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+
+    // when
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+      .or()
+        .processInstanceId(processInstance1.getId())
+        .processInstanceId(processInstance2.getId())
+        .processInstanceId(processInstance3.getId())
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(1, processInstances.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldReturnHistoricProcInstWithVariableValueEqualsOrVariableValueGreaterThan() {
+    // given
+    Map<String, Object> vars = new HashMap<String, Object>();
+    vars.put("longVar", 12345L);
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("longerVar", 56789L);
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    vars = new HashMap<String, Object>();
+    vars.put("longerVar", 56789L);
+    ProcessInstance processInstance3 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+
+    // when
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery()
+      .or()
+        .variableValueEquals("longVar", 12345L)
+        .variableValueGreaterThan("longerVar", 20000L)
+      .endOr();
+
+    // then
+    assertEquals(3, query.count());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance3.getId(), "test");
+  }
+
+  @Test
+  public void shouldReturnHistoricProcInstWithProcessDefinitionNameOrProcessDefinitionKey() {
+    // given
+    BpmnModelInstance aProcessDefinition = Bpmn.createExecutableProcess("aProcessDefinition")
+      .name("process1")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+    repositoryService
+      .createDeployment()
+      .addModelInstance("foo.bpmn", aProcessDefinition)
+      .deploy();
+
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("aProcessDefinition");
+
+    BpmnModelInstance anotherProcessDefinition = Bpmn.createExecutableProcess("anotherProcessDefinition")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+     repositoryService
+       .createDeployment()
+       .addModelInstance("foo.bpmn", anotherProcessDefinition)
+       .deploy();
+
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("anotherProcessDefinition");
+
+    // when
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+      .or()
+        .processDefinitionId(processInstance1.getProcessDefinitionId())
+        .processDefinitionKey("anotherProcessDefinition")
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, processInstances.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+  }
+
+  @Test
+  public void shouldReturnHistoricProcInstWithBusinessKeyOrBusinessKeyLike() {
+    // given
+    BpmnModelInstance aProcessDefinition = Bpmn.createExecutableProcess("aProcessDefinition")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+    repositoryService
+      .createDeployment()
+      .addModelInstance("foo.bpmn", aProcessDefinition)
+      .deploy();
+
+    ProcessInstance processInstance1 = runtimeService
+      .startProcessInstanceByKey("aProcessDefinition", "aBusinessKey");
+
+    BpmnModelInstance anotherProcessDefinition = Bpmn.createExecutableProcess("anotherProcessDefinition")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+     repositoryService
+       .createDeployment()
+       .addModelInstance("foo.bpmn", anotherProcessDefinition)
+       .deploy();
+
+    ProcessInstance processInstance2 = runtimeService
+      .startProcessInstanceByKey("anotherProcessDefinition", "anotherBusinessKey");
+
+    // when
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+      .or()
+        .processInstanceBusinessKey("aBusinessKey")
+        .processInstanceBusinessKeyLike("anotherBusinessKey")
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, processInstances.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+  }
+
+  @Test
+  public void shouldReturnHistoricProcInstWithActivityIdInOrProcInstId() {
+    // given
+    BpmnModelInstance aProcessDefinition = Bpmn.createExecutableProcess("aProcessDefinition")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+    repositoryService
+      .createDeployment()
+      .addModelInstance("foo.bpmn", aProcessDefinition)
+      .deploy();
+
+    ProcessInstance processInstance1 = runtimeService
+      .startProcessInstanceByKey("aProcessDefinition");
+
+    String activityInstanceId = runtimeService.getActivityInstance(processInstance1.getId())
+      .getChildActivityInstances()[0].getActivityId();
+
+    ProcessInstance processInstance2 = runtimeService
+      .startProcessInstanceByKey("aProcessDefinition");
+
+    // when
+    List<HistoricProcessInstance> tasks = historyService.createHistoricProcessInstanceQuery()
+      .or()
+        .activeActivityIdIn(activityInstanceId)
+        .processInstanceId(processInstance2.getId())
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, tasks.size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+  }
+
+  @Test
+  public void shouldReturnHistoricProcInstByVariableAndActiveProcesses() throws Exception {
+    // given
+    BpmnModelInstance aProcessDefinition = Bpmn.createExecutableProcess("oneTaskProcess")
+        .startEvent()
+          .userTask("testQuerySuspensionStateTask")
+        .endEvent()
+        .done();
+
+      repositoryService
+        .createDeployment()
+        .addModelInstance("foo.bpmn", aProcessDefinition)
+        .deploy();
+
+    // start two process instance and leave them active
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+
+    // start one process instance and suspend it
+    Map<String, Object> variables = new HashMap<String, Object>();
+    variables.put("foo", 0);
+    ProcessInstance suspendedProcessInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
+    runtimeService.suspendProcessInstanceById(suspendedProcessInstance.getProcessInstanceId());
+
+    // assume
+    assertEquals(2, historyService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTaskProcess").active().count());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTaskProcess").suspended().count());
+
+    // then
+    assertEquals(3, historyService.createHistoricProcessInstanceQuery().or().active().variableValueEquals("foo", 0).endOr().list().size());
+
+    runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
+    runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
+    runtimeService.deleteProcessInstance(suspendedProcessInstance.getId(), "test");
+  }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricTaskInstanceQueryOrTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricTaskInstanceQueryOrTest.java
@@ -1,0 +1,640 @@
+/*
+ * Copyright © 2012 - 2018 camunda services GmbH and various authors (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.history;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.camunda.bpm.engine.CaseService;
+import org.camunda.bpm.engine.FilterService;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.RepositoryService;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.task.Task;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.camunda.bpm.engine.HistoryService;
+import org.camunda.bpm.engine.history.HistoricTaskInstance;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Tassilo Weidner
+ */
+public class HistoricTaskInstanceQueryOrTest {
+
+  @Rule
+  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  protected HistoryService historyService;
+  protected RuntimeService runtimeService;
+  protected TaskService taskService;
+  protected CaseService caseService;
+  protected RepositoryService repositoryService;
+  protected FilterService filterService;
+
+  @Before
+  public void init() {
+    historyService = processEngineRule.getHistoryService();
+    runtimeService = processEngineRule.getRuntimeService();
+    taskService = processEngineRule.getTaskService();
+    caseService = processEngineRule.getCaseService();
+    repositoryService = processEngineRule.getRepositoryService();
+    filterService = processEngineRule.getFilterService();
+  }
+
+  @After
+  public void tearDown() {
+    for (org.camunda.bpm.engine.repository.Deployment deployment:
+      repositoryService.createDeploymentQuery().list()) {
+      repositoryService.deleteDeployment(deployment.getId(), true);
+    }
+
+    for (Task task: taskService.createTaskQuery().list()) {
+      taskService.deleteTask(task.getId(), true);
+    }
+  }
+
+  @Test
+  public void shouldThrowExceptionByMissingStartOr() {
+    thrown.expect(ProcessEngineException.class);
+    thrown.expectMessage("Invalid query usage: cannot set endOr() before or()");
+
+    historyService.createHistoricTaskInstanceQuery()
+      .or()
+      .endOr()
+      .endOr();
+  }
+
+  @Test
+  public void shouldThrowExceptionByNesting() {
+    thrown.expect(ProcessEngineException.class);
+    thrown.expectMessage("Invalid query usage: cannot set or() within 'or' query");
+
+    historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .or()
+        .endOr()
+      .endOr()
+      .or()
+      .endOr();
+  }
+
+  @Test
+  public void shouldThrowExceptionByWithCandidateGroupsApplied() {
+    thrown.expect(ProcessEngineException.class);
+    thrown.expectMessage("Invalid query usage: cannot set withCandidateGroups() within 'or' query");
+
+    historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .withCandidateGroups()
+      .endOr();
+  }
+
+  @Test
+  public void shouldThrowExceptionByWithoutCandidateGroupsApplied() {
+    thrown.expect(ProcessEngineException.class);
+    thrown.expectMessage("Invalid query usage: cannot set withoutCandidateGroups() within 'or' query");
+
+    historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .withoutCandidateGroups()
+      .endOr();
+  }
+
+  @Test
+  public void shouldThrowExceptionByOrderingApplied() {
+    thrown.expect(ProcessEngineException.class);
+    thrown.expectMessage("Invalid query usage: cannot set orderByCaseExecutionId() within 'or' query");
+
+    historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .orderByCaseExecutionId()
+      .endOr();
+  }
+
+  @Test
+  public void shouldReturnHistoricTasksWithEmptyOrQuery() {
+    // given
+    taskService.saveTask(taskService.newTask());
+    taskService.saveTask(taskService.newTask());
+
+    // when
+    List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery()
+      .or()
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, tasks.size());
+  }
+
+  @Test
+  public void shouldReturnHistoricTasksWithTaskNameOrTaskDescription() {
+    // given
+    Task task1 = taskService.newTask();
+    task1.setName("aTaskName");
+    taskService.saveTask(task1);
+
+    Task task2 = taskService.newTask();
+    task2.setDescription("aTaskDescription");
+    taskService.saveTask(task2);
+
+    // when
+    List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .taskName("aTaskName")
+        .taskDescription("aTaskDescription")
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, tasks.size());
+  }
+
+  @Test
+  public void shouldReturnHistoricTasksWithMultipleOrCriteria() {
+    // given
+    Task task1 = taskService.newTask();
+    task1.setName("aTaskName");
+    taskService.saveTask(task1);
+
+    Task task2 = taskService.newTask();
+    task2.setDescription("aTaskDescription");
+    taskService.saveTask(task2);
+
+    Task task3 = taskService.newTask();
+    taskService.saveTask(task3);
+
+    Task task4 = taskService.newTask();
+    task4.setPriority(5);
+    taskService.saveTask(task4);
+
+    Task task5 = taskService.newTask();
+    task5.setOwner("aTaskOwner");
+    taskService.saveTask(task5);
+
+    // when
+    List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .taskName("aTaskName")
+        .taskDescription("aTaskDescription")
+        .taskId(task3.getId())
+        .taskPriority(5)
+        .taskOwner("aTaskOwner")
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(5, tasks.size());
+  }
+
+  @Test
+  public void shouldReturnHistoricTasksFilteredByMultipleOrAndCriteria() {
+    // given
+    Task task1 = taskService.newTask();
+    task1.setPriority(4);
+    taskService.saveTask(task1);
+
+    Task task2 = taskService.newTask();
+    task2.setName("aTaskName");
+    task2.setOwner("aTaskOwner");
+    task2.setAssignee("aTaskAssignee");
+    task2.setPriority(4);
+    taskService.saveTask(task2);
+
+    Task task3 = taskService.newTask();
+    task3.setName("aTaskName");
+    task3.setOwner("aTaskOwner");
+    task3.setAssignee("aTaskAssignee");
+    task3.setPriority(4);
+    task3.setDescription("aTaskDescription");
+    taskService.saveTask(task3);
+
+    Task task4 = taskService.newTask();
+    task4.setOwner("aTaskOwner");
+    task4.setAssignee("aTaskAssignee");
+    task4.setPriority(4);
+    task4.setDescription("aTaskDescription");
+    taskService.saveTask(task4);
+
+    Task task5 = taskService.newTask();
+    task5.setDescription("aTaskDescription");
+    task5.setOwner("aTaskOwner");
+    taskService.saveTask(task5);
+
+    // when
+    List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .taskName("aTaskName")
+        .taskDescription("aTaskDescription")
+        .taskId(task3.getId())
+      .endOr()
+      .taskOwner("aTaskOwner")
+      .taskPriority(4)
+      .taskAssignee("aTaskAssignee")
+      .list();
+
+    // then
+    assertEquals(3, tasks.size());
+  }
+
+  @Test
+  public void shouldReturnHistoricTasksFilteredByMultipleOrQueries() {
+    // given
+    Task task1 = taskService.newTask();
+    task1.setName("aTaskName");
+    taskService.saveTask(task1);
+
+    Task task2 = taskService.newTask();
+    task2.setName("aTaskName");
+    task2.setDescription("aTaskDescription");
+    taskService.saveTask(task2);
+
+    Task task3 = taskService.newTask();
+    task3.setName("aTaskName");
+    task3.setDescription("aTaskDescription");
+    task3.setOwner("aTaskOwner");
+    taskService.saveTask(task3);
+
+    Task task4 = taskService.newTask();
+    task4.setName("aTaskName");
+    task4.setDescription("aTaskDescription");
+    task4.setOwner("aTaskOwner");
+    task4.setAssignee("aTaskAssignee");
+    taskService.saveTask(task4);
+
+    Task task5 = taskService.newTask();
+    task5.setName("aTaskName");
+    task5.setDescription("aTaskDescription");
+    task5.setOwner("aTaskOwner");
+    task5.setAssignee("aTaskAssignee");
+    task5.setPriority(4);
+    taskService.saveTask(task5);
+
+    Task task6 = taskService.newTask();
+    task6.setName("aTaskName");
+    task6.setDescription("aTaskDescription");
+    task6.setOwner("aTaskOwner");
+    task6.setAssignee("aTaskAssignee");
+    task6.setPriority(4);
+    taskService.saveTask(task6);
+
+    // when
+    List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .taskName("aTaskName")
+        .taskDescription("aTaskDescription")
+      .endOr()
+      .or()
+        .taskName("aTaskName")
+        .taskDescription("aTaskDescription")
+        .taskAssignee("aTaskAssignee")
+      .endOr()
+      .or()
+        .taskName("aTaskName")
+        .taskDescription("aTaskDescription")
+        .taskOwner("aTaskOwner")
+        .taskAssignee("aTaskAssignee")
+      .endOr()
+      .or()
+        .taskAssignee("aTaskAssignee")
+        .taskPriority(4)
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(3, tasks.size());
+  }
+
+  @Test
+  public void shouldReturnHistoricTasksWhereSameCriterionWasAppliedThreeTimesInOneQuery() {
+    // given
+    Task task1 = taskService.newTask();
+    task1.setName("task1");
+    taskService.saveTask(task1);
+
+    Task task2 = taskService.newTask();
+    task2.setName("task2");
+    taskService.saveTask(task2);
+
+    Task task3 = taskService.newTask();
+    task3.setName("task3");
+    taskService.saveTask(task3);
+
+    // when
+    List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .taskName("task1")
+        .taskName("task2")
+        .taskName("task3")
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(1, tasks.size());
+  }
+
+  @Test
+  public void shouldReturnHistoricTasksWithProcessDefinitionNameOrProcessDefinitionKey() {
+    // given
+    BpmnModelInstance aProcessDefinition = Bpmn.createExecutableProcess("aProcessDefinition")
+      .name("process1")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+    repositoryService
+      .createDeployment()
+      .addModelInstance("foo.bpmn", aProcessDefinition)
+      .deploy();
+
+    runtimeService.startProcessInstanceByKey("aProcessDefinition");
+
+    BpmnModelInstance anotherProcessDefinition = Bpmn.createExecutableProcess("anotherProcessDefinition")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+     repositoryService
+       .createDeployment()
+       .addModelInstance("foo.bpmn", anotherProcessDefinition)
+       .deploy();
+
+    runtimeService.startProcessInstanceByKey("anotherProcessDefinition");
+
+    // when
+    List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .processDefinitionName("process1")
+        .processDefinitionKey("anotherProcessDefinition")
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, tasks.size());
+  }
+
+  @Test
+  public void shouldReturnHistoricTasksWithProcessInstanceBusinessKeyOrProcessInstanceBusinessKeyLike() {
+    // given
+    BpmnModelInstance aProcessDefinition = Bpmn.createExecutableProcess("aProcessDefinition")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+    repositoryService
+      .createDeployment()
+      .addModelInstance("foo.bpmn", aProcessDefinition)
+      .deploy();
+
+    runtimeService
+      .startProcessInstanceByKey("aProcessDefinition", "aBusinessKey");
+
+    BpmnModelInstance anotherProcessDefinition = Bpmn.createExecutableProcess("anotherProcessDefinition")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+     repositoryService
+       .createDeployment()
+       .addModelInstance("foo.bpmn", anotherProcessDefinition)
+       .deploy();
+
+    runtimeService
+      .startProcessInstanceByKey("anotherProcessDefinition", "anotherBusinessKey");
+
+    // when
+    List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .processInstanceBusinessKey("aBusinessKey")
+        .processInstanceBusinessKeyLike("anotherBusinessKey")
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, tasks.size());
+  }
+
+  @Test
+  @Deployment(resources={
+    "org/camunda/bpm/engine/test/api/cmmn/oneTaskCase.cmmn",
+    "org/camunda/bpm/engine/test/api/cmmn/oneTaskCase2.cmmn"})
+  public void shouldReturnHistoricTasksWithCaseDefinitionKeyCaseDefinitionName() {
+    // given
+    String caseDefinitionId1 = repositoryService
+      .createCaseDefinitionQuery()
+      .caseDefinitionKey("oneTaskCase")
+      .singleResult()
+      .getId();
+
+    caseService
+      .withCaseDefinition(caseDefinitionId1)
+      .create();
+
+    String caseDefinitionId2 = repositoryService
+      .createCaseDefinitionQuery()
+      .caseDefinitionKey("oneTaskCase2")
+      .singleResult()
+      .getId();
+
+    caseService
+      .withCaseDefinition(caseDefinitionId2)
+      .create();
+
+    // when
+    List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .caseDefinitionKey("oneTaskCase")
+        .caseDefinitionName("One")
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, tasks.size());
+  }
+
+  @Test
+  public void shouldReturnHistoricTasksWithActivityInstanceIdInOrTaskId() {
+    // given
+    BpmnModelInstance aProcessDefinition = Bpmn.createExecutableProcess("aProcessDefinition")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+    repositoryService
+      .createDeployment()
+      .addModelInstance("foo.bpmn", aProcessDefinition)
+      .deploy();
+
+    ProcessInstance processInstance1 = runtimeService
+      .startProcessInstanceByKey("aProcessDefinition");
+
+    String activityInstanceId = runtimeService.getActivityInstance(processInstance1.getId())
+      .getChildActivityInstances()[0].getId();
+
+    Task task2 = taskService.newTask();
+    taskService.saveTask(task2);
+
+    // when
+    List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .activityInstanceIdIn(activityInstanceId)
+        .taskId(task2.getId())
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, tasks.size());
+  }
+
+  @Test
+  public void shouldTestDueDateCombinations() throws ParseException {
+    HashMap<String, Date> dates = createFollowUpAndDueDateTasks();
+
+    assertEquals(2, historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .taskDueDate(dates.get("date"))
+        .taskDueBefore(dates.get("oneHourAgo"))
+      .endOr()
+      .count());
+
+    assertEquals(2, historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .taskDueDate(dates.get("date"))
+        .taskDueAfter(dates.get("oneHourLater"))
+      .endOr()
+      .count());
+
+    assertEquals(2, historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .taskDueBefore(dates.get("oneHourAgo"))
+        .taskDueAfter(dates.get("oneHourLater"))
+      .endOr()
+      .count());
+
+    assertEquals(3, historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .taskDueBefore(dates.get("oneHourLater"))
+        .taskDueAfter(dates.get("oneHourAgo"))
+      .endOr()
+      .count());
+
+    assertEquals(3, historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .taskDueDate(dates.get("date"))
+        .taskDueBefore(dates.get("oneHourAgo"))
+        .taskDueAfter(dates.get("oneHourLater"))
+      .endOr()
+      .count());
+  }
+
+  @Test
+  public void shouldTestFollowUpDateCombinations() throws ParseException {
+    HashMap<String, Date> dates = createFollowUpAndDueDateTasks();
+
+    assertEquals(2, historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .taskFollowUpDate(dates.get("date"))
+        .taskFollowUpBefore(dates.get("oneHourAgo"))
+      .endOr()
+      .count());
+
+    assertEquals(2, historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .taskFollowUpDate(dates.get("date"))
+        .taskFollowUpAfter(dates.get("oneHourLater"))
+      .endOr()
+      .count());
+
+    assertEquals(2, historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .taskFollowUpBefore(dates.get("oneHourAgo"))
+        .taskFollowUpAfter(dates.get("oneHourLater"))
+      .endOr()
+      .count());
+
+    assertEquals(3, historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .taskFollowUpBefore(dates.get("oneHourLater"))
+        .taskFollowUpAfter(dates.get("oneHourAgo"))
+      .endOr()
+      .count());
+
+    assertEquals(3, historyService.createHistoricTaskInstanceQuery()
+      .or()
+        .taskFollowUpDate(dates.get("date"))
+        .taskFollowUpBefore(dates.get("oneHourAgo"))
+        .taskFollowUpAfter(dates.get("oneHourLater"))
+      .endOr()
+      .count());
+
+    // followUp before or null
+    taskService.saveTask(taskService.newTask());
+
+    assertEquals(4, historyService.createHistoricTaskInstanceQuery().count());
+  }
+
+  public HashMap<String, Date> createFollowUpAndDueDateTasks() throws ParseException {
+    final Date date = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("27/07/2017 01:12:13"),
+      oneHourAgo = new Date(date.getTime() - 60 * 60 * 1000),
+      oneHourLater = new Date(date.getTime() + 60 * 60 * 1000);
+
+    Task taskDueBefore = taskService.newTask();
+    taskDueBefore.setFollowUpDate(new Date(oneHourAgo.getTime() - 1000));
+    taskDueBefore.setDueDate(new Date(oneHourAgo.getTime() - 1000));
+    taskService.saveTask(taskDueBefore);
+
+    Task taskDueDate = taskService.newTask();
+    taskDueDate.setFollowUpDate(date);
+    taskDueDate.setDueDate(date);
+    taskService.saveTask(taskDueDate);
+
+    Task taskDueAfter = taskService.newTask();
+    taskDueAfter.setFollowUpDate(new Date(oneHourLater.getTime() + 1000));
+    taskDueAfter.setDueDate(new Date(oneHourLater.getTime() + 1000));
+    taskService.saveTask(taskDueAfter);
+
+    assertEquals(3, historyService.createHistoricTaskInstanceQuery().count());
+
+    return new HashMap<String, Date>() {{
+      put("date", date);
+      put("oneHourAgo", oneHourAgo);
+      put("oneHourLater", oneHourLater);
+    }};
+  }
+}


### PR DESCRIPTION
feat(engine): Implemented OR queries for ProcessInstanceQuery, HistoricProcessInstanceQuery and HistoricTaskInstanceQuery

Based on the already existing or queries for Tasks from tag 7.10.0, I implemented the or queries for ProcessInstanceQuery, HistoricProcessInstanceQuery and HistoricTaskInstanceQuery. I also created JUnit tests for all of them and extended the query DTOs for the rest extension