### PR TITLE
Cam 10409 flush bug

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ManagementServiceImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ManagementServiceImpl.java
@@ -137,7 +137,7 @@ public class ManagementServiceImpl extends ServiceImpl implements ManagementServ
   public void setJobDuedate(String jobId, Date newDuedate) {
     commandExecutor.execute(new SetJobDuedateCmd(jobId, newDuedate));
   }
-  
+
   public void recalculateJobDuedate(String jobId, boolean creationDateBased) {
     commandExecutor.execute(new RecalculateJobDuedateCmd(jobId, creationDateBased));
   }
@@ -179,7 +179,7 @@ public class ManagementServiceImpl extends ServiceImpl implements ManagementServ
       public String execute(CommandContext commandContext) {
         commandContext.getAuthorizationManager().checkCamundaAdmin();
         DbSqlSessionFactory dbSqlSessionFactory = (DbSqlSessionFactory) commandContext.getSessionFactories().get(DbSqlSession.class);
-        DbSqlSession dbSqlSession = new DbSqlSession(dbSqlSessionFactory, connection, catalog, schema);
+        DbSqlSession dbSqlSession = dbSqlSessionFactory.openSession(connection, catalog, schema);
         commandContext.getSessions().put(DbSqlSession.class, dbSqlSession);
         dbSqlSession.dbSchemaUpdate();
 
@@ -213,7 +213,7 @@ public class ManagementServiceImpl extends ServiceImpl implements ManagementServ
       public Set<String> execute(CommandContext commandContext) {
         commandContext.getAuthorizationManager().checkCamundaAdmin();
         Set<String> registeredDeployments = Context.getProcessEngineConfiguration().getRegisteredDeployments();
-        return new HashSet<String>(registeredDeployments);
+        return new HashSet<>(registeredDeployments);
       }
     });
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -616,7 +616,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected ResourceAuthorizationProvider resourceAuthorizationProvider;
 
-  protected List<ProcessEnginePlugin> processEnginePlugins = new ArrayList<ProcessEnginePlugin>();
+  protected List<ProcessEnginePlugin> processEnginePlugins = new ArrayList<>();
 
   protected HistoryEventProducer historyEventProducer;
 
@@ -625,7 +625,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected DmnHistoryEventProducer dmnHistoryEventProducer;
 
   protected HistoryEventHandler historyEventHandler;
-  
+
   protected PermissionProvider permissionProvider;
 
   protected boolean isExecutionTreePrefetchEnabled = true;
@@ -734,7 +734,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected Date historyCleanupBatchWindowStartTimeAsDate;
   protected Date historyCleanupBatchWindowEndTimeAsDate;
 
-  protected Map<Integer, BatchWindowConfiguration> historyCleanupBatchWindows = new HashMap<Integer, BatchWindowConfiguration>();
+  protected Map<Integer, BatchWindowConfiguration> historyCleanupBatchWindows = new HashMap<>();
 
   //shortcuts for batch windows configuration available to be configured from XML
   protected String mondayHistoryCleanupBatchWindowStartTime;
@@ -756,7 +756,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected int historyCleanupDegreeOfParallelism = 1;
 
   protected String historyTimeToLive;
-  
+
   protected String batchOperationHistoryTimeToLive;
   protected Map<String, String> batchOperationsForHistoryCleanup;
   protected Map<String, Integer> parsedBatchOperationsForHistoryCleanup;
@@ -912,7 +912,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       throw LOG.invalidPropertyValue("historyCleanupBatchThreshold", String.valueOf(historyCleanupBatchThreshold),
           "History cleanup batch threshold cannot be negative.");
     }
-    
+
     initHistoryTimeToLive();
 
     initBatchOperationsHistoryTimeToLive();
@@ -965,7 +965,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       historyCleanupBatchWindows.put(Calendar.SUNDAY, new BatchWindowConfiguration(sundayHistoryCleanupBatchWindowStartTime, sundayHistoryCleanupBatchWindowEndTime));
     }
   }
