### PR TITLE
CAM-10258: feat(engine): add customizable resource deployments

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -3192,8 +3192,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return deploymentHandlerFactory;
   }
 
-  public void setDeploymentHandlerFactory(DeploymentHandlerFactory deploymentHandlerFactory) {
+  public ProcessEngineConfigurationImpl setDeploymentHandlerFactory(DeploymentHandlerFactory deploymentHandlerFactory) {
     this.deploymentHandlerFactory = deploymentHandlerFactory;
+    return this;
   }
 
   public ProcessEngineConfigurationImpl setDelegateInterceptor(DelegateInterceptor delegateInterceptor) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -314,6 +314,7 @@ import org.camunda.bpm.engine.impl.persistence.entity.TaskReportManager;
 import org.camunda.bpm.engine.impl.persistence.entity.TenantManager;
 import org.camunda.bpm.engine.impl.persistence.entity.UserOperationLogManager;
 import org.camunda.bpm.engine.impl.persistence.entity.VariableInstanceManager;
+import org.camunda.bpm.engine.impl.repository.DefaultDeploymentHandlerFactory;
 import org.camunda.bpm.engine.impl.runtime.ConditionHandler;
 import org.camunda.bpm.engine.impl.runtime.CorrelationHandler;
 import org.camunda.bpm.engine.impl.runtime.DefaultConditionHandler;
@@ -350,6 +351,7 @@ import org.camunda.bpm.engine.impl.variable.serializer.jpa.EntityManagerSessionF
 import org.camunda.bpm.engine.impl.variable.serializer.jpa.JPAVariableSerializer;
 import org.camunda.bpm.engine.management.Metrics;
 import org.camunda.bpm.engine.repository.DeploymentBuilder;
+import org.camunda.bpm.engine.repository.DeploymentHandlerFactory;
 import org.camunda.bpm.engine.runtime.Incident;
 import org.camunda.bpm.engine.test.mock.MocksResolverFactory;
 import org.camunda.bpm.engine.variable.Variables;
@@ -614,6 +616,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected Set<String> registeredDeployments;
 
+  protected DeploymentHandlerFactory deploymentHandlerFactory;
+
   protected ResourceAuthorizationProvider resourceAuthorizationProvider;
 
   protected List<ProcessEnginePlugin> processEnginePlugins = new ArrayList<>();
@@ -846,6 +850,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     initIncidentHandlers();
     initPasswordDigest();
     initDeploymentRegistration();
+    initDeploymentHandlerFactory();
     initResourceAuthorizationProvider();
     initPermissionProvider();
     initMetrics();
@@ -1050,7 +1055,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       plugin.postProcessEngineBuild(engine);
     }
   }
-
 
   // failedJobCommandFactory ////////////////////////////////////////////////////////
 
@@ -2306,6 +2310,13 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
   }
 
