### PR TITLE
[CAM-10002] fix(engine-spring): enable inner transactions with spring

### DIFF
--- a/engine-spring/compatibility-test-spring4/pom.xml
+++ b/engine-spring/compatibility-test-spring4/pom.xml
@@ -82,6 +82,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/engine-spring/compatibility-test-spring5/pom.xml
+++ b/engine-spring/compatibility-test-spring5/pom.xml
@@ -77,6 +77,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/engine-spring/core/pom.xml
+++ b/engine-spring/core/pom.xml
@@ -89,6 +89,16 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.assert</groupId>
+      <artifactId>camunda-bpm-assert-assertj2</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.hibernate</groupId>

--- a/engine-spring/core/pom.xml
+++ b/engine-spring/core/pom.xml
@@ -94,11 +94,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.camunda.bpm.assert</groupId>
-      <artifactId>camunda-bpm-assert-assertj2</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.hibernate</groupId>

--- a/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/transaction/inner/rollback/InnerProcessService.java
+++ b/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/transaction/inner/rollback/InnerProcessService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.spring.test.transaction.inner.rollback;
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+
+
+public interface InnerProcessService {
+
+  void startInnerProcess(DelegateExecution execution);
+
+}

--- a/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/transaction/inner/rollback/InnerProcessServiceImpl.java
+++ b/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/transaction/inner/rollback/InnerProcessServiceImpl.java
@@ -17,7 +17,7 @@
 package org.camunda.bpm.engine.spring.test.transaction.inner.rollback;
 
 import org.camunda.bpm.engine.delegate.DelegateExecution;
-import org.camunda.bpm.engine.spring.util.EngineSpringUtil;
+import org.camunda.bpm.engine.context.ProcessEngineContext;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,9 +29,14 @@ public class InnerProcessServiceImpl implements InnerProcessService {
   @Transactional(value = "transactionManager", propagation = Propagation.REQUIRES_NEW, rollbackFor = {Throwable.class})
   public void startInnerProcess(DelegateExecution execution) {
 
-    execution.getProcessEngineServices().getRuntimeService()
-      .startProcessInstanceByKey("InnerTxNestedTransactionTest");
+    try {
+      ProcessEngineContext.requiresNew();
+      execution.getProcessEngineServices().getRuntimeService()
+        .startProcessInstanceByKey("InnerTxNestedTransactionTest");
+    } finally {
+      ProcessEngineContext.clear();
+    }
 
-    throw new RuntimeException("Nested Transaction Failed error!");
+    throw new RuntimeException("Inner Transaction Fails and Rolls back error!");
   }
 }

--- a/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/transaction/inner/rollback/InnerProcessServiceImpl.java
+++ b/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/transaction/inner/rollback/InnerProcessServiceImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.spring.test.transaction.inner.rollback;
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.spring.util.EngineSpringUtil;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class InnerProcessServiceImpl implements InnerProcessService {
+
+  @Override
+  @Transactional(value = "transactionManager", propagation = Propagation.REQUIRES_NEW, rollbackFor = {Throwable.class})
+  public void startInnerProcess(DelegateExecution execution) {
+
+    execution.getProcessEngineServices().getRuntimeService()
+      .startProcessInstanceByKey("InnerTxNestedTransactionTest");
+
+    throw new RuntimeException("Nested Transaction Failed error!");
+  }
+}