-  
+
   protected void initHistoryTimeToLive() {
     try {
       ParseUtil.parseHistoryTimeToLive(historyTimeToLive);
@@ -982,7 +982,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
 
     if (batchOperationsForHistoryCleanup == null) {
-      batchOperationsForHistoryCleanup = new HashMap<String, String>();
+      batchOperationsForHistoryCleanup = new HashMap<>();
     } else {
       for (String batchOperation : batchOperationsForHistoryCleanup.keySet()) {
         String timeToLive = batchOperationsForHistoryCleanup.get(batchOperation);
@@ -1007,7 +1007,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       }
     }
 
-    parsedBatchOperationsForHistoryCleanup = new HashMap<String, Integer>();
+    parsedBatchOperationsForHistoryCleanup = new HashMap<>();
     if (batchOperationsForHistoryCleanup != null) {
       for (String operation : batchOperationsForHistoryCleanup.keySet()) {
         Integer historyTimeToLive = ParseUtil.parseHistoryTimeToLive(batchOperationsForHistoryCleanup.get(operation));
@@ -1059,7 +1059,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       failedJobCommandFactory = new DefaultFailedJobCommandFactory();
     }
     if (postParseListeners == null) {
-      postParseListeners = new ArrayList<BpmnParseListener>();
+      postParseListeners = new ArrayList<>();
     }
     postParseListeners.add(new DefaultFailedJobParseListener());
 
@@ -1069,7 +1069,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initIncidentHandlers() {
     if (incidentHandlers == null) {
-      incidentHandlers = new HashMap<String, IncidentHandler>();
+      incidentHandlers = new HashMap<>();
 
       DefaultIncidentHandler failedJobIncidentHandler = new DefaultIncidentHandler(Incident.FAILED_JOB_HANDLER_TYPE);
       incidentHandlers.put(failedJobIncidentHandler.getIncidentHandlerType(), failedJobIncidentHandler);
@@ -1088,7 +1088,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initBatchHandlers() {
     if (batchHandlers == null) {
-      batchHandlers = new HashMap<String, BatchJobHandler<?>>();
+      batchHandlers = new HashMap<>();
 
       MigrationBatchJobHandler migrationHandler = new MigrationBatchJobHandler();
       batchHandlers.put(migrationHandler.getType(), migrationHandler);
@@ -1156,9 +1156,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected void initCommandInterceptorsTxRequired() {
     if (commandInterceptorsTxRequired == null) {
       if (customPreCommandInterceptorsTxRequired != null) {
-        commandInterceptorsTxRequired = new ArrayList<CommandInterceptor>(customPreCommandInterceptorsTxRequired);
+        commandInterceptorsTxRequired = new ArrayList<>(customPreCommandInterceptorsTxRequired);
       } else {
-        commandInterceptorsTxRequired = new ArrayList<CommandInterceptor>();
+        commandInterceptorsTxRequired = new ArrayList<>();
       }
       commandInterceptorsTxRequired.addAll(getDefaultCommandInterceptorsTxRequired());
       if (customPostCommandInterceptorsTxRequired != null) {
@@ -1171,9 +1171,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected void initCommandInterceptorsTxRequiresNew() {
     if (commandInterceptorsTxRequiresNew == null) {
       if (customPreCommandInterceptorsTxRequiresNew != null) {
-        commandInterceptorsTxRequiresNew = new ArrayList<CommandInterceptor>(customPreCommandInterceptorsTxRequiresNew);
+        commandInterceptorsTxRequiresNew = new ArrayList<>(customPreCommandInterceptorsTxRequiresNew);
       } else {
-        commandInterceptorsTxRequiresNew = new ArrayList<CommandInterceptor>();
+        commandInterceptorsTxRequiresNew = new ArrayList<>();
       }
       commandInterceptorsTxRequiresNew.addAll(getDefaultCommandInterceptorsTxRequiresNew());
       if (customPostCommandInterceptorsTxRequiresNew != null) {
@@ -1509,7 +1509,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initSessionFactories() {
     if (sessionFactories == null) {
-      sessionFactories = new HashMap<Class<?>, SessionFactory>();
+      sessionFactories = new HashMap<>();
 
       initPersistenceProviders();
 
@@ -1585,7 +1585,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initPersistenceProviders() {
     ensurePrefixAndSchemaFitToegether(databaseTablePrefix, databaseSchema);
-    dbSqlSessionFactory = new DbSqlSessionFactory();
+    dbSqlSessionFactory = new DbSqlSessionFactory(jdbcBatchProcessing);
     dbSqlSessionFactory.setDatabaseType(databaseType);
     dbSqlSessionFactory.setIdGenerator(idGenerator);
     dbSqlSessionFactory.setSqlSessionFactory(sqlSessionFactory);
@@ -1624,7 +1624,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       migrationInstructionGenerator = new DefaultMigrationInstructionGenerator(migrationActivityMatcher);
     }
 
-    List<MigrationActivityValidator> migrationActivityValidators = new ArrayList<MigrationActivityValidator>();
+    List<MigrationActivityValidator> migrationActivityValidators = new ArrayList<>();
     if (customPreMigrationActivityValidators != null) {
       migrationActivityValidators.addAll(customPreMigrationActivityValidators);
     }
@@ -1639,7 +1639,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initMigrationInstructionValidators() {
     if (migrationInstructionValidators == null) {
-      migrationInstructionValidators = new ArrayList<MigrationInstructionValidator>();
+      migrationInstructionValidators = new ArrayList<>();
       if (customPreMigrationInstructionValidators != null) {
         migrationInstructionValidators.addAll(customPreMigrationInstructionValidators);
       }
@@ -1652,7 +1652,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initMigratingActivityInstanceValidators() {
     if (migratingActivityInstanceValidators == null) {
-      migratingActivityInstanceValidators = new ArrayList<MigratingActivityInstanceValidator>();
+      migratingActivityInstanceValidators = new ArrayList<>();
       if (customPreMigratingActivityInstanceValidators != null) {
         migratingActivityInstanceValidators.addAll(customPreMigratingActivityInstanceValidators);
       }
@@ -1666,14 +1666,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initMigratingTransitionInstanceValidators() {
     if (migratingTransitionInstanceValidators == null) {
-      migratingTransitionInstanceValidators = new ArrayList<MigratingTransitionInstanceValidator>();
+      migratingTransitionInstanceValidators = new ArrayList<>();
       migratingTransitionInstanceValidators.addAll(getDefaultMigratingTransitionInstanceValidators());
     }
   }
 
   protected void initMigratingCompensationInstanceValidators() {
     if (migratingCompensationInstanceValidators == null) {
-      migratingCompensationInstanceValidators = new ArrayList<MigratingCompensationInstanceValidator>();
+      migratingCompensationInstanceValidators = new ArrayList<>();
 
       migratingCompensationInstanceValidators.add(new NoUnmappedLeafInstanceValidator());
       migratingCompensationInstanceValidators.add(new NoUnmappedCompensationStartEventValidator());
@@ -1700,7 +1700,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initDeployers() {
     if (this.deployers == null) {
-      this.deployers = new ArrayList<Deployer>();
+      this.deployers = new ArrayList<>();
       if (customPreDeployers != null) {
         this.deployers.addAll(customPreDeployers);
       }
@@ -1710,7 +1710,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       }
     }
     if (deploymentCache == null) {
-      List<Deployer> deployers = new ArrayList<Deployer>();
+      List<Deployer> deployers = new ArrayList<>();
       if (customPreDeployers != null) {
         deployers.addAll(customPreDeployers);
       }
@@ -1726,7 +1726,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   }
 
   protected Collection<? extends Deployer> getDefaultDeployers() {
-    List<Deployer> defaultDeployers = new ArrayList<Deployer>();
+    List<Deployer> defaultDeployers = new ArrayList<>();
 
     BpmnDeployer bpmnDeployer = getBpmnDeployer();
     defaultDeployers.add(bpmnDeployer);
@@ -1772,7 +1772,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   }
 
   protected List<BpmnParseListener> getDefaultBPMNParseListeners() {
-    List<BpmnParseListener> defaultListeners = new ArrayList<BpmnParseListener>();
+    List<BpmnParseListener> defaultListeners = new ArrayList<>();
     if (!HistoryLevel.HISTORY_LEVEL_NONE.equals(historyLevel)) {
       defaultListeners.add(new HistoryParseListener(historyLevel, historyEventProducer));
     }
@@ -1811,7 +1811,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   }
 
   protected List<CmmnTransformListener> getDefaultCmmnTransformListeners() {
-    List<CmmnTransformListener> defaultListener = new ArrayList<CmmnTransformListener>();
+    List<CmmnTransformListener> defaultListener = new ArrayList<>();
     if (!HistoryLevel.HISTORY_LEVEL_NONE.equals(historyLevel)) {
       defaultListener.add(new CmmnHistoryTransformListener(historyLevel, cmmnHistoryEventProducer));
     }
@@ -1858,7 +1858,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       jobExecutor = new DefaultJobExecutor();
     }
 
-    jobHandlers = new HashMap<String, JobHandler>();
+    jobHandlers = new HashMap<>();
     TimerExecuteNestedActivityJobHandler timerExecuteNestedActivityJobHandler = new TimerExecuteNestedActivityJobHandler();
     jobHandlers.put(timerExecuteNestedActivityJobHandler.getType(), timerExecuteNestedActivityJobHandler);
 
@@ -1943,7 +1943,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
 
     if (historyLevels == null) {
-      historyLevels = new ArrayList<HistoryLevel>();
+      historyLevels = new ArrayList<>();
       historyLevels.add(HistoryLevel.HISTORY_LEVEL_NONE);
       historyLevels.add(HistoryLevel.HISTORY_LEVEL_ACTIVITY);
       historyLevels.add(HistoryLevel.HISTORY_LEVEL_AUDIT);
@@ -2097,7 +2097,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initFormEngines() {
     if (formEngines == null) {
-      formEngines = new HashMap<String, FormEngine>();
+      formEngines = new HashMap<>();
       // html form engine = default form engine
       FormEngine defaultFormEngine = new HtmlFormEngine();
       formEngines.put(null, defaultFormEngine); // default form engine is looked up with null
@@ -2148,7 +2148,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initScripting() {
     if (resolverFactories == null) {
-      resolverFactories = new ArrayList<ResolverFactory>();
+      resolverFactories = new ArrayList<>();
       resolverFactories.add(new MocksResolverFactory());
       resolverFactories.add(new VariableScopeResolverFactory());
       resolverFactories.add(new BeansResolverFactory());
@@ -2161,7 +2161,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       scriptFactory = new ScriptFactory();
     }
     if (scriptEnvResolvers == null) {
-      scriptEnvResolvers = new ArrayList<ScriptEnvResolver>();
+      scriptEnvResolvers = new ArrayList<>();
     }
     if (scriptingEnvironment == null) {
       scriptingEnvironment = new ScriptingEnvironment(scriptFactory, scriptEnvResolvers, scriptingEngines);
@@ -2219,7 +2219,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initEventHandlers() {
     if (eventHandlers == null) {
-      eventHandlers = new HashMap<String, EventHandler>();
+      eventHandlers = new HashMap<>();
 
       SignalEventHandler signalEventHander = new SignalEventHandler();
       eventHandlers.put(signalEventHander.getEventHandlerType(), signalEventHander);
@@ -2243,7 +2243,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initCommandCheckers() {
     if (commandCheckers == null) {
-      commandCheckers = new ArrayList<CommandChecker>();
+      commandCheckers = new ArrayList<>();
 
       // add the default command checkers
       commandCheckers.add(new TenantCommandChecker());
@@ -2275,7 +2275,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initBeans() {
     if (beans == null) {
-      beans = new HashMap<Object, Object>();
+      beans = new HashMap<>();
     }
   }
 
@@ -2357,7 +2357,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initDeploymentRegistration() {
     if (registeredDeployments == null) {
-      registeredDeployments = new CopyOnWriteArraySet<String>();
+      registeredDeployments = new CopyOnWriteArraySet<>();
     }
   }
 
@@ -2376,7 +2376,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       resourceAuthorizationProvider = new DefaultAuthorizationProvider();
     }
   }
-  
+
   protected void initPermissionProvider() {
     if (permissionProvider == null) {
       permissionProvider = new DefaultPermissionProvider();
@@ -2403,13 +2403,13 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initAdminGroups() {
     if (adminGroups == null) {
-      adminGroups = new ArrayList<String>();
+      adminGroups = new ArrayList<>();
     }
     if (adminGroups.isEmpty() || !(adminGroups.contains(Groups.CAMUNDA_ADMIN))) {
       adminGroups.add(Groups.CAMUNDA_ADMIN);
     }
   }
-  
+
   // getters and setters //////////////////////////////////////////////////////
 
   @Override
@@ -3443,11 +3443,11 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   public void setResourceAuthorizationProvider(ResourceAuthorizationProvider resourceAuthorizationProvider) {
     this.resourceAuthorizationProvider = resourceAuthorizationProvider;
   }
-  
+
   public PermissionProvider getPermissionProvider() {
     return permissionProvider;
   }
-  
+
   public void setPermissionProvider(PermissionProvider permissionProvider) {
     this.permissionProvider = permissionProvider;
   }
@@ -3872,7 +3872,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   }
 
   public List<MigrationActivityValidator> getDefaultMigrationActivityValidators() {
-    List<MigrationActivityValidator> migrationActivityValidators = new ArrayList<MigrationActivityValidator>();
+    List<MigrationActivityValidator> migrationActivityValidators = new ArrayList<>();
     migrationActivityValidators.add(SupportedActivityValidator.INSTANCE);
     migrationActivityValidators.add(SupportedPassiveEventTriggerActivityValidator.INSTANCE);
     migrationActivityValidators.add(NoCompensationHandlerActivityValidator.INSTANCE);
@@ -3913,7 +3913,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   }
 
   public List<MigrationInstructionValidator> getDefaultMigrationInstructionValidators() {
-    List<MigrationInstructionValidator> migrationInstructionValidators = new ArrayList<MigrationInstructionValidator>();
+    List<MigrationInstructionValidator> migrationInstructionValidators = new ArrayList<>();
     migrationInstructionValidators.add(new SameBehaviorInstructionValidator());
     migrationInstructionValidators.add(new SameEventTypeValidator());
     migrationInstructionValidators.add(new OnlyOnceMappedActivityInstructionValidator());
@@ -3961,7 +3961,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   }
 
   public List<MigratingActivityInstanceValidator> getDefaultMigratingActivityInstanceValidators() {
-    List<MigratingActivityInstanceValidator> migratingActivityInstanceValidators = new ArrayList<MigratingActivityInstanceValidator>();
+    List<MigratingActivityInstanceValidator> migratingActivityInstanceValidators = new ArrayList<>();
 
     migratingActivityInstanceValidators.add(new NoUnmappedLeafInstanceValidator());
     migratingActivityInstanceValidators.add(new VariableConflictActivityInstanceValidator());
@@ -3971,7 +3971,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   }
 
   public List<MigratingTransitionInstanceValidator> getDefaultMigratingTransitionInstanceValidators() {
-    List<MigratingTransitionInstanceValidator> migratingTransitionInstanceValidators = new ArrayList<MigratingTransitionInstanceValidator>();
+    List<MigratingTransitionInstanceValidator> migratingTransitionInstanceValidators = new ArrayList<>();
 
     migratingTransitionInstanceValidators.add(new NoUnmappedLeafInstanceValidator());
     migratingTransitionInstanceValidators.add(new AsyncAfterMigrationValidator());
@@ -4181,11 +4181,11 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   public void setHistoryCleanupMetricsEnabled(boolean historyCleanupMetricsEnabled) {
     this.historyCleanupMetricsEnabled = historyCleanupMetricsEnabled;
   }
-  
+
   public String getHistoryTimeToLive() {
     return historyTimeToLive;
   }
-  
+
   public void setHistoryTimeToLive(String historyTimeToLive) {
     this.historyTimeToLive = historyTimeToLive;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/AbstractPersistenceSession.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/AbstractPersistenceSession.java
@@ -35,7 +35,7 @@ import org.camunda.bpm.engine.impl.history.HistoryLevel;
 public abstract class AbstractPersistenceSession implements PersistenceSession {
 
   protected static final EnginePersistenceLogger LOG = ProcessEngineLogger.PERSISTENCE_LOGGER;
-  protected List<EntityLoadListener> listeners = new ArrayList<EntityLoadListener>(1);
+  protected List<EntityLoadListener> listeners = new ArrayList<>(1);
 
   public void executeDbOperation(DbOperation operation) {
     switch(operation.getOperationType()) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/EnginePersistenceLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/EnginePersistenceLogger.java
@@ -686,7 +686,7 @@ public class EnginePersistenceLogger extends ProcessEngineLogger {
 
     String exceptionMessage = exceptionMessage(
       "083",
-      "Exception while executing Batch Database Operations with message '{}'. Flush summary: \n {}", message,
+      "Unexpected exception while executing database operations with message '{}'. Flush summary: \n {}", message,
       buildStringFromList(operationsToFlush)
     );
 
@@ -734,4 +734,13 @@ public class EnginePersistenceLogger extends ProcessEngineLogger {
         ));
   }
 
+  public ProcessEngineException batchingNotSupported(DbOperation operation) {
+    throw new ProcessEngineException(exceptionMessage(
+        "089",
+        "Batching not supported: The jdbc driver in use does not return the number of "
+        + "affected rows when executing statement batches. "
+        + "Consider setting the engine configuration property 'jdbcBatchProcessing' to false."
+        + "Failed operation: {}",
+        operation));
+  }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/FlushResult.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/FlushResult.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.db;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
+
+public class FlushResult {
+
+  protected List<DbOperation> failedOperations;
+  protected List<DbOperation> remainingOperations;
+
+  public FlushResult(List<DbOperation> failedOperations, List<DbOperation> remainingOperations) {
+    this.failedOperations = failedOperations;
+    this.remainingOperations = remainingOperations;
+  }
+
+  /**
+   * @return the operation that could not be performed
+   */
+  public List<DbOperation> getFailedOperations() {
+    return failedOperations;
+  }
+
+  /**
+   * @return operations that were not applied, because a preceding operation failed
+   */
+  public List<DbOperation> getRemainingOperations() {
+    return remainingOperations;
+  }
+
+  public boolean hasFailures() {
+    return !failedOperations.isEmpty();
+  }
+
+  public boolean hasRemainingOperations() {
+    return !remainingOperations.isEmpty();
+  }
+
+  public static FlushResult allApplied() {
+    return new FlushResult(Collections.<DbOperation>emptyList(), Collections.<DbOperation>emptyList());
+  }
+
+  public static FlushResult withFailures(List<DbOperation> failedOperations) {
+    return new FlushResult(failedOperations, Collections.<DbOperation>emptyList());
+  }
+
+  public static FlushResult withFailuresAndRemaining(List<DbOperation> failedOperations, List<DbOperation> remainingOperations) {
+    return new FlushResult(failedOperations, remainingOperations);
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/PersistenceSession.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/PersistenceSession.java
@@ -18,8 +18,8 @@ package org.camunda.bpm.engine.impl.db;
 
 import java.util.List;
 
-import org.apache.ibatis.executor.BatchResult;
 import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
+import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation.State;
 import org.camunda.bpm.engine.impl.interceptor.Session;
 
 
@@ -31,7 +31,30 @@ public interface PersistenceSession extends Session {
 
   // Entity Operations /////////////////////////////////
 
-  void executeDbOperation(DbOperation operation);
+  /**
+   * <p>Attempts to perform the operations in order and returns a flush result.
+   * The result indicates if there are operations that were not successful (via {@link FlushResult#getFailedOperations()}
+   * and if some operations were not executed (via {@link FlushResult#getRemainingOperations()}.
+   * The remaining operations must be a suffix of the parameter (e.g. for operations [a, b, c, d],
+   * [c, d] is a valid list of remaining operations, [b, c] is not).
+   *
+   * <p>This method modifies the operation's state, i.e. {@link DbOperation#getState()} will
+   * be updated by calling this method:
+   *
+   * <ul>
+   * <li>Successful operations: {@link State#APPLIED}
+   * <li>Failed operations: {@link State#FAILED_ERROR} or {@link State#FAILED_CONCURRENT_MODIFICATION}.
+   * <li>Remaining operations: {@link State#NOT_APPLIED}
+   * </ul>
+   *
+   * In addition, the number of affected rows and failure (if any) is updated in the operation.
+   *
+   * @throws Exception in case of an unexpected error that is unrelated to an operation result.
+   *   The caller should rollback the transaction in this case
+   */
+  FlushResult executeDbOperations(List<DbOperation> operations);
+
+  void flushOperations();
 
   List<?> selectList(String statement, Object parameter);
 
@@ -41,11 +64,7 @@ public interface PersistenceSession extends Session {
 
   void lock(String statement, Object parameter);
 
-  int executeUpdate(String updateStatement, Object parameter);
-
   int executeNonEmptyUpdateStmt(String updateStmt, Object parameter);
-
-  List<BatchResult> flushOperations();
 
   void commit();
 
@@ -64,9 +83,9 @@ public interface PersistenceSession extends Session {
   void dbSchemaUpdate();
 
   List<String> getTableNamesPresent();
-  
+
   // listeners //////////////////////////////////////////
-  
+
   void addEntityLoadListener(EntityLoadListener listener);
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/entitymanager/operation/DbBulkOperation.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/entitymanager/operation/DbBulkOperation.java
@@ -46,10 +46,6 @@ public class DbBulkOperation extends DbOperation {
     super.recycle();
   }
 
-  public boolean isFailed() {
-    return false;
-  }
-
   public Object getParameter() {
     return parameter;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/entitymanager/operation/DbEntityOperation.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/entitymanager/operation/DbEntityOperation.java
@@ -36,11 +36,6 @@ public class DbEntityOperation extends DbOperation {
 
   protected Set<String> flushRelevantEntityReferences;
 
-  /**
-   * Indicates whether the operation failed to execute due to OptimisticLocking
-   */
-  protected boolean failed = false;
-
   public void recycle() {
     entity = null;
     super.recycle();
@@ -53,14 +48,6 @@ public class DbEntityOperation extends DbOperation {
   public void setEntity(DbEntity dbEntity) {
     this.entityType = dbEntity.getClass();
     this.entity = dbEntity;
-  }
-
-  public void setFailed(boolean failed) {
-    this.failed = failed;
-  }
-
-  public boolean isFailed() {
-    return failed;
   }
 
   public void setFlushRelevantEntityReferences(Set<String> flushRelevantEntityReferences) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/entitymanager/operation/DbOperation.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/entitymanager/operation/DbOperation.java
@@ -33,6 +33,8 @@ public abstract class DbOperation implements Recyclable {
   protected DbOperationType operationType;
 
   protected int rowsAffected;
+  protected Exception failure;
+  protected State state;
 
   /**
    * The type of the DbEntity this operation is executed on.
@@ -46,8 +48,6 @@ public abstract class DbOperation implements Recyclable {
   }
 
   // getters / setters //////////////////////////////////////////
-
-  public abstract boolean isFailed();
 
   public Class<? extends DbEntity> getEntityType() {
     return entityType;
@@ -71,6 +71,44 @@ public abstract class DbOperation implements Recyclable {
 
   public void setRowsAffected(int rowsAffected) {
     this.rowsAffected = rowsAffected;
+  }
+
+  public boolean isFailed() {
+    return state == State.FAILED_CONCURRENT_MODIFICATION || state == State.FAILED_ERROR;
+  }
+
+  public State getState() {
+    return state;
+  }
+
+  public void setState(State state) {
+    this.state = state;
+  }
+
+  public Exception getFailure() {
+    return failure;
+  }
+
+  public void setFailure(Exception failure) {
+    this.failure = failure;
+  }
+
+  public enum State
+  {
+    NOT_APPLIED,
+    APPLIED,
+
+    /**
+     * Indicates that the operation was not performed for any reason except
+     * concurrent modifications.
+     */
+    FAILED_ERROR,
+
+    /**
+     * Indicates that the operation was not performed and that the reason
+     * was a concurrent modification to the data to be updated.
+     */
+    FAILED_CONCURRENT_MODIFICATION
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/BatchDbSqlSession.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/BatchDbSqlSession.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.db.sql;
+
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
+
+import java.sql.BatchUpdateException;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.ibatis.executor.BatchExecutorException;
+import org.apache.ibatis.executor.BatchResult;
+import org.apache.ibatis.session.ExecutorType;
+import org.camunda.bpm.engine.impl.db.DbEntity;
+import org.camunda.bpm.engine.impl.db.FlushResult;
+import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbBulkOperation;
+import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbEntityOperation;
+import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
+import org.camunda.bpm.engine.impl.util.CollectionUtil;
+import org.camunda.bpm.engine.impl.util.EnsureUtil;
+import org.camunda.bpm.engine.impl.util.ExceptionUtil;
+
+/**
+ * For mybatis {@link ExecutorType#BATCH}
+ */
+public class BatchDbSqlSession extends DbSqlSession {
+
+
+  public BatchDbSqlSession(DbSqlSessionFactory dbSqlSessionFactory) {
+    super(dbSqlSessionFactory);
+  }
+
+  public BatchDbSqlSession(DbSqlSessionFactory dbSqlSessionFactory, Connection connection, String catalog, String schema) {
+    super(dbSqlSessionFactory, connection, catalog, schema);
+  }
+
+  @Override
+  public FlushResult executeDbOperations(List<DbOperation> operations) {
+    for (int i = 0; i < operations.size(); i++) {
+
+      DbOperation operation = operations.get(i);
+
+      // stages all operations
+      executeDbOperation(operation);
+    }
+
+    List<BatchResult> batchResults;
+    try {
+      // applies all operations
+      batchResults = flushBatchOperations();
+    } catch (RuntimeException e) {
+      return postProcessBatchFailure(operations, e);
+    }
+
+    return postProcessBatchSuccess(operations, batchResults);
+  }
+
+  protected FlushResult postProcessBatchSuccess(List<DbOperation> operations, List<BatchResult> batchResults) {
+    Iterator<DbOperation> operationsIt = operations.iterator();
+    List<DbOperation> failedOperations = new ArrayList<>();
+    for (BatchResult successfulBatch : batchResults) {
+      // even if all batches are successful, there can be concurrent modification failures
+      // (e.g. 0 rows updated)
+      postProcessJdbcBatchResult(operationsIt, successfulBatch.getUpdateCounts(), null, failedOperations);
+    }
+
+    // there should be no more operations remaining
+    if (operationsIt.hasNext()) {
+      throw LOG.wrongBatchResultsSizeException(operations);
+    }
+
+    return FlushResult.withFailures(failedOperations);
+  }
+
+  protected FlushResult postProcessBatchFailure(List<DbOperation> operations, RuntimeException e) {
+    BatchExecutorException batchExecutorException = ExceptionUtil.findBatchExecutorException(e);
+
+    if (batchExecutorException == null) {
+      // Unexpected exception
+      throw e;
+    }
+
+    List<BatchResult> successfulBatches = batchExecutorException.getSuccessfulBatchResults();
+    BatchUpdateException cause = batchExecutorException.getBatchUpdateException();
+
+    Iterator<DbOperation> operationsIt = operations.iterator();
+    List<DbOperation> failedOperations = new ArrayList<>();
+
+    for (BatchResult successfulBatch : successfulBatches) {
+      postProcessJdbcBatchResult(operationsIt, successfulBatch.getUpdateCounts(), null, failedOperations);
+    }
+
+    int[] failedBatchUpdateCounts = cause.getUpdateCounts();
+    postProcessJdbcBatchResult(operationsIt, failedBatchUpdateCounts, e, failedOperations);
+
+    List<DbOperation> remainingOperations = CollectionUtil.collectInList(operationsIt);
+    return FlushResult.withFailuresAndRemaining(failedOperations, remainingOperations);
+  }
+
+  /**
+   * <p>This method can be called with three cases:
+   *
+   * <ul>
+   * <li>Case 1: Success. statementResults contains the number of
+   * affected rows for all operations.
+   * <li>Case 2: Failure. statementResults contains the number of
+   * affected rows for all successful operations that were executed
+   * before the failed operation.
+   * <li>Case 3: Failure. statementResults contains the number of
+   * affected rows for all operations of the batch, i.e. further
+   * statements were executed after the first failed statement.
+   * </ul>
+   *
+   * <p>See {@link BatchUpdateException#getUpdateCounts()} for the specification
+   * of cases 2 and 3.
+   *
+   * @return all failed operations
+   */
+  protected void postProcessJdbcBatchResult(
+      Iterator<DbOperation> operationsIt,
+      int[] statementResults,
+      Exception failure,
+      List<DbOperation> failedOperations) {
+    boolean failureHandled = false;
+
+    for (int i = 0; i < statementResults.length; i++) {
+      int statementResult = statementResults[i];
+
+      EnsureUtil.ensureTrue("More batch results than scheduled operations detected. This indicates a bug",
+          operationsIt.hasNext());
+
+      DbOperation operation = operationsIt.next();
+
+      if (statementResult == Statement.SUCCESS_NO_INFO) {
+        throw LOG.batchingNotSupported(operation);
+      } else if (statementResult == Statement.EXECUTE_FAILED) {
+
+        /*
+         * All operations are marked with the root failure exception; this is not quite
+         * correct and leads to the situation that we treat all failed operations in the
+         * same way, whereas they might fail for different reasons.
+         *
+         * More precise would be to use BatchUpdateException#getNextException.
+         * E.g. if we have three failed statements in a batch, #getNextException can be used to
+         * access each operation's individual failure. However, this behavior is not
+         * guaranteed by the java.sql javadocs (it doesn't specify that the number
+         * and order of next exceptions matches the number of failures, unlike for row counts),
+         * so we decided to not rely on it.
+         */
+        postProcessOperationPerformed(operation, 0, failure);
+        failureHandled = true;
+      } else { // it is the number of affected rows
+        postProcessOperationPerformed(operation, statementResult, null);
+      }
+
+      if (operation.isFailed()) {
+        failedOperations.add(operation);
+      }
+    }
+
+    /*
+     * case 2: The next operation is the one that failed
+     */
+    if (failure != null && !failureHandled) {
+      EnsureUtil.ensureTrue("More batch results than scheduled operations detected. This indicates a bug",
+          operationsIt.hasNext());
+
+      DbOperation failedOperation = operationsIt.next();
+      postProcessOperationPerformed(failedOperation, 0, failure);
+      failedOperations.add(failedOperation);
+    }
+  }
+
+  protected void postProcessOperationPerformed(DbOperation operation, int rowsAffected, Exception failure) {
+
+    switch(operation.getOperationType()) {
+
+      case INSERT:
+        entityInsertPerformed((DbEntityOperation) operation, rowsAffected, failure);
+        break;
+
+      case DELETE:
+        entityDeletePerformed((DbEntityOperation) operation, rowsAffected, failure);
+        break;
+      case DELETE_BULK:
+        bulkDeletePerformed((DbBulkOperation) operation, rowsAffected, failure);
+        break;
+
+      case UPDATE:
+        entityUpdatePerformed((DbEntityOperation) operation, rowsAffected, failure);
+        break;
+      case UPDATE_BULK:
+        bulkUpdatePerformed((DbBulkOperation) operation, rowsAffected, failure);
+        break;
+
+    }
+  }
+
+
+  @Override
+  protected void updateEntity(DbEntityOperation operation) {
+
+    final DbEntity dbEntity = operation.getEntity();
+
+    String updateStatement = dbSqlSessionFactory.getUpdateStatement(dbEntity);
+    ensureNotNull("no update statement for " + dbEntity.getClass() + " in the ibatis mapping files", "updateStatement", updateStatement);
+
+    LOG.executeDatabaseOperation("UPDATE", dbEntity);
+    executeUpdate(updateStatement, dbEntity);
+  }
+
+  @Override
+  protected void updateBulk(DbBulkOperation operation) {
+    String statement = operation.getStatement();
+    Object parameter = operation.getParameter();
+
+    LOG.executeDatabaseBulkOperation("UPDATE", statement, parameter);
+
+    executeUpdate(statement, parameter);
+  }
+
+  @Override
+  protected void deleteBulk(DbBulkOperation operation) {
+    String statement = operation.getStatement();
+    Object parameter = operation.getParameter();
+
+    LOG.executeDatabaseBulkOperation("DELETE", statement, parameter);
+
+    executeDelete(statement, parameter);
+  }
+
+  @Override
+  protected void deleteEntity(DbEntityOperation operation) {
+
+    final DbEntity dbEntity = operation.getEntity();
+
+    // get statement
+    String deleteStatement = dbSqlSessionFactory.getDeleteStatement(dbEntity.getClass());
+    ensureNotNull("no delete statement for " + dbEntity.getClass() + " in the ibatis mapping files", "deleteStatement", deleteStatement);
+
+    LOG.executeDatabaseOperation("DELETE", dbEntity);
+
+    // execute the delete
+    executeDelete(deleteStatement, dbEntity);
+  }
+
+  @Override
+  protected void executeSelectForUpdate(String statement, Object parameter) {
+    sqlSession.selectList(statement, parameter);
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSession.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSession.java
@@ -33,6 +33,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.ibatis.executor.BatchResult;
 import org.apache.ibatis.mapping.MappedStatement;
@@ -43,23 +44,27 @@ import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.db.AbstractPersistenceSession;
 import org.camunda.bpm.engine.impl.db.DbEntity;
 import org.camunda.bpm.engine.impl.db.EnginePersistenceLogger;
+import org.camunda.bpm.engine.impl.db.HasDbReferences;
 import org.camunda.bpm.engine.impl.db.HasDbRevision;
 import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbBulkOperation;
 import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbEntityOperation;
+import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
+import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation.State;
+import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperationType;
+import org.camunda.bpm.engine.impl.util.ExceptionUtil;
 import org.camunda.bpm.engine.impl.util.IoUtil;
 import org.camunda.bpm.engine.impl.util.ReflectUtil;
 
-
 /**
- *
- * @author Tom Baeyens
- * @author Joram Barrez
- * @author Daniel Meyer
- * @author Sebastian Menski
- * @author Roman Smirnov
- *
- */
-public class DbSqlSession extends AbstractPersistenceSession {
+*
+* @author Tom Baeyens
+* @author Joram Barrez
+* @author Daniel Meyer
+* @author Sebastian Menski
+* @author Roman Smirnov
+*
+*/
+public abstract class DbSqlSession extends AbstractPersistenceSession {
 
   protected static final EnginePersistenceLogger LOG = ProcessEngineLogger.PERSISTENCE_LOGGER;
 
@@ -83,11 +88,6 @@ public class DbSqlSession extends AbstractPersistenceSession {
       .openSession(connection);
     this.connectionMetadataDefaultCatalog = catalog;
     this.connectionMetadataDefaultSchema = schema;
-  }
-
-  @Override
-  public List<BatchResult> flushOperations() {
-    return sqlSession.flushStatements();
   }
 
   // select ////////////////////////////////////////////
@@ -127,12 +127,113 @@ public class DbSqlSession extends AbstractPersistenceSession {
     // Id using the DbIdGenerator while performing a deployment.
     if (!DbSqlSessionFactory.H2.equals(dbSqlSessionFactory.getDatabaseType())) {
       String mappedStatement = dbSqlSessionFactory.mapStatement(statement);
-      if (!Context.getProcessEngineConfiguration().isJdbcBatchProcessing()) {
-        sqlSession.update(mappedStatement, parameter);
+      executeSelectForUpdate(mappedStatement, parameter);
+    }
+  }
+
+  protected abstract void executeSelectForUpdate(String statement, Object parameter);
+
+  protected void entityUpdatePerformed(DbEntityOperation operation, int rowsAffected, Exception failure) {
+    if (failure != null) {
+      operation.setRowsAffected(0);
+      operation.setFailure(failure);
+
+      if (isConcurrentModificationException(operation, failure)) {
+        operation.setState(State.FAILED_CONCURRENT_MODIFICATION);
       } else {
-        sqlSession.selectList(mappedStatement, parameter);
+        operation.setState(State.FAILED_ERROR);
+      }
+    } else {
+      DbEntity dbEntity = operation.getEntity();
+
+      if (dbEntity instanceof HasDbRevision) {
+        if (rowsAffected != 1) {
+          // failed with optimistic locking
+          operation.setState(State.FAILED_CONCURRENT_MODIFICATION);
+        } else {
+          // increment revision of our copy
+          HasDbRevision versionedObject = (HasDbRevision) dbEntity;
+          versionedObject.setRevision(versionedObject.getRevisionNext());
+          operation.setState(State.APPLIED);
+        }
+      } else {
+        operation.setState(State.APPLIED);
       }
     }
+  }
+
+  protected void bulkUpdatePerformed(DbBulkOperation operation, int rowsAffected, Exception failure) {
+
+    bulkOperationPerformed(operation, rowsAffected, failure);
+  }
+
+  protected void bulkDeletePerformed(DbBulkOperation operation, int rowsAffected, Exception failure) {
+
+    bulkOperationPerformed(operation, rowsAffected, failure);
+  }
+
+  protected void bulkOperationPerformed(DbBulkOperation operation, int rowsAffected, Exception failure) {
+
+    if (failure != null) {
+      operation.setFailure(failure);
+      operation.setState(State.FAILED_ERROR);
+    } else {
+      operation.setRowsAffected(rowsAffected);
+      operation.setState(State.APPLIED);
+    }
+  }
+
+  protected void entityDeletePerformed(DbEntityOperation operation, int rowsAffected, Exception failure) {
+    if (failure != null) {
+      operation.setRowsAffected(0);
+      operation.setFailure(failure);
+
+      if (isConcurrentModificationException(operation, failure)) {
+        operation.setState(State.FAILED_CONCURRENT_MODIFICATION);
+      } else {
+        operation.setState(State.FAILED_ERROR);
+      }
+    } else {
+      operation.setRowsAffected(rowsAffected);
+
+      DbEntity dbEntity = operation.getEntity();
+
+      // It only makes sense to check for optimistic locking exceptions for objects that actually have a revision
+      if (dbEntity instanceof HasDbRevision && rowsAffected == 0) {
+        operation.setState(State.FAILED_CONCURRENT_MODIFICATION);
+      } else {
+        operation.setState(State.APPLIED);
+      }
+    }
+  }
+
+  protected boolean isConcurrentModificationException(DbOperation failedOperation, Throwable cause) {
+
+    boolean isConstraintViolation = ExceptionUtil.checkForeignKeyConstraintViolation(cause);
+    boolean isVariableIntegrityViolation = ExceptionUtil.checkVariableIntegrityViolation(cause);
+
+    if (isVariableIntegrityViolation) {
+
+      return true;
+    } else if (
+      isConstraintViolation
+      && failedOperation instanceof DbEntityOperation
+      && ((DbEntityOperation) failedOperation).getEntity() instanceof HasDbReferences
+      && (failedOperation.getOperationType().equals(DbOperationType.INSERT)
+      || failedOperation.getOperationType().equals(DbOperationType.UPDATE))
+      ) {
+
+      DbEntity entity = ((DbEntityOperation) failedOperation).getEntity();
+      for (Map.Entry<String, Class> reference : ((HasDbReferences)entity).getReferencedEntitiesIdAndClass().entrySet()) {
+        DbEntity referencedEntity = selectById(reference.getValue(), reference.getKey());
+        if (referencedEntity == null) {
+
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 
   // insert //////////////////////////////////////////
@@ -149,52 +250,37 @@ public class DbSqlSession extends AbstractPersistenceSession {
 
     // execute the insert
     executeInsertEntity(insertStatement, dbEntity);
-
-    // perform post insert actions on entity
-    entityInserted(dbEntity);
   }
 
   protected void executeInsertEntity(String insertStatement, Object parameter) {
     LOG.executeDatabaseOperation("INSERT", parameter);
     sqlSession.insert(insertStatement, parameter);
-
-    // set revision of our copy to 1
-    if (parameter instanceof HasDbRevision) {
-      HasDbRevision versionedObject = (HasDbRevision) parameter;
-      versionedObject.setRevision(1);
-    }
   }
 
-  protected void entityInserted(final DbEntity entity) {
-    // nothing to do
+  protected void entityInsertPerformed(DbEntityOperation operation, int rowsAffected, Exception failure) {
+    DbEntity entity = operation.getEntity();
+
+    if (failure != null) {
+      operation.setRowsAffected(0);
+      operation.setFailure(failure);
+
+      if (isConcurrentModificationException(operation, failure)) {
+        operation.setState(State.FAILED_CONCURRENT_MODIFICATION);
+      } else {
+        operation.setState(State.FAILED_ERROR);
+      }
+    } else {
+      // set revision of our copy to 1
+      if (entity instanceof HasDbRevision) {
+        HasDbRevision versionedObject = (HasDbRevision) entity;
+        versionedObject.setRevision(1);
+      }
+
+      operation.setState(State.APPLIED);
+    }
   }
 
   // delete ///////////////////////////////////////////
-
-  @Override
-  protected void deleteEntity(DbEntityOperation operation) {
-
-    final DbEntity dbEntity = operation.getEntity();
-
-    // get statement
-    String deleteStatement = dbSqlSessionFactory.getDeleteStatement(dbEntity.getClass());
-    ensureNotNull("no delete statement for " + dbEntity.getClass() + " in the ibatis mapping files", "deleteStatement", deleteStatement);
-
-    LOG.executeDatabaseOperation("DELETE", dbEntity);
-
-    // execute the delete
-    int nrOfRowsDeleted = executeDelete(deleteStatement, dbEntity);
-    operation.setRowsAffected(nrOfRowsDeleted);
-
-    // It only makes sense to check for optimistic locking exceptions for objects that actually have a revision
-    if (dbEntity instanceof HasDbRevision && nrOfRowsDeleted == 0) {
-      operation.setFailed(true);
-      return;
-    }
-
-    // perform post delete action
-    entityDeleted(dbEntity);
-  }
 
   protected int executeDelete(String deleteStatement, Object parameter) {
     // map the statement
@@ -202,58 +288,8 @@ public class DbSqlSession extends AbstractPersistenceSession {
     return sqlSession.delete(deleteStatement, parameter);
   }
 
-  protected void entityDeleted(final DbEntity entity) {
-    // nothing to do
-  }
-
-  @Override
-  protected void deleteBulk(DbBulkOperation operation) {
-    String statement = operation.getStatement();
-    Object parameter = operation.getParameter();
-
-    LOG.executeDatabaseBulkOperation("DELETE", statement, parameter);
-
-    int rowsAffected = executeDelete(statement, parameter);
-    operation.setRowsAffected(rowsAffected);
-  }
-
   // update ////////////////////////////////////////
 
-  @Override
-  protected void updateEntity(DbEntityOperation operation) {
-
-    final DbEntity dbEntity = operation.getEntity();
-
-    String updateStatement = dbSqlSessionFactory.getUpdateStatement(dbEntity);
-    ensureNotNull("no update statement for " + dbEntity.getClass() + " in the ibatis mapping files", "updateStatement", updateStatement);
-
-    LOG.executeDatabaseOperation("UPDATE", dbEntity);
-
-    if (Context.getProcessEngineConfiguration().isJdbcBatchProcessing()) {
-      // execute update
-      executeUpdate(updateStatement, dbEntity);
-    } else {
-      // execute update
-      int numOfRowsUpdated = executeUpdate(updateStatement, dbEntity);
-
-      if (dbEntity instanceof HasDbRevision) {
-        if (numOfRowsUpdated != 1) {
-          // failed with optimistic locking
-          operation.setFailed(true);
-          return;
-        } else {
-          // increment revision of our copy
-          HasDbRevision versionedObject = (HasDbRevision) dbEntity;
-          versionedObject.setRevision(versionedObject.getRevisionNext());
-        }
-      }
-    }
-
-    // perform post update action
-    entityUpdated(dbEntity);
-  }
-
-  @Override
   public int executeUpdate(String updateStatement, Object parameter) {
     updateStatement = dbSqlSessionFactory.mapStatement(updateStatement);
     return sqlSession.update(updateStatement, parameter);
@@ -271,24 +307,17 @@ public class DbSqlSession extends AbstractPersistenceSession {
     return sqlSession.update(updateStmt, parameter);
   }
 
-  protected void entityUpdated(final DbEntity entity) {
-    // nothing to do
-  }
-
-  @Override
-  protected void updateBulk(DbBulkOperation operation) {
-    String statement = operation.getStatement();
-    Object parameter = operation.getParameter();
-
-    LOG.executeDatabaseBulkOperation("UPDATE", statement, parameter);
-
-    executeUpdate(statement, parameter);
-  }
-
   // flush ////////////////////////////////////////////////////////////////////
 
   public void flush() {
-    // nothing to do
+  }
+
+  public void flushOperations() {
+    flushBatchOperations();
+  }
+
+  public List<BatchResult> flushBatchOperations() {
+    return sqlSession.flushStatements();
   }
 
   public void close() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
@@ -16,6 +16,7 @@
  */
 package org.camunda.bpm.engine.impl.db.sql;
 
+import java.sql.Connection;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,48 +44,48 @@ public class DbSqlSessionFactory implements SessionFactory {
   public static final String MARIADB = "mariadb";
   public static final String[] SUPPORTED_DATABASES = {MSSQL, DB2, ORACLE, H2, MYSQL, POSTGRES, MARIADB};
 
-  protected static final Map<String, Map<String, String>> databaseSpecificStatements = new HashMap<String, Map<String,String>>();
+  protected static final Map<String, Map<String, String>> databaseSpecificStatements = new HashMap<>();
 
-  public static final Map<String, String> databaseSpecificLimitBeforeStatements = new HashMap<String, String>();
-  public static final Map<String, String> databaseSpecificLimitAfterStatements = new HashMap<String, String>();
+  public static final Map<String, String> databaseSpecificLimitBeforeStatements = new HashMap<>();
+  public static final Map<String, String> databaseSpecificLimitAfterStatements = new HashMap<>();
   //limit statements that can be used to select first N rows without OFFSET
-  public static final Map<String, String> databaseSpecificLimitBeforeWithoutOffsetStatements = new HashMap<String, String>();
-  public static final Map<String, String> databaseSpecificLimitAfterWithoutOffsetStatements = new HashMap<String, String>();
+  public static final Map<String, String> databaseSpecificLimitBeforeWithoutOffsetStatements = new HashMap<>();
+  public static final Map<String, String> databaseSpecificLimitAfterWithoutOffsetStatements = new HashMap<>();
   // limitAfter statements that can be used with subqueries
-  public static final Map<String, String> databaseSpecificInnerLimitAfterStatements = new HashMap<String, String>();
-  public static final Map<String, String> databaseSpecificLimitBetweenStatements = new HashMap<String, String>();
-  public static final Map<String, String> databaseSpecificLimitBetweenFilterStatements = new HashMap<String, String>();
+  public static final Map<String, String> databaseSpecificInnerLimitAfterStatements = new HashMap<>();
+  public static final Map<String, String> databaseSpecificLimitBetweenStatements = new HashMap<>();
+  public static final Map<String, String> databaseSpecificLimitBetweenFilterStatements = new HashMap<>();
 
-  public static final Map<String, String> optimizeDatabaseSpecificLimitBeforeWithoutOffsetStatements = new HashMap<String, String>();
-  public static final Map<String, String> optimizeDatabaseSpecificLimitAfterWithoutOffsetStatements = new HashMap<String, String>();
+  public static final Map<String, String> optimizeDatabaseSpecificLimitBeforeWithoutOffsetStatements = new HashMap<>();
+  public static final Map<String, String> optimizeDatabaseSpecificLimitAfterWithoutOffsetStatements = new HashMap<>();
 
-  public static final Map<String, String> databaseSpecificEscapeChar = new HashMap<String, String>();
+  public static final Map<String, String> databaseSpecificEscapeChar = new HashMap<>();
 
-  public static final Map<String, String> databaseSpecificOrderByStatements = new HashMap<String, String>();
-  public static final Map<String, String> databaseSpecificLimitBeforeNativeQueryStatements = new HashMap<String, String>();
+  public static final Map<String, String> databaseSpecificOrderByStatements = new HashMap<>();
+  public static final Map<String, String> databaseSpecificLimitBeforeNativeQueryStatements = new HashMap<>();
 
-  public static final Map<String, String> databaseSpecificBitAnd1 = new HashMap<String, String>();
-  public static final Map<String, String> databaseSpecificBitAnd2 = new HashMap<String, String>();
-  public static final Map<String, String> databaseSpecificBitAnd3 = new HashMap<String, String>();
+  public static final Map<String, String> databaseSpecificBitAnd1 = new HashMap<>();
+  public static final Map<String, String> databaseSpecificBitAnd2 = new HashMap<>();
+  public static final Map<String, String> databaseSpecificBitAnd3 = new HashMap<>();
 
-  public static final Map<String, String> databaseSpecificDatepart1 = new HashMap<String, String>();
-  public static final Map<String, String> databaseSpecificDatepart2 = new HashMap<String, String>();
-  public static final Map<String, String> databaseSpecificDatepart3 = new HashMap<String, String>();
+  public static final Map<String, String> databaseSpecificDatepart1 = new HashMap<>();
+  public static final Map<String, String> databaseSpecificDatepart2 = new HashMap<>();
+  public static final Map<String, String> databaseSpecificDatepart3 = new HashMap<>();
 
-  public static final Map<String, String> databaseSpecificDummyTable = new HashMap<String, String>();
+  public static final Map<String, String> databaseSpecificDummyTable = new HashMap<>();
 
-  public static final Map<String, String> databaseSpecificIfNull = new HashMap<String, String>();
+  public static final Map<String, String> databaseSpecificIfNull = new HashMap<>();
 
-  public static final Map<String, String> databaseSpecificTrueConstant = new HashMap<String, String>();
-  public static final Map<String, String> databaseSpecificFalseConstant = new HashMap<String, String>();
+  public static final Map<String, String> databaseSpecificTrueConstant = new HashMap<>();
+  public static final Map<String, String> databaseSpecificFalseConstant = new HashMap<>();
 
-  public static final Map<String, String> databaseSpecificDistinct = new HashMap<String, String>();
+  public static final Map<String, String> databaseSpecificDistinct = new HashMap<>();
 
-  public static final Map<String, Map<String, String>> dbSpecificConstants = new HashMap<String, Map<String, String>>();
+  public static final Map<String, Map<String, String>> dbSpecificConstants = new HashMap<>();
 
-  public static final Map<String, String> databaseSpecificDaysComparator = new HashMap<String, String>();
+  public static final Map<String, String> databaseSpecificDaysComparator = new HashMap<>();
 
-  public static final Map<String, String> databaseSpecificCollationForCaseSensitivity = new HashMap<String, String>();
+  public static final Map<String, String> databaseSpecificCollationForCaseSensitivity = new HashMap<>();
 
   static {
 
@@ -123,8 +124,8 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificDaysComparator.put(H2, "DATEDIFF(DAY, ${date}, #{currentTimestamp}) >= ${days}");
 
     databaseSpecificCollationForCaseSensitivity.put(H2, "");
-    
-    HashMap<String, String> constants = new HashMap<String, String>();
+
+    HashMap<String, String> constants = new HashMap<>();
     constants.put("constant.event", "'event'");
     constants.put("constant.op_message", "NEW_VALUE_ || '_|_' || PROPERTY_");
     constants.put("constant_for_update", "for update");
@@ -208,7 +209,7 @@ public class DbSqlSessionFactory implements SessionFactory {
       addDatabaseSpecificStatement(mysqlLikeDatabase, "updateHistoricIncidentsByProcessInstanceId", "updateHistoricIncidentsByProcessInstanceId_mysql");
       addDatabaseSpecificStatement(mysqlLikeDatabase, "updateIdentityLinkLogByProcessInstanceId", "updateIdentityLinkLogByProcessInstanceId_mysql");
 
-      constants = new HashMap<String, String>();
+      constants = new HashMap<>();
       constants.put("constant.event", "'event'");
       constants.put("constant.op_message", "CONCAT(NEW_VALUE_, '_|_', PROPERTY_)");
       constants.put("constant_for_update", "for update");
@@ -296,7 +297,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     addDatabaseSpecificStatement(POSTGRES, "deleteByteArraysByRemovalTime", "deleteByteArraysByRemovalTime_postgres_or_db2");
     addDatabaseSpecificStatement(POSTGRES, "deleteHistoricBatchesByRemovalTime", "deleteHistoricBatchesByRemovalTime_postgres_or_db2");
 
-    constants = new HashMap<String, String>();
+    constants = new HashMap<>();
     constants.put("constant.event", "'event'");
     constants.put("constant.op_message", "NEW_VALUE_ || '_|_' || PROPERTY_");
     constants.put("constant_for_update", "for update");
@@ -368,7 +369,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     addDatabaseSpecificStatement(ORACLE, "deleteByteArraysByRemovalTime", "deleteByteArraysByRemovalTime_oracle");
     addDatabaseSpecificStatement(ORACLE, "deleteHistoricBatchesByRemovalTime", "deleteHistoricBatchesByRemovalTime_oracle");
 
-    constants = new HashMap<String, String>();
+    constants = new HashMap<>();
     constants.put("constant.event", "cast('event' as nvarchar2(255))");
     constants.put("constant.op_message", "NEW_VALUE_ || '_|_' || PROPERTY_");
     constants.put("constant_for_update", "for update");
@@ -444,7 +445,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     addDatabaseSpecificStatement(DB2, "deleteByteArraysByRemovalTime", "deleteByteArraysByRemovalTime_postgres_or_db2");
     addDatabaseSpecificStatement(DB2, "deleteHistoricBatchesByRemovalTime", "deleteHistoricBatchesByRemovalTime_postgres_or_db2");
 
-    constants = new HashMap<String, String>();
+    constants = new HashMap<>();
     constants.put("constant.event", "'event'");
     constants.put("constant.op_message", "CAST(CONCAT(CONCAT(COALESCE(NEW_VALUE_,''), '_|_'), COALESCE(PROPERTY_,'')) as varchar(255))");
     constants.put("constant_for_update", "for read only with rs use and keep update locks");
@@ -506,7 +507,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     addDatabaseSpecificStatement(MSSQL, "selectEventSubscriptionsByExecutionAndType", "selectEventSubscriptionsByExecutionAndType_mssql");
     addDatabaseSpecificStatement(MSSQL, "selectHistoricDecisionInstancesByNativeQuery", "selectHistoricDecisionInstancesByNativeQuery_mssql_or_db2");
 
-    constants = new HashMap<String, String>();
+    constants = new HashMap<>();
     constants.put("constant.event", "'event'");
     constants.put("constant.op_message", "NEW_VALUE_ + '_|_' + PROPERTY_");
     constants.put("constant.datepart.quarter", "QUARTER");
@@ -531,21 +532,33 @@ public class DbSqlSessionFactory implements SessionFactory {
   protected SqlSessionFactory sqlSessionFactory;
   protected IdGenerator idGenerator;
   protected Map<String, String> statementMappings;
-  protected Map<Class<?>,String>  insertStatements = new ConcurrentHashMap<Class<?>, String>();
-  protected Map<Class<?>,String>  updateStatements = new ConcurrentHashMap<Class<?>, String>();
-  protected Map<Class<?>,String>  deleteStatements = new ConcurrentHashMap<Class<?>, String>();
-  protected Map<Class<?>,String>  selectStatements = new ConcurrentHashMap<Class<?>, String>();
+  protected Map<Class<?>,String>  insertStatements = new ConcurrentHashMap<>();
+  protected Map<Class<?>,String>  updateStatements = new ConcurrentHashMap<>();
+  protected Map<Class<?>,String>  deleteStatements = new ConcurrentHashMap<>();
+  protected Map<Class<?>,String>  selectStatements = new ConcurrentHashMap<>();
   protected boolean isDbIdentityUsed = true;
   protected boolean isDbHistoryUsed = true;
   protected boolean cmmnEnabled = true;
   protected boolean dmnEnabled = true;
+
+  protected boolean jdbcBatchProcessing;
+
+  public DbSqlSessionFactory(boolean jdbcBatchProcessing) {
+    this.jdbcBatchProcessing = jdbcBatchProcessing;
+  }
 
   public Class< ? > getSessionType() {
     return DbSqlSession.class;
   }
 
   public Session openSession() {
-    return new DbSqlSession(this);
+    return jdbcBatchProcessing ? new BatchDbSqlSession(this) : new SimpleDbSqlSession(this);
+  }
+
+  public DbSqlSession openSession(Connection connection, String catalog, String schema) {
+    return jdbcBatchProcessing ?
+        new BatchDbSqlSession(this, connection, catalog, schema) :
+        new SimpleDbSqlSession(this, connection, catalog, schema);
   }
 
   // insert, update and delete statements /////////////////////////////////////
@@ -582,7 +595,7 @@ public class DbSqlSessionFactory implements SessionFactory {
   protected static void addDatabaseSpecificStatement(String databaseType, String activitiStatement, String ibatisStatement) {
     Map<String, String> specificStatements = databaseSpecificStatements.get(databaseType);
     if (specificStatements == null) {
-      specificStatements = new HashMap<String, String>();
+      specificStatements = new HashMap<>();
       databaseSpecificStatements.put(databaseType, specificStatements);
     }
     specificStatements.put(activitiStatement, ibatisStatement);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/SimpleDbSqlSession.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/SimpleDbSqlSession.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.db.sql;
+
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
+
+import java.sql.Connection;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.ibatis.session.ExecutorType;
+import org.camunda.bpm.engine.impl.db.DbEntity;
+import org.camunda.bpm.engine.impl.db.FlushResult;
+import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbBulkOperation;
+import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbEntityOperation;
+import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
+import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation.State;
+
+/**
+ * For mybatis {@link ExecutorType#SIMPLE}
+ */
+public class SimpleDbSqlSession extends DbSqlSession {
+
+  public SimpleDbSqlSession(DbSqlSessionFactory dbSqlSessionFactory) {
+    super(dbSqlSessionFactory);
+  }
+
+  public SimpleDbSqlSession(DbSqlSessionFactory dbSqlSessionFactory, Connection connection, String catalog, String schema) {
+    super(dbSqlSessionFactory, connection, catalog, schema);
+  }
+
+  // lock ////////////////////////////////////////////
+
+  @Override
+  protected void executeSelectForUpdate(String statement, Object parameter) {
+    sqlSession.update(statement, parameter);
+  }
+
+  @Override
+  public FlushResult executeDbOperations(List<DbOperation> operations) {
+
+    for (int i = 0; i < operations.size(); i++) {
+
+      DbOperation operation = operations.get(i);
+
+      executeDbOperation(operation);
+
+      if (operation.getState() != State.APPLIED) {
+        List<DbOperation> remainingOperations = operations.subList(i + 1, operations.size());
+        return FlushResult.withFailuresAndRemaining(Collections.singletonList(operation), remainingOperations);
+      }
+    }
+
+    return FlushResult.allApplied();
+  }
+
+  // insert //////////////////////////////////////////
+
+  @Override
+  protected void insertEntity(DbEntityOperation operation) {
+
+    final DbEntity dbEntity = operation.getEntity();
+
+    // get statement
+    String insertStatement = dbSqlSessionFactory.getInsertStatement(dbEntity);
+    insertStatement = dbSqlSessionFactory.mapStatement(insertStatement);
+    ensureNotNull("no insert statement for " + dbEntity.getClass() + " in the ibatis mapping files", "insertStatement", insertStatement);
+
+    // execute the insert
+    try {
+      executeInsertEntity(insertStatement, dbEntity);
+      entityInsertPerformed(operation, 1, null);
+    } catch (Exception e) {
+      entityInsertPerformed(operation, 0, e);
+    }
+  }
+
+  // delete ///////////////////////////////////////////
+
+  @Override
+  protected void deleteEntity(DbEntityOperation operation) {
+
+    final DbEntity dbEntity = operation.getEntity();
+
+    // get statement
+    String deleteStatement = dbSqlSessionFactory.getDeleteStatement(dbEntity.getClass());
+    ensureNotNull("no delete statement for " + dbEntity.getClass() + " in the ibatis mapping files", "deleteStatement", deleteStatement);
+
+    LOG.executeDatabaseOperation("DELETE", dbEntity);
+
+    try {
+      int nrOfRowsDeleted = executeDelete(deleteStatement, dbEntity);
+      entityDeletePerformed(operation, nrOfRowsDeleted, null);
+    } catch (Exception e) {
+      entityDeletePerformed(operation, 0, e);
+    }
+  }
+
+  @Override
+  protected void deleteBulk(DbBulkOperation operation) {
+    String statement = operation.getStatement();
+    Object parameter = operation.getParameter();
+
+    LOG.executeDatabaseBulkOperation("DELETE", statement, parameter);
+
+    try {
+      int rowsAffected = executeDelete(statement, parameter);
+      bulkDeletePerformed(operation, rowsAffected, null);
+    } catch (Exception e) {
+      bulkDeletePerformed(operation, 0, e);
+    }
+  }
+
+  // update ////////////////////////////////////////
+
+  @Override
+  protected void updateEntity(DbEntityOperation operation) {
+
+    final DbEntity dbEntity = operation.getEntity();
+
+    String updateStatement = dbSqlSessionFactory.getUpdateStatement(dbEntity);
+    ensureNotNull("no update statement for " + dbEntity.getClass() + " in the ibatis mapping files", "updateStatement", updateStatement);
+
+    LOG.executeDatabaseOperation("UPDATE", dbEntity);
+
+    try {
+      int rowsAffected = executeUpdate(updateStatement, dbEntity);
+      entityUpdatePerformed(operation, rowsAffected, null);
+    } catch (Exception e) {
+      entityUpdatePerformed(operation, 0, e);
+    }
+  }
+
+  @Override
+  protected void updateBulk(DbBulkOperation operation) {
+    String statement = operation.getStatement();
+    Object parameter = operation.getParameter();
+
+    LOG.executeDatabaseBulkOperation("UPDATE", statement, parameter);
+
+    try {
+      int rowsAffected = executeUpdate(statement, parameter);
+      bulkUpdatePerformed(operation, rowsAffected, null);
+    } catch (Exception e) {
+      bulkUpdatePerformed(operation, 0, e);
+    }
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/test/AbstractProcessEngineTestCase.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/test/AbstractProcessEngineTestCase.java
@@ -72,7 +72,7 @@ public abstract class AbstractProcessEngineTestCase extends PvmTestCase {
   protected ProcessEngine processEngine;
 
   protected String deploymentId;
-  protected Set<String> deploymentIds = new HashSet<String>();
+  protected Set<String> deploymentIds = new HashSet<>();
 
   protected Throwable exception;
 
@@ -106,8 +106,9 @@ public abstract class AbstractProcessEngineTestCase extends PvmTestCase {
     try {
 
       boolean hasRequiredHistoryLevel = TestHelper.annotationRequiredHistoryLevelCheck(processEngine, getClass(), getName());
-      // ignore test case when current history level is too low
-      if (hasRequiredHistoryLevel) {
+      boolean runsWithRequiredDatabase = TestHelper.annotationRequiredDatabaseCheck(processEngine, getClass(), getName());
+      // ignore test case when current history level is too low or database doesn't match
+      if (hasRequiredHistoryLevel && runsWithRequiredDatabase) {
 
         deploymentId = TestHelper.annotationDeploymentSetUp(processEngine, getClass(), getName());
 
@@ -397,7 +398,7 @@ public abstract class AbstractProcessEngineTestCase extends PvmTestCase {
   }
 
   protected List<ActivityInstance> getInstancesForActivityId(ActivityInstance activityInstance, String activityId) {
-    List<ActivityInstance> result = new ArrayList<ActivityInstance>();
+    List<ActivityInstance> result = new ArrayList<>();
     if(activityInstance.getActivityId().equals(activityId)) {
       result.add(activityInstance);
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/test/RequiredDatabase.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/test/RequiredDatabase.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.test;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.camunda.bpm.engine.impl.db.sql.DbSqlSessionFactory;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+
+/**
+ * <p>This only works if {@link ProcessEngineRule} or {@link AbstractProcessEngineTestCase} is used.
+ * Furthermore, it only checks against the engines managed by these classes, e.g. it cannot prevent
+ * that a test builds a custom engine against any database.
+ *
+ * <p>Check the constants in {@link DbSqlSessionFactory} for valid database names.
+ *
+ * <p>Note that this uses the process engine to check the database type. If the test
+ * builds its own process engine, it may be a better idea to exclude the test via maven,
+ * to avoid the overhead of unnecessarily build the engine.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface RequiredDatabase {
+
+  public String[] excludes();
+
+  /*
+   * Ideas for improvement:
+   * - an includes array that allows you to only specify the
+   *   databases on which you want the test to run
+   */
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/test/TestHelper.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/test/TestHelper.java
@@ -226,6 +226,46 @@ public abstract class TestHelper {
     }
   }
 
+  public static boolean annotationRequiredDatabaseCheck(ProcessEngine processEngine, Description description) {
+    RequiredDatabase annotation = description.getAnnotation(RequiredDatabase.class);
+
+    if (annotation != null) {
+      return databaseCheck(processEngine, annotation);
+
+    } else {
+      return annotationRequiredDatabaseCheck(processEngine, description.getTestClass(), description.getMethodName());
+    }
+  }
+
+  public static boolean annotationRequiredDatabaseCheck(ProcessEngine processEngine, Class<?> testClass, String methodName) {
+    RequiredDatabase annotation = getAnnotation(processEngine, testClass, methodName, RequiredDatabase.class);
+
+    if (annotation != null) {
+      return databaseCheck(processEngine, annotation);
+    } else {
+      return true;
+    }
+  }
+
+  private static boolean databaseCheck(ProcessEngine processEngine, RequiredDatabase annotation) {
+
+    ProcessEngineConfigurationImpl processEngineConfiguration = (ProcessEngineConfigurationImpl) processEngine.getProcessEngineConfiguration();
+    String actualDbType = processEngineConfiguration.getDbSqlSessionFactory().getDatabaseType();
+
+    String[] excludes = annotation.excludes();
+
+    if (excludes != null) {
+      for (String exclude : excludes) {
+        if (exclude.equals(actualDbType)) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+
   private static <T extends Annotation> T getAnnotation(ProcessEngine processEngine, Class<?> testClass, String methodName, Class<T> annotationClass) {
     Method method = null;
     T annotation = null;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/CollectionUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/CollectionUtil.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,7 +44,7 @@ public class CollectionUtil {
    * <String, Object> map.
    */
   public static Map<String, Object> singletonMap(String key, Object value) {
-    Map<String, Object> map = new HashMap<String, Object>();
+    Map<String, Object> map = new HashMap<>();
     map.put(key, value);
     return map;
   }
@@ -52,14 +53,14 @@ public class CollectionUtil {
    * Arrays.asList cannot be reliably used for SQL parameters on MyBatis < 3.3.0
    */
   public static <T> List<T> asArrayList(T[] values) {
-    ArrayList<T> result = new ArrayList<T>();
+    ArrayList<T> result = new ArrayList<>();
     Collections.addAll(result, values);
 
     return result;
   }
 
   public static <T> Set<T> asHashSet(T... elements) {
-    Set<T> set = new HashSet<T>();
+    Set<T> set = new HashSet<>();
     Collections.addAll(set, elements);
 
     return set;
@@ -68,7 +69,7 @@ public class CollectionUtil {
   public static <S, T> void addToMapOfLists(Map<S, List<T>> map, S key, T value) {
     List<T> list = map.get(key);
     if (list == null) {
-      list = new ArrayList<T>();
+      list = new ArrayList<>();
       map.put(key, list);
     }
     list.add(value);
@@ -77,7 +78,7 @@ public class CollectionUtil {
   public static <S, T> void addToMapOfSets(Map<S, Set<T>> map, S key, T value) {
     Set<T> set = map.get(key);
     if (set == null) {
-      set = new HashSet<T>();
+      set = new HashSet<>();
       map.put(key, set);
     }
     set.add(value);
@@ -86,7 +87,7 @@ public class CollectionUtil {
   public static <S, T> void addCollectionToMapOfSets(Map<S, Set<T>> map, S key, Collection<T> values) {
     Set<T> set = map.get(key);
     if (set == null) {
-      set = new HashSet<T>();
+      set = new HashSet<>();
       map.put(key, set);
     }
     set.addAll(values);
@@ -96,11 +97,19 @@ public class CollectionUtil {
    * Chops a list into non-view sublists of length partitionSize.
    */
   public static <T> List<List<T>> partition(List<T> list, final int partitionSize) {
-    List<List<T>> parts = new ArrayList<List<T>>();
+    List<List<T>> parts = new ArrayList<>();
     final int listSize = list.size();
     for (int i = 0; i < listSize; i += partitionSize) {
-      parts.add(new ArrayList<T>(list.subList(i, Math.min(listSize, i + partitionSize))));
+      parts.add(new ArrayList<>(list.subList(i, Math.min(listSize, i + partitionSize))));
     }
     return parts;
+  }
+
+  public static <T> List<T> collectInList(Iterator<T> iterator) {
+    List<T> result = new ArrayList<>();
+    while (iterator.hasNext()) {
+      result.add(iterator.next());
+    }
+    return result;
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/EnsureUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/EnsureUtil.java
@@ -179,6 +179,12 @@ public final class EnsureUtil {
     }
   }
 
+  public static void ensureLessThan(String message, String variable, long value1, long value2) {
+    if (value1 >= value2) {
+      throw generateException(ProcessEngineException.class, message, variable, "is not less than" + value2);
+    }
+  }
+
   public static void ensureGreaterThanOrEqual(String variableName, long value1, long value2) {
     ensureGreaterThanOrEqual("", variableName, value1, value2);
   }
@@ -347,6 +353,13 @@ public final class EnsureUtil {
 
     if (!PATTERN.matcher(resourceId).matches()) {
       throw generateException(ProcessEngineException.class, resourceType + " has an invalid id", "'" + resourceId + "'", "is not a valid resource identifier.");
+    }
+  }
+
+
+  public static void ensureTrue(String message, boolean value) {
+    if (!value) {
+      throw new ProcessEngineException(message);
     }
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/test/ProcessEngineRule.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/test/ProcessEngineRule.java
@@ -101,7 +101,7 @@ public class ProcessEngineRule extends TestWatcher implements ProcessEngineServi
   protected String configurationResource = "camunda.cfg.xml";
   protected String configurationResourceCompat = "activiti.cfg.xml";
   protected String deploymentId = null;
-  protected List<String> additionalDeployments = new ArrayList<String>();
+  protected List<String> additionalDeployments = new ArrayList<>();
 
   protected boolean ensureCleanAfterTest = false;
 
@@ -162,11 +162,13 @@ public class ProcessEngineRule extends TestWatcher implements ProcessEngineServi
     initializeServices();
 
     final boolean hasRequiredHistoryLevel = TestHelper.annotationRequiredHistoryLevelCheck(processEngine, description);
+    final boolean runsWithRequiredDatabase = TestHelper.annotationRequiredDatabaseCheck(processEngine, description);
     return new Statement() {
 
       @Override
       public void evaluate() throws Throwable {
         Assume.assumeTrue("ignored because the current history level is too low", hasRequiredHistoryLevel);
+        Assume.assumeTrue("ignored because the database doesn't match the required ones", runsWithRequiredDatabase);
         ProcessEngineRule.super.apply(base, description).evaluate();
       }
     };

--- a/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrencyTestCase.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrencyTestCase.java
@@ -32,7 +32,7 @@ public abstract class ConcurrencyTestCase extends PluggableProcessEngineTestCase
 
   @Override
   protected void setUp() throws Exception {
-    controllableCommands = new ArrayList<ControllableCommand<?>>();
+    controllableCommands = new ArrayList<>();
     super.setUp();
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ThrowOleWhenDeletingExceptionStacktraceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ThrowOleWhenDeletingExceptionStacktraceTest.java
@@ -32,10 +32,6 @@ public class ThrowOleWhenDeletingExceptionStacktraceTest extends ConcurrencyTest
 
   protected AtomicReference<JobEntity> job = new AtomicReference<>();
 
-  protected void runTest() {
-    // ignored
-  }
-
   protected void tearDown() throws Exception {
     if (job.get() != null) {
       processEngineConfiguration.getCommandExecutorTxRequired().execute(new Command<Void>() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/SequentialJobAcquisitionTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/SequentialJobAcquisitionTest.java
@@ -50,7 +50,7 @@ public class SequentialJobAcquisitionTest {
   private static final String PROCESS_RESOURCE = RESOURCE_BASE + "/IntermediateTimerEventTest.testCatchingTimerEvent.bpmn20.xml";
 
   private JobExecutor jobExecutor = new DefaultJobExecutor();
-  private List<ProcessEngine> createdProcessEngines = new ArrayList<ProcessEngine>();
+  private List<ProcessEngine> createdProcessEngines = new ArrayList<>();
 
   @After
   public void stopJobExecutor() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/persistence/DatabaseFlushTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/persistence/DatabaseFlushTest.java
@@ -34,13 +34,6 @@ import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 
 public class DatabaseFlushTest extends ConcurrencyTestCase {
 
-  public static final BpmnModelInstance ONE_TASK_PROCESS = Bpmn
-      .createExecutableProcess("process")
-      .startEvent()
-      .userTask()
-      .endEvent()
-      .done();
-
   public static final BpmnModelInstance GW_PROCESS = Bpmn
       .createExecutableProcess("process")
       .startEvent()

--- a/engine/src/test/java/org/camunda/bpm/engine/test/persistence/DatabaseFlushTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/persistence/DatabaseFlushTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.camunda.bpm.engine.OptimisticLockingException;
+import org.camunda.bpm.engine.impl.cmd.CompleteTaskCmd;
+import org.camunda.bpm.engine.impl.db.sql.DbSqlSessionFactory;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.test.RequiredDatabase;
+import org.camunda.bpm.engine.task.Task;
+import org.camunda.bpm.engine.test.concurrency.ConcurrencyTestCase;
+import org.camunda.bpm.engine.variable.VariableMap;
+import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+
+public class DatabaseFlushTest extends ConcurrencyTestCase {
+
+  public static final BpmnModelInstance ONE_TASK_PROCESS = Bpmn
+      .createExecutableProcess("process")
+      .startEvent()
+      .userTask()
+      .endEvent()
+      .done();
+
+  public static final BpmnModelInstance GW_PROCESS = Bpmn
+      .createExecutableProcess("process")
+      .startEvent()
+      .parallelGateway()
+      .userTask("task1-1")
+      .userTask("task1-2")
+      .endEvent()
+      .moveToLastGateway()
+      .userTask("task2-1")
+      .userTask("task2-2")
+      .endEvent()
+      .done();
+
+  /**
+   * <p>This test reproduces a bug in which a batch of SQL operations
+   * (here variable instance inserts) fail due to a constraint violation.
+   * That constraint violation should be correctly treated as a case of
+   * optimistic locking (variable name uniqueness in a scope).
+   *
+   * <p>In older versions this was not the case. Instead, the constraint
+   * violation was incorrectly matched to a history
+   * operation and therefore ignored, because we do not raise optimistic locking
+   * exceptions for failed history operations. In consequence, we made an
+   * incomplete runtime flush and the database got into an inconsistent
+   * state.
+   */
+  @RequiredDatabase(excludes = DbSqlSessionFactory.DB2)
+  public void testNoIncompleteFlushOnConstraintViolation()
+  {
+    // given
+    deployment(GW_PROCESS);
+
+    runtimeService.startProcessInstanceByKey("process");
+
+    List<Task> tasks = taskService.createTaskQuery().list();
+
+    Task task1 = tasks.get(0);
+    Task task2 = tasks.get(1);
+
+    // three variables are required to reproduce the incorrect
+    // matching of SQL failure to db operation
+    VariableMap variables = Variables.createVariables()
+        .putValue("key1", "val1")
+        .putValue("key2", "val2")
+        .putValue("key3", "val3");
+    ThreadControl thread1 =
+        executeControllableCommand(new CompleteTaskCommand(task1.getId(), variables));
+    ThreadControl thread2 =
+        executeControllableCommand(new CompleteTaskCommand(task2.getId(), variables));
+    thread2.reportInterrupts();
+
+    thread1.waitForSync();
+    thread2.waitForSync();
+    // both threads are now waiting before the flush
+
+    // thread1 can successfully flush and inserts the variables
+    thread1.waitUntilDone();
+
+    // when
+    // thread2 should encounter the constraint violation
+    thread2.waitUntilDone();
+
+    // then
+    assertThat(thread2.getException()).isInstanceOf(OptimisticLockingException.class);
+
+    // the task was not deleted, indicating that the database is still in a consistent state
+    task2 = taskService.createTaskQuery().taskId(task2.getId()).singleResult();
+    assertThat(task2).isNotNull();
+  }
+
+  private static class CompleteTaskCommand extends ControllableCommand<Void> {
+
+    protected String taskId;
+    protected VariableMap variables;
+
+    public CompleteTaskCommand(String taskId, VariableMap variables)
+    {
+      this.taskId = taskId;
+      this.variables = variables;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+
+      CompleteTaskCmd completeTaskCmd = new CompleteTaskCmd(taskId, variables);
+      completeTaskCmd.execute(commandContext);
+
+      monitor.sync();
+
+      return null;
+    }
+  }
+
+}
+


### PR DESCRIPTION
- fixes the problem that a db operation could fail and
  we would incorrectly assume that this was ok and not rollback the
  transaction
- example:
  - we flush an insert into ACT_RU_VARIABLE which fails, because
    it violates the uniqueness constraint on NAME_ and SCOPE_
  - db entity manager catches the exception and identifies it as a case
    of concurrent modification
  - db entity manager (wrongfully) matched the failure to a history
    operation in the same flush
  - with the setting that we do not raise optimistic locking exception
    in case of history entities, the failed insert does not trigger
    transaction rollback and the flush continues; this leads to
    inconsistencies in the runtime tables
- the core fix is that we must handle the exception raised by mybatis
  differently in case flushing fails; in particular, this commit changes
  how we match failures to database operations
- rewrites how we flush db operations and tries to better separate the
  cases of batched vs non-batched flush
  - creates dedicated sub classes of DbSqlSession for each case
  - moves the logic for matching failures to db operation into the
    batch-specific sql session (was previously in DbEntityManager);
    this should make the responsibilities clearer: db entity manager
    orchestrates the flush, i.e. decides what gets flushed and
    if a failure shall throw a exception, OLE or nothing at all;
    DbSqlSession talks to mybatis

Fixes https://app.camunda.com/jira/browse/CAM-10409 and https://app.camunda.com/jira/browse/CAM-10126

Two implementation notes that I would like to get feedback on:

- In case of errors during the flush, we now use more main memory in the form of lists in the `FlushResult`. The extreme case would be a batch of 50 operation where every operation fails, but the failure is tolerated so that the flush continues. In that case, we will create 50 lists of failed and remaining operations in the flush result, so the memory consumption will be n^2 in the worst case, where n is the number of operations. This was better in the previous implementation of the flush, where the entity manager just did everything in a single loop over the operations.
- In the case of batching, there is a potential bug when it comes to matching a failure to the respective operations and deciding for what reason the operation failed. Details: https://github.com/camunda/camunda-bpm-platform/blob/412d28000ffd02ffac6487670274e57f9c38cd33/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/BatchDbSqlSession.java#L155-L167
  From my understanding, this wasn't better in the previous implementation and I couldn't see an obvious solution to this.