### PR TITLE
[CAM-9938] Only log stacktrace of OptimisticLockingException on DEBUG

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/JobExecutorLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/JobExecutorLogger.java
@@ -61,7 +61,7 @@ public class JobExecutorLogger extends ProcessEngineLogger {
       logWarn(
           "006", 
           "Exception while executing job {}: {}. To see the full stacktrace set logging level to DEBUG.", 
-          t.getClass().getSimpleName());
+          nextJobId, t.getClass().getSimpleName());
     } else {
       logWarn(
           "006", "Exception while executing job {}: ", nextJobId, t);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/JobExecutorLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/JobExecutorLogger.java
@@ -18,6 +18,7 @@ package org.camunda.bpm.engine.impl.jobexecutor;
 
 import java.util.Collection;
 
+import org.camunda.bpm.engine.OptimisticLockingException;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
@@ -56,8 +57,15 @@ public class JobExecutorLogger extends ProcessEngineLogger {
   }
 
   public void exceptionWhileExecutingJob(String nextJobId, Throwable t) {
-    logWarn(
-        "006", "Exception while executing job {}: ", nextJobId, t);
+    if(t instanceof OptimisticLockingException && !isDebugEnabled()) {
+      logWarn(
+          "006", 
+          "Exception while closing command context: {} To see the full stacktrace set logging level to WARNING.", 
+          t.getClass().getSimpleName());
+    } else {
+      logWarn(
+          "006", "Exception while executing job {}: ", nextJobId, t);
+    }
   }
 
   public void couldNotDeterminePriority(ExecutionEntity execution, Object value, ProcessEngineException e) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/JobExecutorLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/JobExecutorLogger.java
@@ -60,7 +60,7 @@ public class JobExecutorLogger extends ProcessEngineLogger {
     if(t instanceof OptimisticLockingException && !isDebugEnabled()) {
       logWarn(
           "006", 
-          "Exception while closing command context: {} To see the full stacktrace set logging level to WARNING.", 
+          "Exception while executing job {}: {}. To see the full stacktrace set logging level to DEBUG.", 
           t.getClass().getSimpleName());
     } else {
       logWarn(


### PR DESCRIPTION
OptimisticLockingExceptions should only be logged fully on logging level DEBUG. On logging levels lower than DEBUG only the occurrence of the exception should be logged.

https://app.camunda.com/jira/browse/CAM-9938

Related to CAM-9938