### PR TITLE
[CAM-10067] configuration for exception logging during cmd/job execution

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/ProcessEngineConfiguration.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/ProcessEngineConfiguration.java
@@ -883,9 +883,8 @@ public abstract class ProcessEngineConfiguration {
     return defaultNumberOfRetries;
   }
 
-  public ProcessEngineConfiguration setDefaultNumberOfRetries(int defaultNumberOfRetries) {
+  public void setDefaultNumberOfRetries(int defaultNumberOfRetries) {
     this.defaultNumberOfRetries = defaultNumberOfRetries;
-    return this;
   }
 
   public ValueTypeResolver getValueTypeResolver() {

--- a/engine/src/main/java/org/camunda/bpm/engine/ProcessEngineConfiguration.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/ProcessEngineConfiguration.java
@@ -381,6 +381,22 @@ public abstract class ProcessEngineConfiguration {
    */
   protected List<String> disabledPermissions = Collections.emptyList();
 
+  /**
+   * If the value of this flag is set to <code>true</code> exceptions that occur
+   * during command execution and are handled within the engine will not be logged.
+   * This flag does not affect exceptions during job execution. See 
+   * {@link #enableReducedJobExceptionLogging}.
+   */
+  protected boolean enableReducedCmdExceptionLogging = false;
+
+  /**
+   * If the value of this flag is set to <code>true</code> exceptions that occur
+   * during the execution of a job that still has retries left will not be logged.
+   * If the job does not have any retries left, the exception will still be logged
+   * on logging level ERROR. Also see {@link #enableReducedCmdExceptionLogging}.
+   */
+  protected boolean enableReducedJobExceptionLogging = false;
+
   /** use one of the static createXxxx methods instead */
   protected ProcessEngineConfiguration() {
   }
@@ -867,8 +883,9 @@ public abstract class ProcessEngineConfiguration {
     return defaultNumberOfRetries;
   }
 
-  public void setDefaultNumberOfRetries(int defaultNumberOfRetries) {
+  public ProcessEngineConfiguration setDefaultNumberOfRetries(int defaultNumberOfRetries) {
     this.defaultNumberOfRetries = defaultNumberOfRetries;
+    return this;
   }
 
   public ValueTypeResolver getValueTypeResolver() {
@@ -968,6 +985,24 @@ public abstract class ProcessEngineConfiguration {
 
   public ProcessEngineConfiguration setPasswordPolicy(PasswordPolicy passwordPolicy) {
     this.passwordPolicy = passwordPolicy;
+    return this;
+  }
+
+  public boolean isEnableReducedCmdExceptionLogging() {
+    return enableReducedCmdExceptionLogging;
+  }
+
+  public ProcessEngineConfiguration setEnableReducedCmdExceptionLogging(boolean enableReducedCmdExceptionLogging) {
+    this.enableReducedCmdExceptionLogging = enableReducedCmdExceptionLogging;
+    return this;
+  }
+
+  public boolean isEnableReducedJobExceptionLogging() {
+    return enableReducedJobExceptionLogging;
+  }
+
+  public ProcessEngineConfiguration setEnableReducedJobExceptionLogging(boolean enableReducedJobExceptionLogging) {
+    this.enableReducedJobExceptionLogging = enableReducedJobExceptionLogging;
     return this;
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessEngineLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessEngineLogger.java
@@ -20,6 +20,7 @@ import java.net.URL;
 
 import org.camunda.bpm.application.impl.ProcessApplicationLogger;
 import org.camunda.bpm.container.impl.ContainerIntegrationLogger;
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.impl.bpmn.behavior.BpmnBehaviorLogger;
 import org.camunda.bpm.engine.impl.bpmn.parser.BpmnParseLogger;
 import org.camunda.bpm.engine.impl.cfg.ConfigurationLogger;
@@ -38,6 +39,7 @@ import org.camunda.bpm.engine.impl.interceptor.ContextLogger;
 import org.camunda.bpm.engine.impl.jobexecutor.JobExecutorLogger;
 import org.camunda.bpm.engine.impl.metrics.MetricsLogger;
 import org.camunda.bpm.engine.impl.migration.MigrationLogger;
+import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
 import org.camunda.bpm.engine.impl.plugin.AdministratorAuthorizationPluginLogger;
 import org.camunda.bpm.engine.impl.pvm.PvmLogger;
 import org.camunda.bpm.engine.impl.scripting.ScriptLogger;
@@ -129,6 +131,15 @@ public class ProcessEngineLogger extends BaseLogger {
 
   public static final IncidentLogger INCIDENT_LOGGER = BaseLogger.createLogger(
       IncidentLogger.class, PROJECT_CODE, "org.camunda.bpm.engine.incident", "26");
+
+  public static boolean shouldLogJobException(ProcessEngineConfiguration processEngineConfiguration, JobEntity currentJob) {
+    boolean enableReducedJobExceptionLogging = processEngineConfiguration.isEnableReducedJobExceptionLogging();
+    return currentJob == null || !enableReducedJobExceptionLogging || enableReducedJobExceptionLogging && currentJob.getRetries() <= 1;
+  }
+
+  public static boolean shouldLogCmdException(ProcessEngineConfiguration processEngineConfiguration) {
+    return !processEngineConfiguration.isEnableReducedCmdExceptionLogging();
+  }
 
   public void processEngineCreated(String name) {
     logInfo("001", "Process Engine {} created.", name);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandContext.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandContext.java
@@ -16,9 +16,22 @@
  */
 package org.camunda.bpm.engine.impl.interceptor;
 
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
 import org.camunda.bpm.application.InvocationContext;
 import org.camunda.bpm.application.ProcessApplicationReference;
-import org.camunda.bpm.engine.*;
+import org.camunda.bpm.engine.BadUserRequestException;
+import org.camunda.bpm.engine.IdentityService;
+import org.camunda.bpm.engine.OptimisticLockingException;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.TaskAlreadyClaimedException;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.cfg.TransactionContext;
@@ -40,12 +53,48 @@ import org.camunda.bpm.engine.impl.identity.ReadOnlyIdentityProvider;
 import org.camunda.bpm.engine.impl.identity.WritableIdentityProvider;
 import org.camunda.bpm.engine.impl.jobexecutor.FailedJobCommandFactory;
 import org.camunda.bpm.engine.impl.optimize.OptimizeManager;
-import org.camunda.bpm.engine.impl.persistence.entity.*;
-
-import java.util.*;
-import java.util.concurrent.Callable;
-
-import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
+import org.camunda.bpm.engine.impl.persistence.entity.AttachmentManager;
+import org.camunda.bpm.engine.impl.persistence.entity.AuthorizationManager;
+import org.camunda.bpm.engine.impl.persistence.entity.BatchManager;
+import org.camunda.bpm.engine.impl.persistence.entity.ByteArrayManager;
+import org.camunda.bpm.engine.impl.persistence.entity.CommentManager;
+import org.camunda.bpm.engine.impl.persistence.entity.DeploymentManager;
+import org.camunda.bpm.engine.impl.persistence.entity.EventSubscriptionManager;
+import org.camunda.bpm.engine.impl.persistence.entity.ExecutionManager;
+import org.camunda.bpm.engine.impl.persistence.entity.ExternalTaskManager;
+import org.camunda.bpm.engine.impl.persistence.entity.FilterManager;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricActivityInstanceManager;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricBatchManager;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricCaseActivityInstanceManager;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricCaseInstanceManager;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricDetailManager;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricExternalTaskLogManager;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricIdentityLinkLogManager;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricIncidentManager;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricJobLogManager;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricProcessInstanceManager;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricStatisticsManager;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricTaskInstanceManager;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricVariableInstanceManager;
+import org.camunda.bpm.engine.impl.persistence.entity.IdentityInfoManager;
+import org.camunda.bpm.engine.impl.persistence.entity.IdentityLinkManager;
+import org.camunda.bpm.engine.impl.persistence.entity.IncidentManager;
+import org.camunda.bpm.engine.impl.persistence.entity.JobDefinitionManager;
+import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.JobManager;
+import org.camunda.bpm.engine.impl.persistence.entity.MeterLogManager;
+import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionManager;
+import org.camunda.bpm.engine.impl.persistence.entity.PropertyManager;
+import org.camunda.bpm.engine.impl.persistence.entity.ReportManager;
+import org.camunda.bpm.engine.impl.persistence.entity.ResourceManager;
+import org.camunda.bpm.engine.impl.persistence.entity.SchemaLogManager;
+import org.camunda.bpm.engine.impl.persistence.entity.StatisticsManager;
+import org.camunda.bpm.engine.impl.persistence.entity.TableDataManager;
+import org.camunda.bpm.engine.impl.persistence.entity.TaskManager;
+import org.camunda.bpm.engine.impl.persistence.entity.TaskReportManager;
+import org.camunda.bpm.engine.impl.persistence.entity.TenantManager;
+import org.camunda.bpm.engine.impl.persistence.entity.UserOperationLogManager;
+import org.camunda.bpm.engine.impl.persistence.entity.VariableInstanceManager;
 
 /**
  * @author Tom Baeyens
@@ -153,14 +202,16 @@ public class CommandContext {
             // fire command failed (must not fail itself)
             fireCommandFailed(commandInvocationContext.getThrowable());
 
-            if (shouldLogInfo(commandInvocationContext.getThrowable())) {
-              LOG.infoException(commandInvocationContext.getThrowable());
-            }
-            else if (shouldLogFine(commandInvocationContext.getThrowable())) {
-              LOG.debugException(commandInvocationContext.getThrowable());
-            }
-            else {
-              LOG.errorException(commandInvocationContext.getThrowable());
+            if(shouldLogException()) {
+              if (shouldLogInfo(commandInvocationContext.getThrowable())) {
+                LOG.infoException(commandInvocationContext.getThrowable());
+              }
+              else if (shouldLogFine(commandInvocationContext.getThrowable())) {
+                LOG.debugException(commandInvocationContext.getThrowable());
+              }
+              else {
+                  LOG.errorException(commandInvocationContext.getThrowable());
+              }
             }
             transactionContext.rollback();
           }
@@ -184,6 +235,15 @@ public class CommandContext {
 
   protected boolean shouldLogFine(Throwable exception) {
     return exception instanceof OptimisticLockingException || exception instanceof BadUserRequestException;
+  }
+
+  protected boolean shouldLogException() {
+    JobEntity job = Context.getCommandContext().getCurrentJob();
+    if(job == null) {
+      return ProcessEngineLogger.shouldLogCmdException(processEngineConfiguration);
+    } else {
+      return ProcessEngineLogger.shouldLogJobException(processEngineConfiguration, job);
+    }
   }
 
   protected void fireCommandContextClose() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/ExecuteJobHelper.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/ExecuteJobHelper.java
@@ -30,9 +30,9 @@ public class ExecuteJobHelper {
 
     @Override
     public void exceptionWhileExecutingJob(String jobId, Throwable exception) {
-
-      // Default behavior, just log exception
-      LOG.exceptionWhileExecutingJob(jobId, exception);
+      
+      // Default behavior, don't log exception. It is logged in ExecuteJobsRunnable#run.
+      // hook for custom logging handler
     }
 
   };
@@ -47,23 +47,18 @@ public class ExecuteJobHelper {
 
   public static void executeJob(String nextJobId, CommandExecutor commandExecutor, JobFailureCollector jobFailureCollector, Command<Void> cmd) {
     try {
-
       commandExecutor.execute(cmd);
-
     } catch (RuntimeException exception) {
       handleJobFailure(nextJobId, jobFailureCollector, exception);
       // throw the original exception to indicate the ExecuteJobCmd failed
       throw exception;
-
     } catch (Throwable exception) {
       handleJobFailure(nextJobId, jobFailureCollector, exception);
       // wrap the exception and throw it to indicate the ExecuteJobCmd failed
       throw LOG.wrapJobExecutionFailure(jobFailureCollector, exception);
-
     } finally {
       invokeJobListener(commandExecutor, jobFailureCollector);
     }
-
   }
 
   protected static void invokeJobListener(CommandExecutor commandExecutor, JobFailureCollector jobFailureCollector) {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/CmdExceptionLoggingTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/CmdExceptionLoggingTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.jobexecutor;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.impl.ProcessEngineLogger;
+import org.camunda.bpm.engine.impl.cfg.StandaloneProcessEngineConfiguration;
+import org.junit.Test;
+
+public class CmdExceptionLoggingTest {
+
+  ProcessEngineConfiguration processEngineConfigurationDefaultLogging = new StandaloneProcessEngineConfiguration();
+  ProcessEngineConfiguration processEngineConfigurationReducedJobLogging = new StandaloneProcessEngineConfiguration()
+      .setEnableReducedJobExceptionLogging(true);
+  ProcessEngineConfiguration processEngineConfigurationReducedCmdLogging = new StandaloneProcessEngineConfiguration()
+      .setEnableReducedCmdExceptionLogging(true);
+  ProcessEngineConfiguration processEngineConfigurationReducedJobAndCmdLogging = new StandaloneProcessEngineConfiguration()
+      .setEnableReducedJobExceptionLogging(true)
+      .setEnableReducedCmdExceptionLogging(true);
+
+  @Test
+  public void testLogCmdException() {
+    // given different engine configurations
+
+    // when
+    boolean shouldLogWithDefault = ProcessEngineLogger.shouldLogCmdException(processEngineConfigurationDefaultLogging);
+    boolean shouldLogWithReducedJobLogging = ProcessEngineLogger.shouldLogCmdException(processEngineConfigurationReducedJobLogging);
+    boolean shouldLogWithReducedCmdLogging = ProcessEngineLogger.shouldLogCmdException(processEngineConfigurationReducedCmdLogging);
+    boolean shouldLogWithReducedJobAndCmdLogging = ProcessEngineLogger.shouldLogCmdException(processEngineConfigurationReducedJobAndCmdLogging);
+
+    // then
+    assertTrue(shouldLogWithDefault);
+    assertTrue(shouldLogWithReducedJobLogging);
+    assertFalse(shouldLogWithReducedCmdLogging);
+    assertFalse(shouldLogWithReducedJobAndCmdLogging);
+  }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExceptionLoggingTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExceptionLoggingTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.jobexecutor;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import java.util.Arrays;
+import java.util.Collection;
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.impl.ProcessEngineLogger;
+import org.camunda.bpm.engine.impl.cfg.StandaloneProcessEngineConfiguration;
+import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.TimerEntity;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class JobExceptionLoggingTest {
+
+  ProcessEngineConfiguration processEngineConfigurationDefaultLogging = new StandaloneProcessEngineConfiguration();
+  ProcessEngineConfiguration processEngineConfigurationReducedJobLogging = new StandaloneProcessEngineConfiguration()
+      .setEnableReducedJobExceptionLogging(true);
+  ProcessEngineConfiguration processEngineConfigurationReducedCmdLogging = new StandaloneProcessEngineConfiguration()
+      .setEnableReducedCmdExceptionLogging(true);
+  ProcessEngineConfiguration processEngineConfigurationReducedJobAndCmdLogging = new StandaloneProcessEngineConfiguration()
+      .setEnableReducedJobExceptionLogging(true)
+      .setEnableReducedCmdExceptionLogging(true);
+
+  @Parameter(0)
+  public JobEntity job;
+
+  @Parameter(1)
+  public boolean expectedDefaultLoggingResult;
+
+  @Parameter(2)
+  public boolean expectedJobExceptionLogging;
+
+  @Parameter(3)
+  public boolean expectedCmdExceptionLogging;
+
+  @Parameter(4)
+  public boolean expectedJobAndCmdExceptionLogging;
+
+  @Parameters(name = "scenario {index}")
+  public static Collection<Object[]> scenarios() {
+    return Arrays.asList(new Object[][] {
+      {jobWithRetries(3), true, false, true, false},
+      {jobWithRetries(1), true, true, true, true},
+      {null, true, true, true, true}
+    });
+  }
+
+  @Test
+  public void testLogJobException() {
+    // given parameters
+
+    // when
+    boolean shouldLogWithDefault = ProcessEngineLogger.shouldLogJobException(processEngineConfigurationDefaultLogging, job);
+    boolean shouldLogWithReducedJobLogging = ProcessEngineLogger.shouldLogJobException(processEngineConfigurationReducedJobLogging, job);
+    boolean shouldLogWithReducedCmdLogging = ProcessEngineLogger.shouldLogJobException(processEngineConfigurationReducedCmdLogging, job);
+    boolean shouldLogWithReducedJobAndCmdLogging = ProcessEngineLogger.shouldLogJobException(processEngineConfigurationReducedJobAndCmdLogging, job);
+
+    // then
+    assertThat(shouldLogWithDefault, is(expectedDefaultLoggingResult));
+    assertThat(shouldLogWithReducedJobLogging, is(expectedJobExceptionLogging));
+    assertThat(shouldLogWithReducedCmdLogging, is(expectedCmdExceptionLogging));
+    assertThat(shouldLogWithReducedJobAndCmdLogging, is(expectedJobAndCmdExceptionLogging));
+  }
+
+  private static JobEntity jobWithRetries(int retries) {
+    JobEntity job = new TimerEntity();
+    job.setRetries(retries);
+    return job;
+  }
+}


### PR DESCRIPTION
* enable reduced job logging -> only exceptions in jobs with no retries
will be logged
* enable reduced cmd logging -> only exceptions in commands that are not
handled by the engine are logged

Related to CAM-10067