### PR TITLE
CAM-10385 make exception include the name of the variable if FormFieldHandler.createFormField throws

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/form/handler/FormFieldHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/form/handler/FormFieldHandler.java
@@ -29,6 +29,7 @@ import org.camunda.bpm.engine.impl.el.StartProcessVariableScope;
 import org.camunda.bpm.engine.impl.form.FormDataImpl;
 import org.camunda.bpm.engine.impl.form.FormFieldImpl;
 import org.camunda.bpm.engine.impl.form.type.AbstractFormFieldType;
+import org.camunda.bpm.engine.impl.form.validator.FormFieldValidationException;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.camunda.bpm.engine.variable.VariableMap;
 import org.camunda.bpm.engine.variable.Variables;
@@ -83,7 +84,13 @@ public class FormFieldHandler {
     // value
     TypedValue value = variableScope.getVariableTyped(id);
     if(value != null) {
-      formField.setValue(type.convertToFormValue(value));
+      final TypedValue formValue;
+      try {
+        formValue = type.convertToFormValue(value);
+      } catch (Exception exception) {
+        throw new FormFieldValidationException(id, "failed to convert '" + id + "'", exception);
+      }
+      formField.setValue(formValue);
     }
     else {
       // first, need to convert to model value since the default value may be a String Constant specified in the model xml.


### PR DESCRIPTION
See https://app.camunda.com/jira/browse/CAM-10385

With the released version of Camunda, I get an exception like this:

01-Jun-2019 10:49:05.607 WARNING [http-nio-8080-exec-225] org.camunda.bpm.engine.rest.exception.ExceptionHandler.toResponse java.lang.NumberFormatException: For input string: "
"
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
        at java.lang.Long.parseLong(Long.java:601)
        at java.lang.Long.<init>(Long.java:965)
        at org.camunda.bpm.engine.impl.form.type.LongFormType.convertValue(LongFormType.java:46)
        at org.camunda.bpm.engine.impl.form.type.SimpleFormFieldType.convertToFormValue(SimpleFormFieldType.java:29)
        at org.camunda.bpm.engine.impl.form.handler.FormFieldHandler.createFormField(FormFieldHandler.java:86)
        at org.camunda.bpm.engine.impl.form.handler.DefaultFormHandler.initializeFormFields(DefaultFormHandler.java:278)
        at org.camunda.bpm.engine.impl.form.handler.DefaultTaskFormHandler.createTaskForm(DefaultTaskFormHandler.java:44)
        at org.camunda.bpm.engine.impl.form.handler.CreateTaskFormInvocation.invoke(CreateTaskFormInvocation.java:37)
        at org.camunda.bpm.engine.impl.delegate.DelegateInvocation.proceed(DelegateInvocation.java:57)
        at org.camunda.bpm.engine.impl.delegate.DefaultDelegateInterceptor.handleInvocationInContext(DefaultDelegateInterceptor.java:90)
        at org.camunda.bpm.engine.impl.delegate.DefaultDelegateInterceptor.handleInvocation(DefaultDelegateInterceptor.java:62)
        at org.camunda.bpm.engine.impl.form.handler.DelegateTaskFormHandler$1.call(DelegateTaskFormHandler.java:41)
        at org.camunda.bpm.engine.impl.form.handler.DelegateTaskFormHandler$1.call(DelegateTaskFormHandler.java:36)
        at org.camunda.bpm.engine.impl.form.handler.DelegateFormHandler.doCall(DelegateFormHandler.java:69)
        at org.camunda.bpm.engine.impl.form.handler.DelegateFormHandler$1.call(DelegateFormHandler.java:57)
        at org.camunda.bpm.engine.impl.context.ProcessApplicationClassloaderInterceptor.call(ProcessApplicationClassloaderInterceptor.java:47)
        at org.camunda.bpm.application.AbstractProcessApplication.execute(AbstractProcessApplication.java:117)
        at org.camunda.bpm.application.AbstractProcessApplication.execute(AbstractProcessApplication.java:128)
        at org.camunda.bpm.engine.impl.context.Context.executeWithinProcessApplication(Context.java:194)
        at org.camunda.bpm.engine.impl.context.Context.executeWithinProcessApplication(Context.java:181)
        at org.camunda.bpm.engine.impl.form.handler.DelegateFormHandler.performContextSwitch(DelegateFormHandler.java:55)
        at org.camunda.bpm.engine.impl.form.handler.DelegateTaskFormHandler.createTaskForm(DelegateTaskFormHandler.java:36)
        at org.camunda.bpm.engine.impl.cmd.GetTaskFormCmd.execute(GetTaskFormCmd.java:56)
        at org.camunda.bpm.engine.impl.cmd.GetTaskFormCmd.execute(GetTaskFormCmd.java:34)
        at org.camunda.bpm.engine.impl.interceptor.CommandExecutorImpl.execute(CommandExecutorImpl.java:27)
        at org.camunda.bpm.engine.impl.interceptor.CommandContextInterceptor.execute(CommandContextInterceptor.java:106)
        at org.camunda.bpm.engine.impl.interceptor.ProcessApplicationContextInterceptor.execute(ProcessApplicationContextInterceptor.java:69)
        at org.camunda.bpm.engine.impl.interceptor.LogInterceptor.execute(LogInterceptor.java:32)
        at org.camunda.bpm.engine.impl.FormServiceImpl.getTaskFormData(FormServiceImpl.java:66)
        at org.camunda.bpm.engine.rest.sub.task.impl.TaskResourceImpl.getForm(TaskResourceImpl.java:186)
        at sun.reflect.GeneratedMethodAccessor574.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)

which doesn't tell me which form field caused the problem.

With this pull request we catch the exception in FormFieldHandler.createField and rethrow it as a FormFieldValidationException so that we can include the name of the offending variable.

Now we get a stack trace like this:

01-Jun-2019 11:39:19.952 SEVERE [http-nio-8080-exec-2] org.camunda.commons.logging.BaseLogger.logError ENGINE-16004 Exception while closing command context: failed to convert '
arrayAzimuthDegrees' caused by java.lang.NumberFormatException: For input string: ""
 org.camunda.bpm.engine.impl.form.validator.FormFieldValidationException: failed to convert 'arrayAzimuthDegrees' caused by java.lang.NumberFormatException: For input string: "
"
        at org.camunda.bpm.engine.impl.form.handler.FormFieldHandler.createFormField(FormFieldHandler.java:91)
        at org.camunda.bpm.engine.impl.form.handler.DefaultFormHandler.initializeFormFields(DefaultFormHandler.java:278)
        at org.camunda.bpm.engine.impl.form.handler.DefaultTaskFormHandler.createTaskForm(DefaultTaskFormHandler.java:44)
        at org.camunda.bpm.engine.impl.form.handler.CreateTaskFormInvocation.invoke(CreateTaskFormInvocation.java:37)

...

Caused by: java.lang.NumberFormatException: For input string: ""
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
        at java.lang.Long.parseLong(Long.java:601)
        at java.lang.Long.<init>(Long.java:965)
        at org.camunda.bpm.engine.impl.form.type.LongFormType.convertValue(LongFormType.java:46)
        at org.camunda.bpm.engine.impl.form.type.SimpleFormFieldType.convertToFormValue(SimpleFormFieldType.java:29)
        at org.camunda.bpm.engine.impl.form.handler.FormFieldHandler.createFormField(FormFieldHandler.java:89)