--- a/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/transaction/inner/rollback/SpringInnerTransactionRollbackTest.java
+++ b/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/transaction/inner/rollback/SpringInnerTransactionRollbackTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.spring.test.transaction.inner.rollback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.assertThat;
+
+import org.camunda.bpm.engine.HistoryService;
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.history.HistoricProcessInstance;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.List;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"classpath:org/camunda/bpm/engine/spring/test/transaction/"
+  + "SpringInnerTransactionRollbackTest-applicationContext.xml"})
+public class SpringInnerTransactionRollbackTest {
+
+  @Rule
+  @Autowired
+  public ProcessEngineRule rule;
+
+  @Autowired
+  public ProcessEngine processEngine;
+
+  @Autowired
+  RuntimeService runtimeService;
+
+  @Autowired
+  HistoryService historyService;
+
+  @Test
+  @Deployment(resources = {
+    "org/camunda/bpm/engine/spring/test/transaction/"
+      + "SpringInnerTransactionRollbackTest.shouldRollbackProcessData-outer.bpmn20.xml",
+    "org/camunda/bpm/engine/spring/test/transaction/"
+      + "SpringInnerTransactionRollbackTest.shouldRollbackProcessData-inner.bpmn20.xml"
+  })
+  public void shouldRollbackProcessData() {
+    // given
+
+    // when
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("OuterTxNestedTransactionTest");
+
+    // then
+
+    // outer process instance should be finished
+    ProcessInstance outerProcessInstance = runtimeService.createProcessInstanceQuery()
+      .processInstanceId(processInstance.getId())
+      .singleResult();
+    assertThat(outerProcessInstance).isNull();
+
+    // inner process instance shouldn't exist
+    List<ProcessInstance> innerProcessInstances = runtimeService.createProcessInstanceQuery()
+      .processDefinitionKey("InnerTxNestedTransactionTest")
+      .list();
+    assertThat(innerProcessInstances).isEmpty();
+
+
+    // historic inner PI shouldn't be available
+    List<HistoricProcessInstance> innerProcessinstances = historyService
+        .createHistoricProcessInstanceQuery()
+        .processDefinitionKey("InnerTxNestedTransactionTest")
+        .list();
+    assertThat(innerProcessinstances).isEmpty();
+  }
+}

--- a/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/transaction/inner/rollback/SpringInnerTransactionRollbackTest.java
+++ b/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/transaction/inner/rollback/SpringInnerTransactionRollbackTest.java
@@ -17,7 +17,6 @@
 package org.camunda.bpm.engine.spring.test.transaction.inner.rollback;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.assertThat;
 
 import org.camunda.bpm.engine.HistoryService;
 import org.camunda.bpm.engine.ProcessEngine;

--- a/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/transaction/inner/rollback/TransactionTestDelegate.java
+++ b/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/transaction/inner/rollback/TransactionTestDelegate.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.spring.test.transaction.inner.rollback;
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("transactionTestDelegate")
+@Transactional(value = "transactionManager", propagation = Propagation.REQUIRED)
+public class TransactionTestDelegate implements JavaDelegate {
+
+  @Autowired
+  InnerProcessService innerProcessService;
+
+  @Override
+  public void execute(DelegateExecution execution) throws Exception {
+
+    try {
+      innerProcessService.startInnerProcess(execution);
+    } catch (Exception ex) {
+      // noop
+    }
+  }
+
+}

--- a/engine-spring/core/src/test/resources/org/camunda/bpm/engine/spring/test/transaction/SpringInnerTransactionRollbackTest-applicationContext.xml
+++ b/engine-spring/core/src/test/resources/org/camunda/bpm/engine/spring/test/transaction/SpringInnerTransactionRollbackTest-applicationContext.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context" xmlns:tx="http://www.springframework.org/schema/tx"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                         http://www.springframework.org/schema/beans/spring-beans.xsd
+                         http://www.springframework.org/schema/context
+                         http://www.springframework.org/schema/context/spring-context-2.5.xsd
+
+        http://www.springframework.org/schema/tx
+        http://www.springframework.org/schema/tx/spring-tx.xsd">
+
+  <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
+    <property name="driverClass" value="org.h2.Driver" />
+    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="username" value="sa" />
+    <property name="password" value="" />
+  </bean>
+
+  <bean id="transactionManager" class="org.springframework.orm.jpa.JpaTransactionManager">
+    <property name="entityManagerFactory" ref="entityManagerFactory"/>
+  </bean>
+
+  <bean id="entityManagerFactory" class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
+    <property name="dataSource" ref="dataSource"/>
+    <property name="persistenceXmlLocation">
+      <value>classpath:/org/camunda/bpm/engine/spring/test/jpa/custom-persistence.xml</value>
+    </property>
+    <property name="jpaVendorAdapter">
+      <bean class="org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter">
+        <property name="database" value="H2" />
+      </bean>
+    </property>
+  </bean>
+  
+  <bean id="processEngineConfiguration" class="org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration">
+    <property name="authorizationEnabled" value="true"/>
+    <property name="dataSource" ref="dataSource" />
+    <property name="transactionManager" ref="transactionManager" />
+    <property name="databaseSchemaUpdate" value="true" />
+    <property name="jobExecutorActivate" value="false" />
+    <!-- turn off metrics reporter -->
+    <property name="dbMetricsReporterActivate" value="false" />
+  </bean>
+
+  <bean id="processEngine" class="org.camunda.bpm.engine.spring.ProcessEngineFactoryBean">
+    <property name="processEngineConfiguration" ref="processEngineConfiguration" />
+  </bean>
+
+  <bean id="processEngineRule" class="org.camunda.bpm.engine.test.ProcessEngineRule">
+    <property name="processEngine" ref="processEngine"/>
+  </bean>
+
+  <bean id="repositoryService" factory-bean="processEngine" factory-method="getRepositoryService" />
+  <bean id="runtimeService" factory-bean="processEngine" factory-method="getRuntimeService" />
+  <bean id="taskService" factory-bean="processEngine" factory-method="getTaskService" />
+  <bean id="historyService" factory-bean="processEngine" factory-method="getHistoryService" />
+  <bean id="managementService" factory-bean="processEngine" factory-method="getManagementService" />
+
+  <context:annotation-config />
+  <context:component-scan base-package="org.camunda.bpm.engine.spring.test.transaction.inner.rollback" />
+  <tx:annotation-driven />
+
+</beans>

