### PR TITLE
[CAM-9114] fix(engine): correct results for or queries with multiple joins

### DIFF
--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
@@ -235,8 +235,12 @@
     <bind name="CD_JOIN" value="false" />
     <bind name="CE_JOIN" value="false" />
     <bind name="E1_JOIN" value="false" />
+    <bind name="JOIN_TYPE" value="'inner join'" />
 
     <foreach collection="queries" item="query">
+      <if test="query.isOrQueryActive">
+        <bind name="JOIN_TYPE" value="'left join'" />
+      </if>
       <if test="query != null &amp;&amp; (query.candidateUser != null || query.candidateGroups != null || query.involvedUser != null || query.withCandidateGroups || query.withCandidateUsers)">
         <bind name="I_JOIN" value="true" />
       </if>
@@ -260,19 +264,19 @@
     </foreach>
 
     <if test="I_JOIN">
-      inner join ${prefix}ACT_RU_IDENTITYLINK I on I.TASK_ID_ = RES.ID_
+      ${JOIN_TYPE} ${prefix}ACT_RU_IDENTITYLINK I on I.TASK_ID_ = RES.ID_
     </if>
     <if test="D_JOIN">
-      inner join ${prefix}ACT_RE_PROCDEF D on RES.PROC_DEF_ID_ = D.ID_
+      ${JOIN_TYPE} ${prefix}ACT_RE_PROCDEF D on RES.PROC_DEF_ID_ = D.ID_
     </if>
     <if test="E_JOIN">
-      inner join ${prefix}ACT_RU_EXECUTION E on RES.PROC_INST_ID_ = E.ID_
+      ${JOIN_TYPE} ${prefix}ACT_RU_EXECUTION E on RES.PROC_INST_ID_ = E.ID_
     </if>
     <if test="CD_JOIN">
-      inner join ${prefix}ACT_RE_CASE_DEF CD on RES.CASE_DEF_ID_ = CD.ID_
+      ${JOIN_TYPE} ${prefix}ACT_RE_CASE_DEF CD on RES.CASE_DEF_ID_ = CD.ID_
     </if>
     <if test="CE_JOIN">
-      inner join ${prefix}ACT_RU_CASE_EXECUTION CE on RES.CASE_INST_ID_ = CE.ID_
+      ${JOIN_TYPE} ${prefix}ACT_RU_CASE_EXECUTION CE on RES.CASE_INST_ID_ = CE.ID_
     </if>
     <if test="E1_JOIN">
       left join ${prefix}ACT_RU_EXECUTION E1 on RES.EXECUTION_ID_ = E1.ID_

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryOrTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryOrTest.java
@@ -16,12 +16,22 @@
  */
 package org.camunda.bpm.engine.test.api.task;
 
+import static org.junit.Assert.assertEquals;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.camunda.bpm.engine.CaseService;
 import org.camunda.bpm.engine.FilterService;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
-import org.camunda.bpm.engine.RepositoryService;
-import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.TaskQueryImpl;
 import org.camunda.bpm.engine.runtime.CaseInstance;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
