### PR TITLE
CAM-9950 Changes for Camunda on DB2 zOS

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/ExceptionUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/ExceptionUtil.java
@@ -80,6 +80,7 @@ public class ExceptionUtil {
     for (SQLException ex: sqlExceptionList) {
       if (ex.getMessage().contains("too long")
         || ex.getMessage().contains("too large")
+        || ex.getMessage().contains("TOO LARGE")
         || ex.getMessage().contains("ORA-01461")
         || ex.getMessage().contains("ORA-01401")
         || ex.getMessage().contains("data would be truncated")
@@ -145,6 +146,8 @@ public class ExceptionUtil {
           || ("23506".equals(exception.getSQLState()) && exception.getErrorCode() == 23506))
         // DB2
         || (exception.getMessage().toLowerCase().contains("sqlstate=23503") && exception.getMessage().toLowerCase().contains("sqlcode=-530"))
+        // DB2 zOS
+        || ("23503".equals(exception.getSQLState()) && exception.getErrorCode() == -530)
         ) {
 
         return true;

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Batch.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Batch.xml
@@ -91,7 +91,7 @@
 
   <update id="updateBatchSuspensionStateByParameters" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject">
     update ${prefix}ACT_RU_BATCH set
-      REV_ = REV_ + 1,
+      REV_ = 1 + REV_ ,
       SUSPENSION_STATE_ = #{parameter.suspensionState, jdbcType=INTEGER}
     <where>
       <if test="parameter.batchId != null">

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/CaseSentryPart.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/CaseSentryPart.xml
@@ -41,7 +41,7 @@
     values
     (
       #{id, jdbcType=VARCHAR},
-      1,
+      (1),
       #{caseInstanceId, jdbcType=VARCHAR},
       #{caseExecutionId, jdbcType=VARCHAR},
       #{sentryId, jdbcType=VARCHAR},

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Execution.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Execution.xml
@@ -96,7 +96,7 @@
   
   <update id="updateExecutionSuspensionStateByParameters" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject">
     update ${prefix}ACT_RU_EXECUTION set
-      REV_ = REV_ + 1,
+      REV_ = 1 + REV_ ,
       SUSPENSION_STATE_ = #{parameter.suspensionState, jdbcType=INTEGER}
     <where>
       <if test="parameter.processInstanceId != null">

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
@@ -42,7 +42,7 @@
 
   <update id="updateJobSuspensionStateByParameters" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject">
     update ${prefix}ACT_RU_JOB set
-      REV_ = REV_ + 1,
+      REV_ = 1 + REV_ ,
       SUSPENSION_STATE_ = #{parameter.suspensionState, jdbcType=INTEGER}
     <where>
       <if test="parameter.jobId != null">
@@ -85,7 +85,7 @@
 
   <update id="updateFailedJobRetriesByParameters" parameterType="java.util.Map">
     update ${prefix}ACT_RU_JOB set
-      REV_ = REV_ + 1,
+      REV_ = 1 + REV_ ,
       LOCK_OWNER_ = NULL,
       LOCK_EXP_TIME_ = NULL,
       RETRIES_ = #{retries, jdbcType=INTEGER}

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/JobDefinition.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/JobDefinition.xml
@@ -66,7 +66,7 @@
 
   <update id="updateJobDefinitionSuspensionStateByParameters" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject">
     update ${prefix}ACT_RU_JOBDEF set
-      REV_ = REV_ + 1,
+      REV_ = 1 + REV_ ,
       SUSPENSION_STATE_ = #{parameter.suspensionState, jdbcType=INTEGER}
     <where>
       <if test="parameter.jobDefinitionId != null">

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ProcessDefinition.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ProcessDefinition.xml
@@ -55,7 +55,7 @@
 
   <update id="updateProcessDefinitionSuspensionStateByParameters" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject">
     update ${prefix}ACT_RE_PROCDEF set
-      REV_ = REV_ + 1,
+      REV_ = 1 + REV_ ,
       SUSPENSION_STATE_ = #{parameter.suspensionState, jdbcType=INTEGER}
     <where>
       <if test="parameter.processDefinitionId != null">

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
@@ -101,7 +101,7 @@
 
   <update id="updateTaskSuspensionStateByParameters" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject">
     update ${prefix}ACT_RU_TASK set
-      REV_ = REV_ + 1,
+      REV_ = 1 + REV_ ,
       SUSPENSION_STATE_ = #{parameter.suspensionState, jdbcType=INTEGER}
     <where>
       <include refid="updateTaskSuspensionStateByParametersSql" />


### PR DESCRIPTION
There seems to be a problem with the DB2 parser on zOS. When using comma
inside the SQL command, DB2 expects somethings else and we get an error:

When we want to run the SQL
update ACT_RU_JOB set       REV_ = REV_ + 1,       LOCK_OWNER_ = NULL,
LOCK_EXP_TIME_ = NULL,       RETRIES_ = ?      WHERE RETRIES_ = 0
and JOB_DEF_ID_ = ?

we get an error

### Cause: com.ibm.db2.jcc.am.SqlSyntaxErrorException: DB2 SQL Error:
SQLCODE=-104, SQLSTATE=42601, SQLERRMC=LOCK_OWNER_;AT MICROSECONDS
MICROSECOND SECONDS SECOND MINUTES MINUTE , DRIVER=4.21.40'.


Changing the order of arguments helps us to run it on DB2 zOS

We already talked with Ingo Richtsmeier to get it run on DB2 zOS:
https://app.camunda.com/jira/browse/SUPPORT-5326
