### PR TITLE
CAM-10639: chore(rest): make assigneeIn filter work with tasklist filters

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/task/TaskQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/task/TaskQueryDto.java
@@ -87,7 +87,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
 
   public static final List<String> VALID_SORT_BY_VALUES;
   static {
-    VALID_SORT_BY_VALUES = new ArrayList<String>();
+    VALID_SORT_BY_VALUES = new ArrayList<>();
     VALID_SORT_BY_VALUES.add(SORT_BY_PROCESS_INSTANCE_ID_VALUE);
     VALID_SORT_BY_VALUES.add(SORT_BY_CASE_INSTANCE_ID_VALUE);
     VALID_SORT_BY_VALUES.add(SORT_BY_DUE_DATE_VALUE);
@@ -1437,7 +1437,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     TaskQueryDto dto = new TaskQueryDto();
 
     if (!isOrQueryActive) {
-      dto.orQueries = new ArrayList<TaskQueryDto>();
+      dto.orQueries = new ArrayList<>();
       for (TaskQueryImpl orQuery: taskQuery.getQueries()) {
         if (orQuery.isOrQueryActive()) {
           dto.orQueries.add(fromQuery(orQuery, true));
@@ -1475,6 +1475,12 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     dto.processDefinitionNameLike = taskQuery.getProcessDefinitionNameLike();
     dto.processInstanceId = taskQuery.getProcessInstanceId();
     dto.assignee = taskQuery.getAssignee();
+
+    if (taskQuery.getAssigneeIn() != null) {
+      dto.assigneeIn = taskQuery.getAssigneeIn()
+          .toArray(new String[taskQuery.getAssigneeIn().size()]);
+    }
+
     dto.assigneeLike = taskQuery.getAssigneeLike();
     dto.taskDefinitionKey = taskQuery.getKey();
     dto.taskDefinitionKeyIn = taskQuery.getKeys();
@@ -1524,9 +1530,9 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
       }
     }
 
-    dto.processVariables = new ArrayList<VariableQueryParameterDto>();
-    dto.taskVariables = new ArrayList<VariableQueryParameterDto>();
-    dto.caseInstanceVariables = new ArrayList<VariableQueryParameterDto>();
+    dto.processVariables = new ArrayList<>();
+    dto.taskVariables = new ArrayList<>();
+    dto.caseInstanceVariables = new ArrayList<>();
     for (TaskQueryVariableValue variableValue : taskQuery.getVariables()) {
       VariableQueryParameterDto variableValueDto = new VariableQueryParameterDto(variableValue);
 
@@ -1616,7 +1622,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
   }
 
   public static List<SortingDto> convertQueryOrderingPropertiesToSortingDtos(List<QueryOrderingProperty> orderingProperties) {
-    List<SortingDto> sortingDtos = new ArrayList<SortingDto>();
+    List<SortingDto> sortingDtos = new ArrayList<>();
     for (QueryOrderingProperty orderingProperty : orderingProperties) {
       SortingDto sortingDto;
       if (orderingProperty instanceof VariableOrderProperty) {
@@ -1728,7 +1734,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
   }
 
   public static Map<String,Object> sortParametersForVariableOrderProperty(VariableOrderProperty variableOrderProperty) {
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     for (QueryEntityRelationCondition relationCondition : variableOrderProperty.getRelationConditions()) {
       QueryProperty property = relationCondition.getProperty();
       if (VariableInstanceQueryProperty.VARIABLE_NAME.equals(property)) {


### PR DESCRIPTION
The `assigneeIn` property wasn't included in the `fromQuery` method of the TaskQueryDto, so it couldn't be used with the Filter Rest service.

I also cleaned up the class to use diamond operators.

Related to CAM-10639 (https://app.camunda.com/jira/browse/CAM-10639)
Main ticket: https://app.camunda.com/jira/browse/CAM-4670