@@ -33,20 +43,9 @@ import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Tassilo Weidner
@@ -257,6 +256,29 @@ public class TaskQueryOrTest {
         .taskCandidateUser("John Doe")
         .taskCandidateGroup("Controlling")
         .includeAssignedTasks()
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(2, tasks.size());
+  }
+
+  @Test
+  public void shouldReturnTasksWithTaskCandidateUserOrAssignee() {
+    // given
+    Task task1 = taskService.newTask();
+    taskService.saveTask(task1);
+    taskService.setAssignee(task1.getId(), "John Doe");
+
+    Task task2 = taskService.newTask();
+    taskService.saveTask(task2);
+    taskService.addCandidateUser(task2.getId(), "John Doe");
+
+    // when
+    List<Task> tasks = taskService.createTaskQuery()
+      .or()
+        .taskCandidateUser("John Doe")
+        .taskAssignee("John Doe")
       .endOr()
       .list();
 
@@ -680,6 +702,111 @@ public class TaskQueryOrTest {
   }
 
   @Test
+  public void shouldReturnTasksWithProcessInstanceBusinessKeyOrProcessInstanceBusinessKeyLikeAndAssignee() {
+    // given
+    BpmnModelInstance aProcessDefinition = Bpmn.createExecutableProcess("aProcessDefinition")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+    repositoryService
+      .createDeployment()
+      .addModelInstance("foo.bpmn", aProcessDefinition)
+      .deploy();
+
+    ProcessInstance processInstance = runtimeService
+      .startProcessInstanceByKey("aProcessDefinition", "aBusinessKey");
+
+    runtimeService
+    .startProcessInstanceByKey("aProcessDefinition", "aBusinessKey");
+
+    BpmnModelInstance anotherProcessDefinition = Bpmn.createExecutableProcess("anotherProcessDefinition")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+     repositoryService
+       .createDeployment()
+       .addModelInstance("foo.bpmn", anotherProcessDefinition)
+       .deploy();
+
+    ProcessInstance processInstanceAnotherDefinition = runtimeService
+      .startProcessInstanceByKey("anotherProcessDefinition", "anotherBusinessKey");
+
+    // set the assignee for one task of each process definition
+    String assignee = "testUser4";
+    String taskId = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId();
+    taskService.setAssignee(taskId, assignee);
+
+    taskId = taskService.createTaskQuery().processInstanceId(processInstanceAnotherDefinition.getId()).singleResult().getId();
+    taskService.setAssignee(taskId, assignee);
+
+    // when
+    List<Task> tasks = taskService.createTaskQuery()
+      .or()
+        .processInstanceBusinessKey("aBusinessKey")
+        .processInstanceBusinessKeyLike("anotherBusinessKey")
+      .endOr()
+      .taskAssignee(assignee)
+      .list();
+
+    // then
+    assertEquals(2, tasks.size());
+  }
+
+  @Test
+  public void shouldReturnTasksWithProcessInstanceBusinessKeyOrProcessInstanceBusinessKeyLikeOrStandaloneAssignee() {
+    // given
+    BpmnModelInstance aProcessDefinition = Bpmn.createExecutableProcess("aProcessDefinition")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+    repositoryService
+      .createDeployment()
+      .addModelInstance("foo.bpmn", aProcessDefinition)
+      .deploy();
+
+    runtimeService
+      .startProcessInstanceByKey("aProcessDefinition", "aBusinessKey");
+    
+    BpmnModelInstance anotherProcessDefinition = Bpmn.createExecutableProcess("anotherProcessDefinition")
+      .startEvent()
+        .userTask()
+      .endEvent()
+      .done();
+
+     repositoryService
+       .createDeployment()
+       .addModelInstance("foo.bpmn", anotherProcessDefinition)
+       .deploy();
+
+    runtimeService
+      .startProcessInstanceByKey("anotherProcessDefinition", "anotherBusinessKey");
+
+    // create a standalone task with assignee
+    String assignee = "testUser4";
+    Task newTask = taskService.newTask();
+    newTask.setAssignee(assignee);
+    taskService.saveTask(newTask);
+
+    // when
+    List<Task> tasks = taskService.createTaskQuery()
+      .or()
+        .processInstanceBusinessKey("aBusinessKey")
+        .processInstanceBusinessKeyLike("anotherBusinessKey")
+        .taskAssignee(assignee)
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(3, tasks.size());
+  }
+
+  @Test
   @Deployment(resources={
     "org/camunda/bpm/engine/test/api/cmmn/oneTaskCase.cmmn",
     "org/camunda/bpm/engine/test/api/cmmn/oneTaskCase2.cmmn"})
@@ -758,7 +885,53 @@ public class TaskQueryOrTest {
   }
 
   @Test
-  @Ignore("CAM-9114")
+  @Deployment(resources={
+    "org/camunda/bpm/engine/test/api/cmmn/oneTaskCase.cmmn",
+    "org/camunda/bpm/engine/test/api/cmmn/oneTaskCase2.cmmn"})
+  public void shouldReturnTasksWithCaseInstanceBusinessKeyOrCaseInstanceBusinessKeyLikeOrStandaloneAssignee() {
+    // given
+    String caseDefinitionId1 = repositoryService
+      .createCaseDefinitionQuery()
+      .caseDefinitionKey("oneTaskCase")
+      .singleResult()
+      .getId();
+
+    CaseInstance caseInstance1 = caseService
+      .withCaseDefinition(caseDefinitionId1)
+      .businessKey("aBusinessKey")
+      .create();
+
+    String caseDefinitionId2 = repositoryService
+      .createCaseDefinitionQuery()
+      .caseDefinitionKey("oneTaskCase2")
+      .singleResult()
+      .getId();
+
+    CaseInstance caseInstance2 = caseService
+      .withCaseDefinition(caseDefinitionId2)
+      .businessKey("anotherBusinessKey")
+      .create();
+
+    // create a standalone task with assignee
+    String assignee = "testUser4";
+    Task newTask = taskService.newTask();
+    newTask.setAssignee(assignee);
+    taskService.saveTask(newTask);
+
+    // when
+    List<Task> tasks = taskService.createTaskQuery()
+      .or()
+        .caseInstanceBusinessKey(caseInstance1.getBusinessKey())
+        .caseInstanceBusinessKeyLike(caseInstance2.getBusinessKey())
+        .taskAssignee(assignee)
+      .endOr()
+      .list();
+
+    // then
+    assertEquals(3, tasks.size());
+  }
+
+  @Test
   @Deployment(resources={"org/camunda/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
   public void shouldReturnTasksWithCaseInstanceBusinessKeyOrProcessInstanceBusinessKey() {
     String businessKey = "aBusinessKey";
@@ -790,7 +963,6 @@ public class TaskQueryOrTest {
     TaskQuery query = taskService.createTaskQuery();
 
     query
-    .processInstanceBusinessKey(businessKey)
       .or()
         .caseInstanceBusinessKey(businessKey)
         .processInstanceBusinessKey(businessKey)
@@ -1057,7 +1229,7 @@ public class TaskQueryOrTest {
     assertEquals(3, taskService.createTaskQuery().or().active().processVariableValueEquals("foo", 0).endOr().list().size());
   }
 
-  public HashMap<String, Date> createFollowUpAndDueDateTasks() throws ParseException {
+  protected HashMap<String, Date> createFollowUpAndDueDateTasks() throws ParseException {
     final Date date = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("27/07/2017 01:12:13"),
       oneHourAgo = new Date(date.getTime() - 60 * 60 * 1000),
       oneHourLater = new Date(date.getTime() + 60 * 60 * 1000);


### PR DESCRIPTION
* use left joins if OR clauses are contained in the query,
  use inner joins otherwise
* degrades the performance of all OR queries

related to CAM-9114