### PR TITLE
CAM-9940 HistoryCleanuoScheduler-Tests withour droping database

### DIFF
--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerActivityInstancesTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerActivityInstancesTest.java
@@ -47,6 +47,7 @@ public class HistoryCleanupSchedulerActivityInstancesTest extends AbstractHistor
 
   public ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
     public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      saveCurrentHistoryLevelAndUpdateTo(configuration, customHistoryLevel.getId());
       return configure(configuration, HistoryEventTypes.ACTIVITY_INSTANCE_START);
     }
   };

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerAttachmentsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerAttachmentsTest.java
@@ -46,6 +46,7 @@ public class HistoryCleanupSchedulerAttachmentsTest extends AbstractHistoryClean
 
   public ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
     public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      saveCurrentHistoryLevelAndUpdateTo(configuration, customHistoryLevel.getId());
       return configure(configuration);
     }
   };

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerBatchesTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerBatchesTest.java
@@ -49,6 +49,7 @@ public class HistoryCleanupSchedulerBatchesTest extends AbstractHistoryCleanupSc
 
   public ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
     public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      saveCurrentHistoryLevelAndUpdateTo(configuration, customHistoryLevel.getId());
       return configure(configuration, HistoryEventTypes.BATCH_START, HistoryEventTypes.BATCH_END);
     }
   };

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerCommentsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerCommentsTest.java
@@ -46,6 +46,7 @@ public class HistoryCleanupSchedulerCommentsTest extends AbstractHistoryCleanupS
 
   public ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
     public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      saveCurrentHistoryLevelAndUpdateTo(configuration, customHistoryLevel.getId());
       return configure(configuration);
     }
   };

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerDecisionsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerDecisionsTest.java
@@ -48,6 +48,7 @@ public class HistoryCleanupSchedulerDecisionsTest extends AbstractHistoryCleanup
 
   public ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
     public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      saveCurrentHistoryLevelAndUpdateTo(configuration, customHistoryLevel.getId());
       return configure(configuration, HistoryEventTypes.DMN_DECISION_EVALUATE);
     }
   };

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerDetailsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerDetailsTest.java
@@ -49,6 +49,7 @@ public class HistoryCleanupSchedulerDetailsTest extends AbstractHistoryCleanupSc
 
   public ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
     public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      saveCurrentHistoryLevelAndUpdateTo(configuration, customHistoryLevel.getId());
       return configure(configuration, HistoryEventTypes.VARIABLE_INSTANCE_UPDATE, HistoryEventTypes.VARIABLE_INSTANCE_UPDATE_DETAIL);
     }
   };

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerExternalTaskLogsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerExternalTaskLogsTest.java
@@ -48,6 +48,7 @@ public class HistoryCleanupSchedulerExternalTaskLogsTest extends AbstractHistory
 
   public ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
     public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      saveCurrentHistoryLevelAndUpdateTo(configuration, customHistoryLevel.getId());
       return configure(configuration, HistoryEventTypes.EXTERNAL_TASK_SUCCESS);
     }
   };

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerIdentityLinkLogsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerIdentityLinkLogsTest.java
@@ -47,6 +47,7 @@ public class HistoryCleanupSchedulerIdentityLinkLogsTest extends AbstractHistory
 
   public ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
     public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      saveCurrentHistoryLevelAndUpdateTo(configuration, customHistoryLevel.getId());
       return configure(configuration, HistoryEventTypes.TASK_INSTANCE_CREATE, HistoryEventTypes.IDENTITY_LINK_ADD);
     }
   };

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerIncidentsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerIncidentsTest.java
@@ -47,6 +47,7 @@ public class HistoryCleanupSchedulerIncidentsTest  extends AbstractHistoryCleanu
 
   public ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
     public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      saveCurrentHistoryLevelAndUpdateTo(configuration, customHistoryLevel.getId());
       return configure(configuration, HistoryEventTypes.INCIDENT_CREATE);
     }
   };

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerJobLogTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerJobLogTest.java
@@ -47,6 +47,7 @@ public class HistoryCleanupSchedulerJobLogTest extends AbstractHistoryCleanupSch
 
   public ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
     public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      saveCurrentHistoryLevelAndUpdateTo(configuration, customHistoryLevel.getId());
       return configure(configuration, HistoryEventTypes.JOB_FAIL);
     }
   };

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerProcessInstancesTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerProcessInstancesTest.java
@@ -47,6 +47,7 @@ public class HistoryCleanupSchedulerProcessInstancesTest extends AbstractHistory
 
   public ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
     public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      saveCurrentHistoryLevelAndUpdateTo(configuration, customHistoryLevel.getId());
       return configure(configuration, HistoryEventTypes.PROCESS_INSTANCE_START);
     }
   };

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerTaskInstancesTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerTaskInstancesTest.java
@@ -49,6 +49,7 @@ public class HistoryCleanupSchedulerTaskInstancesTest extends AbstractHistoryCle
 
   public ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
     public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      saveCurrentHistoryLevelAndUpdateTo(configuration, customHistoryLevel.getId());
       return configure(configuration, HistoryEventTypes.TASK_INSTANCE_CREATE);
     }
   };

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerUserOperationLogsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerUserOperationLogsTest.java
@@ -48,6 +48,7 @@ public class HistoryCleanupSchedulerUserOperationLogsTest extends AbstractHistor
 
   public ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
     public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      saveCurrentHistoryLevelAndUpdateTo(configuration, customHistoryLevel.getId());
       return configure(configuration, HistoryEventTypes.USER_OPERATION_LOG);
     }
   };

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerVariableInstancesTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerVariableInstancesTest.java
@@ -47,6 +47,7 @@ public class HistoryCleanupSchedulerVariableInstancesTest extends AbstractHistor
 
   public ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
     public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      saveCurrentHistoryLevelAndUpdateTo(configuration, customHistoryLevel.getId());
       return configure(configuration, HistoryEventTypes.VARIABLE_INSTANCE_CREATE);
     }
   };


### PR DESCRIPTION
When you are using external databases, you do not want to (or do not
have privileges) drop the whole database. In this case, we change the
history level to the given value and set it back after the test