### PR TITLE
CAM-10506 - Requesting Removal of Call-Out Preventing ECMAScript Compilation

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/SourceExecutableScript.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/SourceExecutableScript.java
@@ -34,6 +34,7 @@ import org.camunda.bpm.engine.impl.context.Context;
  * A script which is provided as source code.
  *
  * @author Daniel Meyer
+ * @author Ryan Johnston
  *
  */
 public class SourceExecutableScript extends CompiledExecutableScript {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/SourceExecutableScript.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/SourceExecutableScript.java
@@ -98,7 +98,7 @@ public class SourceExecutableScript extends CompiledExecutableScript {
   }
 
   public CompiledScript compile(ScriptEngine scriptEngine, String language, String src) {
-    if(scriptEngine instanceof Compilable && !scriptEngine.getFactory().getLanguageName().equalsIgnoreCase("ecmascript")) {
+    if(scriptEngine instanceof Compilable) {
       Compilable compilingEngine = (Compilable) scriptEngine;
 
       try {


### PR DESCRIPTION
Per [this comment](https://stackoverflow.com/questions/30140103/should-i-use-a-separate-scriptengine-and-compiledscript-instances-per-each-threa/30159424#30159424) by one of the original creators of Nashorn, ECMAScript is both compilable and thread-safe. However, in Camunda BPM, there's an explicit call-out preventing the compilation of ECMAScript.

Per my tests, this can be safely removed, and doing so will significantly increase the performance of ECMAScript execution in the engine. Please see [this Forum thread](https://forum.camunda.org/t/javascript-date-manipulation/13249/11) on the topic. I'll include the most important details below for easy reference.

To test the impact of this change, I ran two 100 process instance performance tests with asynchronous continuations (ensuring multi-threading) that compared performance with and without ECMAScript compilation, and here are the results:

- The average execution time for the sample Script Task using JavaScript _without_ compilation was 129 ms.
- The average execution time for the sample Script Task using JavaScript _with_ compilation was 9.2 ms.

I also ensured that the script was thread-safe. The Bindings object is changed for each execution, meaning that the variables aren't shared across invocations.

Please consider this pull request for the next release of Camunda BPM.

-Ryan Johnston
ryan@summit58.co