### PR TITLE
CAM-10399: add timeout task listener

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/helper/BpmnProperties.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/helper/BpmnProperties.java
@@ -28,6 +28,8 @@ import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
 
 import static org.camunda.bpm.engine.impl.bpmn.parser.BpmnParse.PROPERTYNAME_HAS_CONDITIONAL_EVENTS;
 
+import java.util.Map;
+
 import org.camunda.bpm.engine.impl.bpmn.parser.ConditionalEventDefinition;
 
 /**
@@ -50,7 +52,13 @@ public class BpmnProperties {
    * Declaration indexed by activity that is triggered by the event; assumes that there is at most one such declaration per activity.
    * There is code that relies on this assumption (e.g. when determining which declaration matches a job in the migration logic).
    */
-  public static final PropertyMapKey<String, TimerDeclarationImpl> TIMER_DECLARATIONS = new PropertyMapKey<String, TimerDeclarationImpl>("timerDeclarations", false);
+  public static final PropertyMapKey<String, TimerDeclarationImpl> TIMER_DECLARATIONS = new PropertyMapKey<>("timerDeclarations", false);
+
+  /**
+   * Declaration indexed by activity and listener (id) that is triggered by the event; there can be multiple such declarations per activity but only one per listener.
+   * There is code that relies on this assumption (e.g. when determining which declaration matches a job in the migration logic).
+   */
+  public static final PropertyMapKey<String, Map<String, TimerDeclarationImpl>> TIMEOUT_LISTENER_DECLARATIONS = new PropertyMapKey<>("timerListenerDeclarations", false);
 
   /**
    * Declaration indexed by activity that is triggered by the event; assumes that there is at most one such declaration per activity.

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -224,6 +224,7 @@ import org.camunda.bpm.engine.impl.jobexecutor.TimerStartEventJobHandler;
 import org.camunda.bpm.engine.impl.jobexecutor.TimerStartEventSubprocessJobHandler;
 import org.camunda.bpm.engine.impl.jobexecutor.TimerSuspendJobDefinitionHandler;
 import org.camunda.bpm.engine.impl.jobexecutor.TimerSuspendProcessDefinitionHandler;
+import org.camunda.bpm.engine.impl.jobexecutor.TimerTaskListenerJobHandler;
 import org.camunda.bpm.engine.impl.jobexecutor.historycleanup.BatchWindowManager;
 import org.camunda.bpm.engine.impl.jobexecutor.historycleanup.DefaultBatchWindowManager;
 import org.camunda.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupBatch;
@@ -1897,6 +1898,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     TimerActivateJobDefinitionHandler activateJobDefinitionHandler = new TimerActivateJobDefinitionHandler();
     jobHandlers.put(activateJobDefinitionHandler.getType(), activateJobDefinitionHandler);
+
+    TimerTaskListenerJobHandler taskListenerJobHandler = new TimerTaskListenerJobHandler();
+    jobHandlers.put(taskListenerJobHandler.getType(), taskListenerJobHandler);
 
     BatchSeedJobHandler batchSeedJobHandler = new BatchSeedJobHandler();
     jobHandlers.put(batchSeedJobHandler.getType(), batchSeedJobHandler);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/TimerDeclarationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/TimerDeclarationImpl.java
@@ -203,12 +203,32 @@ public class TimerDeclarationImpl extends JobDeclaration<ExecutionEntity, TimerE
     return resolveJobHandler().newConfiguration(rawJobHandlerConfiguration);
   }
 
+  /**
+   * @return all timers declared in the given scope
+   */
   public static Map<String, TimerDeclarationImpl> getDeclarationsForScope(PvmScope scope) {
     if (scope == null) {
       return Collections.emptyMap();
     }
 
     Map<String, TimerDeclarationImpl> result = scope.getProperties().get(BpmnProperties.TIMER_DECLARATIONS);
+    if (result != null) {
+      return result;
+    }
+    else {
+      return Collections.emptyMap();
+    }
+  }
+
+  /**
+   * @return all timeout listeners declared in the given scope
+   */
+  public static Map<String, Map<String, TimerDeclarationImpl>> getTimeoutListenerDeclarationsForScope(PvmScope scope) {
+    if (scope == null) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, Map<String, TimerDeclarationImpl>> result = scope.getProperties().get(BpmnProperties.TIMEOUT_LISTENER_DECLARATIONS);
     if (result != null) {
       return result;
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/TimerTaskListenerJobHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/TimerTaskListenerJobHandler.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.jobexecutor;
+
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
+
+/**
+ * {@link JobHandler} implementation for timer task listeners which can be defined for user tasks.
+ *
+ * The configuration contains the id of the activity as well as the id of the task listener.
+ *
+ */
+public class TimerTaskListenerJobHandler extends TimerEventJobHandler {
+
+  public static final String TYPE = "timer-task-listener";
+
+  public String getType() {
+    return TYPE;
+  }
+
+  public void execute(TimerJobConfiguration configuration, ExecutionEntity execution, CommandContext commandContext, String tenantId) {
+    String activityId = configuration.getTimerElementKey();
+    TaskEntity targetTask = null;
+    for (TaskEntity task : execution.getTasks()) {
+      if (task.getTaskDefinitionKey().equals(activityId)) {
+        targetTask = task;
+      }
+    }
+
+    if (targetTask != null) {
+      targetTask.fireTimeoutEvent(configuration.getTimerElementSecondaryKey());
+    } else {
+      throw new ProcessEngineException("Error while triggering timeout task listener '" + configuration.getTimerElementSecondaryKey()
+          + "': cannot find task for activity id '" + configuration.getTimerElementKey() + "'.");
+    }
+
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/migration/instance/parser/ActivityInstanceJobHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/migration/instance/parser/ActivityInstanceJobHandler.java
@@ -19,9 +19,13 @@ package org.camunda.bpm.engine.impl.migration.instance.parser;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
+import org.camunda.bpm.engine.impl.jobexecutor.JobHandlerConfiguration;
 import org.camunda.bpm.engine.impl.jobexecutor.TimerDeclarationImpl;
+import org.camunda.bpm.engine.impl.jobexecutor.TimerEventJobHandler.TimerJobConfiguration;
 import org.camunda.bpm.engine.impl.jobexecutor.TimerExecuteNestedActivityJobHandler;
+import org.camunda.bpm.engine.impl.jobexecutor.TimerTaskListenerJobHandler;
 import org.camunda.bpm.engine.impl.migration.instance.EmergingJobInstance;
 import org.camunda.bpm.engine.impl.migration.instance.MigratingActivityInstance;
 import org.camunda.bpm.engine.impl.migration.instance.MigratingJobInstance;
@@ -30,7 +34,6 @@ import org.camunda.bpm.engine.impl.persistence.entity.JobDefinitionEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.TimerEntity;
 import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
-import org.camunda.bpm.engine.impl.pvm.process.ScopeImpl;
 import org.camunda.bpm.engine.migration.MigrationInstruction;
 
 /**
@@ -42,8 +45,11 @@ public class ActivityInstanceJobHandler implements MigratingDependentInstancePar
   @Override
   public void handle(MigratingInstanceParseContext parseContext, MigratingActivityInstance activityInstance, List<JobEntity> elements) {
 
-    Map<String, TimerDeclarationImpl> sourceTimerDeclarationsInEventScope = getTimerDeclarationsByTriggeringActivity(activityInstance.getSourceScope());
-    Map<String, TimerDeclarationImpl> targetTimerDeclarationsInEventScope = getTimerDeclarationsByTriggeringActivity(activityInstance.getTargetScope());
+    Map<String, TimerDeclarationImpl> sourceTimerDeclarationsInEventScope = TimerDeclarationImpl.getDeclarationsForScope(activityInstance.getSourceScope());
+    Map<String, TimerDeclarationImpl> targetTimerDeclarationsInEventScope = new HashMap<>(TimerDeclarationImpl.getDeclarationsForScope(activityInstance.getTargetScope()));
+
+    Map<String, Map<String, TimerDeclarationImpl>> sourceTimeoutListenerDeclarationsInEventScope = TimerDeclarationImpl.getTimeoutListenerDeclarationsForScope(activityInstance.getSourceScope());
+    Map<String, Map<String, TimerDeclarationImpl>> targetTimeoutListenerDeclarationsInEventScope = new HashMap<>(TimerDeclarationImpl.getTimeoutListenerDeclarationsForScope(activityInstance.getTargetScope()));
 
     for (JobEntity job : elements) {
       if (!isTimerJob(job)) {
@@ -53,12 +59,15 @@ public class ActivityInstanceJobHandler implements MigratingDependentInstancePar
 
       MigrationInstruction migrationInstruction = parseContext.findSingleMigrationInstruction(job.getActivityId());
       ActivityImpl targetActivity = parseContext.getTargetActivity(migrationInstruction);
+      JobHandlerConfiguration jobHandlerConfiguration = job.getJobHandlerConfiguration();
 
-      if (targetActivity != null && activityInstance.migratesTo(targetActivity.getEventScope())) {
+      if (targetActivity != null && activityInstance.migratesTo(targetActivity.getEventScope()) &&
+          isNoTimeoutListenerOrMigrates(job, jobHandlerConfiguration, targetActivity.getActivityId(), targetTimeoutListenerDeclarationsInEventScope)) {
         // the timer job is migrated
         JobDefinitionEntity targetJobDefinitionEntity = parseContext.getTargetJobDefinition(targetActivity.getActivityId(), job.getJobHandlerType());
 
-        TimerDeclarationImpl targetTimerDeclaration = targetTimerDeclarationsInEventScope.remove(targetActivity.getId());
+        TimerDeclarationImpl targetTimerDeclaration = getTargetTimerDeclaration(job, jobHandlerConfiguration, targetActivity.getActivityId(),
+            targetTimeoutListenerDeclarationsInEventScope, targetTimerDeclarationsInEventScope);
 
         MigratingJobInstance migratingTimerJobInstance =
             new MigratingTimerJobInstance(
@@ -70,8 +79,7 @@ public class ActivityInstanceJobHandler implements MigratingDependentInstancePar
         activityInstance.addMigratingDependentInstance(migratingTimerJobInstance);
         parseContext.submit(migratingTimerJobInstance);
 
-      }
-      else {
+      } else {
         // the timer job is removed
         MigratingJobInstance removingJobInstance = new MigratingTimerJobInstance(job);
         activityInstance.addRemovingDependentInstance(removingJobInstance);
@@ -84,11 +92,48 @@ public class ActivityInstanceJobHandler implements MigratingDependentInstancePar
 
     if (activityInstance.migrates()) {
       addEmergingTimerJobs(parseContext, activityInstance, sourceTimerDeclarationsInEventScope, targetTimerDeclarationsInEventScope);
+      addEmergingTimeoutListenerJobs(parseContext, activityInstance, sourceTimeoutListenerDeclarationsInEventScope, targetTimeoutListenerDeclarationsInEventScope);
     }
+  }
+
+  protected TimerDeclarationImpl getTargetTimerDeclaration(JobEntity job, JobHandlerConfiguration jobHandlerConfiguration,
+      String targetActivity, Map<String, Map<String, TimerDeclarationImpl>> targetTimeoutListenerDeclarationsInEventScope,
+      Map<String, TimerDeclarationImpl> targetTimerDeclarationsInEventScope) {
+    if (isTimeoutListenerJobInTargetScope(jobHandlerConfiguration, targetActivity, targetTimeoutListenerDeclarationsInEventScope)) {
+      return removeTimeoutListenerJobFromTargetScope(jobHandlerConfiguration, targetActivity, targetTimeoutListenerDeclarationsInEventScope);
+    }
+    return targetTimerDeclarationsInEventScope.remove(targetActivity);
   }
 
   protected static boolean isTimerJob(JobEntity job) {
     return job != null && job.getType().equals(TimerEntity.TYPE);
+  }
+
+  protected static boolean isNoTimeoutListenerOrMigrates(JobEntity job, JobHandlerConfiguration jobHandlerConfiguration,
+      String targetActivity, Map<String, Map<String, TimerDeclarationImpl>> targetTimeoutListenerDeclarationsInEventScope) {
+    return !TimerTaskListenerJobHandler.TYPE.equals(job.getJobHandlerType()) ||
+        isTimeoutListenerJobInTargetScope(jobHandlerConfiguration, targetActivity, targetTimeoutListenerDeclarationsInEventScope);
+  }
+
+  protected static boolean isTimeoutListenerJobInTargetScope(JobHandlerConfiguration jobHandlerConfiguration,
+      String targetActivity, Map<String, Map<String, TimerDeclarationImpl>> targetTimeoutListenerDeclarationsInEventScope) {
+    return jobHandlerConfiguration instanceof TimerJobConfiguration &&
+        targetTimeoutListenerDeclarationsInEventScope.containsKey(targetActivity) &&
+        targetTimeoutListenerDeclarationsInEventScope.get(targetActivity).containsKey(
+            ((TimerJobConfiguration) jobHandlerConfiguration).getTimerElementSecondaryKey());
+  }
+
+  protected static TimerDeclarationImpl removeTimeoutListenerJobFromTargetScope(JobHandlerConfiguration jobHandlerConfiguration,
+      String targetActivity, Map<String, Map<String, TimerDeclarationImpl>> targetTimeoutListenerDeclarationsInEventScope) {
+    if (isTimeoutListenerJobInTargetScope(jobHandlerConfiguration, targetActivity, targetTimeoutListenerDeclarationsInEventScope)) {
+      Map<String, TimerDeclarationImpl> activityDeclarations = targetTimeoutListenerDeclarationsInEventScope.get(targetActivity);
+      TimerDeclarationImpl declaration = activityDeclarations.remove(((TimerJobConfiguration) jobHandlerConfiguration).getTimerElementSecondaryKey());
+      if (activityDeclarations.isEmpty()) {
+        targetTimeoutListenerDeclarationsInEventScope.remove(targetActivity);
+      }
+      return declaration;
+    }
+    return  null;
   }
 
   protected void addEmergingTimerJobs(MigratingInstanceParseContext parseContext, MigratingActivityInstance activityInstance,
@@ -96,6 +141,18 @@ public class ActivityInstanceJobHandler implements MigratingDependentInstancePar
     for (TimerDeclarationImpl targetTimerDeclaration : targetTimerDeclarationsInEventScope.values()) {
       if(!isNonInterruptingTimerTriggeredAlready(parseContext, sourceTimerDeclarationsInEventScope, targetTimerDeclaration)) {
         activityInstance.addEmergingDependentInstance(new EmergingJobInstance(targetTimerDeclaration));
+      }
+    }
+  }
+
+  protected void addEmergingTimeoutListenerJobs(MigratingInstanceParseContext parseContext, MigratingActivityInstance activityInstance,
+      Map<String, Map<String, TimerDeclarationImpl>> sourceTimeoutListenerDeclarationsInEventScope,
+      Map<String, Map<String, TimerDeclarationImpl>> targetTimeoutListenerDeclarationsInEventScope) {
+    for (Map<String, TimerDeclarationImpl> targetTimerDeclarations : targetTimeoutListenerDeclarationsInEventScope.values()) {
+      for (Entry<String, TimerDeclarationImpl> targetTimerDeclaration : targetTimerDeclarations.entrySet()) {
+        if(!isNonInterruptingTimeoutListenerTriggeredAlready(parseContext, sourceTimeoutListenerDeclarationsInEventScope, targetTimerDeclaration)) {
+          activityInstance.addEmergingDependentInstance(new EmergingJobInstance(targetTimerDeclaration.getValue()));
+        }
       }
     }
   }
@@ -109,15 +166,33 @@ public class ActivityInstanceJobHandler implements MigratingDependentInstancePar
       MigrationInstruction migrationInstruction = parseContext.findSingleMigrationInstruction(sourceTimerDeclaration.getActivityId());
       ActivityImpl targetActivity = parseContext.getTargetActivity(migrationInstruction);
 
-      if(targetActivity != null && targetTimerDeclaration.getActivityId().equals(targetActivity.getActivityId())) {
+      if (targetActivity != null && targetTimerDeclaration.getActivityId().equals(targetActivity.getActivityId())) {
         return true;
       }
     }
     return false;
   }
 
-  protected Map<String, TimerDeclarationImpl> getTimerDeclarationsByTriggeringActivity(ScopeImpl scope) {
-    return new HashMap<String, TimerDeclarationImpl>(TimerDeclarationImpl.getDeclarationsForScope(scope));
+  protected boolean isNonInterruptingTimeoutListenerTriggeredAlready(MigratingInstanceParseContext parseContext,
+      Map<String, Map<String, TimerDeclarationImpl>> sourceTimeoutListenerDeclarationsInEventScope,
+      Entry<String, TimerDeclarationImpl> targetTimerDeclarationEntry) {
+    TimerDeclarationImpl targetTimerDeclaration = targetTimerDeclarationEntry.getValue();
+    if (targetTimerDeclaration.isInterruptingTimer() || targetTimerDeclaration.getJobHandlerType() != TimerTaskListenerJobHandler.TYPE || sourceTimeoutListenerDeclarationsInEventScope.values().size() == 0) {
+      return false;
+    }
+    for (Entry<String, Map<String, TimerDeclarationImpl>> sourceTimerDeclarationsEntry : sourceTimeoutListenerDeclarationsInEventScope.entrySet()) {
+      MigrationInstruction migrationInstruction = parseContext.findSingleMigrationInstruction(sourceTimerDeclarationsEntry.getKey());
+      ActivityImpl targetActivity = parseContext.getTargetActivity(migrationInstruction);
+
+      if (targetActivity != null && targetTimerDeclaration.getActivityId().equals(targetActivity.getActivityId())) {
+        for (Entry<String, TimerDeclarationImpl> sourceTimerDeclarationEntry : sourceTimerDeclarationsEntry.getValue().entrySet()) {
+          if (sourceTimerDeclarationEntry.getKey().equals(targetTimerDeclarationEntry.getKey())) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/migration/validation/instruction/UpdateEventTriggersValidator.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/migration/validation/instruction/UpdateEventTriggersValidator.java
@@ -43,7 +43,8 @@ public class UpdateEventTriggersValidator implements MigrationInstructionValidat
 
     if (eventScope != null) {
       return TimerDeclarationImpl.getDeclarationsForScope(eventScope).containsKey(activity.getId())
-          || EventSubscriptionDeclaration.getDeclarationsForScope(eventScope).containsKey(activity.getId());
+          || EventSubscriptionDeclaration.getDeclarationsForScope(eventScope).containsKey(activity.getId())
+          || TimerDeclarationImpl.getTimeoutListenerDeclarationsForScope(eventScope).containsKey(activity.getId());
     }
     else {
       return false;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExecutionEntity.java
@@ -413,7 +413,13 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
   public void initializeTimerDeclarations() {
     LOG.initializeTimerDeclaration(this);
     ScopeImpl scope = getScopeActivity();
-    Collection<TimerDeclarationImpl> timerDeclarations = TimerDeclarationImpl.getDeclarationsForScope(scope).values();
+    createTimerInstances(TimerDeclarationImpl.getDeclarationsForScope(scope).values());
+    for (Map<String, TimerDeclarationImpl> timerDeclarations : TimerDeclarationImpl.getTimeoutListenerDeclarationsForScope(scope).values()) {
+      createTimerInstances(timerDeclarations.values());
+    }
+  }
+
+  protected void createTimerInstances(Collection<TimerDeclarationImpl> timerDeclarations) {
     for (TimerDeclarationImpl timerDeclaration : timerDeclarations) {
       timerDeclaration.createTimerInstance(this);
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/TaskEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/TaskEntity.java
@@ -1001,7 +1001,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
 
   protected TaskListener getTimeoutListener(String timeoutId) {
     TaskDefinition resolvedTaskDefinition = getTaskDefinition();
-    if (resolvedTaskDefinition == null || skipCustomListeners) {
+    if (resolvedTaskDefinition == null) {
       return null;
     } else {
       return resolvedTaskDefinition.getTimeoutTaskListener(timeoutId);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/TaskEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/TaskEntity.java
@@ -23,6 +23,7 @@ import org.camunda.bpm.engine.delegate.DelegateTask;
 import org.camunda.bpm.engine.delegate.Expression;
 import org.camunda.bpm.engine.delegate.TaskListener;
 import org.camunda.bpm.engine.delegate.VariableScope;
+import org.camunda.bpm.engine.exception.NotFoundException;
 import org.camunda.bpm.engine.exception.NullValueException;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.bpmn.helper.BpmnExceptionHandler;
@@ -959,26 +960,67 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
 
     if (taskEventListeners != null) {
       for (TaskListener taskListener : taskEventListeners) {
-        CoreExecution execution = getExecution();
-        if (execution == null) {
-          execution = getCaseExecution();
-        }
-
-        if (execution != null) {
-          setEventName(taskEventName);
-        }
-        try {
-          boolean success = invokeListener(execution, taskEventName, taskListener);
-          if (!success) {
-            return false;
-          }
-        } catch (Exception e) {
-          throw LOG.invokeTaskListenerException(e);
+        if (!invokeListener(taskEventName, taskListener)){
+          return false;
         }
       }
     }
 
     return true;
+  }
+
+  protected List<TaskListener> getListenersForEvent(String event) {
+    TaskDefinition resolvedTaskDefinition = getTaskDefinition();
+    if (resolvedTaskDefinition != null) {
+      if (skipCustomListeners) {
+        return resolvedTaskDefinition.getBuiltinTaskListeners(event);
+      }
+      else {
+        return resolvedTaskDefinition.getTaskListeners(event);
+      }
+
+    }
+    else {
+      return null;
+    }
+  }
+
+  /**
+   * @return true if invoking the listener was successful;
+   *   if not successful, either false is returned (case: BPMN error propagation)
+   *   or an exception is thrown
+   */
+  public boolean fireTimeoutEvent(String timeoutId) {
+    TaskListener taskListener = getTimeoutListener(timeoutId);
+    if (taskListener == null) {
+      throw LOG.invokeTaskListenerException(new NotFoundException("Cannot find timeout taskListener with id '"
+          + timeoutId + "' for task " + this.id));
+    }
+    return invokeListener(TaskListener.EVENTNAME_TIMEOUT, taskListener);
+  }
+
+  protected TaskListener getTimeoutListener(String timeoutId) {
+    TaskDefinition resolvedTaskDefinition = getTaskDefinition();
+    if (resolvedTaskDefinition == null || skipCustomListeners) {
+      return null;
+    } else {
+      return resolvedTaskDefinition.getTimeoutTaskListener(timeoutId);
+    }
+  }
+
+  protected boolean invokeListener(String taskEventName, TaskListener taskListener) {
+    CoreExecution execution = getExecution();
+    if (execution == null) {
+      execution = getCaseExecution();
+    }
+    if (execution != null) {
+      setEventName(taskEventName);
+    }
+    try {
+      return invokeListener(execution, taskEventName, taskListener);
+    } catch (Exception e) {
+      throw LOG.invokeTaskListenerException(e);
+    }
   }
 
   /**
@@ -1011,22 +1053,6 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
       }
     }
     return true;
-  }
-
-  protected List<TaskListener> getListenersForEvent(String event) {
-    TaskDefinition resolvedTaskDefinition = getTaskDefinition();
-    if (resolvedTaskDefinition != null) {
-      if (skipCustomListeners) {
-        return resolvedTaskDefinition.getBuiltinTaskListeners(event);
-      }
-      else {
-        return resolvedTaskDefinition.getTaskListeners(event);
-      }
-
-    }
-    else {
-      return null;
-    }
   }
 
   /**

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/task/TaskDefinition.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/task/TaskDefinition.java
@@ -52,8 +52,9 @@ public class TaskDefinition {
   protected Expression formKey;
 
   // task listeners
-  protected Map<String, List<TaskListener>> taskListeners = new HashMap<String, List<TaskListener>>();
-  protected Map<String, List<TaskListener>> builtinTaskListeners = new HashMap<String, List<TaskListener>>();
+  protected Map<String, List<TaskListener>> taskListeners = new HashMap<>();
+  protected Map<String, List<TaskListener>> builtinTaskListeners = new HashMap<>();
+  protected Map<String, TaskListener> timeoutTaskListeners = new HashMap<>();
 
   public TaskDefinition(TaskFormHandler taskFormHandler) {
     this.taskFormHandler = taskFormHandler;
@@ -161,6 +162,10 @@ public class TaskDefinition {
     return builtinTaskListeners.get(eventName);
   }
 
+  public TaskListener getTimeoutTaskListener(String timeoutId) {
+    return timeoutTaskListeners.get(timeoutId);
+  }
+
   public void addTaskListener(String eventName, TaskListener taskListener) {
     CollectionUtil.addToMapOfLists(taskListeners, eventName, taskListener);
   }
@@ -177,6 +182,9 @@ public class TaskDefinition {
     CollectionUtil.addToMapOfLists(builtinTaskListeners, eventName, taskListener);
   }
 
+  public void addTimeoutTaskListener(String timeoutId, TaskListener taskListener) {
+    timeoutTaskListeners.put(timeoutId, taskListener);
+  }
 
   public Expression getFormKey() {
     return formKey;

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.java
@@ -20,23 +20,35 @@ import static org.camunda.bpm.engine.test.api.runtime.migration.ModifiableBpmnMo
 import static org.camunda.bpm.engine.test.util.ActivityInstanceAssert.describeActivityInstanceTree;
 import static org.camunda.bpm.engine.test.util.ExecutionAssert.describeExecutionTree;
 import static org.camunda.bpm.engine.test.util.MigratingProcessInstanceValidationReportAssert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
+import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
-import org.camunda.bpm.engine.delegate.DelegateTask;
 import org.camunda.bpm.engine.delegate.TaskListener;
 import org.camunda.bpm.engine.impl.history.HistoryLevel;
+import org.camunda.bpm.engine.impl.jobexecutor.TimerTaskListenerJobHandler;
+import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.util.ClockUtil;
+import org.camunda.bpm.engine.management.JobDefinition;
 import org.camunda.bpm.engine.migration.MigratingProcessInstanceValidationException;
 import org.camunda.bpm.engine.migration.MigrationPlan;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.engine.runtime.Job;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.api.runtime.migration.models.ProcessModels;
+import org.camunda.bpm.engine.test.api.runtime.migration.util.AccessModelInstanceTaskListener;
+import org.camunda.bpm.engine.test.util.ClockTestUtil;
 import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.camunda.bpm.model.bpmn.instance.UserTask;
 import org.camunda.bpm.model.bpmn.instance.camunda.CamundaTaskListener;
+import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -284,7 +296,7 @@ public class MigrationUserTaskTest {
   }
 
   @Test
-  public void testAccessModelInTaskListenerAfterMigration() {
+  public void testAccessModelInNewAssignmentTaskListenerAfterMigration() {
     BpmnModelInstance targetModel = modify(ProcessModels.ONE_TASK_PROCESS).changeElementId("userTask", "newUserTask");
     addTaskListener(targetModel, "newUserTask", TaskListener.EVENTNAME_ASSIGNMENT, AccessModelInstanceTaskListener.class.getName());
 
@@ -292,12 +304,12 @@ public class MigrationUserTaskTest {
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(targetModel);
 
-    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+    MigrationPlan migrationPlan = rule.getRuntimeService()
+      .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
       .mapActivities("userTask", "newUserTask")
       .build();
 
-    ProcessInstance processInstance = rule.getRuntimeService().startProcessInstanceById(sourceProcessDefinition.getId());
-    testHelper.migrateProcessInstance(migrationPlan, processInstance);
+    ProcessInstance processInstance = testHelper.createProcessInstanceAndMigrate(migrationPlan);
 
     // when
     Task task = rule.getTaskService().createTaskQuery().singleResult();
@@ -311,6 +323,494 @@ public class MigrationUserTaskTest {
 
   }
 
+  @Test
+  public void testAccessModelInNewTimeoutTaskListenerAfterMigration() {
+    // given
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.noTimeoutTaskListener.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListener.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapEqualActivities()
+      .build();
+
+    // when
+    ProcessInstance processInstance = testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    testHelper.assertTaskListenerTimerJobCreated("userTask");
+
+    // and the task listener was able to access the bpmn model instance and set a variable
+    testTimeoutListenerCanBeTriggered(processInstance, "userTask");
+  }
+
+  @Test
+  public void testTimeoutTaskListenerRemovedAfterMigration() {
+    // given
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListener.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.noTimeoutTaskListener.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapEqualActivities()
+      .build();
+
+    // when
+    testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    testHelper.assertTaskListenerTimerJobRemoved("userTask");
+  }
+
+  @Test
+  public void testTimeoutTaskListenerMigratedAfterMigration() {
+    // given
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListener.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.changedTimeoutTaskListener.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapEqualActivities()
+      .build();
+
+    // when
+    ProcessInstance processInstance = testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    testHelper.assertTaskListenerTimerJobMigrated("userTask", "userTask");
+
+    // and the task listener was able to access the bpmn model instance and set a variable
+    testTimeoutListenerCanBeTriggered(processInstance, "userTask");
+  }
+
+  @Test
+  public void testTimeoutTaskListenerMigratedAndUpdatedAfterMigration() {
+    // given
+    ClockTestUtil.setClockToDateWithoutMilliseconds();
+
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListener.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.changedTimeoutTaskListener.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapEqualActivities().updateEventTriggers()
+      .build();
+
+    // when
+    ProcessInstance processInstance = testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    Date newDueDate = new DateTime(ClockUtil.getCurrentTime()).plusHours(3).toDate();
+    testHelper.assertJobMigrated(
+        testHelper.snapshotBeforeMigration.getJobs().get(0),
+        "userTask",
+        newDueDate);
+
+    // and the task listener was able to access the bpmn model instance and set a variable
+    testTimeoutListenerCanBeTriggered(processInstance, "userTask");
+  }
+
+  @Test
+  public void testAccessModelInNewTimeoutTaskListenerAfterMigrationToDifferentUserTask() {
+    // given
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.noTimeoutTaskListener.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListenerDifferentTask.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapActivities("userTask", "userTask2")
+      .build();
+
+    // when
+    ProcessInstance processInstance = testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    testHelper.assertTaskListenerTimerJobCreated("userTask2");
+    assertThat(testHelper.snapshotBeforeMigration.getJobs().size(), is(0));
+    assertThat(testHelper.snapshotAfterMigration.getJobs().size(), is(1));
+
+    // and the task listener was able to access the bpmn model instance and set a variable
+    testTimeoutListenerCanBeTriggered(processInstance, "userTask2");
+  }
+
+  @Test
+  public void testTimeoutTaskListenerRemovedAfterMigrationToDifferentUserTask() {
+    // given
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListenerDifferentTask.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.noTimeoutTaskListener.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapActivities("userTask2", "userTask")
+      .build();
+
+    // when
+    testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    testHelper.assertTaskListenerTimerJobRemoved("userTask2");
+    assertThat(testHelper.snapshotBeforeMigration.getJobs().size(), is(1));
+    assertThat(testHelper.snapshotAfterMigration.getJobs().size(), is(0));
+  }
+
+  @Test
+  public void testTimeoutTaskListenerMigratedAfterMigrationToDifferentUserTask() {
+    // given
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListenerDifferentTask.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.changedTimeoutTaskListener.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapActivities("userTask2", "userTask")
+      .build();
+
+    // when
+    ProcessInstance processInstance = testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    testHelper.assertTaskListenerTimerJobMigrated("userTask2", "userTask");
+    assertThat(testHelper.snapshotBeforeMigration.getJobs().size(), is(1));
+    assertThat(testHelper.snapshotAfterMigration.getJobs().size(), is(1));
+
+    // and the task listener was able to access the bpmn model instance and set a variable
+    testTimeoutListenerCanBeTriggered(processInstance, "userTask");
+  }
+
+  @Test
+  public void testTimeoutTaskListenerMigratedAndUpdatedAfterMigrationToDifferentUserTask() {
+    // given
+    ClockTestUtil.setClockToDateWithoutMilliseconds();
+
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListenerDifferentTask.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.changedTimeoutTaskListener.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapActivities("userTask2", "userTask").updateEventTrigger()
+      .build();
+
+    // when
+    ProcessInstance processInstance = testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    Date newDueDate = new DateTime(ClockUtil.getCurrentTime()).plusHours(3).toDate();
+    testHelper.assertTaskListenerTimerJobMigrated("userTask2", "userTask", newDueDate);
+    assertThat(testHelper.snapshotBeforeMigration.getJobs().size(), is(1));
+    assertThat(testHelper.snapshotAfterMigration.getJobs().size(), is(1));
+
+    // and the task listener was able to access the bpmn model instance and set a variable
+    testTimeoutListenerCanBeTriggered(processInstance, "userTask");
+  }
+
+  @Test
+  public void testAccessModelInNewTimeoutTaskListenerAfterMultipleListenerMigration() {
+    // given
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.noTimeoutTaskListener.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.twoTimeoutTaskListeners.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapEqualActivities()
+      .build();
+
+    // when
+    ProcessInstance processInstance = testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    testHelper.assertTaskListenerTimerJobsCreated("userTask", 2);
+    ClockUtil.offset(TimeUnit.MINUTES.toMillis(70L));
+    testHelper.waitForJobExecutorToProcessAllJobs(5000L);
+    String variableValue =
+        (String) rule.getRuntimeService().getVariable(processInstance.getId(), AccessModelInstanceTaskListener.VARIABLE_NAME);
+    Assert.assertEquals("userTask", variableValue);
+  }
+
+  @Test
+  public void testOneTimeoutTaskListenerRemovedAfterMigration() {
+    // given
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.twoTimeoutTaskListeners.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListener.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapEqualActivities()
+      .build();
+
+    // when
+    testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    assertThat(testHelper.snapshotBeforeMigration.getJobs().size(), is(2));
+    assertThat(testHelper.snapshotAfterMigration.getJobs().size(), is(1));
+    JobEntity job = (JobEntity) testHelper.snapshotAfterMigration.getJobs().get(0);
+    String jobHandlerConfiguration = job.getJobHandlerConfigurationRaw();
+    assertThat(jobHandlerConfiguration, containsString("timeout-friendly"));
+  }
+
+  @Test
+  public void testOneTimeoutTaskListenerAddedAfterMigration() {
+    // given
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListener.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.twoTimeoutTaskListeners.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapEqualActivities()
+      .build();
+
+    // when
+    testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    assertThat(testHelper.snapshotBeforeMigration.getJobs().size(), is(1));
+    JobEntity job = (JobEntity) testHelper.snapshotBeforeMigration.getJobs().get(0);
+    String jobHandlerConfiguration = job.getJobHandlerConfigurationRaw();
+    assertThat(jobHandlerConfiguration, containsString("timeout-friendly"));
+
+    assertThat(testHelper.snapshotAfterMigration.getJobs().size(), is(2));
+    job = (JobEntity) testHelper.snapshotAfterMigration.getJobs().get(1);
+    jobHandlerConfiguration = job.getJobHandlerConfigurationRaw();
+    assertThat(jobHandlerConfiguration, containsString("timeout-hard"));
+  }
+
+  @Test
+  public void testTriggeredTimeoutTaskListenerNotStartedAgainAfterMigration() {
+    // given
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.twoTimeoutTaskListenersPastDate.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.twoTimeoutTaskListenersPastDate.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapEqualActivities()
+      .build();
+
+    ProcessInstance processInstance = rule.getRuntimeService().startProcessInstanceById(sourceProcessDefinitionId);
+    assertThat(rule.getManagementService().createJobQuery().count(), is(2L));
+    assertThat(rule.getManagementService().createJobQuery().executable().count(), is(1L));
+    testHelper.waitForJobExecutorToProcessAllJobs(5000L);
+    assertThat(rule.getManagementService().createJobQuery().count(), is(1L));
+
+    // when
+    testHelper.migrateProcessInstance(migrationPlan, processInstance);
+
+    // then
+    assertThat(rule.getManagementService().createJobQuery().count(), is(1L));
+  }
+
+  @Test
+  public void testTimeoutTaskListenerMigratedAfterMultipleListenerMigration() {
+    // given
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListener.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.changedTimeoutTaskListener.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapEqualActivities()
+      .build();
+
+    // when
+    ProcessInstance processInstance = testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    testHelper.assertTaskListenerTimerJobMigrated("userTask", "userTask");
+
+    // and the task listener was able to access the bpmn model instance and set a variable
+    testTimeoutListenerCanBeTriggered(processInstance, "userTask");
+  }
+
+  @Test
+  public void testTimeoutTaskListenerMigratedAndUpdatedAfterMultipleListenerMigration() {
+    // given
+    ClockTestUtil.setClockToDateWithoutMilliseconds();
+
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListener.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.changedTimeoutTaskListener.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapEqualActivities().updateEventTriggers()
+      .build();
+
+    // when
+    ProcessInstance processInstance = testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    Date newDueDate = new DateTime(ClockUtil.getCurrentTime()).plusHours(3).toDate();
+    testHelper.assertJobMigrated(
+        testHelper.snapshotBeforeMigration.getJobs().get(0),
+        "userTask",
+        newDueDate);
+
+    // and the task listener was able to access the bpmn model instance and set a variable
+    testTimeoutListenerCanBeTriggered(processInstance, "userTask");
+  }
+
+  @Test
+  public void testAccessModelInMigratedTimeoutTaskListenerAfterMigrationToDifferentUserTask() {
+    // given
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.noTimeoutTaskListener.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListener.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapEqualActivities()
+      .build();
+
+    // when
+    ProcessInstance processInstance = testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    testHelper.assertTaskListenerTimerJobCreated("userTask");
+
+    // and the task listener was able to access the bpmn model instance and set a variable
+    testTimeoutListenerCanBeTriggered(processInstance, "userTask");
+  }
+
+
+  @Test
+  public void testAccessModelInNewTimeoutTaskListenerAfterMigrationWithBoundaryEvent() {
+    // given
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.noTimeoutTaskListenerWithBoundaryEvent.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListenerWithBoundaryEvent.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapEqualActivities()
+      .build();
+
+    // when
+    ProcessInstance processInstance = testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    testHelper.assertTaskListenerTimerJobCreated("userTask");
+
+    // and the task listener was able to access the bpmn model instance and set a variable
+    testTimeoutListenerCanBeTriggered(processInstance, "userTask");
+  }
+
+  @Test
+  public void testTimeoutTaskListenerRemovedAfterMigrationWithBoundaryEvent() {
+    // given
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListenerWithBoundaryEvent.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.noTimeoutTaskListenerWithBoundaryEvent.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapEqualActivities()
+      .build();
+
+    // when
+    testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    testHelper.assertTaskListenerTimerJobRemoved("userTask");
+  }
+
+  @Test
+  public void testTimeoutTaskListenerMigratedAfterMigrationWithBoundaryEvent() {
+    // given
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListenerWithBoundaryEvent.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.changedTimeoutTaskListenerWithBoundaryEvent.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapEqualActivities()
+      .build();
+
+    // when
+    ProcessInstance processInstance = testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    testHelper.assertTaskListenerTimerJobMigrated("userTask", "userTask");
+
+    // and the task listener was able to access the bpmn model instance and set a variable
+    testTimeoutListenerCanBeTriggered(processInstance, "userTask");
+  }
+
+  @Test
+  public void testTimeoutTaskListenerMigratedAndUpdatedAfterMigrationWithBoundaryEvent() {
+    // given
+    ClockTestUtil.setClockToDateWithoutMilliseconds();
+
+    String sourceProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListenerWithBoundaryEvent.bpmn20.xml")
+        .getId();
+    String targetProcessDefinitionId = testHelper
+        .deployAndGetDefinition("org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.changedTimeoutTaskListenerWithBoundaryEvent.bpmn20.xml")
+        .getId();
+
+    MigrationPlan migrationPlan = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinitionId, targetProcessDefinitionId)
+      .mapEqualActivities().updateEventTriggers()
+      .build();
+
+    // when
+    ProcessInstance processInstance = testHelper.createProcessInstanceAndMigrate(migrationPlan);
+
+    // then
+    Date newDueDate = new DateTime(ClockUtil.getCurrentTime()).plusHours(3).toDate();
+    Job taskListenerJob = testHelper.snapshotBeforeMigration.getJobForDefinitionId(
+        testHelper.snapshotBeforeMigration.getJobDefinitionForActivityIdAndType(
+            "userTask", TimerTaskListenerJobHandler.TYPE).getId());
+    testHelper.assertJobMigrated(taskListenerJob, "userTask", newDueDate);
+
+    // and the task listener was able to access the bpmn model instance and set a variable
+    testTimeoutListenerCanBeTriggered(processInstance, "userTask");
+  }
+
   protected static void addTaskListener(BpmnModelInstance targetModel, String activityId, String event, String className) {
     CamundaTaskListener taskListener = targetModel.newInstance(CamundaTaskListener.class);
     taskListener.setCamundaClass(className);
@@ -320,16 +820,12 @@ public class MigrationUserTaskTest {
     task.builder().addExtensionElement(taskListener);
   }
 
-  public static class AccessModelInstanceTaskListener implements TaskListener {
-
-    public static final String VARIABLE_NAME = "userTaskId";
-
-    @Override
-    public void notify(DelegateTask delegateTask) {
-      UserTask userTask = delegateTask.getBpmnModelElementInstance();
-      delegateTask.setVariable(VARIABLE_NAME, userTask.getId());
-    }
-
+  protected void testTimeoutListenerCanBeTriggered(ProcessInstance processInstance, String activityId) {
+    JobDefinition jobDefinition = testHelper.snapshotAfterMigration.getJobDefinitionForActivityIdAndType(activityId, TimerTaskListenerJobHandler.TYPE);
+    rule.getManagementService().executeJob(testHelper.snapshotAfterMigration.getJobForDefinitionId(jobDefinition.getId()).getId());
+    String variableValue =
+        (String) rule.getRuntimeService().getVariable(processInstance.getId(), AccessModelInstanceTaskListener.VARIABLE_NAME);
+    Assert.assertEquals(activityId, variableValue);
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/ProcessInstanceSnapshot.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/ProcessInstanceSnapshot.java
@@ -209,12 +209,7 @@ public class ProcessInstanceSnapshot {
 
   public JobDefinition getJobDefinitionForActivityIdAndType(String activityId, String jobHandlerType) {
 
-    List<JobDefinition> collectedDefinitions = new ArrayList<JobDefinition>();
-    for (JobDefinition jobDefinition : getJobDefinitions()) {
-      if (activityId.equals(jobDefinition.getActivityId()) && jobHandlerType.equals(jobDefinition.getJobType())) {
-        collectedDefinitions.add(jobDefinition);
-      }
-    }
+    List<JobDefinition> collectedDefinitions = getJobDefinitionsForActivityIdAndType(activityId, jobHandlerType);
 
     if (collectedDefinitions.isEmpty()) {
       return null;
@@ -225,6 +220,16 @@ public class ProcessInstanceSnapshot {
     else {
       throw new RuntimeException("There is more than one job definition for activity " + activityId + " and job handler type " + jobHandlerType);
     }
+  }
+
+  protected List<JobDefinition> getJobDefinitionsForActivityIdAndType(String activityId, String jobHandlerType) {
+    List<JobDefinition> collectedDefinitions = new ArrayList<JobDefinition>();
+    for (JobDefinition jobDefinition : getJobDefinitions()) {
+      if (activityId.equals(jobDefinition.getActivityId()) && jobHandlerType.equals(jobDefinition.getJobType())) {
+        collectedDefinitions.add(jobDefinition);
+      }
+    }
+    return collectedDefinitions;
   }
 
   public void setJobDefinitions(List<JobDefinition> jobDefinitions) {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/util/AccessModelInstanceTaskListener.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/util/AccessModelInstanceTaskListener.java
@@ -14,31 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.camunda.bpm.engine.delegate;
+package org.camunda.bpm.engine.test.api.runtime.migration.util;
 
-/**
- * Listener interface implemented by user code which wants to be notified when a property of a task changes.
- *
- * <p>The following Task Events are supported:
- * <ul>
- * <li>{@link #EVENTNAME_CREATE}</li>
- * <li>{@link #EVENTNAME_ASSIGNMENT}</li>
- * <li>{@link #EVENTNAME_COMPLETE}</li>
- * <li>{@link #EVENTNAME_DELETE}</li>
- * <li>{@link #EVENTNAME_TIMEOUT}</li>
- * </ul>
- * </p>
- *
- * @author Tom Baeyens
- */
-public interface TaskListener {
+import org.camunda.bpm.engine.delegate.DelegateTask;
+import org.camunda.bpm.engine.delegate.TaskListener;
+import org.camunda.bpm.model.bpmn.instance.UserTask;
 
-  String EVENTNAME_CREATE = "create";
-  String EVENTNAME_ASSIGNMENT = "assignment";
-  String EVENTNAME_COMPLETE = "complete";
-  String EVENTNAME_DELETE = "delete";
-  String EVENTNAME_TIMEOUT = "timeout";
+public class AccessModelInstanceTaskListener implements TaskListener {
 
-  void notify(DelegateTask delegateTask);
+  public static final String VARIABLE_NAME = "userTaskId";
+
+  @Override
+  public void notify(DelegateTask delegateTask) {
+    UserTask userTask = delegateTask.getBpmnModelElementInstance();
+    delegateTask.setVariable(VARIABLE_NAME, userTask.getId());
+  }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/util/SetBusinessKeyListener.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/util/SetBusinessKeyListener.java
@@ -14,31 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.camunda.bpm.engine.delegate;
+package org.camunda.bpm.engine.test.api.runtime.util;
 
-/**
- * Listener interface implemented by user code which wants to be notified when a property of a task changes.
- *
- * <p>The following Task Events are supported:
- * <ul>
- * <li>{@link #EVENTNAME_CREATE}</li>
- * <li>{@link #EVENTNAME_ASSIGNMENT}</li>
- * <li>{@link #EVENTNAME_COMPLETE}</li>
- * <li>{@link #EVENTNAME_DELETE}</li>
- * <li>{@link #EVENTNAME_TIMEOUT}</li>
- * </ul>
- * </p>
- *
- * @author Tom Baeyens
- */
-public interface TaskListener {
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.DelegateTask;
+import org.camunda.bpm.engine.delegate.TaskListener;
 
-  String EVENTNAME_CREATE = "create";
-  String EVENTNAME_ASSIGNMENT = "assignment";
-  String EVENTNAME_COMPLETE = "complete";
-  String EVENTNAME_DELETE = "delete";
-  String EVENTNAME_TIMEOUT = "timeout";
+public class SetBusinessKeyListener implements TaskListener {
 
-  void notify(DelegateTask delegateTask);
+  public static final String BUSINESS_KEY_VARIABLE = "businessKeyVar";
+
+  @Override
+  public void notify(DelegateTask delegateTask) {
+    DelegateExecution execution = delegateTask.getExecution();
+    String newKeyValue = (String) execution.getVariable(BUSINESS_KEY_VARIABLE);
+    execution.setProcessBusinessKey(newKeyValue);
+  }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
@@ -109,7 +109,7 @@ public class BoundaryTimerEventTest extends PluggableProcessEngineTestCase {
     // which means the process has ended
     assertProcessEnded(pi.getId());
   }
-  
+
   @Deployment
   public void testRecalculateUnchangedExpressionOnTimerCurrentDateBased(){
     // Set the clock fixed
@@ -126,7 +126,7 @@ public class BoundaryTimerEventTest extends PluggableProcessEngineTestCase {
     assertEquals(1, jobs.size());
     Job job = jobs.get(0);
     Date oldDate = job.getDuedate();
-    
+
     // After recalculation of the timer, the job's duedate should be changed
     Date currentTime = new Date(startTime.getTime() + TimeUnit.MINUTES.toMillis(5));
     ClockUtil.setCurrentTime(currentTime);
@@ -146,7 +146,7 @@ public class BoundaryTimerEventTest extends PluggableProcessEngineTestCase {
     // which means the process has ended
     assertProcessEnded(pi.getId());
   }
-  
+
   @Deployment(resources = "org/camunda/bpm/engine/test/bpmn/event/timer/BoundaryTimerEventTest.testRecalculateUnchangedExpressionOnTimerCurrentDateBased.bpmn20.xml")
   public void testRecalculateUnchangedExpressionOnTimerCreationDateBased(){
     // Set the clock fixed
@@ -162,7 +162,7 @@ public class BoundaryTimerEventTest extends PluggableProcessEngineTestCase {
     List<Job> jobs = jobQuery.list();
     assertEquals(1, jobs.size());
     Job job = jobs.get(0);
-    
+
     // After recalculation of the timer, the job's duedate should be based on the creation date
     ClockUtil.setCurrentTime(new Date(startTime.getTime() + TimeUnit.SECONDS.toMillis(5)));
     managementService.recalculateJobDuedate(job.getId(), true);
@@ -179,7 +179,7 @@ public class BoundaryTimerEventTest extends PluggableProcessEngineTestCase {
     // which means the process has ended
     assertProcessEnded(pi.getId());
   }
-  
+
   @Deployment(resources = "org/camunda/bpm/engine/test/bpmn/event/timer/BoundaryTimerEventTest.testRecalculateUnchangedExpressionOnTimerCurrentDateBased.bpmn20.xml")
   public void testRecalculateChangedExpressionOnTimerCurrentDateBased(){
     // Set the clock fixed
@@ -196,24 +196,23 @@ public class BoundaryTimerEventTest extends PluggableProcessEngineTestCase {
     assertEquals(1, jobs.size());
     Job job = jobs.get(0);
     Date oldDate = job.getDuedate();
-    
+
     // After recalculation of the timer, the job's duedate should be changed
-    runtimeService.setVariable(pi.getId(), "duedate", "PT15M");
     managementService.recalculateJobDuedate(job.getId(), false);
     Job jobUpdated = jobQuery.singleResult();
     assertEquals(job.getId(), jobUpdated.getId());
     assertNotEquals(oldDate, jobUpdated.getDuedate());
-    assertTrue(oldDate.after(jobUpdated.getDuedate()));
+    assertTrue(oldDate.before(jobUpdated.getDuedate()));
 
     // After setting the clock to time '16 minutes', the timer should fire
-    ClockUtil.setCurrentTime(new Date(startTime.getTime() + TimeUnit.MINUTES.toMillis(16L)));
+    ClockUtil.setCurrentTime(new Date(startTime.getTime() + TimeUnit.HOURS.toMillis(2L)));
     waitForJobExecutorToProcessAllJobs(5000L);
     assertEquals(0L, jobQuery.count());
 
     // which means the process has ended
     assertProcessEnded(pi.getId());
   }
-  
+
   @Deployment(resources = "org/camunda/bpm/engine/test/bpmn/event/timer/BoundaryTimerEventTest.testRecalculateUnchangedExpressionOnTimerCurrentDateBased.bpmn20.xml")
   public void testRecalculateChangedExpressionOnTimerCreationDateBased(){
     // Set the clock fixed
@@ -230,7 +229,7 @@ public class BoundaryTimerEventTest extends PluggableProcessEngineTestCase {
     assertEquals(1, jobs.size());
     Job job = jobs.get(0);
     Date oldDate = job.getDuedate();
-    
+
     // After recalculation of the timer, the job's duedate should be the same
     runtimeService.setVariable(pi.getId(), "duedate", "PT15M");
     managementService.recalculateJobDuedate(job.getId(), true);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerDelegateCompletionTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerDelegateCompletionTest.java
@@ -20,8 +20,11 @@ import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.delegate.TaskListener;
+import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.task.Task;
+import org.camunda.bpm.engine.task.TaskQuery;
+import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.api.authorization.util.AuthorizationTestRule;
 import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
@@ -36,9 +39,11 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.RuleChain;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Askar Akhmerov
@@ -111,6 +116,25 @@ public class TaskListenerDelegateCompletionTest {
     //then
     task = taskService.createTaskQuery().singleResult();
     assertThat(task, is(nullValue()));
+  }
+
+  @Test
+  @Deployment
+  public void testCompletionIsPossibleOnTimeout() {
+    TaskQuery taskQuery = taskService.createTaskQuery();
+
+    // given
+    runtimeService.startProcessInstanceByKey("process");
+
+    // assume
+    assertThat(taskQuery.count(), is(1L));
+
+    // when
+    ClockUtil.offset(TimeUnit.MINUTES.toMillis(70L));
+    testHelper.waitForJobExecutorToProcessAllJobs(5000L);
+
+    // then
+    assertThat(taskQuery.count(), is(0L));
   }
 
   @Test

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/tasklistener/util/TimeoutTaskListener.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/tasklistener/util/TimeoutTaskListener.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.bpmn.tasklistener.util;
+
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.delegate.DelegateTask;
+import org.camunda.bpm.engine.delegate.TaskListener;
+
+public class TimeoutTaskListener implements TaskListener {
+
+  public void notify(DelegateTask delegateTask) {
+    RuntimeService runtimeService = delegateTask.getProcessEngine().getRuntimeService();
+    int triggerCount = 1;
+    Integer triggerCountVariable = (Integer) runtimeService.getVariable(delegateTask.getExecutionId(), "triggerCount");
+    if (triggerCountVariable != null) {
+      triggerCount += triggerCountVariable;
+    }
+    runtimeService.setVariable(delegateTask.getExecutionId(), "timeout-status", "fired" + (triggerCount == 1 ? "" : triggerCount));
+    runtimeService.setVariable(delegateTask.getExecutionId(), "triggerCount", triggerCount);
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/usertask/UserTaskBpmnModelExecutionContextTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/usertask/UserTaskBpmnModelExecutionContextTest.java
@@ -16,29 +16,70 @@
  */
 package org.camunda.bpm.engine.test.bpmn.usertask;
 
-import org.camunda.bpm.engine.delegate.TaskListener;
-import org.camunda.bpm.engine.impl.test.PluggableProcessEngineTestCase;
-import org.camunda.bpm.model.bpmn.Bpmn;
-import org.camunda.bpm.model.bpmn.BpmnModelInstance;
-import org.camunda.bpm.model.bpmn.instance.*;
-import org.camunda.bpm.model.bpmn.instance.Process;
-import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import static org.camunda.bpm.model.bpmn.impl.BpmnModelConstants.CAMUNDA_NS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 
-import static org.camunda.bpm.model.bpmn.impl.BpmnModelConstants.CAMUNDA_NS;
+import org.camunda.bpm.engine.RepositoryService;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.delegate.TaskListener;
+import org.camunda.bpm.engine.impl.util.ClockUtil;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.camunda.bpm.model.bpmn.instance.Event;
+import org.camunda.bpm.model.bpmn.instance.Process;
+import org.camunda.bpm.model.bpmn.instance.Task;
+import org.camunda.bpm.model.bpmn.instance.UserTask;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 /**
  * @author Daniel Meyer
  *
  */
-public class UserTaskBpmnModelExecutionContextTest extends PluggableProcessEngineTestCase {
+public class UserTaskBpmnModelExecutionContextTest {
 
   private static final String PROCESS_ID = "process";
   private static final String USER_TASK_ID = "userTask";
-  private String deploymentId;
 
-  public void testGetBpmnModelElementInstanceOnCreate() {
+  private RepositoryService repositoryService;
+  private RuntimeService runtimeService;
+  private TaskService taskService;
+
+  protected ProcessEngineRule rule = new ProvidedProcessEngineRule();
+  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(rule);
+
+  @Rule
+  public RuleChain ruleChain = RuleChain.outerRule(rule).around(testRule);
+
+  @Before
+  public void setup() {
+    runtimeService = rule.getRuntimeService();
+    repositoryService = rule.getRepositoryService();
+    taskService = rule.getTaskService();
+  }
+
+  @After
+  public void tearDown() {
+    ModelExecutionContextTaskListener.clear();
+  }
+
+  @Test
+  public void shouldGetBpmnModelElementInstanceOnCreate() {
     String eventName = TaskListener.EVENTNAME_CREATE;
     deployProcess(eventName);
 
@@ -46,12 +87,10 @@ public class UserTaskBpmnModelExecutionContextTest extends PluggableProcessEngin
 
     assertModelInstance();
     assertUserTask(eventName);
-
-    String taskId = taskService.createTaskQuery().active().singleResult().getId();
-    taskService.complete(taskId);
   }
 
-  public void testGetBpmnModelElementInstanceOnAssignment() {
+  @Test
+  public void shouldGetBpmnModelElementInstanceOnAssignment() {
     String eventName = TaskListener.EVENTNAME_ASSIGNMENT;
     deployProcess(eventName);
 
@@ -65,11 +104,10 @@ public class UserTaskBpmnModelExecutionContextTest extends PluggableProcessEngin
 
     assertModelInstance();
     assertUserTask(eventName);
-
-    taskService.complete(taskId);
   }
 
-  public void testGetBpmnModelElementInstanceOnComplete() {
+  @Test
+  public void shouldGetBpmnModelElementInstanceOnComplete() {
     String eventName = TaskListener.EVENTNAME_COMPLETE;
     deployProcess(eventName);
 
@@ -88,6 +126,21 @@ public class UserTaskBpmnModelExecutionContextTest extends PluggableProcessEngin
 
     assertModelInstance();
     assertUserTask(eventName);
+  }
+
+  @Test
+  @Deployment
+  public void shouldGetBpmnModelElementInstanceOnTimeout() {
+    runtimeService.startProcessInstanceByKey(PROCESS_ID);
+
+    assertNull(ModelExecutionContextTaskListener.modelInstance);
+    assertNull(ModelExecutionContextTaskListener.userTask);
+
+    ClockUtil.offset(TimeUnit.MINUTES.toMillis(70L));
+    testRule.waitForJobExecutorToProcessAllJobs(5000L);
+
+    assertModelInstance();
+    assertUserTask(TaskListener.EVENTNAME_TIMEOUT);
   }
 
   private void assertModelInstance() {
@@ -122,22 +175,11 @@ public class UserTaskBpmnModelExecutionContextTest extends PluggableProcessEngin
     BpmnModelInstance modelInstance = Bpmn.createExecutableProcess(PROCESS_ID)
       .startEvent()
       .userTask(USER_TASK_ID)
+        .camundaTaskListenerClass(eventName, ModelExecutionContextTaskListener.class)
       .endEvent()
       .done();
 
-    ExtensionElements extensionElements = modelInstance.newInstance(ExtensionElements.class);
-    ModelElementInstance taskListener = extensionElements.addExtensionElement(CAMUNDA_NS, "taskListener");
-    taskListener.setAttributeValueNs(CAMUNDA_NS, "class", ModelExecutionContextTaskListener.class.getName());
-    taskListener.setAttributeValueNs(CAMUNDA_NS, "event", eventName);
-
-    UserTask userTask = modelInstance.getModelElementById(USER_TASK_ID);
-    userTask.setExtensionElements(extensionElements);
-
-    deploymentId = repositoryService.createDeployment().addModelInstance("process.bpmn", modelInstance).deploy().getId();
+    rule.manageDeployment(repositoryService.createDeployment().addModelInstance("process.bpmn", modelInstance).deploy());
   }
 
-  public void tearDown() {
-    ModelExecutionContextTaskListener.clear();
-    repositoryService.deleteDeployment(deploymentId, true);
-  }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/util/ProcessEngineTestRule.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/util/ProcessEngineTestRule.java
@@ -30,17 +30,13 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import org.camunda.bpm.engine.ProcessEngine;
-import org.camunda.bpm.engine.ProcessEngineConfiguration;
-import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.delegate.Expression;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.cmmn.behavior.CaseControlRuleImpl;
 import org.camunda.bpm.engine.impl.el.FixedValue;
 import org.camunda.bpm.engine.impl.history.HistoryLevel;
-import org.camunda.bpm.engine.impl.history.HistoryLevelFull;
 import org.camunda.bpm.engine.impl.jobexecutor.JobExecutor;
-import org.camunda.bpm.engine.impl.test.AbstractProcessEngineTestCase;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.camunda.bpm.engine.repository.Deployment;
 import org.camunda.bpm.engine.repository.DeploymentBuilder;
@@ -147,6 +143,19 @@ public class ProcessEngineTestRule extends TestWatcher {
 
   public ProcessDefinition deployAndGetDefinition(BpmnModelInstance bpmnModel) {
     return deployForTenantAndGetDefinition(null, bpmnModel);
+  }
+
+  public ProcessDefinition deployAndGetDefinition(String classpathResource) {
+    return deployForTenantAndGetDefinition(null, classpathResource);
+  }
+
+  public ProcessDefinition deployForTenantAndGetDefinition(String tenant, String classpathResource) {
+    Deployment deployment = deploy(createDeploymentBuilder().tenantId(tenant), Collections.<BpmnModelInstance>emptyList(), Collections.singletonList(classpathResource));
+
+    return processEngineRule.getRepositoryService()
+      .createProcessDefinitionQuery()
+      .deploymentId(deployment.getId())
+      .singleResult();
   }
 
   public ProcessDefinition deployForTenantAndGetDefinition(String tenant, BpmnModelInstance bpmnModel) {

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/SetBusinessKeyTest.testNewKeyInTimeoutTaskListener.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/SetBusinessKeyTest.testNewKeyInTimeoutTaskListener.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="Task_0bc7eqe" />
+    <bpmn:userTask id="Task_0bc7eqe">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.api.runtime.util.SetBusinessKeyListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="Task_0bc7eqe" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.changedTimeoutTaskListener.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.changedTimeoutTaskListener.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="userTask" />
+    <bpmn:userTask id="userTask">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.api.runtime.migration.util.AccessModelInstanceTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT3H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="userTask" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.changedTimeoutTaskListenerAndTask.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.changedTimeoutTaskListenerAndTask.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="userTask" />
+    <bpmn:userTask id="userTask2">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.api.runtime.migration.util.AccessModelInstanceTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT3H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="userTask" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.changedTimeoutTaskListenerWithBoundaryEvent.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.changedTimeoutTaskListenerWithBoundaryEvent.bpmn20.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="userTask" />
+    <bpmn:userTask id="userTask">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.api.runtime.migration.util.AccessModelInstanceTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT3H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:boundaryEvent id="timer" attachedToRef="userTask">
+      <bpmn:outgoing>SequenceFlow_063ksng</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_063ksng" sourceRef="timer" targetRef="EndEvent_130kn1h" />
+    <bpmn:endEvent id="EndEvent_130kn1h">
+      <bpmn:incoming>SequenceFlow_063ksng</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="userTask" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.noTimeoutTaskListener.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.noTimeoutTaskListener.bpmn20.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="userTask" />
+    <bpmn:userTask id="userTask">
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="userTask" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.noTimeoutTaskListenerWithBoundaryEvent.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.noTimeoutTaskListenerWithBoundaryEvent.bpmn20.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="userTask" />
+    <bpmn:userTask id="userTask">
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:boundaryEvent id="timer" attachedToRef="userTask">
+      <bpmn:outgoing>SequenceFlow_063ksng</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_063ksng" sourceRef="timer" targetRef="EndEvent_130kn1h" />
+    <bpmn:endEvent id="EndEvent_130kn1h">
+      <bpmn:incoming>SequenceFlow_063ksng</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="userTask" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListener.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListener.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="userTask" />
+    <bpmn:userTask id="userTask">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.api.runtime.migration.util.AccessModelInstanceTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="userTask" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListenerDifferentTask.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListenerDifferentTask.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="userTask2" />
+    <bpmn:userTask id="userTask2">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.api.runtime.migration.util.AccessModelInstanceTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="userTask2" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListenerWithBoundaryEvent.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.oneTimeoutTaskListenerWithBoundaryEvent.bpmn20.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="userTask" />
+    <bpmn:userTask id="userTask">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.api.runtime.migration.util.AccessModelInstanceTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT2H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:boundaryEvent id="timer" attachedToRef="userTask">
+      <bpmn:outgoing>SequenceFlow_063ksng</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_063ksng" sourceRef="timer" targetRef="EndEvent_130kn1h" />
+    <bpmn:endEvent id="EndEvent_130kn1h">
+      <bpmn:incoming>SequenceFlow_063ksng</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="userTask" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.twoChangedTimeoutTaskListeners.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.twoChangedTimeoutTaskListeners.bpmn20.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="userTask" />
+    <bpmn:userTask id="userTask">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.api.runtime.migration.util.AccessModelInstanceTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.api.runtime.migration.util.AccessModelInstanceTaskListener" event="timeout" id="timeout-hard" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT2H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="userTask" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.twoChangedTimeoutTaskListenersAndTask.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.twoChangedTimeoutTaskListenersAndTask.bpmn20.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="userTask" />
+    <bpmn:userTask id="userTask">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.api.runtime.migration.util.AccessModelInstanceTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.api.runtime.migration.util.AccessModelInstanceTaskListener" event="timeout" id="timeout-hard" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT2H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="userTask" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.twoTimeoutTaskListeners.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.twoTimeoutTaskListeners.bpmn20.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="userTask" />
+    <bpmn:userTask id="userTask">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.api.runtime.migration.util.AccessModelInstanceTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.api.runtime.migration.util.AccessModelInstanceTaskListener" event="timeout" id="timeout-hard" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT2H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="userTask" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.twoTimeoutTaskListenersPastDate.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.twoTimeoutTaskListenersPastDate.bpmn20.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="userTask" />
+    <bpmn:userTask id="userTask">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.api.runtime.migration.util.AccessModelInstanceTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.api.runtime.migration.util.AccessModelInstanceTaskListener" event="timeout" id="timeout-hard" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2012-09-03T12:00:00</bpmn:timeDate>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="userTask" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerDelegateCompletionTest.testCompletionIsPossibleOnTimeout.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerDelegateCompletionTest.testCompletionIsPossibleOnTimeout.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="Task_0bc7eqe" />
+    <bpmn:userTask id="Task_0bc7eqe">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.bpmn.tasklistener.util.CompletingTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="Task_0bc7eqe" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.testMultipleTimeoutTaskListeners.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.testMultipleTimeoutTaskListeners.bpmn20.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="Task_0bc7eqe" />
+    <bpmn:userTask id="Task_0bc7eqe">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.bpmn.tasklistener.util.TimeoutTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.bpmn.tasklistener.util.TimeoutTaskListener" event="timeout" id="timeout-hard" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT2H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="Task_0bc7eqe" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.testRecalculateTimeoutTaskListenerDuedateCreationDateBased.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.testRecalculateTimeoutTaskListenerDuedateCreationDateBased.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="Task_0bc7eqe" />
+    <bpmn:userTask id="Task_0bc7eqe">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.bpmn.tasklistener.util.TimeoutTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">${duration}</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="Task_0bc7eqe" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.testRecalculateTimeoutTaskListenerDuedateCreationDateBasedWithDefinedBoundaryEvent.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.testRecalculateTimeoutTaskListenerDuedateCreationDateBasedWithDefinedBoundaryEvent.bpmn20.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="userTask" />
+    <bpmn:userTask id="userTask">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.bpmn.tasklistener.util.TimeoutTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">${duration}</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:boundaryEvent id="timer" attachedToRef="userTask">
+      <bpmn:outgoing>SequenceFlow_063ksng</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_063ksng" sourceRef="timer" targetRef="EndEvent_130kn1h" />
+    <bpmn:endEvent id="EndEvent_130kn1h">
+      <bpmn:incoming>SequenceFlow_063ksng</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="userTask" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.testTimeoutTaskListenerCycle.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.testTimeoutTaskListenerCycle.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="Task_0bc7eqe" />
+    <bpmn:userTask id="Task_0bc7eqe">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.bpmn.tasklistener.util.TimeoutTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/PT1H</bpmn:timeCycle>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="Task_0bc7eqe" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.testTimeoutTaskListenerDate.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.testTimeoutTaskListenerDate.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="Task_0bc7eqe" />
+    <bpmn:userTask id="Task_0bc7eqe">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.bpmn.tasklistener.util.TimeoutTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-09-09T12:00:00</bpmn:timeDate>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="Task_0bc7eqe" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.testTimeoutTaskListenerDuration.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.testTimeoutTaskListenerDuration.bpmn20.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="Task_0bc7eqe" />
+    <bpmn:userTask id="Task_0bc7eqe">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.bpmn.tasklistener.util.TimeoutTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="Task_0bc7eqe" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0x9b8rw">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1azm3nc_di" bpmnElement="SequenceFlow_1azm3nc">
+        <di:waypoint x="215" y="121" />
+        <di:waypoint x="270" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_0qiofpm_di" bpmnElement="Task_0bc7eqe">
+        <dc:Bounds x="270" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1ejgtlr_di" bpmnElement="EndEvent_1ejgtlr">
+        <dc:Bounds x="432" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_18ewnwn_di" bpmnElement="SequenceFlow_18ewnwn">
+        <di:waypoint x="370" y="121" />
+        <di:waypoint x="432" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.testTimeoutTaskListenerNotCalledWhenTaskCompletedByBoundaryEvent.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.testTimeoutTaskListenerNotCalledWhenTaskCompletedByBoundaryEvent.bpmn20.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="Task_0bc7eqe" />
+    <bpmn:userTask id="Task_0bc7eqe">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.bpmn.tasklistener.util.TimeoutTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT2H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:boundaryEvent id="timer" attachedToRef="Task_0bc7eqe">
+      <bpmn:outgoing>SequenceFlow_063ksng</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_063ksng" sourceRef="timer" targetRef="EndEvent_130kn1h" />
+    <bpmn:endEvent id="EndEvent_130kn1h">
+      <bpmn:incoming>SequenceFlow_063ksng</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="Task_0bc7eqe" targetRef="EndEvent_1ejgtlr" />
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/usertask/UserTaskBpmnModelExecutionContextTest.shouldGetBpmnModelElementInstanceOnTimeout.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/usertask/UserTaskBpmnModelExecutionContextTest.shouldGetBpmnModelElementInstanceOnTimeout.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="Task_0bc7eqe" />
+    <bpmn:userTask id="Task_0bc7eqe">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.engine.test.bpmn.usertask.ModelExecutionContextTaskListener" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="Task_0bc7eqe" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/jobexecutor/TimeoutTaskListenerExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/jobexecutor/TimeoutTaskListenerExecutionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.integrationtest.jobexecutor;
+
+import java.util.List;
+
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.task.Task;
+import org.camunda.bpm.integrationtest.jobexecutor.beans.SampleTaskListenerBean;
+import org.camunda.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class TimeoutTaskListenerExecutionTest extends AbstractFoxPlatformIntegrationTest {
+
+  @Deployment
+  public static WebArchive processArchive() {
+    WebArchive archive = initWebArchiveDeployment()
+            .addAsResource("org/camunda/bpm/integrationtest/jobexecutor/TimeoutTaskListenerExecution.bpmn20.xml")
+            .addClass(SampleTaskListenerBean.class);
+
+    return archive;
+  }
+
+  @Test
+  public void testProcessExecution() {
+
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey("process");
+
+    waitForJobExecutorToProcessAllJobs();
+
+    List<ProcessInstance> finallyRunningInstances = runtimeService.createProcessInstanceQuery().processInstanceId(instance.getId()).list();
+    Assert.assertEquals(1, finallyRunningInstances.size());
+
+    Task task = taskService.createTaskQuery().processInstanceId(instance.getId()).singleResult();
+    Assert.assertNotNull(task);
+
+    Object variable = taskService.getVariable(task.getId(), "called");
+    Assert.assertNotNull(variable);
+
+    Assert.assertTrue((boolean) variable);
+  }
+}

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/jobexecutor/beans/SampleTaskListenerBean.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/jobexecutor/beans/SampleTaskListenerBean.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.integrationtest.jobexecutor.beans;
+
+import org.camunda.bpm.engine.delegate.DelegateTask;
+import org.camunda.bpm.engine.delegate.TaskListener;
+
+public class SampleTaskListenerBean implements TaskListener {
+
+  @Override
+  public void notify(DelegateTask delegateTask) {
+    delegateTask.setVariable("called", true);
+  }
+
+}

--- a/qa/integration-tests-engine/src/test/resources/org/camunda/bpm/integrationtest/jobexecutor/TimeoutTaskListenerExecution.bpmn20.xml
+++ b/qa/integration-tests-engine/src/test/resources/org/camunda/bpm/integrationtest/jobexecutor/TimeoutTaskListenerExecution.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mm4dtf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1azm3nc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1azm3nc" sourceRef="StartEvent_1" targetRef="userTask" />
+    <bpmn:userTask id="userTask">
+      <bpmn:extensionElements>
+        <camunda:taskListener class="org.camunda.bpm.integrationtest.jobexecutor.beans.SampleTaskListenerBean" event="timeout" id="timeout-friendly" >
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1S</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </camunda:taskListener>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1azm3nc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_18ewnwn</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1ejgtlr">
+      <bpmn:incoming>SequenceFlow_18ewnwn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_18ewnwn" sourceRef="userTask" targetRef="EndEvent_1ejgtlr" />
+  </bpmn:process>
+</bpmn:definitions>


### PR DESCRIPTION
* add parsing routine for 'timeout' task listeners that
  * creates timer declarations and attaches them to the user task
    at a new property 'timerListenerDeclarations'
  * sets the activity's 'isScope' to true so its timers
    get picked up at activity creation
  * sets the activity's 'eventScope' to itself so all timers
    are handled upon migration
* add timeoutTaskListeners map to TaskDefinition based on listener IDs
* add 'fireTimeoutEvent' method to TaskEntity based on listener IDs
* add a new job handler for timeout task listeners
* add the listener ID as a secondary timer element key
  in the 'TimerJobConfiguration'
* add migration routines for timeout listeners in ActivityInstanceJobHandler
* allow user tasks with timeout handlers to remove event scope in migration
* allow timeout duedates to be recalculated

related to https://app.camunda.com/jira/browse/CAM-10399