### PR TITLE
CAM-10730: fix(engine): task query assignee in filter can be extended

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
@@ -1688,6 +1688,16 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
       extendedQuery.taskAssigneeLike(this.getAssigneeLike());
     }
 
+    if (extendingQuery.getAssigneeIn() != null) {
+      extendedQuery.taskAssigneeIn(extendingQuery
+                                       .getAssigneeIn()
+                                       .toArray(new String[extendingQuery.getAssigneeIn().size()]));
+    }
+    else if (this.getAssigneeIn() != null) {
+      extendedQuery.taskAssigneeIn(this.getAssigneeIn()
+                                       .toArray(new String[this.getAssigneeIn().size()]));
+    }
+
     if (extendingQuery.getInvolvedUser() != null) {
       extendedQuery.taskInvolvedUser(extendingQuery.getInvolvedUser());
     }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/filter/FilterTaskQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/filter/FilterTaskQueryTest.java
@@ -714,6 +714,30 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTestCase {
     }
   }
 
+  public void testExtendingTaskQueryWithAssigneeIn() {
+    // given
+    Task task = taskService.newTask("assigneeTask");
+    task.setName("Task 4");
+    task.setOwner(testUser.getId());
+    taskService.saveTask(task);
+    taskService.setAssignee(task.getId(), "john");
+
+    // then
+    TaskQuery query = taskService.createTaskQuery().taskAssigneeIn("john");
+    saveQuery(query);
+    List<Task> origQueryTasks = filterService.list(filter.getId());
+    List<Task> selfExtendQueryTasks = filterService.list(filter.getId(), query);
+
+    TaskQuery extendingQuery = taskService.createTaskQuery();
+    extendingQuery.taskAssigneeIn("john", "kermit");
+    List<Task> extendingQueryTasks = filterService.list(filter.getId(), extendingQuery);
+
+    // then
+    assertEquals(1, origQueryTasks.size());
+    assertEquals(1, selfExtendQueryTasks.size());
+    assertEquals(2, extendingQueryTasks.size());
+  }
+
   public void testExtendingTaskQueryListWithCandidateGroups() {
     TaskQuery query = taskService.createTaskQuery();
 


### PR DESCRIPTION
Related to [CAM-10730](https://app.camunda.com/jira/browse/CAM-10730)

The ticket implements the `assigneeIn` task query filter when the query is extended. This is used when executing the query on Tasklist Filters.