### PR TITLE
CAM-5164 fix(engine): correct handling of history level with 'auto' history

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoryLevelSetupCommand.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoryLevelSetupCommand.java
@@ -42,6 +42,9 @@ public final class HistoryLevelSetupCommand implements Command<Void> {
     determineAutoHistoryLevel(processEngineConfiguration, databaseHistoryLevel);
 
     HistoryLevel configuredHistoryLevel = processEngineConfiguration.getHistoryLevel();
+    if (!processEngineConfiguration.isDbHistoryUsed() && !configuredHistoryLevel.equals(HistoryLevel.HISTORY_LEVEL_NONE)) {
+      throw LOG.databaseHistoryLevelException(configuredHistoryLevel.getName());
+    }
 
     if (databaseHistoryLevel == null) {
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessEngineImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessEngineImpl.java
@@ -87,10 +87,10 @@ public class ProcessEngineImpl implements ProcessEngine {
     this.commandExecutor = processEngineConfiguration.getCommandExecutorTxRequired();
     commandExecutorSchemaOperations = processEngineConfiguration.getCommandExecutorSchemaOperations();
     this.sessionFactories = processEngineConfiguration.getSessionFactories();
-    this.historyLevel = processEngineConfiguration.getHistoryLevel();
     this.transactionContextFactory = processEngineConfiguration.getTransactionContextFactory();
 
     executeSchemaOperations();
+    this.historyLevel = processEngineConfiguration.getHistoryLevel();
 
     if (name == null) {
       LOG.processEngineCreated(ProcessEngines.NAME_DEFAULT);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -795,7 +795,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   @Override
   public ProcessEngine buildProcessEngine() {
     init();
-    processEngine = new ProcessEngineImpl(this);
+    processEngine = initProcessEngine();
     invokePostProcessEngineBuild(processEngine);
     return processEngine;
   }
@@ -817,7 +817,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     initFormTypes();
     initFormFieldValidators();
     initScripting();
-    initDmnEngine();
     initBusinessCalendarManager();
     initCommandContextFactory();
     initTransactionContextFactory();
@@ -825,7 +824,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     initServices();
     initIdGenerator();
     initFailedJobCommandFactory();
-    initDeployers();
     initJobProvider();
     initExternalTaskPriorityProvider();
     initBatchHandlers();
@@ -1044,11 +1042,17 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       plugin.postInit(this);
     }
   }
+  
+  protected ProcessEngineImpl initProcessEngine() {
+    return new ProcessEngineImpl(this);
+  }
 
   protected void invokePostProcessEngineBuild(ProcessEngine engine) {
     for (ProcessEnginePlugin plugin : processEnginePlugins) {
       plugin.postProcessEngineBuild(engine);
     }
+    initDmnEngine();
+    initDeployers();
   }
 
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/AbstractPersistenceSession.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/AbstractPersistenceSession.java
@@ -76,13 +76,6 @@ public abstract class AbstractPersistenceSession implements PersistenceSession {
   public void dbSchemaCreate() {
     ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
 
-    HistoryLevel configuredHistoryLevel = processEngineConfiguration.getHistoryLevel();
-    if ( (!processEngineConfiguration.isDbHistoryUsed())
-         && (!configuredHistoryLevel.equals(HistoryLevel.HISTORY_LEVEL_NONE))
-       ) {
-      throw LOG.databaseHistoryLevelException(configuredHistoryLevel.getName());
-    }
-
     if (isEngineTablePresent()) {
       String dbVersion = getDbVersion();
       if (!ProcessEngine.VERSION.equals(dbVersion)) {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/cfg/DatabaseTablePrefixTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/cfg/DatabaseTablePrefixTest.java
@@ -108,8 +108,7 @@ public class DatabaseTablePrefixTest {
   private static class CustomStandaloneInMemProcessEngineConfiguration extends StandaloneInMemProcessEngineConfiguration {
 
     @Override
-    public ProcessEngine buildProcessEngine() {
-      init();
+    protected ProcessEngineImpl initProcessEngine() {
       return new NoSchemaProcessEngineImpl(this);
     }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/deploy/DeploymentAutoHistoryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/deploy/DeploymentAutoHistoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.standalone.deploy;
+
+import static org.junit.Assert.assertEquals;
+
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.repository.DeploymentWithDefinitions;
+import org.camunda.bpm.engine.test.util.ProcessEngineBootstrapRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class DeploymentAutoHistoryTest {
+
+  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule(bootstrapRule);
+  protected ProcessEngineTestRule testHelper = new ProcessEngineTestRule(engineRule);
+
+  @ClassRule
+  public static ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
+    @Override
+    public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      configuration.setJdbcUrl("jdbc:h2:mem:DeploymentTest-HistoryLevelAuto;DB_CLOSE_DELAY=1000");
+      configuration.setDatabaseSchemaUpdate(ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP);
+      configuration.setHistoryLevel(null);
+      configuration.setHistory(ProcessEngineConfiguration.HISTORY_AUTO);
+      return configuration;
+    }
+  };
+
+  @Rule
+  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testHelper);
+
+  @Test
+  public void shouldCreateDeployment() {
+     BpmnModelInstance instance = Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
+
+     DeploymentWithDefinitions deployment = engineRule.getRepositoryService()
+         .createDeployment()
+         .addModelInstance("foo.bpmn", instance)
+         .deployWithResult();
+
+     long count = engineRule.getRepositoryService().createDeploymentQuery().count();
+     assertEquals(1, count);
+     engineRule.getRepositoryService().deleteDeployment(deployment.getId(), true);
+  }
+
+
+}


### PR DESCRIPTION
- initialize objects that depend on the history level after the process engine has been
  initialized

related to CAM-5164