### PR TITLE
CAM-9838: improve job acquisition query

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -1464,6 +1464,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       properties.put("innerLimitAfter", DbSqlSessionFactory.databaseSpecificInnerLimitAfterStatements.get(databaseType));
       properties.put("limitBetween", DbSqlSessionFactory.databaseSpecificLimitBetweenStatements.get(databaseType));
       properties.put("limitBetweenFilter", DbSqlSessionFactory.databaseSpecificLimitBetweenFilterStatements.get(databaseType));
+      properties.put("limitBetweenAcquisition", DbSqlSessionFactory.databaseSpecificLimitBetweenAcquisitionStatements.get(databaseType));
       properties.put("orderBy", DbSqlSessionFactory.databaseSpecificOrderByStatements.get(databaseType));
       properties.put("limitBeforeNativeQuery", DbSqlSessionFactory.databaseSpecificLimitBeforeNativeQueryStatements.get(databaseType));
       properties.put("distinct", DbSqlSessionFactory.databaseSpecificDistinct.get(databaseType));

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/entitymanager/cache/DbEntityCache.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/entitymanager/cache/DbEntityCache.java
@@ -81,6 +81,9 @@ public class DbEntityCache {
     CachedDbEntity cachedDbEntity = getCachedEntity(cacheKey, id);
     if(cachedDbEntity != null) {
       DbEntity dbEntity = cachedDbEntity.getEntity();
+      if (!type.isAssignableFrom(dbEntity.getClass())) {
+        throw LOG.entityCacheLookupException(type, id, dbEntity.getClass(), null);
+      }
       try {
         return (T) dbEntity;
       } catch(ClassCastException e) {
@@ -102,7 +105,7 @@ public class DbEntityCache {
       for (CachedDbEntity cachedEntity : entities.values()) {
         if (type != cacheKey) {
           // if the cacheKey of this type differs from the actual type,
-          // not all cached entites with the key should be returned.
+          // not all cached entities with the key should be returned.
           // Then we only add those entities whose type matches the argument type.
           if (type.isAssignableFrom(cachedEntity.getClass())) {
             result.add((T) cachedEntity.getEntity());

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/entitymanager/cache/DbEntityCacheKeyMapping.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/entitymanager/cache/DbEntityCacheKeyMapping.java
@@ -23,6 +23,7 @@ import org.camunda.bpm.engine.impl.db.DbEntity;
 import org.camunda.bpm.engine.impl.history.event.HistoricDetailEventEntity;
 import org.camunda.bpm.engine.impl.history.event.HistoricFormPropertyEventEntity;
 import org.camunda.bpm.engine.impl.history.event.HistoricVariableUpdateEventEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.HistoricDetailVariableInstanceUpdateEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.HistoricFormPropertyEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
@@ -61,9 +62,10 @@ public class DbEntityCacheKeyMapping {
   public static DbEntityCacheKeyMapping defaultEntityCacheKeyMapping() {
     DbEntityCacheKeyMapping mapping = new DbEntityCacheKeyMapping();
 
+    mapping.registerEntityCacheKey(JobEntity.class, AcquirableJobEntity.class);
     // subclasses of JobEntity
-    mapping.registerEntityCacheKey(MessageEntity.class, JobEntity.class);
-    mapping.registerEntityCacheKey(TimerEntity.class, JobEntity.class);
+    mapping.registerEntityCacheKey(MessageEntity.class, AcquirableJobEntity.class);
+    mapping.registerEntityCacheKey(TimerEntity.class, AcquirableJobEntity.class);
 
     // subclasses of HistoricDetailEventEntity
     mapping.registerEntityCacheKey(HistoricFormPropertyEntity.class, HistoricDetailEventEntity.class);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
@@ -55,6 +55,7 @@ public class DbSqlSessionFactory implements SessionFactory {
   public static final Map<String, String> databaseSpecificInnerLimitAfterStatements = new HashMap<>();
   public static final Map<String, String> databaseSpecificLimitBetweenStatements = new HashMap<>();
   public static final Map<String, String> databaseSpecificLimitBetweenFilterStatements = new HashMap<>();
+  public static final Map<String, String> databaseSpecificLimitBetweenAcquisitionStatements = new HashMap<>();
 
   public static final Map<String, String> optimizeDatabaseSpecificLimitBeforeWithoutOffsetStatements = new HashMap<>();
   public static final Map<String, String> optimizeDatabaseSpecificLimitAfterWithoutOffsetStatements = new HashMap<>();
@@ -103,6 +104,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificInnerLimitAfterStatements.put(H2, databaseSpecificLimitAfterStatements.get(H2));
     databaseSpecificLimitBetweenStatements.put(H2, "");
     databaseSpecificLimitBetweenFilterStatements.put(H2, "");
+    databaseSpecificLimitBetweenAcquisitionStatements.put(H2, "");
     databaseSpecificOrderByStatements.put(H2, defaultOrderBy);
     databaseSpecificLimitBeforeNativeQueryStatements.put(H2, "");
     databaseSpecificDistinct.put(H2, "distinct");
@@ -151,6 +153,7 @@ public class DbSqlSessionFactory implements SessionFactory {
       databaseSpecificInnerLimitAfterStatements.put(mysqlLikeDatabase, databaseSpecificLimitAfterStatements.get(mysqlLikeDatabase));
       databaseSpecificLimitBetweenStatements.put(mysqlLikeDatabase, "");
       databaseSpecificLimitBetweenFilterStatements.put(mysqlLikeDatabase, "");
+      databaseSpecificLimitBetweenAcquisitionStatements.put(mysqlLikeDatabase, "");
       databaseSpecificOrderByStatements.put(mysqlLikeDatabase, defaultOrderBy);
       databaseSpecificLimitBeforeNativeQueryStatements.put(mysqlLikeDatabase, "");
       databaseSpecificDistinct.put(mysqlLikeDatabase, "distinct");
@@ -233,6 +236,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificInnerLimitAfterStatements.put(POSTGRES, databaseSpecificLimitAfterStatements.get(POSTGRES));
     databaseSpecificLimitBetweenStatements.put(POSTGRES, "");
     databaseSpecificLimitBetweenFilterStatements.put(POSTGRES, "");
+    databaseSpecificLimitBetweenAcquisitionStatements.put(POSTGRES, "");
     databaseSpecificOrderByStatements.put(POSTGRES, defaultOrderBy);
     databaseSpecificLimitBeforeNativeQueryStatements.put(POSTGRES, "");
     databaseSpecificDistinct.put(POSTGRES, "distinct");
@@ -320,6 +324,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificInnerLimitAfterStatements.put(ORACLE, databaseSpecificLimitAfterStatements.get(ORACLE));
     databaseSpecificLimitBetweenStatements.put(ORACLE, "");
     databaseSpecificLimitBetweenFilterStatements.put(ORACLE, "");
+    databaseSpecificLimitBetweenAcquisitionStatements.put(ORACLE, "");
     databaseSpecificOrderByStatements.put(ORACLE, defaultOrderBy);
     databaseSpecificLimitBeforeNativeQueryStatements.put(ORACLE, "");
     databaseSpecificDistinct.put(ORACLE, "distinct");
@@ -388,8 +393,11 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificInnerLimitAfterStatements.put(DB2, ")RES ) SUB WHERE SUB.rnk >= #{firstRow} AND SUB.rnk < #{lastRow}");
     databaseSpecificLimitAfterStatements.put(DB2, databaseSpecificInnerLimitAfterStatements.get(DB2) + " ORDER BY SUB.rnk");
     optimizeDatabaseSpecificLimitAfterWithoutOffsetStatements.put(DB2, "FETCH FIRST ${maxResults} ROWS ONLY");
-    databaseSpecificLimitBetweenStatements.put(DB2, ", row_number() over (ORDER BY ${internalOrderBy}) rnk FROM ( select distinct RES.* ");
-    databaseSpecificLimitBetweenFilterStatements.put(DB2, ", row_number() over (ORDER BY ${internalOrderBy}) rnk FROM ( select distinct RES.ID_, RES.REV_, RES.RESOURCE_TYPE_, RES.NAME_, RES.OWNER_ ");
+    String db2LimitBetweenWithoutColumns = ", row_number() over (ORDER BY ${internalOrderBy}) rnk FROM ( select distinct ";
+    databaseSpecificLimitBetweenStatements.put(DB2, db2LimitBetweenWithoutColumns + "RES.* ");
+    databaseSpecificLimitBetweenFilterStatements.put(DB2, db2LimitBetweenWithoutColumns + "RES.ID_, RES.REV_, RES.RESOURCE_TYPE_, RES.NAME_, RES.OWNER_ ");
+    databaseSpecificLimitBetweenAcquisitionStatements.put(DB2, db2LimitBetweenWithoutColumns
+        + "RES.ID_, RES.REV_, RES.TYPE_, RES.LOCK_EXP_TIME_, RES.LOCK_OWNER_, RES.EXCLUSIVE_, RES.PROCESS_INSTANCE_ID_, RES.RETRIES_, RES.DUEDATE_, RES.DEPLOYMENT_ID_, RES.SUSPENSION_STATE_, RES.PRIORITY_ ");
     databaseSpecificLimitBeforeWithoutOffsetStatements.put(DB2, "");
     databaseSpecificLimitAfterWithoutOffsetStatements.put(DB2, "FETCH FIRST ${maxResults} ROWS ONLY");
     databaseSpecificOrderByStatements.put(DB2, defaultOrderBy);
@@ -464,8 +472,11 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificInnerLimitAfterStatements.put(MSSQL, ")RES ) SUB WHERE SUB.rnk >= #{firstRow} AND SUB.rnk < #{lastRow}");
     databaseSpecificLimitAfterStatements.put(MSSQL, databaseSpecificInnerLimitAfterStatements.get(MSSQL) + " ORDER BY SUB.rnk");
     optimizeDatabaseSpecificLimitAfterWithoutOffsetStatements.put(MSSQL, "");
-    databaseSpecificLimitBetweenStatements.put(MSSQL, ", row_number() over (ORDER BY ${internalOrderBy}) rnk FROM ( select distinct RES.* ");
+    String mssqlLimitBetweenWithoutColumns = ", row_number() over (ORDER BY ${internalOrderBy}) rnk FROM ( select distinct ";
+    databaseSpecificLimitBetweenStatements.put(MSSQL, mssqlLimitBetweenWithoutColumns + "RES.* ");
     databaseSpecificLimitBetweenFilterStatements.put(MSSQL, "");
+    databaseSpecificLimitBetweenAcquisitionStatements.put(MSSQL, mssqlLimitBetweenWithoutColumns
+        + "RES.ID_, RES.REV_, RES.TYPE_, RES.LOCK_EXP_TIME_, RES.LOCK_OWNER_, RES.EXCLUSIVE_, RES.PROCESS_INSTANCE_ID_, RES.RETRIES_, RES.DUEDATE_, RES.DEPLOYMENT_ID_, RES.SUSPENSION_STATE_, RES.PRIORITY_ ");
     databaseSpecificLimitBeforeWithoutOffsetStatements.put(MSSQL, "TOP (#{maxResults})");
     databaseSpecificLimitAfterWithoutOffsetStatements.put(MSSQL, "");
     databaseSpecificOrderByStatements.put(MSSQL, "");

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/AcquirableJobEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/AcquirableJobEntity.java
@@ -163,6 +163,10 @@ public class AcquirableJobEntity implements DbEntity, HasDbRevision {
     return type;
   }
 
+  public void setType(String type) {
+    this.type = type;
+  }
+
   @Override
   public int hashCode() {
     final int prime = 31;
@@ -170,7 +174,6 @@ public class AcquirableJobEntity implements DbEntity, HasDbRevision {
     result = prime * result + ((id == null) ? 0 : id.hashCode());
     return result;
   }
-
 
   @Override
   public boolean equals(Object obj) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/AcquirableJobEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/AcquirableJobEntity.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.persistence.entity;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.camunda.bpm.engine.impl.db.DbEntity;
+import org.camunda.bpm.engine.impl.db.HasDbRevision;
+
+public class AcquirableJobEntity implements DbEntity, HasDbRevision {
+
+  protected String id;
+  protected int revision;
+
+  protected String lockOwner = null;
+  protected Date lockExpirationTime = null;
+  protected Date duedate;
+
+  protected String deploymentId;
+  protected String processInstanceId = null;
+
+  protected boolean isExclusive;
+  protected int retries;
+  protected long priority;
+  protected String type;
+  // entity is active by default
+  protected int suspensionState;
+
+
+  @Override
+  public Object getPersistentState() {
+    Map<String, Object> persistentState = new HashMap<String, Object>();
+    persistentState.put("lockOwner", lockOwner);
+    persistentState.put("lockExpirationTime", lockExpirationTime);
+    return persistentState;
+  }
+
+  public int getRevisionNext() {
+    return revision + 1;
+  }
+
+  // getters and setters //////////////////////////////////////////////////////
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public int getRevision() {
+    return revision;
+  }
+
+  public void setRevision(int revision) {
+    this.revision = revision;
+  }
+
+  public Date getDuedate() {
+    return duedate;
+  }
+
+  public void setDuedate(Date duedate) {
+    this.duedate = duedate;
+  }
+
+  public String getLockOwner() {
+    return lockOwner;
+  }
+
+  public void setLockOwner(String lockOwner) {
+    this.lockOwner = lockOwner;
+  }
+
+  public Date getLockExpirationTime() {
+    return lockExpirationTime;
+  }
+
+  public void setLockExpirationTime(Date lockExpirationTime) {
+    this.lockExpirationTime = lockExpirationTime;
+  }
+
+  public String getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  public void setProcessInstanceId(String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  public boolean isExclusive() {
+    return isExclusive;
+  }
+
+  public void setExclusive(boolean isExclusive) {
+    this.isExclusive = isExclusive;
+  }
+
+  public int getRetries() {
+    return retries;
+  }
+
+  public void setRetries(int retries) {
+    this.retries = retries;
+  }
+
+  public int getSuspensionState() {
+    return suspensionState;
+  }
+
+  public void setSuspensionState(int suspensionState) {
+    this.suspensionState = suspensionState;
+  }
+
+  public boolean isSuspended() {
+    return suspensionState == SuspensionState.SUSPENDED.getStateCode();
+  }
+
+  public String getDeploymentId() {
+    return deploymentId;
+  }
+
+  public void setDeploymentId(String deploymentId) {
+    this.deploymentId = deploymentId;
+  }
+
+  public long getPriority() {
+    return priority;
+  }
+
+  public void setPriority(long priority) {
+    this.priority = priority;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    AcquirableJobEntity other = (AcquirableJobEntity) obj;
+    if (id == null) {
+      if (other.id != null)
+        return false;
+    } else if (!id.equals(other.id))
+      return false;
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return this.getClass().getSimpleName()
+        + "[id=" + id
+        + ", revision=" + revision
+        + ", lockOwner=" + lockOwner
+        + ", lockExpirationTime=" + lockExpirationTime
+        + ", duedate=" + duedate
+        + ", deploymentId=" + deploymentId
+        + ", processInstanceId=" + processInstanceId
+        + ", isExclusive=" + isExclusive
+        + ", retries=" + retries
+        + ", priority=" + priority
+        + ", type=" + type
+        + ", suspensionState=" + suspensionState
+        + "]";
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/JobEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/JobEntity.java
@@ -58,7 +58,7 @@ import org.camunda.bpm.engine.runtime.Job;
  * @author Dave Syer
  * @author Frederik Heremans
  */
-public abstract class JobEntity implements Serializable, Job, DbEntity, HasDbRevision, HasDbReferences {
+public abstract class JobEntity extends AcquirableJobEntity implements Serializable, Job, DbEntity, HasDbRevision, HasDbReferences {
 
   private final static EnginePersistenceLogger LOG = ProcessEngineLogger.PERSISTENCE_LOGGER;
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/JobManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/JobManager.java
@@ -166,7 +166,7 @@ public class JobManager extends AbstractManager {
   }
 
   @SuppressWarnings("unchecked")
-  public List<JobEntity> findNextJobsToExecute(Page page) {
+  public List<AcquirableJobEntity> findNextJobsToExecute(Page page) {
     Map<String,Object> params = new HashMap<String, Object>();
     Date now = ClockUtil.getCurrentTime();
     params.put("now", now);

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
@@ -155,7 +155,7 @@
     <result property="deploymentId" column="DEPLOYMENT_ID_" jdbcType="VARCHAR" />
     <result property="processInstanceId" column="PROCESS_INSTANCE_ID_" jdbcType="VARCHAR" />
     <result property="exclusive" column="EXCLUSIVE_" jdbcType="BOOLEAN" />
-    <result property="retries" column="RETRIES_" jdbcType="INTEGER" />
+    <result property="retriesFromPersistence" column="RETRIES_" jdbcType="INTEGER" />
     <result property="priority" column="PRIORITY_" jdbcType="BIGINT" />
     <result property="type" column="TYPE_" jdbcType="VARCHAR" />
     <result property="suspensionState" column="SUSPENSION_STATE_" jdbcType="INTEGER"/>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
@@ -146,18 +146,45 @@
     <result property="repeat" column="REPEAT_" jdbcType="VARCHAR" />
   </resultMap>
 
+  <resultMap id="acquirableJobResultMap" type="org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity">
+    <id property="id" column="ID_" jdbcType="VARCHAR" />
+    <result property="revision" column="REV_" jdbcType="INTEGER" />
+    <result property="lockOwner" column="LOCK_OWNER_" jdbcType="VARCHAR" />
+    <result property="lockExpirationTime" column="LOCK_EXP_TIME_" jdbcType="TIMESTAMP" />
+    <result property="duedate" column="DUEDATE_" jdbcType="TIMESTAMP" />
+    <result property="deploymentId" column="DEPLOYMENT_ID_" jdbcType="VARCHAR" />
+    <result property="processInstanceId" column="PROCESS_INSTANCE_ID_" jdbcType="VARCHAR" />
+    <result property="exclusive" column="EXCLUSIVE_" jdbcType="BOOLEAN" />
+    <result property="retries" column="RETRIES_" jdbcType="INTEGER" />
+    <result property="priority" column="PRIORITY_" jdbcType="BIGINT" />
+    <result property="type" column="TYPE_" jdbcType="VARCHAR" />
+    <result property="suspensionState" column="SUSPENSION_STATE_" jdbcType="INTEGER"/>
+  </resultMap>
+
+
   <!-- JOB SELECT (FOR TIMER AND MESSAGE) -->
 
   <select id="selectJob" parameterType="string" resultMap="jobResultMap">
     select * from ${prefix}ACT_RU_JOB where ID_ = #{id}
   </select>
 
-  <select id="selectNextJobsToExecute" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject" resultMap="jobResultMap">
+  <select id="selectNextJobsToExecute" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject" resultMap="acquirableJobResultMap">
     <bind name="orderingProperties" value="parameter.orderingProperties" />
     <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.bindOrderBy"/>
     ${limitBefore}
-    select
-      RES.* ${limitBetween}
+    select RES.ID_,
+      RES.REV_,
+      RES.LOCK_EXP_TIME_,
+      RES.LOCK_OWNER_,
+      RES.DUEDATE_,
+      RES.DEPLOYMENT_ID_,
+      RES.PROCESS_INSTANCE_ID_,
+      RES.EXCLUSIVE_,
+      RES.RETRIES_,
+      RES.PRIORITY_,
+      RES.TYPE_,
+      RES.SUSPENSION_STATE_
+    ${limitBetweenAcquisition}
     from ${prefix}ACT_RU_JOB RES
 
     where (RES.RETRIES_ &gt; 0)
@@ -645,6 +672,26 @@
             SEQUENCE_COUNTER_ = #{sequenceCounter, jdbcType=BIGINT}
         </set>
         where ID_= #{id, jdbcType=VARCHAR}
+        and REV_ = #{revision, jdbcType=INTEGER}
+    </update>
+
+    <!-- ACQUIRABLE JOB UPDATE -->
+    <update id="updateAcquirableJob" parameterType="org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity">
+      update ${prefix}ACT_RU_JOB
+      <set>
+          REV_ =  #{revisionNext, jdbcType=INTEGER},
+          LOCK_EXP_TIME_ = #{lockExpirationTime, jdbcType=TIMESTAMP},
+          LOCK_OWNER_ = #{lockOwner, jdbcType=VARCHAR},
+          DUEDATE_ = #{duedate, jdbcType=TIMESTAMP},
+          DEPLOYMENT_ID_ = #{deploymentId, jdbcType=VARCHAR},
+          PROCESS_INSTANCE_ID_ = #{processInstanceId, jdbcType=VARCHAR},
+          EXCLUSIVE_ = #{exclusive, jdbcType=BOOLEAN},
+          RETRIES_ = #{retries, jdbcType=INTEGER},
+          PRIORITY_ = #{priority, jdbcType=BIGINT},
+          TYPE_ = #{type, jdbcType=VARCHAR},
+          SUSPENSION_STATE_ = #{suspensionState, jdbcType=INTEGER}
+      </set>
+      where ID_= #{id, jdbcType=VARCHAR}
         and REV_ = #{revision, jdbcType=INTEGER}
     </update>
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/async/FoxJobRetryCmdTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/async/FoxJobRetryCmdTest.java
@@ -27,6 +27,7 @@ import org.camunda.bpm.engine.impl.Page;
 import org.camunda.bpm.engine.impl.bpmn.parser.BpmnParse;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
 import org.camunda.bpm.engine.impl.test.PluggableProcessEngineTestCase;
@@ -275,7 +276,7 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTestCase {
     assertNotNull(pi);
 
     // a job is acquirable
-    List<JobEntity> acquirableJobs = findAndLockAcquirableJobs();
+    List<AcquirableJobEntity> acquirableJobs = findAndLockAcquirableJobs();
     assertEquals(1, acquirableJobs.size());
 
     // execute job
@@ -817,13 +818,13 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTestCase {
     return dateFormat.parse(dateString);
   }
 
-  protected List<JobEntity> findAndLockAcquirableJobs() {
-    return processEngineConfiguration.getCommandExecutorTxRequired().execute(new Command<List<JobEntity>>() {
+  protected List<AcquirableJobEntity> findAndLockAcquirableJobs() {
+    return processEngineConfiguration.getCommandExecutorTxRequired().execute(new Command<List<AcquirableJobEntity>>() {
 
       @Override
-      public List<JobEntity> execute(CommandContext commandContext) {
-        List<JobEntity> jobs = commandContext.getJobManager().findNextJobsToExecute(new Page(0, 100));
-        for (JobEntity job : jobs) {
+      public List<AcquirableJobEntity> execute(CommandContext commandContext) {
+        List<AcquirableJobEntity> jobs = commandContext.getJobManager().findNextJobsToExecute(new Page(0, 100));
+        for (AcquirableJobEntity job : jobs) {
           job.setLockOwner("test");
         }
         return jobs;

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/AbstractJobExecutorAcquireJobsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/AbstractJobExecutorAcquireJobsTest.java
@@ -24,7 +24,7 @@ import org.camunda.bpm.engine.impl.Page;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
-import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.util.ClockTestUtil;
@@ -81,11 +81,11 @@ public abstract class AbstractJobExecutorAcquireJobsTest {
     ClockUtil.reset();
   }
 
-  protected List<JobEntity> findAcquirableJobs() {
-    return configuration.getCommandExecutorTxRequired().execute(new Command<List<JobEntity>>() {
+  protected List<AcquirableJobEntity> findAcquirableJobs() {
+    return configuration.getCommandExecutorTxRequired().execute(new Command<List<AcquirableJobEntity>>() {
 
       @Override
-      public List<JobEntity> execute(CommandContext commandContext) {
+      public List<AcquirableJobEntity> execute(CommandContext commandContext) {
         return commandContext
           .getJobManager()
           .findNextJobsToExecute(new Page(0, 100));

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/AcquirableJobCacheTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/AcquirableJobCacheTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.jobexecutor;
+
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
+import org.camunda.bpm.engine.ManagementService;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.impl.Page;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.interceptor.Command;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.JobManager;
+import org.camunda.bpm.engine.impl.persistence.entity.TimerEntity;
+import org.camunda.bpm.engine.runtime.Execution;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class AcquirableJobCacheTest {
+
+  protected ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
+  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
+
+  @Rule
+  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+
+  protected ManagementService managementService;
+  protected ProcessEngineConfigurationImpl processEngineConfiguration;
+  protected RuntimeService runtimeService;
+
+  @Before
+  public void setup() {
+    managementService = engineRule.getManagementService();
+    processEngineConfiguration = engineRule.getProcessEngineConfiguration();
+    runtimeService = engineRule.getRuntimeService();
+  }
+
+  @Test
+  @Deployment(resources = "org/camunda/bpm/engine/test/api/mgmt/metrics/asyncServiceTaskProcess.bpmn20.xml")
+  public void testFetchJobEntityWhenAcquirableJobIsCached() {
+    // given
+    runtimeService.startProcessInstanceByKey("asyncServiceTaskProcess");
+
+    try {
+      // when
+      fetchJobAfterCachedAcquirableJob();
+      fail("expected exception");
+    } catch (Exception e) {
+      // then
+      assertThat(e).isInstanceOf(ProcessEngineException.class);
+      assertThat(e.getMessage())
+          .contains("Could not lookup entity of type")
+          .contains(AcquirableJobEntity.class.getSimpleName())
+          .contains(JobEntity.class.getSimpleName());
+    }
+  }
+
+  @Test
+  public void testFetchTimerEntityWhenAcquirableJobIsCached() {
+    // given
+    BpmnModelInstance process = Bpmn.createExecutableProcess("startTimer")
+        .startEvent()
+        .userTask("userTask")
+          .boundaryEvent()
+          .timerWithDate("2016-02-11T12:13:14Z")
+        .done();
+    testRule.deploy(process);
+    runtimeService.startProcessInstanceByKey("startTimer");
+    Execution execution = runtimeService.createExecutionQuery().activityId("userTask").singleResult();
+
+    try {
+      // when
+      fetchTimerJobAfterCachedAcquirableJob(execution.getId());
+      fail("expected exception");
+    } catch (Exception e) {
+      // then
+      assertThat(e).isInstanceOf(ProcessEngineException.class);
+      assertThat(e.getMessage())
+          .contains("Could not lookup entity of type")
+          .contains(TimerEntity.class.getSimpleName())
+          .contains(AcquirableJobEntity.class.getSimpleName());
+    }
+  }
+
+  @Test
+  @Deployment(resources = "org/camunda/bpm/engine/test/api/mgmt/metrics/asyncServiceTaskProcess.bpmn20.xml")
+  public void testFetchAcquirableJobWhenJobEntityIsCached() {
+    // given
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncServiceTaskProcess");
+
+    // when
+    AcquirableJobEntity job = fetchAcquirableJobAfterCachedJob(processInstance.getId());
+
+    // then
+    assertThat(job).isNotNull();
+    assertThat(job.getProcessInstanceId()).isEqualTo(processInstance.getId());
+  }
+
+  @Test
+  public void testFetchAcquirableJobWhenTimerEntityIsCached() {
+    // given
+    BpmnModelInstance process = Bpmn.createExecutableProcess("startTimer")
+      .startEvent()
+      .userTask("userTask")
+        .boundaryEvent()
+        .timerWithDate("2016-02-11T12:13:14Z")
+      .done();
+    testRule.deploy(process);
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startTimer");
+    Execution execution = runtimeService.createExecutionQuery().activityId("userTask").singleResult();
+
+    // when
+    AcquirableJobEntity job = fetchAcquirableJobAfterCachedTimerEntity(execution.getId());
+
+    // then
+    assertThat(job).isNotNull();
+    assertThat(job.getProcessInstanceId()).isEqualTo(processInstance.getId());
+  }
+
+  protected JobEntity fetchJobAfterCachedAcquirableJob() {
+    return processEngineConfiguration.getCommandExecutorTxRequiresNew().execute(new Command<JobEntity>() {
+      public JobEntity execute(CommandContext commandContext) {
+        JobManager jobManager = commandContext.getJobManager();
+        List<AcquirableJobEntity> acquirableJobs = jobManager.findNextJobsToExecute(new Page(0, 100));
+        JobEntity job = jobManager.findJobById(acquirableJobs.get(0).getId());
+        return job;
+      }
+    });
+  }
+
+  protected TimerEntity fetchTimerJobAfterCachedAcquirableJob(final String executionId) {
+    return processEngineConfiguration.getCommandExecutorTxRequiresNew().execute(new Command<TimerEntity>() {
+      public TimerEntity execute(CommandContext commandContext) {
+        JobManager jobManager = commandContext.getJobManager();
+        jobManager.findNextJobsToExecute(new Page(0, 100));
+        List<TimerEntity> timerJobs = jobManager.findTimersByExecutionId(executionId);
+        return timerJobs.get(0);
+      }
+    });
+  }
+
+  protected AcquirableJobEntity fetchAcquirableJobAfterCachedTimerEntity(final String executionId) {
+    return processEngineConfiguration.getCommandExecutorTxRequiresNew().execute(new Command<AcquirableJobEntity>() {
+      public AcquirableJobEntity execute(CommandContext commandContext) {
+        JobManager jobManager = commandContext.getJobManager();
+        jobManager.findTimersByExecutionId(executionId);
+        List<AcquirableJobEntity> acquirableJob = jobManager.findNextJobsToExecute(new Page(0, 100));
+        return acquirableJob.get(0);
+      }
+    });
+  }
+
+  protected AcquirableJobEntity fetchAcquirableJobAfterCachedJob(final String processInstanceId) {
+    return processEngineConfiguration.getCommandExecutorTxRequiresNew().execute(new Command<AcquirableJobEntity>() {
+      public AcquirableJobEntity execute(CommandContext commandContext) {
+        JobManager jobManager = commandContext.getJobManager();
+        jobManager.findJobsByProcessInstanceId(processInstanceId);
+        List<AcquirableJobEntity> acquirableJobs = jobManager.findNextJobsToExecute(new Page(0, 100));
+        return acquirableJobs.get(0);
+      }
+    });
+  }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/AcquirableJobCacheTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/AcquirableJobCacheTest.java
@@ -16,6 +16,7 @@
  */
 package org.camunda.bpm.engine.test.jobexecutor;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.List;
@@ -39,7 +40,6 @@ import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
 import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
-import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -128,14 +128,14 @@ public class AcquirableJobCacheTest {
   @Test
   public void testFetchAcquirableJobWhenTimerEntityIsCached() {
     // given
-    BpmnModelInstance process = Bpmn.createExecutableProcess("startTimer")
+    BpmnModelInstance process = Bpmn.createExecutableProcess("timer")
       .startEvent()
       .userTask("userTask")
         .boundaryEvent()
         .timerWithDate("2016-02-11T12:13:14Z")
       .done();
     testRule.deploy(process);
-    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startTimer");
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("timer");
     Execution execution = runtimeService.createExecutionQuery().activityId("userTask").singleResult();
 
     // when

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/AcquireJobCmdUnitTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/AcquireJobCmdUnitTest.java
@@ -22,7 +22,7 @@ import org.camunda.bpm.engine.impl.db.entitymanager.DbEntityManager;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.jobexecutor.AcquiredJobs;
 import org.camunda.bpm.engine.impl.jobexecutor.JobExecutor;
-import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.JobManager;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,8 +69,8 @@ public class AcquireJobCmdUnitTest {
   @Test
   public void nonExclusiveJobsSameInstance() {
     // given: two non-exclusive jobs for a different process instance
-    JobEntity job1 = createNonExclusiveJob(JOB_ID_1, PROCESS_INSTANCE_ID_1);
-    JobEntity job2 = createNonExclusiveJob(JOB_ID_2, PROCESS_INSTANCE_ID_1);
+    AcquirableJobEntity job1 = createNonExclusiveJob(JOB_ID_1, PROCESS_INSTANCE_ID_1);
+    AcquirableJobEntity job2 = createNonExclusiveJob(JOB_ID_2, PROCESS_INSTANCE_ID_1);
 
     // when the job executor acquire new jobs
     when(jobManager.findNextJobsToExecute(any(Page.class))).thenReturn(Arrays.asList(job1, job2));
@@ -82,8 +82,8 @@ public class AcquireJobCmdUnitTest {
   @Test
   public void nonExclusiveDifferentInstance() {
     // given: two non-exclusive jobs for the same process instance
-    JobEntity job1 = createNonExclusiveJob(JOB_ID_1, PROCESS_INSTANCE_ID_1);
-    JobEntity job2 = createNonExclusiveJob(JOB_ID_2, PROCESS_INSTANCE_ID_2);
+    AcquirableJobEntity job1 = createNonExclusiveJob(JOB_ID_1, PROCESS_INSTANCE_ID_1);
+    AcquirableJobEntity job2 = createNonExclusiveJob(JOB_ID_2, PROCESS_INSTANCE_ID_2);
 
     // when the job executor acquire new jobs
     when(jobManager.findNextJobsToExecute(any(Page.class))).thenReturn(Arrays.asList(job1, job2));
@@ -95,8 +95,8 @@ public class AcquireJobCmdUnitTest {
   @Test
   public void exclusiveJobsSameInstance() {
     // given: two exclusive jobs for the same process instance
-    JobEntity job1 = createExclusiveJob(JOB_ID_1, PROCESS_INSTANCE_ID_1);
-    JobEntity job2 = createExclusiveJob(JOB_ID_2, PROCESS_INSTANCE_ID_1);
+    AcquirableJobEntity job1 = createExclusiveJob(JOB_ID_1, PROCESS_INSTANCE_ID_1);
+    AcquirableJobEntity job2 = createExclusiveJob(JOB_ID_2, PROCESS_INSTANCE_ID_1);
 
     // when the job executor acquire new jobs
     when(jobManager.findNextJobsToExecute(any(Page.class))).thenReturn(Arrays.asList(job1, job2));
@@ -113,8 +113,8 @@ public class AcquireJobCmdUnitTest {
   @Test
   public void exclusiveJobsDifferentInstance() {
     // given: two exclusive jobs for a different process instance
-    JobEntity job1 = createExclusiveJob(JOB_ID_1, PROCESS_INSTANCE_ID_1);
-    JobEntity job2 = createExclusiveJob(JOB_ID_2, PROCESS_INSTANCE_ID_2);
+    AcquirableJobEntity job1 = createExclusiveJob(JOB_ID_1, PROCESS_INSTANCE_ID_1);
+    AcquirableJobEntity job2 = createExclusiveJob(JOB_ID_2, PROCESS_INSTANCE_ID_2);
 
     // when the job executor acquire new jobs
     when(jobManager.findNextJobsToExecute(any(Page.class))).thenReturn(Arrays.asList(job1, job2));
@@ -123,14 +123,14 @@ public class AcquireJobCmdUnitTest {
     checkThatAcquiredJobsInDifferentBatches();
   }
 
-  protected JobEntity createExclusiveJob(String id, String processInstanceId) {
-    JobEntity job = createNonExclusiveJob(id, processInstanceId);
+  protected AcquirableJobEntity createExclusiveJob(String id, String processInstanceId) {
+    AcquirableJobEntity job = createNonExclusiveJob(id, processInstanceId);
     when(job.isExclusive()).thenReturn(true);
     return job;
   }
 
-  protected JobEntity createNonExclusiveJob(String id, String processInstanceId) {
-    JobEntity job = mock(JobEntity.class);
+  protected AcquirableJobEntity createNonExclusiveJob(String id, String processInstanceId) {
+    AcquirableJobEntity job = mock(AcquirableJobEntity.class);
     when(job.getId()).thenReturn(id);
     when(job.getProcessInstanceId()).thenReturn(processInstanceId);
     return job;

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/DeploymentAwareJobExecutorForOracleTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/DeploymentAwareJobExecutorForOracleTest.java
@@ -23,7 +23,7 @@ import org.camunda.bpm.engine.impl.Page;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
-import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.api.runtime.migration.models.ProcessModels;
 import org.camunda.bpm.engine.test.util.ProcessEngineBootstrapRule;
@@ -103,11 +103,11 @@ public class DeploymentAwareJobExecutorForOracleTest {
     findAcquirableJobs();
   }
 
-  protected List<JobEntity> findAcquirableJobs() {
-    return engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired().execute(new Command<List<JobEntity>>() {
+  protected List<AcquirableJobEntity> findAcquirableJobs() {
+    return engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired().execute(new Command<List<AcquirableJobEntity>>() {
 
       @Override
-      public List<JobEntity> execute(CommandContext commandContext) {
+      public List<AcquirableJobEntity> execute(CommandContext commandContext) {
         return commandContext
           .getJobManager()
           .findNextJobsToExecute(new Page(0, 100));

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/DeploymentAwareJobExecutorTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/DeploymentAwareJobExecutorTest.java
@@ -35,7 +35,7 @@ import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 import org.camunda.bpm.engine.impl.jobexecutor.AcquiredJobs;
 import org.camunda.bpm.engine.impl.jobexecutor.JobExecutor;
-import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.MessageEntity;
 import org.camunda.bpm.engine.impl.test.PluggableProcessEngineTestCase;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
@@ -230,7 +230,7 @@ public class DeploymentAwareJobExecutorTest extends PluggableProcessEngineTestCa
 
     ClockUtil.setCurrentTime(new Date(System.currentTimeMillis() + 61 * 1000));
 
-    List<JobEntity> acquirableJobs = findAcquirableJobs();
+    List<AcquirableJobEntity> acquirableJobs = findAcquirableJobs();
 
     assertEquals(1, acquirableJobs.size());
     assertEquals(existingJob.getId(), acquirableJobs.get(0).getId());
@@ -251,7 +251,7 @@ public class DeploymentAwareJobExecutorTest extends PluggableProcessEngineTestCa
 
     ClockUtil.setCurrentTime(new Date(System.currentTimeMillis()+1000));
 
-    List<JobEntity> acquirableJobs = findAcquirableJobs();
+    List<AcquirableJobEntity> acquirableJobs = findAcquirableJobs();
 
     assertEquals(1, acquirableJobs.size());
     assertEquals(existingJob.getId(), acquirableJobs.get(0).getId());
@@ -263,11 +263,11 @@ public class DeploymentAwareJobExecutorTest extends PluggableProcessEngineTestCa
     assertEquals(0, acquirableJobs.size());
   }
 
-  protected List<JobEntity> findAcquirableJobs() {
-    return processEngineConfiguration.getCommandExecutorTxRequired().execute(new Command<List<JobEntity>>() {
+  protected List<AcquirableJobEntity> findAcquirableJobs() {
+    return processEngineConfiguration.getCommandExecutorTxRequired().execute(new Command<List<AcquirableJobEntity>>() {
 
       @Override
-      public List<JobEntity> execute(CommandContext commandContext) {
+      public List<AcquirableJobEntity> execute(CommandContext commandContext) {
         return commandContext
           .getJobManager()
           .findNextJobsToExecute(new Page(0, 100));

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsByDueDateNotPriorityTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsByDueDateNotPriorityTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
-import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity;
 import org.camunda.bpm.engine.test.Deployment;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,7 +51,7 @@ public class JobExecutorAcquireJobsByDueDateNotPriorityTest extends AbstractJobE
     incrementClock(1);
     String instance4 = startProcess("jobPrioProcess", "task1");
 
-    List<JobEntity> acquirableJobs = findAcquirableJobs();
+    List<AcquirableJobEntity> acquirableJobs = findAcquirableJobs();
     assertEquals(4, acquirableJobs.size());
 
     assertEquals(5, (int) acquirableJobs.get(0).getPriority());

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsByDueDateTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsByDueDateTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.camunda.bpm.engine.runtime.Job;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
@@ -88,7 +88,7 @@ public class JobExecutorAcquireJobsByDueDateTest extends AbstractJobExecutorAcqu
     assertTrue(timerJob1.getDuedate().before(timerJob2.getDuedate()));
     assertTrue(timerJob2.getDuedate().before(messageJob2.getDuedate()));
 
-    List<JobEntity> acquirableJobs = findAcquirableJobs();
+    List<AcquirableJobEntity> acquirableJobs = findAcquirableJobs();
     assertEquals(4, acquirableJobs.size());
     assertEquals(messageJob1.getId(), acquirableJobs.get(0).getId());
     assertEquals(timerJob1.getId(), acquirableJobs.get(1).getId());

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsByPriorityAndDueDateTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsByPriorityAndDueDateTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity;
 import org.camunda.bpm.engine.test.Deployment;
 import org.junit.Before;
 import org.junit.Test;
@@ -64,7 +64,7 @@ public class JobExecutorAcquireJobsByPriorityAndDueDateTest extends AbstractJobE
     incrementClock(1);
     String instance4 = startProcess("jobPrioProcess", "task2");
 
-    List<JobEntity> acquirableJobs = findAcquirableJobs();
+    List<AcquirableJobEntity> acquirableJobs = findAcquirableJobs();
     assertEquals(4, acquirableJobs.size());
     assertEquals(instance1, acquirableJobs.get(0).getProcessInstanceId());
     assertEquals(instance3, acquirableJobs.get(1).getProcessInstanceId());

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsByPriorityTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsByPriorityTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity;
 import org.camunda.bpm.engine.test.Deployment;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,7 +63,7 @@ public class JobExecutorAcquireJobsByPriorityTest extends AbstractJobExecutorAcq
     // make timers due
     incrementClock(61);
 
-    List<JobEntity> acquirableJobs = findAcquirableJobs();
+    List<AcquirableJobEntity> acquirableJobs = findAcquirableJobs();
     assertEquals(20, acquirableJobs.size());
     for (int i = 0; i < 5; i++) {
       assertEquals(10, acquirableJobs.get(i).getPriority());

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsByTypeAndDueDateTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsByTypeAndDueDateTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.camunda.bpm.engine.runtime.Job;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
@@ -89,7 +89,7 @@ public class JobExecutorAcquireJobsByTypeAndDueDateTest extends AbstractJobExecu
     assertTrue(timerJob1.getDuedate().before(timerJob2.getDuedate()));
     assertTrue(timerJob2.getDuedate().before(messageJob2.getDuedate()));
 
-    List<JobEntity> acquirableJobs = findAcquirableJobs();
+    List<AcquirableJobEntity> acquirableJobs = findAcquirableJobs();
     assertEquals(4, acquirableJobs.size());
     assertEquals(timerJob1.getId(), acquirableJobs.get(0).getId());
     assertEquals(timerJob2.getId(), acquirableJobs.get(1).getId());

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsByTypeTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsByTypeTest.java
@@ -17,7 +17,6 @@
 package org.camunda.bpm.engine.test.jobexecutor;
 
 import org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity;
-import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.MessageEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.TimerEntity;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
@@ -92,14 +91,10 @@ public class JobExecutorAcquireJobsByTypeTest extends AbstractJobExecutorAcquire
 
     List<AcquirableJobEntity> acquirableJobs = findAcquirableJobs();
     assertEquals(4, acquirableJobs.size());
-    JobEntity timerJob1 = (JobEntity) managementService.createJobQuery().jobId(acquirableJobs.get(0).getId()).singleResult();
-    JobEntity timerJob2 = (JobEntity) managementService.createJobQuery().jobId(acquirableJobs.get(1).getId()).singleResult();
-    JobEntity messageJob1 = (JobEntity) managementService.createJobQuery().jobId(acquirableJobs.get(2).getId()).singleResult();
-    JobEntity messageJob2 = (JobEntity) managementService.createJobQuery().jobId(acquirableJobs.get(3).getId()).singleResult();
-    assertEquals(TimerEntity.TYPE, timerJob1.getType());
-    assertEquals(TimerEntity.TYPE, timerJob2.getType());
-    assertEquals(MessageEntity.TYPE, messageJob1.getType());
-    assertEquals(MessageEntity.TYPE, messageJob2.getType());
+    assertEquals(TimerEntity.TYPE, acquirableJobs.get(0).getType());
+    assertEquals(TimerEntity.TYPE, acquirableJobs.get(1).getType());
+    assertEquals(MessageEntity.TYPE, acquirableJobs.get(2).getType());
+    assertEquals(MessageEntity.TYPE, acquirableJobs.get(3).getType());
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsByTypeTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsByTypeTest.java
@@ -16,6 +16,7 @@
  */
 package org.camunda.bpm.engine.test.jobexecutor;
 
+import org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.MessageEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.TimerEntity;
@@ -89,12 +90,16 @@ public class JobExecutorAcquireJobsByTypeTest extends AbstractJobExecutorAcquire
     // increment clock so that timer events are acquirable
     incrementClock(70);
 
-    List<JobEntity> acquirableJobs = findAcquirableJobs();
+    List<AcquirableJobEntity> acquirableJobs = findAcquirableJobs();
     assertEquals(4, acquirableJobs.size());
-    assertTrue(acquirableJobs.get(0) instanceof TimerEntity);
-    assertTrue(acquirableJobs.get(1) instanceof TimerEntity);
-    assertTrue(acquirableJobs.get(2) instanceof MessageEntity);
-    assertTrue(acquirableJobs.get(3) instanceof MessageEntity);
+    JobEntity timerJob1 = (JobEntity) managementService.createJobQuery().jobId(acquirableJobs.get(0).getId()).singleResult();
+    JobEntity timerJob2 = (JobEntity) managementService.createJobQuery().jobId(acquirableJobs.get(1).getId()).singleResult();
+    JobEntity messageJob1 = (JobEntity) managementService.createJobQuery().jobId(acquirableJobs.get(2).getId()).singleResult();
+    JobEntity messageJob2 = (JobEntity) managementService.createJobQuery().jobId(acquirableJobs.get(3).getId()).singleResult();
+    assertEquals(TimerEntity.TYPE, timerJob1.getType());
+    assertEquals(TimerEntity.TYPE, timerJob2.getType());
+    assertEquals(MessageEntity.TYPE, messageJob1.getType());
+    assertEquals(MessageEntity.TYPE, messageJob2.getType());
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsDefaultTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsDefaultTest.java
@@ -16,7 +16,7 @@
  */
 package org.camunda.bpm.engine.test.jobexecutor;
 
-import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.AcquirableJobEntity;
 import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.util.ClockTestUtil;
 import org.junit.Before;
@@ -67,7 +67,7 @@ public class JobExecutorAcquireJobsDefaultTest extends AbstractJobExecutorAcquir
   public void testJobDueDateValue() {
     // when
     runtimeService.startProcessInstanceByKey("simpleAsyncProcess");
-    List<JobEntity> jobList = findAcquirableJobs();
+    List<AcquirableJobEntity> jobList = findAcquirableJobs();
 
     // then
     assertEquals(1, jobList.size());


### PR DESCRIPTION
* by reducing the select of all column but rather only the needed
* update the job lock details accordingly

* introduce AcquirableJobEntity
-- to contains the selected job data
-- to update the job lock details

Related to [CAM-9838](https://app.camunda.com/jira/browse/CAM-9838)