### PR TITLE
CAM-9949 fix(engine): UserOperationLogEntry not created for starting processes

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/StartProcessInstanceAtActivitiesCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/StartProcessInstanceAtActivitiesCmd.java
@@ -16,12 +16,14 @@
 package org.camunda.bpm.engine.impl.cmd;
 
 
+import java.util.Collections;
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotEmpty;
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 import java.util.List;
 
 import org.camunda.bpm.engine.exception.NotValidException;
+import org.camunda.bpm.engine.history.UserOperationLogEntry;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.ProcessInstanceModificationBuilderImpl;
 import org.camunda.bpm.engine.impl.ProcessInstantiationBuilderImpl;
@@ -33,6 +35,7 @@ import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionVariableSnapshotObserver;
 import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.ProcessInstanceWithVariablesImpl;
+import org.camunda.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
 import org.camunda.bpm.engine.impl.pvm.process.ProcessDefinitionImpl;
 import org.camunda.bpm.engine.impl.pvm.process.TransitionImpl;
@@ -103,6 +106,13 @@ public class StartProcessInstanceAtActivitiesCmd implements Command<ProcessInsta
       // due to preserveScope setting
       processInstance.propagateEnd();
     }
+
+    commandContext.getOperationLogManager().logProcessInstanceOperation(
+        UserOperationLogEntry.OPERATION_TYPE_CREATE,
+        processInstance.getId(),
+        processInstance.getProcessDefinitionId(),
+        processInstance.getProcessDefinition().getKey(),
+        Collections.singletonList(PropertyChange.EMPTY_CHANGE));
 
     return new ProcessInstanceWithVariablesImpl(processInstance, variablesListener.getVariables());
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/StartProcessInstanceCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/StartProcessInstanceCmd.java
@@ -16,6 +16,8 @@
 package org.camunda.bpm.engine.impl.cmd;
 
 import java.io.Serializable;
+import java.util.Collections;
+import org.camunda.bpm.engine.history.UserOperationLogEntry;
 
 import org.camunda.bpm.engine.impl.ProcessInstantiationBuilderImpl;
 import org.camunda.bpm.engine.impl.cfg.CommandChecker;
@@ -25,6 +27,7 @@ import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionVariableSnapshotObserver;
 import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.ProcessInstanceWithVariablesImpl;
