### PR TITLE
CAM-10622: Support setting a start/task form handler from a parse listener

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/form/handler/DelegateFormHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/form/handler/DelegateFormHandler.java
@@ -45,13 +45,13 @@ public abstract class DelegateFormHandler {
 
   public void parseConfiguration(Element activityElement, DeploymentEntity deployment, ProcessDefinitionEntity processDefinition, BpmnParse bpmnParse) {
     // should not be called!
+    throw new UnsupportedOperationException();
   }
 
   protected <T> T performContextSwitch(final Callable<T> callable) {
-
     ProcessApplicationReference targetProcessApplication = ProcessApplicationContextUtil.getTargetProcessApplication(deploymentId);
 
-    if(targetProcessApplication != null) {
+    if (targetProcessApplication != null) {
 
       return Context.executeWithinProcessApplication(new Callable<T>() {
         public T call() throws Exception {

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/standalone/deploy/BPMNParseListenerTest.testAlterFormHandlers.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/standalone/deploy/BPMNParseListenerTest.testAlterFormHandlers.bpmn20.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" targetNamespace="http://bpmn.io/schema/bpmn">
+
+    <process id="alterFormHandlersProcess" name="alterFormHandlersProcess" isExecutable="true">
+        <documentation>This is a process for testing form handlers</documentation>
+
+        <startEvent id="theStart" />
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+        <userTask id="theTask" name="my task" />
+        <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
+        <endEvent id="theEnd" />
+    </process>
+
+</definitions>


### PR DESCRIPTION
This resolves the issue I mentioned in [CAM-10622](https://app.camunda.com/jira/browse/CAM-10622), related to setting start/task form handlers from parse listeners.

There was an inconsistency between how start and task forms were handled:
- In the case of task forms, the "default" (or explicitly specified) form handler was set first, then its parseConfiguration method is called, and finally the parse listener is invoked. Therefore if you override the form handler in the parse listener, the parseConfiguration method will never be invoked on it.
- In the case of start forms, the parse listener was invoked first, then the "default" form handler was set, overriding any custom form handler that was set in the parse listener.

I changed both start and task form handlers to behave as follows, because it seems the most flexible:
1. the "default" form handler is set.
2. the parse listener is called, allowing it to override the form handler and use the original one how it desires (e.g. for decorating)
3. the parseConfiguration method is invoked on the form handler.
4. it is wrapped in a Delegate*FormHandler.