--- a/engine-spring/core/src/test/resources/org/camunda/bpm/engine/spring/test/transaction/SpringInnerTransactionRollbackTest.shouldRollbackProcessData-inner.bpmn20.xml
+++ b/engine-spring/core/src/test/resources/org/camunda/bpm/engine/spring/test/transaction/SpringInnerTransactionRollbackTest.shouldRollbackProcessData-inner.bpmn20.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1fom8sc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.0">
+  <bpmn:process id="InnerTxNestedTransactionTest" name="Inner Transaction Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start Inner TX">
+      <bpmn:outgoing>SequenceFlow_0xcnqy3</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0xcnqy3" sourceRef="StartEvent_1" targetRef="Task_1djyki0" />
+    <bpmn:endEvent id="EndEvent_0s23van" name="End Inner TX">
+      <bpmn:incoming>SequenceFlow_0q610er</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0q610er" sourceRef="Task_1djyki0" targetRef="EndEvent_0s23van" />
+    <bpmn:serviceTask id="Task_1djyki0" name="Do Something" camunda:asyncAfter="true" camunda:expression="${true}" camunda:resultVariable="innerVariable">
+      <bpmn:incoming>SequenceFlow_0xcnqy3</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0q610er</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="InnerTxNestedTransactionTest">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="159" y="146" width="78" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0xcnqy3_di" bpmnElement="SequenceFlow_0xcnqy3">
+        <di:waypoint x="215" y="121" />
+        <di:waypoint x="265" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0s23van_di" bpmnElement="EndEvent_0s23van">
+        <dc:Bounds x="415" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="398" y="146" width="72" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0q610er_di" bpmnElement="SequenceFlow_0q610er">
+        <di:waypoint x="365" y="121" />
+        <di:waypoint x="415" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_1bq5qwa_di" bpmnElement="Task_1djyki0">
+        <dc:Bounds x="265" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine-spring/core/src/test/resources/org/camunda/bpm/engine/spring/test/transaction/SpringInnerTransactionRollbackTest.shouldRollbackProcessData-outer.bpmn20.xml
+++ b/engine-spring/core/src/test/resources/org/camunda/bpm/engine/spring/test/transaction/SpringInnerTransactionRollbackTest.shouldRollbackProcessData-outer.bpmn20.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1ys0ol0" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.0">
+  <bpmn:process id="OuterTxNestedTransactionTest" name="Outer Transaction Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start Outer TX">
+      <bpmn:outgoing>SequenceFlow_1xrn9u3</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1xrn9u3" sourceRef="StartEvent_1" targetRef="Task_0p68azq" />
+    <bpmn:endEvent id="EndEvent_115acy2" name="End Outer TX">
+      <bpmn:incoming>SequenceFlow_0n3vfv0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0n3vfv0" sourceRef="Task_0p68azq" targetRef="EndEvent_115acy2" />
+    <bpmn:serviceTask id="Task_0p68azq" name="Do Nested Transaction" camunda:delegateExpression="${transactionTestDelegate}">
+      <bpmn:incoming>SequenceFlow_1xrn9u3</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0n3vfv0</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="OuterTxNestedTransactionTest">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="157" y="146" width="80" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1xrn9u3_di" bpmnElement="SequenceFlow_1xrn9u3">
+        <di:waypoint x="215" y="121" />
+        <di:waypoint x="265" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_115acy2_di" bpmnElement="EndEvent_115acy2">
+        <dc:Bounds x="415" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="397" y="146" width="74" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0n3vfv0_di" bpmnElement="SequenceFlow_0n3vfv0">
+        <di:waypoint x="365" y="121" />
+        <di:waypoint x="415" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0b42xu5_di" bpmnElement="Task_0p68azq">
+        <dc:Bounds x="265" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine/src/main/java/org/camunda/bpm/engine/context/ProcessEngineContext.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/context/ProcessEngineContext.java
@@ -22,8 +22,8 @@ import java.util.concurrent.Callable;
 
 /**
  * <p>When a Process Engine API call is performed, the engine
- * will create a Process Engine Context. The context caches queries
- * to the database, so that multiple operations on the same entity do not
+ * will create a Process Engine Context. The context caches database
+ * entities, so that multiple operations on the same entity do not
  * result in multiple database queries. This also means that the changes
  * to these entities are accumulated and are flushed to the database
  * as soon as the Process Engine API call returns (however, the current
@@ -32,18 +32,20 @@ import java.util.concurrent.Callable;
  * <p>If a Process Engine API call is nested into another call, the
  * default behaviour is to reuse the existing Process Engine Context.
  * This means that the nested call will have access to the same cached
- * entities and the changes made to them.
+ * entities and the changes made to them.</p>
  *
- * When the nested call needs to be executed in a new transaction, it is
- * possible to create a new Process Engine Context for it. In this case, the
- * nested call will use a new cache for the database queries, independent of
- * the previous (outer) call. When the nested call returns, the changes are
- * flushed to the database independently of the Process Engine Context of the
- * outer call.</p>
+ * <p>When the nested call is to be executed in a new transaction, a new Process
+ * Engine Context needs to be created for its execution. In this case, the
+ * nested call will use a new cache for the database entities, independent of
+ * the previous (outer) call cache. This means that, the changes in the cache of
+ * one call are invisible to the other call and vice versa. When the nested call
+ * returns, the changes are flushed to the database independently of the Process
+ * Engine Context of the outer call.</p>
  *
- * <p>The <code>ProcessEngineContext</code> is a utility class to declare a
- * new Process Engine Context in order for database operations in a nested
- * Process Engine API call to be separated in a new transaction.</p>
+ * <p>The <code>ProcessEngineContext</code> is a utility class to declare to
+ * the Process Engine that a new Process Engine Context needs to be created
+ * in order for the database operations in a nested Process Engine API call
+ * to be separated in a new transaction.</p>
  *
  * Example on declaring a new Process Engine Context:
  *
@@ -61,10 +63,12 @@ public class ProcessEngineContext {
   /**
    * Declares to the Process Engine that a new, separate context,
    * bound to the current thread, needs to be created for all subsequent
-   * Process Engine database operations.
+   * Process Engine database operations. The method should always be used
+   * in a try-finally block to ensure that {@link #clear()} is called
+   * under any circumstances.
    *
-   * The method should always be used in a try-finally block
-   * to ensure that {@link #clear()} is called under any circumstances.
+   * Please see the {@link ProcessEngineContext} class documentation for
+   * a more detailed description on the purpose of this method.
    */
   public static void requiresNew() {
     ProcessEngineContextImpl.set(true);
@@ -72,7 +76,9 @@ public class ProcessEngineContext {
 
   /**
    * Declares to the Process Engine that the new Context created
-   * by the {@link #requiresNew()} method can be closed.
+   * by the {@link #requiresNew()} method can be closed. Please
+   * see the {@link ProcessEngineContext} class documentation for
+   * a more detailed description on the purpose of this method.
    */
   public static void clear() {
     ProcessEngineContextImpl.clear();
@@ -80,7 +86,9 @@ public class ProcessEngineContext {
 
   /**
    * <p>Takes a callable and executes all engine API invocations
-   * within that callable in a new Process Engine Context</p>
+   * within that callable in a new Process Engine Context. Please
+   * see the {@link ProcessEngineContext} class documentation for
+   * a more detailed description on the purpose of this method.</p>
    *
    * An alternative to calling:
    *

--- a/engine/src/main/java/org/camunda/bpm/engine/context/ProcessEngineContext.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/context/ProcessEngineContext.java
@@ -21,8 +21,29 @@ import org.camunda.bpm.engine.impl.context.ProcessEngineContextImpl;
 import java.util.concurrent.Callable;
 
 /**
- * <p>A utility to declare a new Process Engine Context in order
- * for database operations to be separated in a new transaction.</p>
+ * <p>When a Process Engine API call is performed, the engine
+ * will create a Process Engine Context. The context caches queries
+ * to the database, so that multiple operations on the same entity do not
+ * result in multiple database queries. This also means that the changes
+ * to these entities are accumulated and are flushed to the database
+ * as soon as the Process Engine API call returns (however, the current
+ * transaction might be committed at a later time).</p>
+ *
+ * <p>If a Process Engine API call is nested into another call, the
+ * default behaviour is to reuse the existing Process Engine Context.
+ * This means that the nested call will have access to the same cached
+ * entities and the changes made to them.
+ *
+ * When the nested call needs to be executed in a new transaction, it is
+ * possible to create a new Process Engine Context for it. In this case, the
+ * nested call will use a new cache for the database queries, independent of
+ * the previous (outer) call. When the nested call returns, the changes are
+ * flushed to the database independently of the Process Engine Context of the
+ * outer call.</p>
+ *
+ * <p>The <code>ProcessEngineContext</code> is a utility class to declare a
+ * new Process Engine Context in order for database operations in a nested
+ * Process Engine API call to be separated in a new transaction.</p>
  *
  * Example on declaring a new Process Engine Context:
  *

--- a/engine/src/main/java/org/camunda/bpm/engine/context/ProcessEngineContext.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/context/ProcessEngineContext.java
@@ -18,6 +18,8 @@ package org.camunda.bpm.engine.context;
 
 import org.camunda.bpm.engine.impl.context.ProcessEngineContextImpl;
 
+import java.util.concurrent.Callable;
+
 /**
  * <p>A utility to declare a new Process Engine Context in order
  * for database operations to be separated in a new transaction.</p>
@@ -53,5 +55,33 @@ public class ProcessEngineContext {
    */
   public static void clear() {
     ProcessEngineContextImpl.clear();
+  }
+
+  /**
+   * <p>Takes a callable and executes all engine API invocations
+   * within that callable in a new Process Engine Context</p>
+   *
+   * An alternative to calling:
+   *
+   * <code>
+   *   try {
+   *     requiresNew();
+   *     callable.call();
+   *   } finally {
+   *     clear();
+   *   }
+   * </code>
+   *
+   * @param callable the callable to execute
+   * @return what is defined by the callable passed to the method
+   * @throws Exception
+   */
+  public static <T> T withNewProcessEngineContext(Callable<T> callable) throws Exception {
+    try {
+      requiresNew();
+      return callable.call();
+    } finally {
+      clear();
+    }
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/context/ProcessEngineContext.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/context/ProcessEngineContext.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.context;
+
+import org.camunda.bpm.engine.impl.context.ProcessEngineContextImpl;
+
+/**
+ * <p>A utility to declare a new Process Engine Context in order
+ * for database operations to be separated in a new transaction.</p>
+ *
+ * Example on declaring a new Process Engine Context:
+ *
+ * <pre>
+ *  try {
+ *    ProcessEngineContext.requiresNew();
+ *    runtimeService.startProcessInstanceByKey("EXAMPLE_INSTANCE");
+ *  } finally {
+ *    ProcessEngineContext.clear();
+ *  }
+ * </pre>
+ */
+public class ProcessEngineContext {
+
+  /**
+   * Declares to the Process Engine that a new, separate context,
+   * bound to the current thread, needs to be created for all subsequent
+   * Process Engine database operations.
+   *
+   * The method should always be used in a try-finally block
+   * to ensure that {@link #clear()} is called under any circumstances.
+   */
+  public static void requiresNew() {
+    ProcessEngineContextImpl.set(true);
+  }
+
+  /**
+   * Declares to the Process Engine that the new Context created
+   * by the {@link #requiresNew()} method can be closed.
+   */
+  public static void clear() {
+    ProcessEngineContextImpl.clear();
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/context/ProcessEngineContextImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/context/ProcessEngineContextImpl.java
@@ -18,7 +18,12 @@ package org.camunda.bpm.engine.impl.context;
 
 public class ProcessEngineContextImpl {
 
-  protected static ThreadLocal<Boolean> commandContextNew = new ThreadLocal<>();
+  protected static ThreadLocal<Boolean> commandContextNew = new ThreadLocal<Boolean>() {
+    @Override
+    protected Boolean initialValue() {
+      return Boolean.FALSE;
+    }
+  };
 
   public static boolean get() {
     return commandContextNew.get();
@@ -36,6 +41,6 @@ public class ProcessEngineContextImpl {
   }
 
   public static void clear() {
-    commandContextNew.remove();
+    commandContextNew.set(false);
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/context/ProcessEngineContextImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/context/ProcessEngineContextImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.context;
+
+public class ProcessEngineContextImpl {
+
+  protected static ThreadLocal<Boolean> commandContextNew = new ThreadLocal<>();
+
+  public static boolean get() {
+    return commandContextNew.get();
+  }
+
+  public static void set(boolean requiresNew) {
+    commandContextNew.set(requiresNew);
+  }
+
+  public static boolean consume() {
+    boolean isNewCommandContext = get();
+    clear();
+
+    return isNewCommandContext;
+  }
+
+  public static void clear() {
+    commandContextNew.remove();
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandContextInterceptor.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandContextInterceptor.java
@@ -21,6 +21,7 @@ import org.camunda.bpm.engine.delegate.ProcessEngineServicesAware;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.cmd.CommandLogger;
 import org.camunda.bpm.engine.impl.context.Context;
+import org.camunda.bpm.engine.impl.context.ProcessEngineContextImpl;
 
 /**
  * <p>Interceptor used for opening the {@link CommandContext} and {@link CommandInvocationContext}.</p>
@@ -85,7 +86,9 @@ public class CommandContextInterceptor extends CommandInterceptor {
       }
     }
 
-    boolean openNew = (context == null);
+    // only create a new command context on the current command level (CAM-10002)
+    boolean isNew = ProcessEngineContextImpl.consume();
+    boolean openNew = (context == null || isNew);
 
     CommandInvocationContext commandInvocationContext = new CommandInvocationContext(command);
     Context.setCommandInvocationContext(commandInvocationContext);
@@ -121,6 +124,9 @@ public class CommandContextInterceptor extends CommandInterceptor {
         Context.removeCommandInvocationContext();
         Context.removeCommandContext();
         Context.removeProcessEngineConfiguration();
+
+        // restore the new command context flag
+        ProcessEngineContextImpl.set(isNew);
       }
     }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/context/ProcessEngineContextTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/context/ProcessEngineContextTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.api.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.camunda.bpm.engine.context.ProcessEngineContext;
+import org.camunda.bpm.engine.impl.interceptor.Command;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+public class ProcessEngineContextTest {
+
+  protected final ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
+  protected final ProcessEngineTestRule testHelper = new ProcessEngineTestRule(engineRule);
+  @Rule
+  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testHelper);
+
+  protected static final String SIMPLE_PROCESS_KEY = "simple_process";
+  protected static final BpmnModelInstance SIMPLE_PROCESS = Bpmn.createExecutableProcess(SIMPLE_PROCESS_KEY)
+    .startEvent()
+      .userTask("simpleUserTask")
+    .endEvent()
+    .done();
+
+  @Before
+  public void setUp() {
+    testHelper.deploy(SIMPLE_PROCESS);
+  }
+
+  @Test
+  public void shouldUseFreshCacheOnNewCommandContext() throws Exception {
+    /* The test ensures that when `ProcessEngineContext#requiresNew()` is called,
+    a fresh cache is used for the new command, and no cached data of the outer command
+    cache is available (i.e. only persisted data is available).
+     */
+
+    // given
+    engineRule.getProcessEngineConfiguration()
+      .getCommandExecutorTxRequired()
+      .execute(
+        // a Command that executes an engine API call
+        new OuterCommand<Void>(
+          // when
+          // a nested Command is executed with an explicitly declared, new CommandContext
+          new NestedCommand<Void>() {
+            @Override
+            public Void call() {
+
+              List<ProcessInstance> processInstanceList = engineRule.getRuntimeService()
+                .createProcessInstanceQuery()
+                .processDefinitionKey(SIMPLE_PROCESS_KEY)
+                .list();
+
+              // then
+              // the nested CommandContext should be new
+              assertThat(getOuterCommandContext()).isNotEqualTo(nestedCommandContext);
+
+              return null;
+            }
+        }, true));
+  }
+
+  @Test
+  public void shouldUseSameCommandContextOnTxRequired() throws Exception {
+    /* The test ensures that, even if the `requiresNew()` method is called on a command,
+    inner commands still reuse the current CommandContext (unless otherwise specified)
+     */
+
+    // given
+    // a new CommandContext is explicitly declared for an engine API call
+    ProcessEngineContext.withNewProcessEngineContext(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+
+        return engineRule.getProcessEngineConfiguration()
+          .getCommandExecutorTxRequired()
+          .execute(
+            // a Command is executed with the new Context
+            new OuterCommand<Void>(
+              // and a nested Command reuses that context
+              new NestedCommand<Void>() {
+                @Override
+                public Void call() {
+
+                  List<ProcessInstance> processInstanceList = engineRule.getRuntimeService()
+                    .createProcessInstanceQuery()
+                    .processDefinitionKey(SIMPLE_PROCESS_KEY)
+                    .list();
+
+                  // then
+                  // assertThat(processInstanceList).isNotEmpty();
+                  // the outer CommandContext should be reused
+                  assertThat(getOuterCommandContext()).isEqualTo(nestedCommandContext);
+
+                  return null;
+                }
+            }, false
+          )
+        );
+      }
+    });
+  }
+
+  protected class OuterCommand<T> implements Command<T> {
+
+    protected NestedCommand<T> nestedCommand;
+    protected Boolean requiresNew;
+
+    public OuterCommand(NestedCommand<T> nestedCommand, Boolean requiresNew) {
+      this.nestedCommand = nestedCommand;
+      this.requiresNew = requiresNew;
+    }
+
+    @Override
+    public T execute(final CommandContext commandContext) {
+
+      engineRule.getRuntimeService().startProcessInstanceByKey(SIMPLE_PROCESS_KEY);
+
+      // make the outer CommandContext available
+      nestedCommand.setOuterCommandContext(commandContext);
+
+      if (requiresNew) {
+        try {
+          ProcessEngineContext.withNewProcessEngineContext(new Callable<T>() {
+            @Override
+            public T call() {
+
+              return commandContext.getProcessEngineConfiguration()
+                .getCommandExecutorTxRequired()
+                .execute(nestedCommand);
+            }
+          });
+        } catch (Exception e) {
+          fail("Test failed with exception: " + e.getMessage());
+        }
+      } else {
+        return commandContext.getProcessEngineConfiguration()
+          .getCommandExecutorTxRequired()
+          .execute(nestedCommand);
+      }
+
+      return null;
+    }
+  }
+
+  protected abstract class NestedCommand<T> implements Command<T>, Callable<T>{
+
+    CommandContext nestedCommandContext;
+    CommandContext outerCommandContext;
+
+    public abstract T call();
+
+    @Override
+    public T execute(CommandContext commandContext) {
+      // make the nested CommandContext available
+      this.nestedCommandContext = commandContext;
+
+      try {
+        return call();
+      } catch (Exception e) {
+        fail("Test failed with exception: " + e.getMessage());
+      }
+
+      return null;
+    }
+
+    public CommandContext getNestedCommandContext() {
+      return nestedCommandContext;
+    }
+
+    public void setNestedCommandContext(CommandContext nestedCommandContext) {
+      this.nestedCommandContext = nestedCommandContext;
+    }
+
+    public CommandContext getOuterCommandContext() {
+      return outerCommandContext;
+    }
+
+    public void setOuterCommandContext(CommandContext outerCommandContext) {
+      this.outerCommandContext = outerCommandContext;
+    }
+  }
+}


### PR DESCRIPTION
* Provide static methods to declare a new CommandContext creation;
* Provide a test case for inner transactions (REQUIRES_NEW) in the Spring integration.

Related to CAM-10002 (https://app.camunda.com/jira/browse/CAM-10002)