+import org.camunda.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.camunda.bpm.engine.runtime.ProcessInstanceWithVariables;
 
 /**
@@ -60,6 +63,14 @@ public class StartProcessInstanceCmd implements Command<ProcessInstanceWithVaria
     final ExecutionVariableSnapshotObserver variablesListener = new ExecutionVariableSnapshotObserver(processInstance);
 
     processInstance.start(instantiationBuilder.getVariables());
+
+    commandContext.getOperationLogManager().logProcessInstanceOperation(
+        UserOperationLogEntry.OPERATION_TYPE_CREATE,
+        processInstance.getId(),
+        processInstance.getProcessDefinitionId(),
+        processInstance.getProcessDefinition().getKey(),
+        Collections.singletonList(PropertyChange.EMPTY_CHANGE));
+
     return new ProcessInstanceWithVariablesImpl(processInstance, variablesListener.getVariables());
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/UserOperationIdTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/UserOperationIdTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.util.List;
 
@@ -31,6 +32,7 @@ import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.history.HistoricDetail;
 import org.camunda.bpm.engine.history.UserOperationLogEntry;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
@@ -188,6 +190,55 @@ public class UserOperationIdTest {
     HistoricDetail historicDetail = historyService.createHistoricDetailQuery().singleResult();
     // no user operation log id is set for this update, as it is not written as part of the user operation
     assertNull(historicDetail.getUserOperationId());
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void testStartProcessOperationId() {
+    // given
+    identityService.setAuthenticatedUserId("demo");
+
+    // when
+    ProcessInstance pi = runtimeService.startProcessInstanceByKey(PROCESS_KEY, getVariables());
+
+    //then
+    List<UserOperationLogEntry> userOperationLogEntries = historyService.createUserOperationLogQuery()
+        .operationType(UserOperationLogEntry.OPERATION_TYPE_CREATE)
+        .processInstanceId(pi.getId())
+        .list();
+    List<HistoricDetail> historicDetails = historyService.createHistoricDetailQuery().list();
+    for (HistoricDetail historicDetail : historicDetails) {
+        System.out.println(historicDetail.getUserOperationId());
+    }
+    assertFalse(userOperationLogEntries.isEmpty());
+    assertFalse(historicDetails.isEmpty());
+    verifySameOperationId(userOperationLogEntries, historicDetails);
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void testStartProcessAtActivityOperationId() {
+    // given
+    identityService.setAuthenticatedUserId("demo");
+
+    // when
+    ProcessInstance pi = runtimeService.createProcessInstanceByKey(PROCESS_KEY)
+            .startBeforeActivity("theTask")
+            .setVariables(getVariables())
+            .execute();
+
+    //then
+    List<UserOperationLogEntry> userOperationLogEntries = historyService.createUserOperationLogQuery()
+        .operationType(UserOperationLogEntry.OPERATION_TYPE_CREATE)
+        .processInstanceId(pi.getId())
+        .list();
+    List<HistoricDetail> historicDetails = historyService.createHistoricDetailQuery().list();
+    for (HistoricDetail historicDetail : historicDetails) {
+        System.out.println(historicDetail.getUserOperationId());
+    }
+    assertFalse(userOperationLogEntries.isEmpty());
+    assertFalse(historicDetails.isEmpty());
+    verifySameOperationId(userOperationLogEntries, historicDetails);
   }
 
   private void verifySameOperationId(List<UserOperationLogEntry> userOperationLogEntries, List<HistoricDetail> historicDetails) {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/UserOperationIdTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/UserOperationIdTest.java
@@ -207,9 +207,7 @@ public class UserOperationIdTest {
         .processInstanceId(pi.getId())
         .list();
     List<HistoricDetail> historicDetails = historyService.createHistoricDetailQuery().list();
-    for (HistoricDetail historicDetail : historicDetails) {
-        System.out.println(historicDetail.getUserOperationId());
-    }
+
     assertFalse(userOperationLogEntries.isEmpty());
     assertFalse(historicDetails.isEmpty());
     verifySameOperationId(userOperationLogEntries, historicDetails);
@@ -233,9 +231,7 @@ public class UserOperationIdTest {
         .processInstanceId(pi.getId())
         .list();
     List<HistoricDetail> historicDetails = historyService.createHistoricDetailQuery().list();
-    for (HistoricDetail historicDetail : historicDetails) {
-        System.out.println(historicDetail.getUserOperationId());
-    }
+
     assertFalse(userOperationLogEntries.isEmpty());
     assertFalse(historicDetails.isEmpty());
     verifySameOperationId(userOperationLogEntries, historicDetails);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/UserOperationLogAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/UserOperationLogAuthorizationTest.java
@@ -125,7 +125,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
     // then
-    verifyQueryResults(query, 1);
+    verifyQueryResults(query, 2);
   }
 
   public void testQuerySetAssigneeTaskUserOperationLogWithReadHistoryPermissionOnAnyProcessDefinition() {
@@ -140,7 +140,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
     // then
-    verifyQueryResults(query, 1);
+    verifyQueryResults(query, 2);
   }
 
   public void testQuerySetAssigneeTaskUserOperationLogWithMultiple() {
@@ -156,7 +156,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
     // then
-    verifyQueryResults(query, 1);
+    verifyQueryResults(query, 2);
   }
 
   // (case) human task /////////////////////////////
@@ -233,7 +233,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
     // then
-    verifyQueryResults(query, 1);
+    verifyQueryResults(query, 2);
   }
 
   public void testQuerySetJobRetriesUserOperationLogWithReadHistoryPermissionOnAnyProcessDefinition() {
@@ -251,7 +251,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
     // then
-    verifyQueryResults(query, 1);
+    verifyQueryResults(query, 2);
   }
 
   // process definition ////////////////////////////////////////////
@@ -324,7 +324,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
     // then
-    verifyQueryResults(query, 1);
+    verifyQueryResults(query, 2);
 
     clearDatabase();
   }
@@ -340,7 +340,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
     // then
-    verifyQueryResults(query, 1);
+    verifyQueryResults(query, 2);
 
     clearDatabase();
   }
@@ -364,7 +364,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
     // then
-    verifyQueryResults(query, 2);
+    verifyQueryResults(query, 3);
 
     disableAuthorization();
     List<HistoricProcessInstance> instances = historyService.createHistoricProcessInstanceQuery().list();
@@ -401,7 +401,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     setAssignee(taskId, "demo");
 
     disableAuthorization();
-    String entryId = historyService.createUserOperationLogQuery().singleResult().getId();
+    String entryId = historyService.createUserOperationLogQuery().entityType("Task").singleResult().getId();
     enableAuthorization();
 
     try {
@@ -426,7 +426,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, DELETE_HISTORY);
 
     disableAuthorization();
-    String entryId = historyService.createUserOperationLogQuery().singleResult().getId();
+    String entryId = historyService.createUserOperationLogQuery().entityType("Task").singleResult().getId();
     enableAuthorization();
 
     // when
@@ -434,7 +434,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     // then
     disableAuthorization();
-    assertNull(historyService.createUserOperationLogQuery().singleResult());
+    assertNull(historyService.createUserOperationLogQuery().entityType("Task").singleResult());
     enableAuthorization();
   }
 
@@ -446,7 +446,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, DELETE_HISTORY);
 
     disableAuthorization();
-    String entryId = historyService.createUserOperationLogQuery().singleResult().getId();
+    String entryId = historyService.createUserOperationLogQuery().entityType("Task").singleResult().getId();
     enableAuthorization();
 
     // when
@@ -454,7 +454,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     // then
     disableAuthorization();
-    assertNull(historyService.createUserOperationLogQuery().singleResult());
+    assertNull(historyService.createUserOperationLogQuery().entityType("Task").singleResult());
     enableAuthorization();
   }
 
@@ -470,14 +470,14 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     deleteDeployment(deploymentId, false);
 
-    String entryId = historyService.createUserOperationLogQuery().singleResult().getId();
+    String entryId = historyService.createUserOperationLogQuery().entityType("Task").singleResult().getId();
 
     // when
     historyService.deleteUserOperationLogEntry(entryId);
 
     // then
     disableAuthorization();
-    assertNull(historyService.createUserOperationLogQuery().singleResult());
+    assertNull(historyService.createUserOperationLogQuery().entityType("Task").singleResult());
     enableAuthorization();
 
     disableAuthorization();

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/ModificationUserOperationLogTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/ModificationUserOperationLogTest.java
@@ -102,7 +102,10 @@ public class ModificationUserOperationLogTest {
     rule.getIdentityService().clearAuthentication();
 
     // then
-    List<UserOperationLogEntry> opLogEntries = rule.getHistoryService().createUserOperationLogQuery().list();
+    List<UserOperationLogEntry> opLogEntries = rule.getHistoryService()
+            .createUserOperationLogQuery()
+            .operationType(UserOperationLogEntry.OPERATION_TYPE_MODIFY_PROCESS_INSTANCE)
+            .list();
     Assert.assertEquals(2, opLogEntries.size());
 
     Map<String, UserOperationLogEntry> entries = asMap(opLogEntries);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/SetProcessDefinitionVersionCmdTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/SetProcessDefinitionVersionCmdTest.java
@@ -698,7 +698,7 @@ public class SetProcessDefinitionVersionCmdTest extends PluggableProcessEngineTe
             .processInstanceId(processInstance.getId())
             .list();
 
-        assertEquals(1, userOperations.size());
+        assertEquals(2, userOperations.size());
 
         UserOperationLogEntry userOperationLogEntry = userOperations.get(0);
         assertEquals(UserOperationLogEntry.OPERATION_TYPE_MODIFY_PROCESS_INSTANCE, userOperationLogEntry.getOperationType());

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/SetProcessDefinitionVersionCmdTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/SetProcessDefinitionVersionCmdTest.java
@@ -696,12 +696,12 @@ public class SetProcessDefinitionVersionCmdTest extends PluggableProcessEngineTe
         List<UserOperationLogEntry> userOperations = historyService
             .createUserOperationLogQuery()
             .processInstanceId(processInstance.getId())
+            .operationType(UserOperationLogEntry.OPERATION_TYPE_MODIFY_PROCESS_INSTANCE)
             .list();
 
-        assertEquals(2, userOperations.size());
+        assertEquals(1, userOperations.size());
 
         UserOperationLogEntry userOperationLogEntry = userOperations.get(0);
-        assertEquals(UserOperationLogEntry.OPERATION_TYPE_MODIFY_PROCESS_INSTANCE, userOperationLogEntry.getOperationType());
         assertEquals("processDefinitionVersion", userOperationLogEntry.getProperty());
         assertEquals("1", userOperationLogEntry.getOrgValue());
         assertEquals("2", userOperationLogEntry.getNewValue());

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/useroperationlog/LegacyUserOperationLogTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/useroperationlog/LegacyUserOperationLogTest.java
@@ -108,7 +108,8 @@ public class LegacyUserOperationLogTest {
       assertTrue((Boolean) runtimeService.getVariable(processInstanceId, "serviceTaskCalled"));
 
       UserOperationLogQuery query = userOperationLogQuery().userId(USER_ID);
-      assertEquals(3, query.count());
+      assertEquals(4, query.count());
+      assertEquals(1, query.operationType(UserOperationLogEntry.OPERATION_TYPE_CREATE).count());
       assertEquals(1, query.operationType(UserOperationLogEntry.OPERATION_TYPE_COMPLETE).count());
       assertEquals(2, query.operationType(UserOperationLogEntry.OPERATION_TYPE_SET_VARIABLE).count());
 
@@ -132,10 +133,17 @@ public class LegacyUserOperationLogTest {
     assertTrue((Boolean) runtimeService.getVariable(processInstanceId, "taskListenerCalled"));
     assertTrue((Boolean) runtimeService.getVariable(processInstanceId, "serviceTaskCalled"));
 
-    assertEquals(4, userOperationLogQuery().count());
+    assertEquals(5, userOperationLogQuery().count());
     assertEquals(1, userOperationLogQuery().operationType(UserOperationLogEntry.OPERATION_TYPE_COMPLETE).count());
     assertEquals(2, userOperationLogQuery().operationType(UserOperationLogEntry.OPERATION_TYPE_SET_VARIABLE).count());
-    assertEquals(1, userOperationLogQuery().operationType(UserOperationLogEntry.OPERATION_TYPE_CREATE).count());
+    assertEquals(1, userOperationLogQuery()
+            .entityType(EntityTypes.DEPLOYMENT)
+            .operationType(UserOperationLogEntry.OPERATION_TYPE_CREATE)
+            .count());
+    assertEquals(1, userOperationLogQuery()
+            .entityType(EntityTypes.PROCESS_INSTANCE)
+            .operationType(UserOperationLogEntry.OPERATION_TYPE_CREATE)
+            .count());
   }
 
   @Test
@@ -148,9 +156,16 @@ public class LegacyUserOperationLogTest {
     runtimeService.setVariable(processInstanceId, "aVariable", "aValue");
 
     // then
-    assertEquals(2, userOperationLogQuery().count());
+    assertEquals(3, userOperationLogQuery().count());
     assertEquals(1, userOperationLogQuery().operationType(UserOperationLogEntry.OPERATION_TYPE_SET_VARIABLE).count());
-    assertEquals(1, userOperationLogQuery().operationType(UserOperationLogEntry.OPERATION_TYPE_CREATE).count());
+    assertEquals(1, userOperationLogQuery()
+            .entityType(EntityTypes.DEPLOYMENT)
+            .operationType(UserOperationLogEntry.OPERATION_TYPE_CREATE)
+            .count());
+    assertEquals(1, userOperationLogQuery()
+            .entityType(EntityTypes.PROCESS_INSTANCE)
+            .operationType(UserOperationLogEntry.OPERATION_TYPE_CREATE)
+            .count());
   }
 
   @Test
@@ -169,7 +184,7 @@ public class LegacyUserOperationLogTest {
       managementService.executeJob(pending.getId());
     }
 
-    assertEquals(4, userOperationLogQuery().count());
+    assertEquals(5, userOperationLogQuery().count());
   }
 
   @Test
@@ -200,10 +215,14 @@ public class LegacyUserOperationLogTest {
     managementService.executeJob(migrationJob.getId());
 
     // then
-    assertEquals(5, userOperationLogQuery().count());
+    assertEquals(6, userOperationLogQuery().count());
     assertEquals(2, userOperationLogQuery()
         .operationType(UserOperationLogEntry.OPERATION_TYPE_CREATE)
         .entityType(EntityTypes.DEPLOYMENT)
+        .count());
+    assertEquals(1, userOperationLogQuery()
+        .operationType(UserOperationLogEntry.OPERATION_TYPE_CREATE)
+        .entityType(EntityTypes.PROCESS_INSTANCE)
         .count());
     assertEquals(3, userOperationLogQuery()
         .operationType(UserOperationLogEntry.OPERATION_TYPE_MIGRATE)

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/useroperationlog/UserOperationLogDeletionTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/useroperationlog/UserOperationLogDeletionTest.java
@@ -119,13 +119,13 @@ public class UserOperationLogDeletionTest extends AbstractUserOperationLogTest {
     UserOperationLogQuery query = historyService
         .createUserOperationLogQuery()
         .processInstanceId(processInstanceId);
-    assertEquals(3, query.count());
+    assertEquals(4, query.count());
 
     // when
     historyService.deleteHistoricProcessInstance(processInstanceId);
 
     // then
-    assertEquals(3, query.count());
+    assertEquals(4, query.count());
   }
 
   @Deployment(resources={"org/camunda/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -174,13 +174,13 @@ public class UserOperationLogDeletionTest extends AbstractUserOperationLogTest {
     UserOperationLogQuery query = historyService
         .createUserOperationLogQuery()
         .processInstanceId(processInstanceId);
-    assertEquals(1, query.count());
+    assertEquals(2, query.count());
 
     // when
     repositoryService.deleteProcessDefinition(processDefinitionId, true);
 
     // then new log is created and old stays
-    assertEquals(1, query.count());
+    assertEquals(2, query.count());
   }
 
   public void testDeleteProcessDefinitionsByKey() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/useroperationlog/UserOperationLogJobDefinitionTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/useroperationlog/UserOperationLogJobDefinitionTest.java
@@ -133,20 +133,25 @@ public class UserOperationLogJobDefinitionTest extends AbstractUserOperationLogT
     // when I set an overriding priority with cascade=true
     managementService.setOverridingJobPriorityForJobDefinition(jobDefinition.getId(), 42, true);
 
-    // then there are two op log entries
-    assertEquals(2, historyService.createUserOperationLogQuery().count());
+    // then there are three op log entries
+    assertEquals(3, historyService.createUserOperationLogQuery().count());
 
-    // (1): One for the job definition priority
+    // (1): One for the process instance start
+    UserOperationLogEntry processInstanceStartOpLogEntry = historyService.createUserOperationLogQuery()
+        .entityType(EntityTypes.PROCESS_INSTANCE).singleResult();
+    assertNotNull(processInstanceStartOpLogEntry);
+
+    // (2): One for the job definition priority
     UserOperationLogEntry jobDefOpLogEntry = historyService.createUserOperationLogQuery()
         .entityType(EntityTypes.JOB_DEFINITION).singleResult();
     assertNotNull(jobDefOpLogEntry);
 
-    // (2): and another one for the job priorities
+    // (3): and another one for the job priorities
     UserOperationLogEntry jobOpLogEntry = historyService.createUserOperationLogQuery()
         .entityType(EntityTypes.JOB).singleResult();
     assertNotNull(jobOpLogEntry);
 
-    assertEquals("both entries should be part of the same operation",
+    assertEquals("the two job related entries should be part of the same operation",
         jobDefOpLogEntry.getOperationId(), jobOpLogEntry.getOperationId());
 
     assertEquals(EntityTypes.JOB, jobOpLogEntry.getEntityType());

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/useroperationlog/UserOperationLogJobTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/useroperationlog/UserOperationLogJobTest.java
@@ -36,7 +36,10 @@ public class UserOperationLogJobTest extends AbstractUserOperationLogTest {
     managementService.setJobPriority(job.getId(), 42);
 
     // then an op log entry is written
-    UserOperationLogEntry userOperationLogEntry = historyService.createUserOperationLogQuery().singleResult();
+    UserOperationLogEntry userOperationLogEntry = historyService
+            .createUserOperationLogQuery()
+            .operationType(UserOperationLogEntry.OPERATION_TYPE_SET_PRIORITY)
+            .singleResult();
     assertNotNull(userOperationLogEntry);
 
     assertEquals(EntityTypes.JOB, userOperationLogEntry.getEntityType());

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/useroperationlog/UserOperationLogQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/useroperationlog/UserOperationLogQueryTest.java
@@ -105,16 +105,17 @@ public class UserOperationLogQueryTest extends AbstractUserOperationLogTest {
     createLogEntries();
 
     // expect: all entries can be fetched
-    assertEquals(17, query().count());
+    assertEquals(18, query().count());
 
     // entity type
     assertEquals(11, query().entityType(EntityTypes.TASK).count());
     assertEquals(4, query().entityType(EntityTypes.IDENTITY_LINK).count());
     assertEquals(2, query().entityType(EntityTypes.ATTACHMENT).count());
+    assertEquals(1, query().entityType(EntityTypes.PROCESS_INSTANCE).count());
     assertEquals(0, query().entityType("unknown entity type").count());
 
     // operation type
-    assertEquals(1, query().operationType(OPERATION_TYPE_CREATE).count());
+    assertEquals(2, query().operationType(OPERATION_TYPE_CREATE).count());
     assertEquals(1, query().operationType(OPERATION_TYPE_SET_PRIORITY).count());
     assertEquals(4, query().operationType(OPERATION_TYPE_UPDATE).count());
     assertEquals(1, query().operationType(OPERATION_TYPE_ADD_USER_LINK).count());
@@ -125,8 +126,8 @@ public class UserOperationLogQueryTest extends AbstractUserOperationLogTest {
     assertEquals(1, query().operationType(OPERATION_TYPE_DELETE_ATTACHMENT).count());
 
     // process and execution reference
-    assertEquals(11, query().processDefinitionId(process.getProcessDefinitionId()).count());
-    assertEquals(11, query().processInstanceId(process.getId()).count());
+    assertEquals(12, query().processDefinitionId(process.getProcessDefinitionId()).count());
+    assertEquals(12, query().processInstanceId(process.getId()).count());
     assertEquals(11, query().executionId(execution.getId()).count());
 
     // task reference
@@ -148,13 +149,13 @@ public class UserOperationLogQueryTest extends AbstractUserOperationLogTest {
 
     // ascending order results by time
     List<UserOperationLogEntry> ascLog = query().orderByTimestamp().asc().list();
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < 5; i++) {
       assertTrue(yesterday.getTime()<=ascLog.get(i).getTimestamp().getTime());
     }
-    for (int i = 4; i < 12; i++) {
+    for (int i = 5; i < 13; i++) {
       assertTrue(today.getTime()<=ascLog.get(i).getTimestamp().getTime());
     }
-    for (int i = 12; i < 16; i++) {
+    for (int i = 13; i < 18; i++) {
       assertTrue(tomorrow.getTime()<=ascLog.get(i).getTimestamp().getTime());
     }
 
@@ -166,14 +167,14 @@ public class UserOperationLogQueryTest extends AbstractUserOperationLogTest {
     for (int i = 4; i < 11; i++) {
       assertTrue(today.getTime()<=descLog.get(i).getTimestamp().getTime());
     }
-    for (int i = 11; i < 15; i++) {
+    for (int i = 11; i < 18; i++) {
       assertTrue(yesterday.getTime()<=descLog.get(i).getTimestamp().getTime());
     }
 
     // filter by time, created yesterday
-    assertEquals(4, query().beforeTimestamp(today).count());
+    assertEquals(5, query().beforeTimestamp(today).count());
     // filter by time, created today and before
-    assertEquals(12, query().beforeTimestamp(tomorrow).count());
+    assertEquals(13, query().beforeTimestamp(tomorrow).count());
     // filter by time, created today and later
     assertEquals(13, query().afterTimestamp(yesterday).count());
     // filter by time, created tomorrow
@@ -186,7 +187,7 @@ public class UserOperationLogQueryTest extends AbstractUserOperationLogTest {
     createLogEntries();
 
     // expect: all entries can be fetched
-    assertEquals(17, query().count());
+    assertEquals(18, query().count());
 
     // entity type
     assertEquals(11, query().entityType(ENTITY_TYPE_TASK).count());
@@ -207,7 +208,7 @@ public class UserOperationLogQueryTest extends AbstractUserOperationLogTest {
     runtimeService.deleteProcessInstance(process.getId(), "a delete reason");
 
     // then
-    assertEquals(3, query().entityType(PROCESS_INSTANCE).count());
+    assertEquals(4, query().entityType(PROCESS_INSTANCE).count());
 
     UserOperationLogEntry deleteEntry = query()
         .entityType(PROCESS_INSTANCE)
@@ -263,7 +264,7 @@ public class UserOperationLogQueryTest extends AbstractUserOperationLogTest {
     runtimeService.activateProcessInstanceByProcessDefinitionId(process.getProcessDefinitionId());
 
     // then
-    assertEquals(2, query().entityType(PROCESS_INSTANCE).count());
+    assertEquals(3, query().entityType(PROCESS_INSTANCE).count());
 
     UserOperationLogEntry suspendEntry = query()
         .entityType(PROCESS_INSTANCE)
@@ -308,7 +309,7 @@ public class UserOperationLogQueryTest extends AbstractUserOperationLogTest {
     runtimeService.activateProcessInstanceByProcessDefinitionKey("oneTaskProcess");
 
     // then
-    assertEquals(2, query().entityType(PROCESS_INSTANCE).count());
+    assertEquals(3, query().entityType(PROCESS_INSTANCE).count());
 
     UserOperationLogEntry suspendEntry = query()
         .entityType(PROCESS_INSTANCE)

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/db/entitymanager/PurgeDatabaseTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/db/entitymanager/PurgeDatabaseTest.java
@@ -213,7 +213,7 @@ public class PurgeDatabaseTest {
       assertEquals(2, (long) databasePurgeReport.getReportValue(databaseTablePrefix + "ACT_HI_TASKINST"));
       assertEquals(7, (long) databasePurgeReport.getReportValue(databaseTablePrefix + "ACT_HI_JOB_LOG"));
       assertEquals(2, (long) databasePurgeReport.getReportValue(databaseTablePrefix + "ACT_HI_VARINST"));
-      assertEquals(3, (long) databasePurgeReport.getReportValue(databaseTablePrefix + "ACT_HI_OP_LOG"));
+      assertEquals(5, (long) databasePurgeReport.getReportValue(databaseTablePrefix + "ACT_HI_OP_LOG"));
     }
 
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/history/CustomHistoryLevelUserOperationLogTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/history/CustomHistoryLevelUserOperationLogTest.java
@@ -145,7 +145,7 @@ public class CustomHistoryLevelUserOperationLogTest {
     runtimeService.deleteProcessInstance(process.getId(), "a delete reason");
 
     // then
-    assertEquals(3, query().entityType(PROCESS_INSTANCE).count());
+    assertEquals(4, query().entityType(PROCESS_INSTANCE).count());
 
     UserOperationLogEntry deleteEntry = query()
         .entityType(PROCESS_INSTANCE)


### PR DESCRIPTION
Starting a process with a set of variables creates HistoricDetail entries.
These entries also carry a UserOperationId, however, that UserOperationId
can't be resolved to a UserOperationLogEntry.

Not being able to audit the creation of a process instance/the initial
setting of variables at process creation time is considered a bug.

This commit modifies the StartProcessInstance and 
StartProcessInstanceAtActivities to create the necessary 
UserOperationLogEntry.

This results in a larger set of UserOperationLogEntrys that will be generated
by the process engine, which needs to be accounted for/filtered accordingly.

Unittests that reproduce the problematic behavior were add, existing unittest
updated to work with the new situation.