### PR TITLE
CAM-10589: fix(qa): add transitive dependency versions to poms

### DIFF
--- a/qa/test-db-instance-migration/test-fixture-710/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-710/pom.xml
@@ -55,6 +55,26 @@
       <artifactId>camunda-engine</artifactId>
       <version>7.10.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-dmn</artifactId>
+      <version>7.10.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-api</artifactId>
+      <version>7.10.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-juel</artifactId>
+      <version>7.10.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.commons</groupId>
+      <artifactId>camunda-commons-typed-values</artifactId>
+      <version>1.6.1</version>
+    </dependency>
 
     <dependency>
       <groupId>org.camunda.spin</groupId>

--- a/qa/test-db-instance-migration/test-fixture-711/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-711/pom.xml
@@ -55,6 +55,26 @@
       <artifactId>camunda-engine</artifactId>
       <version>7.11.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-dmn</artifactId>
+      <version>7.11.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-api</artifactId>
+      <version>7.11.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-juel</artifactId>
+      <version>7.11.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.commons</groupId>
+      <artifactId>camunda-commons-typed-values</artifactId>
+      <version>1.7.1</version>
+    </dependency>
 
     <dependency>
       <groupId>org.camunda.spin</groupId>

--- a/qa/test-db-instance-migration/test-fixture-74/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-74/pom.xml
@@ -58,6 +58,26 @@
       <artifactId>camunda-engine</artifactId>
       <version>7.4.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-dmn</artifactId>
+      <version>7.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-api</artifactId>
+      <version>7.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-juel</artifactId>
+      <version>7.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.commons</groupId>
+      <artifactId>camunda-commons-typed-values</artifactId>
+      <version>1.2.0</version>
+    </dependency>
 
     <dependency>
       <groupId>org.camunda.bpm.qa.upgrade</groupId>

--- a/qa/test-db-instance-migration/test-fixture-75/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-75/pom.xml
@@ -54,6 +54,26 @@
       <artifactId>camunda-engine</artifactId>
       <version>7.5.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-dmn</artifactId>
+      <version>7.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-api</artifactId>
+      <version>7.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-juel</artifactId>
+      <version>7.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.commons</groupId>
+      <artifactId>camunda-commons-typed-values</artifactId>
+      <version>1.3.0</version>
+    </dependency>
 
     <dependency>
       <groupId>org.camunda.bpm.qa.upgrade</groupId>

--- a/qa/test-db-instance-migration/test-fixture-76/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-76/pom.xml
@@ -55,6 +55,26 @@
       <artifactId>camunda-engine</artifactId>
       <version>7.6.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-dmn</artifactId>
+      <version>7.6.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-api</artifactId>
+      <version>7.6.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-juel</artifactId>
+      <version>7.6.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.commons</groupId>
+      <artifactId>camunda-commons-typed-values</artifactId>
+      <version>1.4.0</version>
+    </dependency>
 
     <dependency>
       <groupId>org.camunda.bpm.qa.upgrade</groupId>

--- a/qa/test-db-instance-migration/test-fixture-77/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-77/pom.xml
@@ -55,6 +55,26 @@
       <artifactId>camunda-engine</artifactId>
       <version>7.7.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-dmn</artifactId>
+      <version>7.7.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-api</artifactId>
+      <version>7.7.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-juel</artifactId>
+      <version>7.7.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.commons</groupId>
+      <artifactId>camunda-commons-typed-values</artifactId>
+      <version>1.4.0</version>
+    </dependency>
 
     <dependency>
       <groupId>org.camunda.bpm.qa.upgrade</groupId>

--- a/qa/test-db-instance-migration/test-fixture-78/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-78/pom.xml
@@ -55,6 +55,26 @@
       <artifactId>camunda-engine</artifactId>
       <version>7.8.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-dmn</artifactId>
+      <version>7.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-api</artifactId>
+      <version>7.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-juel</artifactId>
+      <version>7.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.commons</groupId>
+      <artifactId>camunda-commons-typed-values</artifactId>
+      <version>1.4.0</version>
+    </dependency>
 
     <dependency>
       <groupId>org.camunda.spin</groupId>

--- a/qa/test-db-instance-migration/test-fixture-79/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-79/pom.xml
@@ -55,6 +55,26 @@
       <artifactId>camunda-engine</artifactId>
       <version>7.9.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-dmn</artifactId>
+      <version>7.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-api</artifactId>
+      <version>7.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.dmn</groupId>
+      <artifactId>camunda-engine-feel-juel</artifactId>
+      <version>7.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.commons</groupId>
+      <artifactId>camunda-commons-typed-values</artifactId>
+      <version>1.5.0</version>
+    </dependency>
 
     <dependency>
       <groupId>org.camunda.spin</groupId>


### PR DESCRIPTION
* The recent move of the DMN Engine and Typed Values directly into the platform resulted in them becoming transitive dependencies, whose versions have to be explicitly declared in the test fixtures of the instance migration test suite.

Related to CAM-10589 (https://app.camunda.com/jira/browse/CAM-10589)