+  // deployment handler //////////////////////////////////////////////////////
+  protected void initDeploymentHandlerFactory() {
+    if (deploymentHandlerFactory == null) {
+      deploymentHandlerFactory = new DefaultDeploymentHandlerFactory();
+    }
+  }
+
   // history handlers /////////////////////////////////////////////////////
 
   protected void initHistoryEventProducer() {
@@ -3175,6 +3186,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public void setDeploymentCache(DeploymentCache deploymentCache) {
     this.deploymentCache = deploymentCache;
+  }
+
+  public DeploymentHandlerFactory getDeploymentHandlerFactory() {
+    return deploymentHandlerFactory;
+  }
+
+  public void setDeploymentHandlerFactory(DeploymentHandlerFactory deploymentHandlerFactory) {
+    this.deploymentHandlerFactory = deploymentHandlerFactory;
   }
 
   public ProcessEngineConfigurationImpl setDelegateInterceptor(DelegateInterceptor delegateInterceptor) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeployCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeployCmd.java
@@ -19,7 +19,6 @@ package org.camunda.bpm.engine.impl.cmd;
 import java.io.ByteArrayInputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -36,14 +35,12 @@ import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.exception.NotFoundException;
 import org.camunda.bpm.engine.exception.NotValidException;
 import org.camunda.bpm.engine.history.UserOperationLogEntry;
-import org.camunda.bpm.engine.impl.DeploymentQueryImpl;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.bpmn.deployer.BpmnDeployer;
 import org.camunda.bpm.engine.impl.cfg.CommandChecker;
 import org.camunda.bpm.engine.impl.cfg.TransactionLogger;
 import org.camunda.bpm.engine.impl.cfg.TransactionState;
 import org.camunda.bpm.engine.impl.cmmn.deployer.CmmnDeployer;
-import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.persistence.deploy.DeploymentFailListener;
@@ -55,11 +52,20 @@ import org.camunda.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.camunda.bpm.engine.impl.persistence.entity.ResourceEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.ResourceManager;
 import org.camunda.bpm.engine.impl.persistence.entity.UserOperationLogManager;
+import org.camunda.bpm.engine.impl.repository.CandidateDeploymentImpl;
 import org.camunda.bpm.engine.impl.repository.DeploymentBuilderImpl;
 import org.camunda.bpm.engine.impl.repository.ProcessApplicationDeploymentBuilderImpl;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.camunda.bpm.engine.impl.util.StringUtil;
-import org.camunda.bpm.engine.repository.*;
+import org.camunda.bpm.engine.repository.CandidateDeployment;
+import org.camunda.bpm.engine.repository.Deployment;
+import org.camunda.bpm.engine.repository.DeploymentHandler;
+import org.camunda.bpm.engine.repository.DeploymentWithDefinitions;
+import org.camunda.bpm.engine.repository.ProcessApplicationDeployment;
+import org.camunda.bpm.engine.repository.ProcessApplicationDeploymentBuilder;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.engine.repository.Resource;
+import org.camunda.bpm.engine.repository.ResumePreviousBy;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.camunda.bpm.model.bpmn.instance.Process;
@@ -75,12 +81,12 @@ import org.camunda.bpm.model.cmmn.instance.Case;
  */
 public class DeployCmd implements Command<DeploymentWithDefinitions>, Serializable {
 
-  private final static CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
-  private final static TransactionLogger TX_LOG = ProcessEngineLogger.TX_LOGGER;
-
   private static final long serialVersionUID = 1L;
+  private static final CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
+  private static final TransactionLogger TX_LOG = ProcessEngineLogger.TX_LOGGER;
 
   protected DeploymentBuilderImpl deploymentBuilder;
+  protected DeploymentHandler deploymentHandler;
 
   public DeployCmd(DeploymentBuilderImpl deploymentBuilder) {
     this.deploymentBuilder = deploymentBuilder;
@@ -102,6 +108,12 @@ public class DeployCmd implements Command<DeploymentWithDefinitions>, Serializab
 
   protected DeploymentWithDefinitions doExecute(final CommandContext commandContext) {
     DeploymentManager deploymentManager = commandContext.getDeploymentManager();
+
+    // load deployment handler
+    ProcessEngine processEngine = commandContext.getProcessEngineConfiguration().getProcessEngine();
+    deploymentHandler = commandContext.getProcessEngineConfiguration()
+        .getDeploymentHandlerFactory()
+        .buildDeploymentHandler(processEngine);
 
     Set<String> deploymentIds = getAllDeploymentIds(deploymentBuilder);
     if (!deploymentIds.isEmpty()) {
@@ -131,33 +143,41 @@ public class DeployCmd implements Command<DeploymentWithDefinitions>, Serializab
       @Override
       public DeploymentWithDefinitions call() throws Exception {
         acquireExclusiveLock(commandContext);
-        DeploymentEntity deployment = initDeployment();
-        Map<String, ResourceEntity> resourcesToDeploy = resolveResourcesToDeploy(commandContext, deployment);
-        Map<String, ResourceEntity> resourcesToIgnore = new HashMap<String, ResourceEntity>(deployment.getResources());
-        resourcesToIgnore.keySet().removeAll(resourcesToDeploy.keySet());
+        DeploymentEntity deploymentToRegister = initDeployment();
+        Map<String, ResourceEntity> resourcesToDeploy =
+            resolveResourcesToDeploy(commandContext, deploymentToRegister);
 
+        // save initial deployment resources before they are replaced with only the deployed ones
+        CandidateDeployment candidateDeployment =
+            CandidateDeploymentImpl.fromDeploymentEntity(deploymentToRegister);
         if (!resourcesToDeploy.isEmpty()) {
           LOG.debugCreatingNewDeployment();
-          deployment.setResources(resourcesToDeploy);
-          deploy(deployment);
+          deploymentToRegister.setResources(resourcesToDeploy);
+          deploy(commandContext, deploymentToRegister);
         } else {
-          LOG.usingExistingDeployment();
-          deployment = getExistingDeployment(commandContext, deployment.getName());
+          // if there are no resources to be deployed, find an existing deployment
+          String duplicateDeploymentId =
+              deploymentHandler.determineDuplicateDeployment(candidateDeployment);
+          deploymentToRegister =
+              commandContext.getDeploymentManager().findDeploymentById(duplicateDeploymentId);
         }
 
-        scheduleProcessDefinitionActivation(commandContext, deployment);
+        scheduleProcessDefinitionActivation(commandContext, deploymentToRegister);
 
         if(deploymentBuilder instanceof ProcessApplicationDeploymentBuilder) {
-          // for process application deployments, job executor registration is managed by
-          // process application manager
-          Set<String> processesToRegisterFor = retrieveProcessKeysFromResources(resourcesToIgnore);
-          ProcessApplicationRegistration registration = registerProcessApplication(commandContext, deployment, processesToRegisterFor);
-          return new ProcessApplicationDeploymentImpl(deployment, registration);
+          // for process application deployments, job executor registration
+          // is managed by the ProcessApplicationManager
+          ProcessApplicationRegistration registration = registerProcessApplication(
+              commandContext,
+              deploymentToRegister,
+              candidateDeployment);
+
+          return new ProcessApplicationDeploymentImpl(deploymentToRegister, registration);
         } else {
-          registerWithJobExecutor(commandContext, deployment);
+          registerWithJobExecutor(commandContext, deploymentToRegister);
         }
 
-        return deployment;
+        return deploymentToRegister;
       }
     });
 
@@ -166,10 +186,163 @@ public class DeployCmd implements Command<DeploymentWithDefinitions>, Serializab
     return deployment;
   }
 
+  protected void acquireExclusiveLock(CommandContext commandContext) {
+    if (commandContext.getProcessEngineConfiguration().isDeploymentLockUsed()) {
+      // Acquire global exclusive lock: this ensures that there can be only one
+      // transaction in the cluster which is allowed to perform deployments.
+      // This is important to ensure that duplicate filtering works correctly
+      // in a multi-node cluster. See also https://app.camunda.com/jira/browse/CAM-2128
+
+      // It is also important to ensure the uniqueness of a process definition key,
+      // version and tenant-id since there is no database constraint to check it.
+
+      commandContext.getPropertyManager().acquireExclusiveLock();
+    } else {
+      LOG.warnDisabledDeploymentLock();
+    }
+  }
+
+  protected Map<String, ResourceEntity> resolveResourcesToDeploy(
+      CommandContext commandContext,
+      DeploymentEntity candidateDeployment) {
+
+    Map<String, ResourceEntity> resourcesToDeploy = new HashMap<>();
+    Map<String, ResourceEntity> candidateResources = candidateDeployment.getResources();
+
+    if (deploymentBuilder.isDuplicateFilterEnabled()) {
+
+      String source = candidateDeployment.getSource();
+      if (source == null || source.isEmpty()) {
+        source = ProcessApplicationDeployment.PROCESS_APPLICATION_DEPLOYMENT_SOURCE;
+      }
+
+      Map<String, ResourceEntity> existingResources = commandContext
+          .getResourceManager()
+          .findLatestResourcesByDeploymentName(
+              candidateDeployment.getName(),
+              candidateResources.keySet(),
+              source,
+              candidateDeployment.getTenantId());
+
+      for (ResourceEntity deployedResource : candidateResources.values()) {
+        String resourceName = deployedResource.getName();
+        ResourceEntity existingResource = existingResources.get(resourceName);
+
+        if (existingResource == null
+            || existingResource.isGenerated()
+            || deploymentHandler.shouldDeployResource(deployedResource, existingResource)) {
+
+          if (deploymentBuilder.isDeployChangedOnly()) {
+            // resource should be deployed
+            resourcesToDeploy.put(resourceName, deployedResource);
+          } else {
+            // all resources should be deployed
+            resourcesToDeploy = candidateResources;
+            break;
+          }
+        }
+      }
+
+    } else {
+      resourcesToDeploy = candidateResources;
+    }
+
+    return resourcesToDeploy;
+  }
+
+  protected void deploy(CommandContext commandContext, DeploymentEntity deployment) {
+    deployment.setNew(true);
+    commandContext.getDeploymentManager().insertDeployment(deployment);
+  }
+
+  protected void scheduleProcessDefinitionActivation(CommandContext commandContext,
+      DeploymentWithDefinitions deployment) {
+
+    if (deploymentBuilder.getProcessDefinitionsActivationDate() != null) {
+      RepositoryService repositoryService = commandContext.getProcessEngineConfiguration()
+          .getRepositoryService();
+
+      for (ProcessDefinition processDefinition: getDeployedProcesses(commandContext, deployment)) {
+
+        // If activation date is set, we first suspend all the process definition
+        repositoryService
+            .updateProcessDefinitionSuspensionState()
+            .byProcessDefinitionId(processDefinition.getId())
+            .suspend();
+
+        // And we schedule an activation at the provided date
+        repositoryService
+            .updateProcessDefinitionSuspensionState()
+            .byProcessDefinitionId(processDefinition.getId())
+            .executionDate(deploymentBuilder.getProcessDefinitionsActivationDate())
+            .activate();
+      }
+    }
+  }
+
+  protected ProcessApplicationRegistration registerProcessApplication(CommandContext commandContext,
+      DeploymentEntity deploymentToRegister,
+      CandidateDeployment candidateDeployment) {
+
+    ProcessApplicationDeploymentBuilderImpl appDeploymentBuilder = (ProcessApplicationDeploymentBuilderImpl) deploymentBuilder;
+    final ProcessApplicationReference appReference = appDeploymentBuilder.getProcessApplicationReference();
+
+    // build set of deployment ids this process app should be registered for:
+    Set<String> deploymentsToRegister = new HashSet<>(Collections.singleton(deploymentToRegister.getId()));
+    if (appDeploymentBuilder.isResumePreviousVersions()) {
+      String resumePreviousBy = appDeploymentBuilder.getResumePreviousVersionsBy();
+
+      switch (resumePreviousBy) {
+
+      case ResumePreviousBy.RESUME_BY_DEPLOYMENT_NAME:
+
+        deploymentsToRegister.addAll(deploymentHandler
+            .determineDeploymentsToResumeByDeploymentName(candidateDeployment));
+        break;
+
+      case ResumePreviousBy.RESUME_BY_PROCESS_DEFINITION_KEY:
+      default:
+
+        String[] processDefinitionKeys = getProcessDefinitionsFromResources(commandContext,
+            deploymentToRegister,
+            candidateDeployment);
+
+        // only determine deployments to resume if there are actual process definitions to look for
+        if (processDefinitionKeys.length > 0) {
+          deploymentsToRegister.addAll(deploymentHandler
+              .determineDeploymentsToResumeByProcessDefinitionKey(processDefinitionKeys));
+        }
+        break;
+      }
+    }
+
+    // register process application for deployments
+    return new RegisterProcessApplicationCmd(deploymentsToRegister, appReference).execute(commandContext);
+  }
+
+  protected void registerWithJobExecutor(CommandContext commandContext, Deployment deployment) {
+    try {
+      new RegisterDeploymentCmd(deployment.getId()).execute(commandContext);
+
+    } finally {
+      DeploymentFailListener listener = new DeploymentFailListener(deployment.getId(),
+          commandContext.getProcessEngineConfiguration().getCommandExecutorTxRequiresNew());
+
+      try {
+        commandContext.getTransactionContext().addTransactionListener(TransactionState.ROLLED_BACK, listener);
+      } catch (Exception e) {
+        TX_LOG.debugTransactionOperation("Could not register transaction synchronization. Probably the TX has already been rolled back by application code.");
+        listener.execute(commandContext);
+      }
+    }
+  }
+
+  // setters, initializers etc.
+
   protected void createUserOperationLog(DeploymentBuilderImpl deploymentBuilder, Deployment deployment, CommandContext commandContext) {
     UserOperationLogManager logManager = commandContext.getOperationLogManager();
 
-    List<PropertyChange> properties = new ArrayList<PropertyChange>();
+    List<PropertyChange> properties = new ArrayList<>();
 
     PropertyChange filterDuplicate = new PropertyChange("duplicateFilterEnabled", null, deploymentBuilder.isDuplicateFilterEnabled());
     properties.add(filterDuplicate);
@@ -182,85 +355,18 @@ public class DeployCmd implements Command<DeploymentWithDefinitions>, Serializab
     logManager.logDeploymentOperation(UserOperationLogEntry.OPERATION_TYPE_CREATE, deployment.getId(), properties);
   }
 
+  protected DeploymentEntity initDeployment() {
+    DeploymentEntity deployment = deploymentBuilder.getDeployment();
+    deployment.setDeploymentTime(ClockUtil.getCurrentTime());
+    return deployment;
+  }
+
   protected void setDeploymentName(String deploymentId, DeploymentBuilderImpl deploymentBuilder, CommandContext commandContext) {
     if (deploymentId != null && !deploymentId.isEmpty()) {
       DeploymentManager deploymentManager = commandContext.getDeploymentManager();
       DeploymentEntity deployment = deploymentManager.findDeploymentById(deploymentId);
       deploymentBuilder.getDeployment().setName(deployment.getName());
     }
-  }
-
-  protected List<ResourceEntity> getResources(final DeploymentBuilderImpl deploymentBuilder, final CommandContext commandContext) {
-    List<ResourceEntity> resources = new ArrayList<ResourceEntity>();
-
-    Set<String> deploymentIds = deploymentBuilder.getDeployments();
-    resources.addAll(getResourcesByDeploymentId(deploymentIds, commandContext));
-
-    Map<String, Set<String>> deploymentResourcesById = deploymentBuilder.getDeploymentResourcesById();
-    resources.addAll(getResourcesById(deploymentResourcesById, commandContext));
-
-    Map<String, Set<String>> deploymentResourcesByName = deploymentBuilder.getDeploymentResourcesByName();
-    resources.addAll(getResourcesByName(deploymentResourcesByName, commandContext));
-
-    checkDuplicateResourceName(resources);
-
-    return resources;
-  }
-
-  protected List<ResourceEntity> getResourcesByDeploymentId(Set<String> deploymentIds, CommandContext commandContext) {
-    List<ResourceEntity> result = new ArrayList<ResourceEntity>();
-
-    if (!deploymentIds.isEmpty()) {
-
-      DeploymentManager deploymentManager = commandContext.getDeploymentManager();
-
-      for (String deploymentId : deploymentIds) {
-        DeploymentEntity deployment = deploymentManager.findDeploymentById(deploymentId);
-        Map<String, ResourceEntity> resources = deployment.getResources();
-        Collection<ResourceEntity> values = resources.values();
-        result.addAll(values);
-      }
-    }
-
-    return result;
-  }
-
-  protected List<ResourceEntity> getResourcesById(Map<String, Set<String>> resourcesById, CommandContext commandContext) {
-    List<ResourceEntity> result = new ArrayList<ResourceEntity>();
-
-    ResourceManager resourceManager = commandContext.getResourceManager();
-
-    for (String deploymentId : resourcesById.keySet()) {
-      Set<String> resourceIds = resourcesById.get(deploymentId);
-
-      String[] resourceIdArray = resourceIds.toArray(new String[resourceIds.size()]);
-      List<ResourceEntity> resources = resourceManager.findResourceByDeploymentIdAndResourceIds(deploymentId, resourceIdArray);
-
-      ensureResourcesWithIdsExist(deploymentId, resourceIds, resources);
-
-      result.addAll(resources);
-    }
-
-    return result;
-  }
-
-  protected List<ResourceEntity> getResourcesByName(Map<String, Set<String>> resourcesByName, CommandContext commandContext) {
-    List<ResourceEntity> result = new ArrayList<ResourceEntity>();
-
-    ResourceManager resourceManager = commandContext.getResourceManager();
-
-    for (String deploymentId : resourcesByName.keySet()) {
-      Set<String> resourceNames = resourcesByName.get(deploymentId);
-
-      String[] resourceNameArray = resourceNames.toArray(new String[resourceNames.size()]);
-      List<ResourceEntity> resources = resourceManager.findResourceByDeploymentIdAndResourceNames(deploymentId, resourceNameArray);
-
-      ensureResourcesWithNamesExist(deploymentId, resourceNames, resources);
-
-      result.addAll(resources);
-    }
-
-    return result;
   }
 
   protected void addResources(List<ResourceEntity> resources, DeploymentBuilderImpl deploymentBuilder) {
@@ -283,8 +389,166 @@ public class DeployCmd implements Command<DeploymentWithDefinitions>, Serializab
     }
   }
 
+  // getters
+
+  protected List<String> getMissingElements(Set<String> expected, Map<String, ?> actual) {
+    List<String> missingElements = new ArrayList<>();
+    for (String value : expected) {
+      if (!actual.containsKey(value)) {
+        missingElements.add(value);
+      }
+    }
+    return missingElements;
+  }
+
+  protected List<ResourceEntity> getResources(final DeploymentBuilderImpl deploymentBuilder, final CommandContext commandContext) {
+    List<ResourceEntity> resources = new ArrayList<>();
+
+    Set<String> deploymentIds = deploymentBuilder.getDeployments();
+    resources.addAll(getResourcesByDeploymentId(deploymentIds, commandContext));
+
+    Map<String, Set<String>> deploymentResourcesById = deploymentBuilder.getDeploymentResourcesById();
+    resources.addAll(getResourcesById(deploymentResourcesById, commandContext));
+
+    Map<String, Set<String>> deploymentResourcesByName = deploymentBuilder.getDeploymentResourcesByName();
+    resources.addAll(getResourcesByName(deploymentResourcesByName, commandContext));
+
+    checkDuplicateResourceName(resources);
+
+    return resources;
+  }
+
+  protected List<ResourceEntity> getResourcesByDeploymentId(Set<String> deploymentIds, CommandContext commandContext) {
+    List<ResourceEntity> result = new ArrayList<>();
+
+    if (!deploymentIds.isEmpty()) {
+
+      DeploymentManager deploymentManager = commandContext.getDeploymentManager();
+
+      for (String deploymentId : deploymentIds) {
+        DeploymentEntity deployment = deploymentManager.findDeploymentById(deploymentId);
+        Map<String, ResourceEntity> resources = deployment.getResources();
+        Collection<ResourceEntity> values = resources.values();
+        result.addAll(values);
+      }
+    }
+
+    return result;
+  }
+
+  protected List<ResourceEntity> getResourcesById(Map<String, Set<String>> resourcesById, CommandContext commandContext) {
+    List<ResourceEntity> result = new ArrayList<>();
+
+    ResourceManager resourceManager = commandContext.getResourceManager();
+
+    for (String deploymentId : resourcesById.keySet()) {
+      Set<String> resourceIds = resourcesById.get(deploymentId);
+
+      String[] resourceIdArray = resourceIds.toArray(new String[resourceIds.size()]);
+      List<ResourceEntity> resources = resourceManager.findResourceByDeploymentIdAndResourceIds(deploymentId, resourceIdArray);
+
+      ensureResourcesWithIdsExist(deploymentId, resourceIds, resources);
+
+      result.addAll(resources);
+    }
+
+    return result;
+  }
+
+  protected List<ResourceEntity> getResourcesByName(Map<String, Set<String>> resourcesByName, CommandContext commandContext) {
+    List<ResourceEntity> result = new ArrayList<>();
+
+    ResourceManager resourceManager = commandContext.getResourceManager();
+
+    for (String deploymentId : resourcesByName.keySet()) {
+      Set<String> resourceNames = resourcesByName.get(deploymentId);
+
+      String[] resourceNameArray = resourceNames.toArray(new String[resourceNames.size()]);
+      List<ResourceEntity> resources = resourceManager.findResourceByDeploymentIdAndResourceNames(deploymentId, resourceNameArray);
+
+      ensureResourcesWithNamesExist(deploymentId, resourceNames, resources);
+
+      result.addAll(resources);
+    }
+
+    return result;
+  }
+
+  protected List<? extends ProcessDefinition> getDeployedProcesses(CommandContext commandContext, DeploymentWithDefinitions deployment) {
+    List<? extends ProcessDefinition> deployedProcessDefinitions = deployment.getDeployedProcessDefinitions();
+    if (deployedProcessDefinitions == null) {
+      // existing deployment
+      ProcessDefinitionManager manager = commandContext.getProcessDefinitionManager();
+      deployedProcessDefinitions = manager.findProcessDefinitionsByDeploymentId(deployment.getId());
+    }
+
+    return deployedProcessDefinitions;
+  }
+
+  protected String[] getProcessDefinitionsFromResources(CommandContext commandContext,
+      DeploymentEntity deploymentToRegister,
+      CandidateDeployment candidateDeployment) {
+
+    Set<String> processDefinitionKeys = new HashSet<>();
+
+    // get process definition keys for updated process definitions
+    for (ProcessDefinition processDefinition :
+        getDeployedProcesses(commandContext, deploymentToRegister)) {
+      if (processDefinition.getVersion() > 1) {
+        processDefinitionKeys.add(processDefinition.getKey());
+      }
+    }
+
+    // get process definition keys for already available process definitions
+    Map<String, Resource> candidateResources = candidateDeployment.getResources();
+    // and remove resources that are getting deployed, so that we don't do double checks
+    candidateResources.keySet().removeAll(deploymentToRegister.getResources().keySet());
+
+    for (Resource resource : candidateResources.values()) {
+      if (isBpmnResource(resource)) {
+
+        ByteArrayInputStream byteStream = new ByteArrayInputStream(resource.getBytes());
+        BpmnModelInstance model = Bpmn.readModelFromStream(byteStream);
+        for (Process process : model.getDefinitions().getChildElementsByType(Process.class)) {
+          processDefinitionKeys.add(process.getId());
+        }
+      } else if (isCmmnResource(resource)) {
+
+        ByteArrayInputStream byteStream = new ByteArrayInputStream(resource.getBytes());
+        CmmnModelInstance model = Cmmn.readModelFromStream(byteStream);
+        for (Case cmmnCase : model.getDefinitions().getCases()) {
+          processDefinitionKeys.add(cmmnCase.getId());
+        }
+      }
+    }
+
+    return processDefinitionKeys.toArray(new String[processDefinitionKeys.size()]);
+  }
+
+  protected Set<String> getAllDeploymentIds(DeploymentBuilderImpl deploymentBuilder) {
+    Set<String> result = new HashSet<>();
+
+    String nameFromDeployment = deploymentBuilder.getNameFromDeployment();
+    if (nameFromDeployment != null && !nameFromDeployment.isEmpty()) {
+      result.add(nameFromDeployment);
+    }
+
+    Set<String> deployments = deploymentBuilder.getDeployments();
+    result.addAll(deployments);
+
+    deployments = deploymentBuilder.getDeploymentResourcesById().keySet();
+    result.addAll(deployments);
+
+    deployments = deploymentBuilder.getDeploymentResourcesByName().keySet();
+    result.addAll(deployments);
+
+    return result;
+  }
+
+  // checkers
+
   protected void checkDuplicateResourceName(List<ResourceEntity> resources) {
-    Map<String, ResourceEntity> resourceMap = new HashMap<String, ResourceEntity>();
+    Map<String, ResourceEntity> resourceMap = new HashMap<>();
 
     for (ResourceEntity resource : resources) {
       String name = resource.getName();
@@ -301,8 +565,27 @@ public class DeployCmd implements Command<DeploymentWithDefinitions>, Serializab
     }
   }
 
+  protected void checkCreateAndReadDeployments(CommandContext commandContext, Set<String> deploymentIds) {
+    for(CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+      checker.checkCreateDeployment();
+      for (String deploymentId : deploymentIds) {
+        checker.checkReadDeployment(deploymentId);
+      }
+    }
+  }
+
+  protected boolean isBpmnResource(Resource resourceEntity) {
+    return StringUtil.hasAnySuffix(resourceEntity.getName(), BpmnDeployer.BPMN_RESOURCE_SUFFIXES);
+  }
+
+  protected boolean isCmmnResource(Resource resourceEntity) {
+    return StringUtil.hasAnySuffix(resourceEntity.getName(), CmmnDeployer.CMMN_RESOURCE_SUFFIXES);
+  }
+
+  // ensures
+
   protected void ensureDeploymentsWithIdsExists(Set<String> expected, List<DeploymentEntity> actual) {
-    Map<String, DeploymentEntity> deploymentMap = new HashMap<String, DeploymentEntity>();
+    Map<String, DeploymentEntity> deploymentMap = new HashMap<>();
     for (DeploymentEntity deployment : actual) {
       deploymentMap.put(deployment.getId(), deployment);
     }
@@ -329,7 +612,7 @@ public class DeployCmd implements Command<DeploymentWithDefinitions>, Serializab
   }
 
   protected void ensureResourcesWithIdsExist(String deploymentId, Set<String> expectedIds, List<ResourceEntity> actual) {
-    Map<String, ResourceEntity> resources = new HashMap<String, ResourceEntity>();
+    Map<String, ResourceEntity> resources = new HashMap<>();
     for (ResourceEntity resource : actual) {
       resources.put(resource.getId(), resource);
     }
@@ -337,7 +620,7 @@ public class DeployCmd implements Command<DeploymentWithDefinitions>, Serializab
   }
 
   protected void ensureResourcesWithNamesExist(String deploymentId, Set<String> expectedNames, List<ResourceEntity> actual) {
-    Map<String, ResourceEntity> resources = new HashMap<String, ResourceEntity>();
+    Map<String, ResourceEntity> resources = new HashMap<>();
     for (ResourceEntity resource : actual) {
       resources.put(resource.getName(), resource);
     }
@@ -367,290 +650,6 @@ public class DeployCmd implements Command<DeploymentWithDefinitions>, Serializab
       }
 
       throw new NotFoundException(builder.toString());
-    }
-  }
-
-  protected List<String> getMissingElements(Set<String> expected, Map<String, ?> actual) {
-    List<String> missingElements = new ArrayList<String>();
-    for (String value : expected) {
-      if (!actual.containsKey(value)) {
-        missingElements.add(value);
-      }
-    }
-    return missingElements;
-  }
-
-  protected Set<String> getAllDeploymentIds(DeploymentBuilderImpl deploymentBuilder) {
-    Set<String> result = new HashSet<String>();
-
-    String nameFromDeployment = deploymentBuilder.getNameFromDeployment();
-    if (nameFromDeployment != null && !nameFromDeployment.isEmpty()) {
-      result.add(nameFromDeployment);
-    }
-
-    Set<String> deployments = deploymentBuilder.getDeployments();
-    result.addAll(deployments);
-
-    deployments = deploymentBuilder.getDeploymentResourcesById().keySet();
-    result.addAll(deployments);
-
-    deployments = deploymentBuilder.getDeploymentResourcesByName().keySet();
-    result.addAll(deployments);
-
-    return result;
-  }
-
-  protected void checkCreateAndReadDeployments(CommandContext commandContext, Set<String> deploymentIds) {
-      for(CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
-        checker.checkCreateDeployment();
-        for (String deploymentId : deploymentIds) {
-          checker.checkReadDeployment(deploymentId);
-        }
-      }
-  }
-
-  protected void acquireExclusiveLock(CommandContext commandContext) {
-    if (Context.getProcessEngineConfiguration().isDeploymentLockUsed()) {
-      // Acquire global exclusive lock: this ensures that there can be only one
-      // transaction in the cluster which is allowed to perform deployments.
-      // This is important to ensure that duplicate filtering works correctly
-      // in a multi-node cluster. See also https://app.camunda.com/jira/browse/CAM-2128
-
-      // It is also important to ensure the uniqueness of a process definition key,
-      // version and tenant-id since there is no database constraint to check it.
-
-      commandContext.getPropertyManager().acquireExclusiveLock();
-    } else {
-      LOG.warnDisabledDeploymentLock();
-    }
-  }
-
-  protected DeploymentEntity initDeployment() {
-    DeploymentEntity deployment = deploymentBuilder.getDeployment();
-    deployment.setDeploymentTime(ClockUtil.getCurrentTime());
-    return deployment;
-  }
-
-  protected Map<String, ResourceEntity> resolveResourcesToDeploy(CommandContext commandContext, DeploymentEntity deployment) {
-    Map<String, ResourceEntity> resourcesToDeploy = new HashMap<String, ResourceEntity>();
-    Map<String, ResourceEntity> containedResources = deployment.getResources();
-
-    if (deploymentBuilder.isDuplicateFilterEnabled()) {
-
-      String source = deployment.getSource();
-      if (source == null || source.isEmpty()) {
-        source = ProcessApplicationDeployment.PROCESS_APPLICATION_DEPLOYMENT_SOURCE;
-      }
-
-      Map<String, ResourceEntity> existingResources = commandContext
-          .getResourceManager()
-          .findLatestResourcesByDeploymentName(deployment.getName(), containedResources.keySet(), source, deployment.getTenantId());
-
-      for (ResourceEntity deployedResource : containedResources.values()) {
-        String resourceName = deployedResource.getName();
-        ResourceEntity existingResource = existingResources.get(resourceName);
-
-        if (existingResource == null
-            || existingResource.isGenerated()
-            || resourcesDiffer(deployedResource, existingResource)) {
-          // resource should be deployed
-
-          if (deploymentBuilder.isDeployChangedOnly()) {
-            resourcesToDeploy.put(resourceName, deployedResource);
-          } else {
-            // all resources should be deployed
-            resourcesToDeploy = containedResources;
-            break;
-          }
-        }
-      }
-
-    } else {
-      resourcesToDeploy = containedResources;
-    }
-
-    return resourcesToDeploy;
-  }
-
-  protected boolean resourcesDiffer(ResourceEntity resource, ResourceEntity existing) {
-    byte[] bytes = resource.getBytes();
-    byte[] savedBytes = existing.getBytes();
-    return !Arrays.equals(bytes, savedBytes);
-  }
-
-  protected void deploy(DeploymentEntity deployment) {
-    deployment.setNew(true);
-    Context
-      .getCommandContext()
-      .getDeploymentManager()
-      .insertDeployment(deployment);
-  }
-
-  protected DeploymentEntity getExistingDeployment(CommandContext commandContext, String deploymentName) {
-    return commandContext
-        .getDeploymentManager()
-        .findLatestDeploymentByName(deploymentName);
-  }
-
-  protected void scheduleProcessDefinitionActivation(CommandContext commandContext, DeploymentEntity deployment) {
-    if (deploymentBuilder.getProcessDefinitionsActivationDate() != null) {
-      RepositoryService repositoryService = commandContext.getProcessEngineConfiguration().getRepositoryService();
-
-      for (ProcessDefinition processDefinition: deployment.getDeployedProcessDefinitions()) {
-
-        // If activation date is set, we first suspend all the process definition
-        repositoryService
-          .updateProcessDefinitionSuspensionState()
-          .byProcessDefinitionId(processDefinition.getId())
-          .suspend();
-
-        // And we schedule an activation at the provided date
-        repositoryService
-          .updateProcessDefinitionSuspensionState()
-          .byProcessDefinitionId(processDefinition.getId())
-          .executionDate(deploymentBuilder.getProcessDefinitionsActivationDate())
-          .activate();
-      }
-    }
-  }
-
-  protected ProcessApplicationRegistration registerProcessApplication(CommandContext commandContext, DeploymentEntity deployment,
-      Set<String> processKeysToRegisterFor) {
-    ProcessApplicationDeploymentBuilderImpl appDeploymentBuilder = (ProcessApplicationDeploymentBuilderImpl) deploymentBuilder;
-    final ProcessApplicationReference appReference = appDeploymentBuilder.getProcessApplicationReference();
-
-    // build set of deployment ids this process app should be registered for:
-    Set<String> deploymentsToRegister = new HashSet<String>(Collections.singleton(deployment.getId()));
-
-    if (appDeploymentBuilder.isResumePreviousVersions()) {
-      if (ResumePreviousBy.RESUME_BY_PROCESS_DEFINITION_KEY.equals(appDeploymentBuilder.getResumePreviousVersionsBy())) {
-        deploymentsToRegister.addAll(resumePreviousByProcessDefinitionKey(commandContext, deployment, processKeysToRegisterFor));
-      }else if(ResumePreviousBy.RESUME_BY_DEPLOYMENT_NAME.equals(appDeploymentBuilder.getResumePreviousVersionsBy())){
-        deploymentsToRegister.addAll(resumePreviousByDeploymentName(commandContext, deployment));
-      }
-    }
-
-    // register process application for deployments
-    return new RegisterProcessApplicationCmd(deploymentsToRegister, appReference).execute(commandContext);
-
-  }
-
-  /**
-   * Searches in previous deployments for the same processes and retrieves the deployment ids.
-   *
-   * @param commandContext
-   * @param deployment
-   *          the current deployment
-   * @param processKeysToRegisterFor
-   *          the process keys this process application wants to register
-   * @param deployment
-   *          the set where to add further deployments this process application
-   *          should be registered for
-   * @return a set of deployment ids that contain versions of the
-   *         processKeysToRegisterFor
-   */
-  protected Set<String> resumePreviousByProcessDefinitionKey(CommandContext commandContext, DeploymentEntity deployment, Set<String> processKeysToRegisterFor) {
-    Set<String> processDefinitionKeys = new HashSet<String>(processKeysToRegisterFor);
-
-    List<? extends ProcessDefinition> deployedProcesses = getDeployedProcesses(deployment);
-    for (ProcessDefinition deployedProcess : deployedProcesses) {
-      if (deployedProcess.getVersion() > 1) {
-        processDefinitionKeys.add(deployedProcess.getKey());
-      }
-    }
-
-    return findDeploymentIdsForProcessDefinitions(commandContext, processDefinitionKeys);
-  }
-
-  /**
-   * Searches for previous deployments with the same name.
-   * @param commandContext
-   * @param deployment the current deployment
-   * @return a set of deployment ids
-   */
-  protected Set<String> resumePreviousByDeploymentName(CommandContext commandContext, DeploymentEntity deployment) {
-    List<Deployment> previousDeployments = new DeploymentQueryImpl().deploymentName(deployment.getName()).list();
-    Set<String> deploymentIds = new HashSet<String>(previousDeployments.size());
-    for (Deployment d : previousDeployments) {
-      deploymentIds.add(d.getId());
-    }
-    return deploymentIds;
-  }
-
-  protected List<? extends ProcessDefinition> getDeployedProcesses(DeploymentEntity deployment) {
-    List<? extends ProcessDefinition> deployedProcessDefinitions = deployment.getDeployedProcessDefinitions();
-    if (deployedProcessDefinitions == null) {
-      // existing deployment
-      CommandContext commandContext = Context.getCommandContext();
-      ProcessDefinitionManager manager = commandContext.getProcessDefinitionManager();
-      deployedProcessDefinitions = manager.findProcessDefinitionsByDeploymentId(deployment.getId());
-    }
-
-    return deployedProcessDefinitions;
-  }
-
-  protected Set<String> retrieveProcessKeysFromResources(Map<String, ResourceEntity> resources) {
-    Set<String> keys = new HashSet<String>();
-
-    for (ResourceEntity resource : resources.values()) {
-      if (isBpmnResource(resource)) {
-
-        ByteArrayInputStream byteStream = new ByteArrayInputStream(resource.getBytes());
-        BpmnModelInstance model = Bpmn.readModelFromStream(byteStream);
-        for (Process process : model.getDefinitions().getChildElementsByType(Process.class)) {
-          keys.add(process.getId());
-        }
-      } else if (isCmmnResource(resource)) {
-
-        ByteArrayInputStream byteStream = new ByteArrayInputStream(resource.getBytes());
-        CmmnModelInstance model = Cmmn.readModelFromStream(byteStream);
-        for (Case cmmnCase : model.getDefinitions().getCases()) {
-          keys.add(cmmnCase.getId());
-        }
-      }
-    }
-
-    return keys;
-  }
-
-  protected boolean isBpmnResource(ResourceEntity resourceEntity) {
-    return StringUtil.hasAnySuffix(resourceEntity.getName(), BpmnDeployer.BPMN_RESOURCE_SUFFIXES);
-  }
-
-  protected boolean isCmmnResource(ResourceEntity resourceEntity) {
-    return StringUtil.hasAnySuffix(resourceEntity.getName(), CmmnDeployer.CMMN_RESOURCE_SUFFIXES);
-  }
-
-  protected Set<String> findDeploymentIdsForProcessDefinitions(CommandContext commandContext, Set<String> processDefinitionKeys) {
-    Set<String> deploymentsToRegister = new HashSet<String>();
-
-    if (!processDefinitionKeys.isEmpty()) {
-
-      String[] keys = processDefinitionKeys.toArray(new String[processDefinitionKeys.size()]);
-      ProcessDefinitionManager processDefinitionManager = commandContext.getProcessDefinitionManager();
-      List<ProcessDefinition> previousDefinitions = processDefinitionManager.findProcessDefinitionsByKeyIn(keys);
-
-      for (ProcessDefinition definition : previousDefinitions) {
-        deploymentsToRegister.add(definition.getDeploymentId());
-      }
-    }
-    return deploymentsToRegister;
-  }
-
-  protected void registerWithJobExecutor(CommandContext commandContext, DeploymentEntity deployment) {
-    try {
-      new RegisterDeploymentCmd(deployment.getId()).execute(commandContext);
-
-    } finally {
-      DeploymentFailListener listener = new DeploymentFailListener(deployment.getId(),
-        Context.getProcessEngineConfiguration().getCommandExecutorTxRequiresNew());
-
-      try {
-        commandContext.getTransactionContext().addTransactionListener(TransactionState.ROLLED_BACK, listener);
-      } catch (Exception e) {
-        TX_LOG.debugTransactionOperation("Could not register transaction synchronization. Probably the TX has already been rolled back by application code.");
-        listener.execute(commandContext);
-      }
     }
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/DeploymentEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/DeploymentEntity.java
@@ -60,7 +60,7 @@ public class DeploymentEntity implements Serializable, DeploymentWithDefinitions
 
   public void addResource(ResourceEntity resource) {
     if (resources==null) {
-      resources = new HashMap<String, ResourceEntity>();
+      resources = new HashMap<>();
     }
     resources.put(resource.getName(), resource);
   }
@@ -78,7 +78,7 @@ public class DeploymentEntity implements Serializable, DeploymentWithDefinitions
         .getCommandContext()
         .getResourceManager()
         .findResourcesByDeploymentId(id);
-      resources = new HashMap<String, ResourceEntity>();
+      resources = new HashMap<>();
       for (ResourceEntity resource: resourcesList) {
         resources.put(resource.getName(), resource);
       }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/repository/CandidateDeploymentImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/repository/CandidateDeploymentImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.repository;
+
+import org.camunda.bpm.engine.impl.persistence.entity.DeploymentEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.ResourceEntity;
+import org.camunda.bpm.engine.repository.CandidateDeployment;
+import org.camunda.bpm.engine.repository.Resource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CandidateDeploymentImpl implements CandidateDeployment {
+
+  protected String name;
+  protected Map<String, Resource> resources;
+
+  public CandidateDeploymentImpl(String name, Map<String, Resource> resources) {
+    this.name = name;
+    this.resources = resources;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public Map<String, Resource> getResources() {
+    return resources;
+  }
+
+  public void setResources(Map<String, Resource> resources) {
+    this.resources = resources;
+  }
+
+  public static CandidateDeploymentImpl fromDeploymentEntity(DeploymentEntity deploymentEntity) {
+    // first cast ResourceEntity map to Resource
+    Map<String, Resource> resources = new HashMap<>((Map<String, ? extends Resource>) deploymentEntity.getResources());
+    return new CandidateDeploymentImpl(deploymentEntity.getName(), resources);
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/repository/DefaultDeploymentHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/repository/DefaultDeploymentHandler.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.repository;
+
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.RepositoryService;
+import org.camunda.bpm.engine.impl.context.Context;
+import org.camunda.bpm.engine.repository.CandidateDeployment;
+import org.camunda.bpm.engine.repository.Deployment;
+import org.camunda.bpm.engine.repository.DeploymentHandler;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.engine.repository.Resource;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class DefaultDeploymentHandler implements DeploymentHandler {
+
+  protected ProcessEngine processEngine;
+  protected RepositoryService repositoryService;
+
+  public DefaultDeploymentHandler(ProcessEngine processEngine) {
+    this.processEngine = processEngine;
+    this.repositoryService = processEngine.getRepositoryService();
+  }
+
+  @Override
+  public boolean shouldDeployResource(Resource newResource, Resource existingResource) {
+    return resourcesDiffer(newResource, existingResource);
+  }
+
+  @Override
+  public String determineDuplicateDeployment(CandidateDeployment candidateDeployment) {
+    return Context.getCommandContext()
+        .getDeploymentManager()
+        .findLatestDeploymentByName(candidateDeployment.getName())
+        .getId();
+  }
+
+  @Override
+  public Set<String> determineDeploymentsToResumeByProcessDefinitionKey(
+      String[] processDefinitionKeys) {
+
+    Set<String> deploymentIds = new HashSet<>();
+    List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery()
+        .processDefinitionKeysIn(processDefinitionKeys).list();
+    for (ProcessDefinition processDefinition : processDefinitions) {
+      deploymentIds.add(processDefinition.getDeploymentId());
+    }
+
+    return deploymentIds;
+  }
+
+  @Override
+  public Set<String> determineDeploymentsToResumeByDeploymentName(CandidateDeployment candidateDeployment) {
+
+    List<Deployment> previousDeployments = processEngine.getRepositoryService()
+        .createDeploymentQuery()
+        .deploymentName(candidateDeployment.getName())
+        .list();
+
+    Set<String> deploymentIds = new HashSet<>();
+    for (Deployment deployment : previousDeployments) {
+      deploymentIds.add(deployment.getId());
+    }
+
+    return deploymentIds;
+  }
+
+  protected boolean resourcesDiffer(Resource resource, Resource existing) {
+    byte[] bytes = resource.getBytes();
+    byte[] savedBytes = existing.getBytes();
+    return !Arrays.equals(bytes, savedBytes);
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/repository/DefaultDeploymentHandlerFactory.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/repository/DefaultDeploymentHandlerFactory.java
@@ -14,20 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.camunda.bpm.engine.repository;
+package org.camunda.bpm.engine.impl.repository;
 
-/**
- * @author kristin.polenz@camunda.com
- */
-public interface Resource {
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.repository.DeploymentHandler;
+import org.camunda.bpm.engine.repository.DeploymentHandlerFactory;
 
 
-  String getId();
+public class DefaultDeploymentHandlerFactory implements DeploymentHandlerFactory {
 
-  String getName();
-
-  String getDeploymentId();
-
-  byte[] getBytes();
-
+  @Override
+  public DeploymentHandler buildDeploymentHandler(ProcessEngine processEngine) {
+    return new DefaultDeploymentHandler(processEngine);
+  }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/repository/CandidateDeployment.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/repository/CandidateDeployment.java
@@ -16,18 +16,18 @@
  */
 package org.camunda.bpm.engine.repository;
 
-/**
- * @author kristin.polenz@camunda.com
- */
-public interface Resource {
+import java.util.Map;
 
 
-  String getId();
+public interface  CandidateDeployment {
 
+  /**
+   * @return the name to be used for the deployment
+   */
   String getName();
 
-  String getDeploymentId();
-
-  byte[] getBytes();
-
+  /**
+   * @return a map of all the resources provided for deployment
+   */
+  Map<String, Resource> getResources();
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/repository/DeploymentHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/repository/DeploymentHandler.java
@@ -96,19 +96,15 @@ public interface DeploymentHandler {
    * @param processDefinitionKeys are the Process Definition Keys of a subset of Process Resources
    *                              provided for deployment. The subset includes Process Definition
    *                              Keys from:
-   *                              <li>
-   *                                <ul>
-   *                                  Processes from Resources that will not be deployed to the
+   *                              <ul>
+   *                              <li>Processes from Resources that will not be deployed to the
    *                                  Process Engine database due to the outcome of the
-   *                                  {@link #shouldDeployResource(Resource, Resource)} method.
-   *                                </ul>
-   *                                <ul>
-   *                                  Processes from Resources that will be deployed to the Process
+   *                                  {@link #shouldDeployResource(Resource, Resource)} method.</li>
+   *                              <li>Processes from Resources that will be deployed to the Process
    *                                  Engine database, that update an existing Process Definition,
    *                                  i.e. there is a Process Definition with the same key present
-   *                                  in the Process Engine database.
-   *                                </ul>
-   *                              </li>
+   *                                  in the Process Engine database.</li>
+   *                              </ul>
    *                              It should be noted that, if {@link #shouldDeployResource(Resource, Resource)}
    *                              determines that all of the provided resources should be deployed
    *                              to the database, and there are no Process Definitions with the

--- a/engine/src/main/java/org/camunda/bpm/engine/repository/DeploymentHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/repository/DeploymentHandler.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.repository;
+
+import java.util.Set;
+
+/**
+ * <p>The {@link DeploymentHandler} interface should be implemented when there is a need to
+ * define a custom behavior for determining what Resources should be added to a new Deployment.</p>
+ *
+ * <p>The class that implements this interface must provide a Process Engine parameter in it's
+ * constructor. Custom implementations of this interface should be coupled with an implementation
+ * of the {@link DeploymentHandlerFactory} interface, which can then be wired to the Process Engine
+ * through the
+ * {@link org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl#setDeploymentHandlerFactory(DeploymentHandlerFactory)}
+ * method.</p>
+ *
+ * <p>See {@link org.camunda.bpm.engine.impl.repository.DefaultDeploymentHandler} for the default
+ * behavior of the deployment process.</p>
+ */
+public interface DeploymentHandler {
+
+  /**
+   * <p>This method is called in the first stage of the deployment process. It determines if there
+   * is a difference between a {@link Resource} that is included in the set of resources provided
+   * for deployment, and a Resource of the same name, already deployed to the Process Engine
+   * with a previous Deployment. The method will be called for every (new, existing) Resource
+   * pair. If a Resource of the same name doesn't exist in the Process Engine database, the new
+   * Resource is deployed by default and this method is not called.</p>
+   *
+   * <p>An implementation should define the comparison criteria for the two provided
+   * Resources. For the default comparison criteria, see
+   * {@link org.camunda.bpm.engine.impl.repository.DefaultDeploymentHandler#shouldDeployResource(Resource, Resource)}.</p>
+   *
+   * <p>The output of this method (Boolean) will determine if <code>newResource</code> is
+   * included in the list of Resources to be deployed (true), or not (false).</p>
+   *
+   * @param newResource      is a resource that is part of the new Deployment.
+   * @param existingResource is the most recently deployed resource that has the same resource name.
+   * @return <code>true</code>, if the new Resource satisfies the comparison criteria, or
+   * <code>false</code> if not.
+   */
+  boolean shouldDeployResource(Resource newResource, Resource existingResource);
+
+  /**
+   * <p>This method is called in the second stage of the deployment process, when the previously
+   * called {@link #shouldDeployResource(Resource, Resource)} method determines that none of the
+   * provided resources for deployment satisfy the comparison criteria, i.e. there are no new
+   * Resources to deploy. This method then determines a {@link Deployment} already present in the
+   * Process Engine database that is a duplicate of the new Deployment.</p>
+   *
+   * <p>An implementation should determine what defines a duplicate Deployment.</p>
+   *
+   * <p>The returned Deployment ID (String) will be used to retrieve the corresponding
+   * Deployment from the Process Engine database. This Deployment will then be registered
+   * with the JobExecutor and the Process Application (if a Process Application Deployment is
+   * performed). Furthermore, any Process Definitions that this Deployment contains will be
+   * scheduled for activation, if a Process Definition Activation Date was set.</p>
+   *
+   * @param candidateDeployment a wrapper for the set of Resources provided for deployment and the
+   *                            name under which they should have been deployed. At this stage,
+   *                            it should be assumed that all of the Resources of this set didn't
+   *                            satisfy the comparison criteria and will not be deployed.
+   * @return the Deployment ID of the Deployment determined to be a duplicate of the data
+   * provided by the <code>candidateDeployment</code>.
+   */
+  String determineDuplicateDeployment(CandidateDeployment candidateDeployment);
+
+  /**
+   * <p>This method is called in the last stage of the deployment process, if a Process Application
+   * deployment is performed. An additional condition is that the
+   * {@link ProcessApplicationDeploymentBuilder#resumePreviousVersions()} flag of the Process
+   * Application Deployment Builder is set, and
+   * {@link ProcessApplicationDeploymentBuilder#resumePreviousVersionsBy(String)} ()} is set to the
+   * default, {@link ResumePreviousBy#RESUME_BY_PROCESS_DEFINITION_KEY} value.</p>
+   *
+   * <p>The implementation of this method determines a {@link Set} of Deployment IDs of Deployments
+   * already present in the Process Engine database. These deployments will then be registered
+   * with the Process Application, so that any Java classes that the Process Application provides
+   * can be utilised by the Process Definitions of the Deployments.</p>
+   *
+   * @param processDefinitionKeys are the Process Definition Keys of a subset of Process Resources
+   *                              provided for deployment. The subset includes Process Definition
+   *                              Keys from:
+   *                              <li>
+   *                                <ul>
+   *                                  Processes from Resources that will not be deployed to the
+   *                                  Process Engine database due to the outcome of the
+   *                                  {@link #shouldDeployResource(Resource, Resource)} method.
+   *                                </ul>
+   *                                <ul>
+   *                                  Processes from Resources that will be deployed to the Process
+   *                                  Engine database, that update an existing Process Definition,
+   *                                  i.e. there is a Process Definition with the same key present
+   *                                  in the Process Engine database.
+   *                                </ul>
+   *                              </li>
+   *                              It should be noted that, if {@link #shouldDeployResource(Resource, Resource)}
+   *                              determines that all of the provided resources should be deployed
+   *                              to the database, and there are no Process Definitions with the
+   *                              same key already present in the database (i.e. the Process
+   *                              Resources are completely new), this method will not be called.
+   *
+   * @return a {@link Set} of deployment IDs of Deployments already present in the Process Engine
+   * database, that should be resumed (registered with the
+   * {@link org.camunda.bpm.engine.impl.jobexecutor.JobExecutor} and registered with the newly
+   * deployed Process Application).
+   */
+  Set<String> determineDeploymentsToResumeByProcessDefinitionKey(String[] processDefinitionKeys);
+
+  /**
+   * <p>This method is called in the last stage of the deployment process, if a Process Application
+   * deployment is performed. An additional condition is that the
+   * {@link ProcessApplicationDeploymentBuilder#resumePreviousVersions()} flag of the Process
+   * Application Deployment Builder is set, and
+   * {@link ProcessApplicationDeploymentBuilder#resumePreviousVersionsBy(String)} ()} is set to the
+   * {@link ResumePreviousBy#RESUME_BY_DEPLOYMENT_NAME} value.</p>
+   *
+   * <p>The implementation of this method should determine a set of Deployment IDs of Deployments
+   * with the same name, that are already present in the Process Engine database.</p>
+   *
+   * @param candidateDeployment a wrapper for the set of resources that were provided for
+   *                            deployment and the name that should be used for this deployment.
+   *                            This information can be used to find any Deployments of the same
+   *                            name already present in the Process Engine database. The set of
+   *                            Resources can then be used, if needed, to filter out the resulting
+   *                            Deployments according to a given criteria.
+   * @return a {@link Set} of deployment IDs of Deployments already present in the Process Engine
+   * database, that should be resumed (registered with the
+   * {@link org.camunda.bpm.engine.impl.jobexecutor.JobExecutor} and registered with the newly
+   * deployed Process Application).
+   */
+  Set<String> determineDeploymentsToResumeByDeploymentName(CandidateDeployment candidateDeployment);
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/repository/DeploymentHandlerFactory.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/repository/DeploymentHandlerFactory.java
@@ -16,18 +16,19 @@
  */
 package org.camunda.bpm.engine.repository;
 
+import org.camunda.bpm.engine.ProcessEngine;
+
 /**
- * @author kristin.polenz@camunda.com
+ * <p>Builds the {@link DeploymentHandler} for determining of the deployment process for the
+ * Process Engine.</p>
  */
-public interface Resource {
+public interface DeploymentHandlerFactory {
 
-
-  String getId();
-
-  String getName();
-
-  String getDeploymentId();
-
-  byte[] getBytes();
-
+  /**
+   * Creates a {@link DeploymentHandler} instance.
+   *
+   * @param processEngine is the {@link ProcessEngine} where the Deployment is deployed to.
+   * @return the {@link DeploymentHandler} implementation.
+   */
+  DeploymentHandler buildDeploymentHandler(ProcessEngine processEngine);
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/cfg/DatabaseTablePrefixTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/cfg/DatabaseTablePrefixTest.java
@@ -110,7 +110,8 @@ public class DatabaseTablePrefixTest {
     @Override
     public ProcessEngine buildProcessEngine() {
       init();
-      return new NoSchemaProcessEngineImpl(this);
+      processEngine =  new NoSchemaProcessEngineImpl(this);
+      return processEngine;
     }
 
     class NoSchemaProcessEngineImpl extends ProcessEngineImpl {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.java
@@ -30,14 +30,13 @@ import org.camunda.bpm.engine.impl.pvm.ReadOnlyProcessDefinition;
 import org.camunda.bpm.engine.impl.test.PluggableProcessEngineTestCase;
 import org.camunda.bpm.engine.impl.util.IoUtil;
 import org.camunda.bpm.engine.impl.util.ReflectUtil;
-import org.camunda.bpm.engine.repository.CaseDefinition;
+import org.camunda.bpm.engine.repository.DeploymentHandlerFactory;
 import org.camunda.bpm.engine.repository.DeploymentWithDefinitions;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.camunda.bpm.engine.repository.Resource;
 import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.Test;
 
 
 /**
@@ -45,6 +44,23 @@ import org.junit.Test;
  * @author Thorben Lindhauer
  */
 public class BpmnDeploymentTest extends PluggableProcessEngineTestCase {
+
+  DeploymentHandlerFactory defaultDeploymentHandlerFactory;
+  DeploymentHandlerFactory customDeploymentHandlerFactory;
+
+  @Override
+  protected void setUp() throws Exception {
+    defaultDeploymentHandlerFactory = processEngineConfiguration.getDeploymentHandlerFactory();
+    customDeploymentHandlerFactory = new VersionedDeploymentHandlerFactory();
+
+    super.setUp();
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    processEngineConfiguration.setDeploymentHandlerFactory(defaultDeploymentHandlerFactory);
+    super.tearDown();
+  }
 
   @Deployment
   public void testGetBpmnXmlFileThroughService() {
@@ -110,6 +126,66 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTestCase {
     assertEquals(1, deploymentList.size());
 
     repositoryService.deleteDeployment(deploymentId);
+  }
+
+  public void testDuplicateFilteringDefaultBehavior() {
+    // given
+    BpmnModelInstance oldModel = Bpmn.createExecutableProcess("versionedProcess")
+      .camundaVersionTag("3").done();
+    BpmnModelInstance newModel = Bpmn.createExecutableProcess("versionedProcess")
+      .camundaVersionTag("1").done();
+
+    deploymentIds.add(repositoryService.createDeployment()
+      .enableDuplicateFiltering(true)
+      .addModelInstance("model", oldModel)
+      .name("defaultDeploymentHandling")
+      .deploy().getId());
+
+    // when
+    deploymentIds.add(repositoryService.createDeployment()
+      .enableDuplicateFiltering(true)
+      .addModelInstance("model", newModel)
+      .name("defaultDeploymentHandling")
+      .deploy().getId());
+
+    // then
+    long deploymentCount = repositoryService.createDeploymentQuery().count();
+    assertEquals(2, deploymentCount);
+  }
+
+  public void testDuplicateFilteringCustomBehavior() {
+    // given
+    processEngineConfiguration.setDeploymentHandlerFactory(customDeploymentHandlerFactory);
+    BpmnModelInstance oldModel = Bpmn.createExecutableProcess("versionedProcess")
+      .camundaVersionTag("1").done();
+    BpmnModelInstance newModel = Bpmn.createExecutableProcess("versionedProcess")
+      .camundaVersionTag("2").done();
+
+    org.camunda.bpm.engine.repository.Deployment deployment1 = repositoryService.createDeployment()
+        .enableDuplicateFiltering(true)
+        .addModelInstance("model.bpmn", oldModel)
+        .name("customDeploymentHandling")
+        .deploy();
+    deploymentIds.add(deployment1.getId());
+
+    // when
+    deploymentIds.add(repositoryService.createDeployment()
+        .enableDuplicateFiltering(true)
+        .addModelInstance("model.bpmn", newModel)
+        .name("customDeploymentHandling")
+        .deploy()
+        .getId());
+
+    org.camunda.bpm.engine.repository.Deployment deployment3 = repositoryService.createDeployment()
+        .enableDuplicateFiltering(true)
+        .addModelInstance("model.bpmn", oldModel)
+        .name("customDeploymentHandling")
+        .deploy();
+
+    // then
+    long deploymentCount = repositoryService.createDeploymentQuery().count();
+    assertEquals(2, deploymentCount);
+    assertEquals(deployment1.getId(), deployment3.getId());
   }
 
   public void testPartialChangesDeployAll() {
@@ -198,7 +274,6 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTestCase {
     repositoryService.deleteDeployment(deployment2.getId());
     repositoryService.deleteDeployment(deployment3.getId());
   }
-
 
   public void testPartialChangesRedeployOldVersion() {
     // deployment 1 deploys process version 1

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/deployment/VersionedDeploymentHandler.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/deployment/VersionedDeploymentHandler.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.bpmn.deployment;
+
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.RepositoryService;
+import org.camunda.bpm.engine.impl.bpmn.deployer.BpmnDeployer;
+import org.camunda.bpm.engine.impl.util.StringUtil;
+import org.camunda.bpm.engine.repository.CandidateDeployment;
+import org.camunda.bpm.engine.repository.Deployment;
+import org.camunda.bpm.engine.repository.DeploymentHandler;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.engine.repository.Resource;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.camunda.bpm.model.bpmn.instance.Process;
+
+import java.io.ByteArrayInputStream;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class VersionedDeploymentHandler implements DeploymentHandler {
+
+  protected ProcessEngine processEngine;
+  protected RepositoryService repositoryService;
+  protected String candidateVersionTag;
+  protected String candidateProcessDefinitionKey;
+
+  public VersionedDeploymentHandler(ProcessEngine processEngine) {
+    this.processEngine = processEngine;
+    this.repositoryService = processEngine.getRepositoryService();
+  }
+
+  @Override
+  public boolean shouldDeployResource(Resource newResource, Resource existingResource) {
+
+    if (isBpmnResource(newResource)) {
+
+      Integer existingVersion = parseCamundaVersionTag(existingResource);
+      Integer newVersion = parseCamundaVersionTag(newResource);
+      if (this.candidateVersionTag == null) {
+        this.candidateProcessDefinitionKey = parseProcessDefinitionKey(newResource);
+        this.candidateVersionTag = String.valueOf(newVersion);
+      }
+
+      return newVersion > existingVersion;
+    }
+
+    return false;
+  }
+
+  @Override
+  public String determineDuplicateDeployment(CandidateDeployment candidateDeployment) {
+
+    String deploymentId = repositoryService.createProcessDefinitionQuery()
+        .processDefinitionKey(candidateProcessDefinitionKey)
+        .versionTag(String.valueOf(candidateVersionTag))
+        .orderByProcessDefinitionVersion()
+        .desc()
+        .singleResult()
+        .getDeploymentId();
+
+    return repositoryService.createDeploymentQuery()
+        .deploymentId(deploymentId).singleResult().getId();
+  }
+
+  @Override
+  public Set<String> determineDeploymentsToResumeByProcessDefinitionKey(
+      String[] processDefinitionKeys) {
+
+    List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery()
+        .processDefinitionKeysIn(processDefinitionKeys).list();
+
+    Set<String> deploymentIds = new HashSet<>();
+    for (ProcessDefinition processDefinition : processDefinitions) {
+      // If all the resources are new, the candidateVersionTag
+      // property will be null since there's nothing to compare it to.
+      if (candidateVersionTag != null && candidateVersionTag.equals(processDefinition.getVersionTag())) {
+        deploymentIds.add(processDefinition.getDeploymentId());
+      }
+    }
+
+    return deploymentIds;
+  }
+
+  @Override
+  public Set<String> determineDeploymentsToResumeByDeploymentName(CandidateDeployment candidateDeployment) {
+    Set<String> deploymentIds = new HashSet<>();
+
+    List<Deployment> previousDeployments = processEngine.getRepositoryService()
+        .createDeploymentQuery().deploymentName(candidateDeployment.getName()).list();
+
+    for (Deployment deployment : previousDeployments) {
+
+      // find the Process Definitions included in this deployment
+      List<ProcessDefinition> deploymentPDs = repositoryService.createProcessDefinitionQuery()
+          .deploymentId(deployment.getId())
+          .list();
+
+      for (ProcessDefinition processDefinition : deploymentPDs) {
+        // only deploy Deployments of the same name that contain a Process Definition with the
+        // correct Camunda Version Tag. If all the resources are new, the candidateVersionTag
+        // property will be null since there's nothing to compare it to.
+        if (candidateVersionTag != null && candidateVersionTag.equals(processDefinition.getVersionTag())) {
+          deploymentIds.add(deployment.getId());
+          break;
+        }
+      }
+    }
+
+    return deploymentIds;
+  }
+
+  protected Integer parseCamundaVersionTag(Resource resource) {
+    BpmnModelInstance model = Bpmn
+        .readModelFromStream(new ByteArrayInputStream(resource.getBytes()));
+
+    Process process = model.getDefinitions().getChildElementsByType(Process.class)
+        .iterator().next();
+
+    return process.getCamundaVersionTag() != null ?
+        Integer.valueOf(process.getCamundaVersionTag()) :
+        0;
+  }
+
+  protected String parseProcessDefinitionKey(Resource resource) {
+    BpmnModelInstance model = Bpmn
+        .readModelFromStream(new ByteArrayInputStream(resource.getBytes()));
+
+    Process process = model.getDefinitions().getChildElementsByType(Process.class)
+        .iterator().next();
+
+    return process.getId();
+  }
+
+  protected boolean isBpmnResource(Resource resource) {
+    return StringUtil.hasAnySuffix(resource.getName(), BpmnDeployer.BPMN_RESOURCE_SUFFIXES);
+  }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/deployment/VersionedDeploymentHandlerFactory.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/deployment/VersionedDeploymentHandlerFactory.java
@@ -14,20 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.camunda.bpm.engine.repository;
+package org.camunda.bpm.engine.test.bpmn.deployment;
 
-/**
- * @author kristin.polenz@camunda.com
- */
-public interface Resource {
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.repository.DeploymentHandler;
+import org.camunda.bpm.engine.repository.DeploymentHandlerFactory;
 
+public class VersionedDeploymentHandlerFactory implements DeploymentHandlerFactory {
 
-  String getId();
-
-  String getName();
-
-  String getDeploymentId();
-
-  byte[] getBytes();
-
+  @Override
+  public DeploymentHandler buildDeploymentHandler(ProcessEngine processEngine) {
+    return new VersionedDeploymentHandler(processEngine);
+  }
 }


### PR DESCRIPTION
Decisions:
- The `Handler` interface was extended to include separate resume methods for resuming by Process Definition Keys and Deployment Name.
- The `Handler` interface now also provides a method to determine a `Duplicate` deployment  (old implementation calls it an `existingDeployment`.
- A Factory interface is provided to instantiate DeploymentHandlers in the DeployCmd class.

Related to https://app.camunda.com/jira/browse/CAM-10258