### PR TITLE
CAM-10640: allow access to all external schemas by default

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/EngineUtilLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/EngineUtilLogger.java
@@ -219,4 +219,12 @@ public class EngineUtilLogger extends ProcessEngineLogger {
       "030",
       "Exception while parsing JSON: {}", e.getMessage(), e);
   }
+
+  public void logAccessExternalSchemaNotSupported(Exception e) {
+    logDebug(
+        "031",
+        "Could not restrict external schema access. "
+        + "This indicates that this is not supported by your JAXP implementation: {}",
+        e.getMessage());
+  }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/xml/Parse.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/xml/Parse.java
@@ -43,6 +43,7 @@ import org.xml.sax.helpers.DefaultHandler;
  */
 public class Parse extends DefaultHandler {
 
+
   private static final EngineUtilLogger LOG = ProcessEngineLogger.UTIL_LOGGER;
 
   private static final String JAXP_SCHEMA_SOURCE = "http://java.sun.com/xml/jaxp/properties/schemaSource";
@@ -50,12 +51,16 @@ public class Parse extends DefaultHandler {
   private static final String W3C_XML_SCHEMA = "http://www.w3.org/2001/XMLSchema";
   private static final String XXE_PROCESSING = "http://xml.org/sax/features/external-general-entities";
 
+  private static final String JAXP_ACCESS_EXTERNAL_SCHEMA = "http://javax.xml.XMLConstants/property/accessExternalSchema";
+  private static final String JAXP_ACCESS_EXTERNAL_SCHEMA_SYSTEM_PROPERTY = "javax.xml.accessExternalSchema";
+  private static final String JAXP_ACCESS_EXTERNAL_SCHEMA_ALL = "all";
+
   protected Parser parser;
   protected String name;
   protected StreamSource streamSource;
   protected Element rootElement = null;
-  protected List<Problem> errors = new ArrayList<Problem>();
-  protected List<Problem> warnings = new ArrayList<Problem>();
+  protected List<Problem> errors = new ArrayList<>();
+  protected List<Problem> warnings = new ArrayList<>();
   protected String schemaResource;
   protected boolean enableXxeProcessing = true;
 
@@ -143,9 +148,10 @@ public class Parse extends DefaultHandler {
 
       SAXParser saxParser = parser.getSaxParser();
       try {
-        saxParser.setProperty("http://javax.xml.XMLConstants/property/accessExternalSchema", "file,http,https,jar,wsjar");
+        saxParser.setProperty(JAXP_ACCESS_EXTERNAL_SCHEMA, resolveAccessExternalSchemaProperty());
       } catch (Exception e) {
         // ignore unavailable option
+        LOG.logAccessExternalSchemaNotSupported(e);
       }
       if (schemaResource != null) {
         saxParser.setProperty(JAXP_SCHEMA_LANGUAGE, W3C_XML_SCHEMA);
@@ -157,6 +163,23 @@ public class Parse extends DefaultHandler {
     }
 
     return this;
+  }
+
+  /*
+   * JAXP allows users to override the default value via system properties and
+   * a central properties file (see https://docs.oracle.com/javase/tutorial/jaxp/properties/scope.html).
+   * However, both are overridden by an explicit configuration in code, as we apply it.
+   * Since we want users to customize the value, we take the system property into account.
+   * The properties file is not supported at the moment.
+   */
+  protected String resolveAccessExternalSchemaProperty() {
+    String systemProperty = System.getProperty(JAXP_ACCESS_EXTERNAL_SCHEMA_SYSTEM_PROPERTY);
+
+    if (systemProperty != null) {
+      return systemProperty;
+    } else {
+      return JAXP_ACCESS_EXTERNAL_SCHEMA_ALL;
+    }
   }
 
   public Element getRootElement() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/parse/BpmnParseTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/parse/BpmnParseTest.java
@@ -16,24 +16,31 @@
  */
 package org.camunda.bpm.engine.test.bpmn.parse;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.List;
 
+import org.camunda.bpm.engine.ActivityTypes;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.impl.bpmn.behavior.BoundaryConditionalEventActivityBehavior;
 import org.camunda.bpm.engine.impl.bpmn.behavior.BoundaryEventActivityBehavior;
 import org.camunda.bpm.engine.impl.bpmn.behavior.CompensationEventActivityBehavior;
+import org.camunda.bpm.engine.impl.bpmn.behavior.EventSubProcessStartConditionalEventActivityBehavior;
 import org.camunda.bpm.engine.impl.bpmn.behavior.EventSubProcessStartEventActivityBehavior;
+import org.camunda.bpm.engine.impl.bpmn.behavior.IntermediateConditionalEventBehavior;
 import org.camunda.bpm.engine.impl.bpmn.behavior.NoneStartEventActivityBehavior;
 import org.camunda.bpm.engine.impl.bpmn.behavior.ThrowEscalationEventActivityBehavior;
 import org.camunda.bpm.engine.impl.bpmn.helper.BpmnProperties;
-import org.camunda.bpm.engine.ActivityTypes;
-import org.camunda.bpm.engine.impl.bpmn.behavior.BoundaryConditionalEventActivityBehavior;
-import org.camunda.bpm.engine.impl.bpmn.behavior.EventSubProcessStartConditionalEventActivityBehavior;
-import org.camunda.bpm.engine.impl.bpmn.behavior.IntermediateConditionalEventBehavior;
 import org.camunda.bpm.engine.impl.bpmn.parser.BpmnParse;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.context.Context;
@@ -47,15 +54,21 @@ import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
 import org.camunda.bpm.engine.impl.pvm.process.ScopeImpl;
 import org.camunda.bpm.engine.impl.pvm.process.TransitionImpl;
 import org.camunda.bpm.engine.impl.test.TestHelper;
+import org.camunda.bpm.engine.repository.DeploymentBuilder;
+import org.camunda.bpm.engine.repository.DeploymentWithDefinitions;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
 import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.engine.test.util.SystemPropertiesRule;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.RuleChain;
 
 /**
@@ -69,6 +82,12 @@ public class BpmnParseTest {
 
   @Rule
   public RuleChain chain = RuleChain.outerRule(engineRule).around(testRule);
+
+  @Rule
+  public SystemPropertiesRule systemProperties = SystemPropertiesRule.resetPropsAfterTest();
+
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
 
   public RepositoryService repositoryService;
   public RuntimeService runtimeService;
@@ -1061,28 +1080,70 @@ public class BpmnParseTest {
 
   @Test
   public void testFeatureSecureProcessingAcceptsDefinitionWhenAttributeLimitOverridden() {
+    // given
     System.setProperty("jdk.xml.elementAttributeLimit", "0");
-    try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseProcessDefinitionFSP");
-      String deploymentId = repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy().getId();
-      assertEquals(1, repositoryService.createProcessDefinitionQuery().count());
-      repositoryService.deleteDeployment(deploymentId, true);
-    } finally {
-      System.clearProperty("jdk.xml.elementAttributeLimit");
-    }
+
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseProcessDefinitionFSP");
+    DeploymentBuilder deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
+
+    // when
+    testRule.deploy(deploymentBuilder);
+
+    // then
+    assertEquals(1, repositoryService.createProcessDefinitionQuery().count());
   }
 
   @Test
-  public void testFeatureSecureProcessingCannotOverrideExternalSchemaAccess() {
-    // system property will have no effect, schema access still allowed
-    System.setProperty("javax.xml.accessExternalSchema", "");
-    try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseIntermediateConditionalEvent");
-      String deploymentId = repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy().getId();
-      assertEquals(1, repositoryService.createProcessDefinitionQuery().count());
-      repositoryService.deleteDeployment(deploymentId, true);
-    } finally {
-      System.clearProperty("javax.xml.accessExternalSchema");
-    }
+  public void testFeatureSecureProcessingRestrictExternalSchemaAccess() {
+    // given
+    // the external schema access property is not supported on certain
+    // IBM JDK versions, in which case schema access cannot be restricted
+    Assume.assumeTrue(doesJdkSupportExternalSchemaAccessProperty());
+
+    BpmnModelInstance process = Bpmn.createExecutableProcess("process")
+        .startEvent()
+        .userTask()
+        .endEvent()
+        .done();
+
+    System.setProperty("javax.xml.accessExternalSchema", ""); // empty string prohibits all external schema access
+
+    // then
+    exception.expect(ProcessEngineException.class);
+    exception.expectMessage("Failed to read schema document 'BPMNDI.xsd'");
+
+    // when
+    testRule.deploy(process);
+  }
+
+  @Test
+  public void testFeatureSecureProcessingAllowExternalSchemaAccess() {
+    // given
+    BpmnModelInstance process = Bpmn.createExecutableProcess("process")
+        .startEvent()
+        .userTask()
+        .endEvent()
+        .done();
+
+    System.setProperty("javax.xml.accessExternalSchema", "all"); // empty string prohibits all external schema access
+
+    // when
+    DeploymentWithDefinitions deployment = testRule.deploy(process);
+
+    // then
+    assertThat(deployment).isNotNull();
+  }
+
+
+  protected boolean doesJdkSupportExternalSchemaAccessProperty() {
+    String jvmVendor = System.getProperty("java.vm.vendor");
+    String javaVersion = System.getProperty("java.version");
+
+    boolean isIbmJDK = jvmVendor != null && jvmVendor.contains("IBM");
+    boolean isJava6 = javaVersion != null && javaVersion.startsWith("1.6");
+    boolean isJava7 = javaVersion != null && javaVersion.startsWith("1.7");
+
+    return !isJava6 && !(isIbmJDK && isJava7);
+
   }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/util/SystemPropertiesRule.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/util/SystemPropertiesRule.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.util;
+
+import java.util.Properties;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+/**
+ * Restores the system properties after a test
+ */
+public class SystemPropertiesRule extends TestWatcher {
+
+  protected Properties originalProperties;
+
+  private SystemPropertiesRule() {
+  }
+
+  /**
+   * Use the static method so the test is more readable
+   */
+  public static SystemPropertiesRule resetPropsAfterTest() {
+    return new SystemPropertiesRule();
+  }
+
+  @Override
+  protected void starting(Description description) {
+    originalProperties = System.getProperties();
+    System.setProperties(new Properties(originalProperties));
+  }
+
+  @Override
+  protected void finished(Description description) {
+    System.setProperties(originalProperties);
+  }
+}


### PR DESCRIPTION
- configuration is respected via the jaxp system property

related to CAM-10640