### PR TITLE
CAM-10853: feat(engine): allow to call Spring bean methods from script tasks

### DIFF
--- a/engine-spring/compatibility-test-spring4/pom.xml
+++ b/engine-spring/compatibility-test-spring4/pom.xml
@@ -91,6 +91,16 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-all</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.python</groupId>
+      <artifactId>jython</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
 

--- a/engine-spring/compatibility-test-spring5/pom.xml
+++ b/engine-spring/compatibility-test-spring5/pom.xml
@@ -86,6 +86,16 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-all</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.python</groupId>
+      <artifactId>jython</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
 

--- a/engine-spring/core/pom.xml
+++ b/engine-spring/core/pom.xml
@@ -80,6 +80,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.python</groupId>
+      <artifactId>jython</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>

--- a/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringBeansResolverFactory.java
+++ b/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringBeansResolverFactory.java
@@ -27,15 +27,14 @@ import org.springframework.context.ApplicationContext;
 
 /**
  * <p>
- * The {@link ResolverFactory} and {@link Resolver}class to access all the beans
- * managed by the Spring container, to make them available in scripting.
+ * {@link ResolverFactory} and {@link Resolver} classes to make the beans
+ * managed by the Spring container available in scripting
  * </p>
  * 
  * <p>
  * {@see org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration#initScripting()}
  * <p>
  *
- * @author Laszlo Palossy
  */
 public class SpringBeansResolverFactory implements ResolverFactory, Resolver {
 

--- a/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringBeansResolverFactory.java
+++ b/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringBeansResolverFactory.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.spring;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.camunda.bpm.engine.delegate.VariableScope;
+import org.camunda.bpm.engine.impl.scripting.engine.Resolver;
+import org.camunda.bpm.engine.impl.scripting.engine.ResolverFactory;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * <p>
+ * The {@link ResolverFactory} and {@link Resolver}class to access all the beans
+ * managed by the Spring container, to make them available in scripting.
+ * </p>
+ * 
+ * <p>
+ * {@see org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration#initScripting()}
+ * <p>
+ *
+ * @author Laszlo Palossy
+ */
+public class SpringBeansResolverFactory implements ResolverFactory, Resolver {
+
+  private ApplicationContext applicationContext;
+  private Set<String> keySet;
+
+  public SpringBeansResolverFactory(ApplicationContext applicationContext) {
+    this.applicationContext = applicationContext;
+
+    String[] beannames = applicationContext.getBeanDefinitionNames();
+    this.keySet = new HashSet<String>(Arrays.asList(beannames));
+  }
+
+  @Override
+  public Resolver createResolver(VariableScope variableScope) {
+    return this;
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    if (key instanceof String) {
+      return keySet.contains((String) key);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public Object get(Object key) {
+    if (key instanceof String) {
+      return applicationContext.getBean((String) key);
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public Set<String> keySet() {
+    return keySet;
+  }
+}

--- a/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringBeansResolverFactory.java
+++ b/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringBeansResolverFactory.java
@@ -45,7 +45,7 @@ public class SpringBeansResolverFactory implements ResolverFactory, Resolver {
     this.applicationContext = applicationContext;
 
     String[] beannames = applicationContext.getBeanDefinitionNames();
-    this.keySet = new HashSet<String>(Arrays.asList(beannames));
+    this.keySet = new HashSet<>(Arrays.asList(beannames));
   }
 
   @Override

--- a/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringProcessEngineConfiguration.java
+++ b/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringProcessEngineConfiguration.java
@@ -20,11 +20,11 @@ import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
-
 /**
  * @author Svetlana Dorokhova
  */
-public class SpringProcessEngineConfiguration extends SpringTransactionsProcessEngineConfiguration implements ApplicationContextAware {
+public class SpringProcessEngineConfiguration extends SpringTransactionsProcessEngineConfiguration
+    implements ApplicationContextAware {
 
   protected ApplicationContext applicationContext;
 
@@ -38,5 +38,14 @@ public class SpringProcessEngineConfiguration extends SpringTransactionsProcessE
   @Override
   public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
     this.applicationContext = applicationContext;
+  }
+
+  /**
+   * Make the beans managed by the Spring container available in scripting
+   */
+  @Override
+  protected void initScripting() {
+    super.initScripting();
+    this.getResolverFactories().add(new SpringBeansResolverFactory(applicationContext));
   }
 }

--- a/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringProcessEngineConfiguration.java
+++ b/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringProcessEngineConfiguration.java
@@ -40,12 +40,10 @@ public class SpringProcessEngineConfiguration extends SpringTransactionsProcessE
     this.applicationContext = applicationContext;
   }
 
-  /**
-   * Make the beans managed by the Spring container available in scripting
-   */
   @Override
   protected void initScripting() {
     super.initScripting();
+    // make Spring container managed beans available for scripting
     this.getResolverFactories().add(new SpringBeansResolverFactory(applicationContext));
   }
 }

--- a/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/scripttask/ScriptTaskTest.java
+++ b/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/scripttask/ScriptTaskTest.java
@@ -17,10 +17,10 @@
 package org.camunda.bpm.engine.spring.test.scripttask;
 
 import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import org.camunda.bpm.application.impl.metadata.spi.ProcessArchiveXml;
 import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.repository.Deployment;
@@ -61,10 +61,22 @@ public class ScriptTaskTest {
   }
 
   @Test
-  public void testSpringBeanVisibility() {
+  public void testJavascriptSpringBeanVisibility() {
     testSpringBeanVisibility(JAVASCRIPT, "execution.setVariable('foo', testbean.name);");
+  }
+
+  @Test
+  public void testGroovySpringBeanVisibility() {
     testSpringBeanVisibility(GROOVY, "execution.setVariable('foo', testbean.name)\n");
+  }
+
+  @Test
+  public void testPythonSpringBeanVisibility() {
     testSpringBeanVisibility(PYTHON, "execution.setVariable('foo', testbean.name)\n");
+  }
+
+  @Test
+  public void testJuelSpringBeanVisibility() {
     testSpringBeanVisibility(JUEL, "${execution.setVariable('foo', testbean.name)}");
   }
 
@@ -79,8 +91,10 @@ public class ScriptTaskTest {
   }
 
   protected BpmnModelInstance createProcess(String scriptFormat, String scriptText) {
-
-    return Bpmn.createExecutableProcess("testProcess").startEvent().scriptTask().scriptFormat(scriptFormat)
+    return Bpmn.createExecutableProcess("testProcess")
+        .startEvent()
+        .scriptTask()
+        .scriptFormat(scriptFormat)
         .scriptText(scriptText).userTask().endEvent().done();
   }
 

--- a/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/scripttask/ScriptTaskTest.java
+++ b/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/scripttask/ScriptTaskTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.spring.test.scripttask;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.camunda.bpm.engine.RepositoryService;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.repository.Deployment;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.spring.test.SpringProcessEngineTestCase;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ *
+ * @author Laszlo Palossy
+ *
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+    "classpath:org/camunda/bpm/engine/spring/test/scripttask/ScriptTaskTest-applicationContext.xml" })
+public class ScriptTaskTest extends SpringProcessEngineTestCase {
+
+  @Autowired
+  private RuntimeService runtimeService;
+
+  @Autowired
+  private RepositoryService repositoryService;
+
+  @Autowired
+  Testbean testbean;
+
+  private static final String JAVASCRIPT = "javascript";
+  private static final String PYTHON = "python";
+  private static final String GROOVY = "groovy";
+  private static final String JUEL = "juel";
+
+  private List<String> deploymentIds = new ArrayList<String>();
+
+  @After
+  public void after() {
+    for (String deploymentId : deploymentIds) {
+      repositoryService.deleteDeployment(deploymentId, true);
+    }
+  }
+
+  @Test
+  public void testJavascriptProcessVarVisibility() {
+
+    deployProcess(JAVASCRIPT,
+
+        // GIVEN
+        // an execution variable 'foo', value is set to the testbean's name property
+        "execution.setVariable('foo', testbean.name);");
+
+    // GIVEN
+    // that we start an instance of this process
+    ProcessInstance pi = runtimeService.startProcessInstanceByKey("testProcess");
+
+    // THEN
+    // the script task can be executed without exceptions
+    // the execution variable is stored and has the correct value
+    Object variableValue = runtimeService.getVariable(pi.getId(), "foo");
+    assertEquals("name property of the testbean", variableValue);
+
+  }
+
+  @Test
+  public void testPythonProcessVarVisibility() {
+
+    deployProcess(PYTHON,
+
+        // GIVEN
+        // an execution variable 'foo', value is set to the testbean's name property
+        "execution.setVariable('foo', testbean.name)\n");
+
+    // GIVEN
+    // that we start an instance of this process
+    ProcessInstance pi = runtimeService.startProcessInstanceByKey("testProcess");
+
+    // THEN
+    // the script task can be executed without exceptions
+    // the execution variable is stored and has the correct value
+    Object variableValue = runtimeService.getVariable(pi.getId(), "foo");
+    assertEquals("name property of the testbean", variableValue);
+
+  }
+
+  @Test
+  public void testGroovyProcessVarVisibility() {
+
+    deployProcess(GROOVY,
+
+        // GIVEN
+        // an execution variable 'foo', value is set to the testbean's name property
+        "execution.setVariable('foo', testbean.name)\n");
+
+    // GIVEN
+    // that we start an instance of this process
+    ProcessInstance pi = runtimeService.startProcessInstanceByKey("testProcess");
+
+    // THEN
+    // the script task can be executed without exceptions
+    // the execution variable is stored and has the correct value
+    Object variableValue = runtimeService.getVariable(pi.getId(), "foo");
+    assertEquals("name property of the testbean", variableValue);
+
+  }
+
+  @Test
+  public void testJuelExpression() {
+    deployProcess(JUEL, "${execution.setVariable('foo', testbean.name)}");
+
+    ProcessInstance pi = runtimeService.startProcessInstanceByKey("testProcess");
+
+    String variableValue = (String) runtimeService.getVariable(pi.getId(), "foo");
+    assertEquals("name property of the testbean", variableValue);
+  }
+
+  protected void deployProcess(BpmnModelInstance process) {
+    Deployment deployment = repositoryService.createDeployment().addModelInstance("testProcess.bpmn", process).deploy();
+    deploymentIds.add(deployment.getId());
+  }
+
+  protected void deployProcess(String scriptFormat, String scriptText) {
+    BpmnModelInstance process = createProcess(scriptFormat, scriptText);
+    deployProcess(process);
+  }
+
+  protected BpmnModelInstance createProcess(String scriptFormat, String scriptText) {
+
+    return Bpmn.createExecutableProcess("testProcess").startEvent().scriptTask().scriptFormat(scriptFormat)
+        .scriptText(scriptText).userTask().endEvent().done();
+  }
+}

--- a/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/scripttask/Testbean.java
+++ b/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/scripttask/Testbean.java
@@ -1,11 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.bpm.engine.spring.test.scripttask;
 
 import org.springframework.stereotype.Component;
 
 @Component
 public class Testbean {
-	private String name = "name property of the testbean";
-	public String getName() {
-		return name;
-	}
+  private String name = "name property of testbean";
+
+  public String getName() {
+    return name;
+  }
 }

--- a/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/scripttask/Testbean.java
+++ b/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/scripttask/Testbean.java
@@ -1,0 +1,11 @@
+package org.camunda.bpm.engine.spring.test.scripttask;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class Testbean {
+	private String name = "name property of the testbean";
+	public String getName() {
+		return name;
+	}
+}

--- a/engine-spring/core/src/test/resources/org/camunda/bpm/engine/spring/test/scripttask/ScriptTaskTest-applicationContext.xml
+++ b/engine-spring/core/src/test/resources/org/camunda/bpm/engine/spring/test/scripttask/ScriptTaskTest-applicationContext.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans" 
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd
+                           http://www.springframework.org/schema/tx      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd">
+
+  <bean id="testbean" class="org.camunda.bpm.engine.spring.test.scripttask.Testbean" />
+
+  <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
+    <property name="driverClass" value="org.h2.Driver" />
+    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="username" value="sa" />
+    <property name="password" value="" />
+  </bean>
+
+  <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <property name="dataSource" ref="dataSource" />
+  </bean>
+  
+  <bean id="processEngineConfiguration" class="org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration">
+    <property name="dataSource" ref="dataSource" />
+    <property name="transactionManager" ref="transactionManager" />
+    <property name="databaseSchemaUpdate" value="true" />
+    <property name="jobExecutorActivate" value="false" />
+    <!-- turn off metrics reporter -->
+    <property name="dbMetricsReporterActivate" value="false" />
+  </bean>
+  
+  <bean id="processEngine" class="org.camunda.bpm.engine.spring.ProcessEngineFactoryBean">
+    <property name="processEngineConfiguration" ref="processEngineConfiguration" />
+  </bean>
+  
+  <bean id="repositoryService" factory-bean="processEngine" factory-method="getRepositoryService" />
+  <bean id="runtimeService" factory-bean="processEngine" factory-method="getRuntimeService" />
+  <bean id="taskService" factory-bean="processEngine" factory-method="getTaskService" />
+  <bean id="historyService" factory-bean="processEngine" factory-method="getHistoryService" />
+  <bean id="managementService" factory-bean="processEngine" factory-method="getManagementService" />
+
+</beans>


### PR DESCRIPTION
Allow to execute bean (i.e. Spring beans) methods from a script task  (for example JavaScript or Groovy).
Makes available all beans managed by the Spring container by implementing the `org.camunda.bpm.engine.impl.scripting.engine.Resolver` and `org.camunda.bpm.engine.impl.scripting.engine.ResolverFactory` interfaces.

This solution was suggested by Thorben Lindhauer on the Camuda Forum:
[Inability to Access Spring Beans in Input/Output Mapping Script](https://forum.camunda.org/t/inability-to-access-spring-beans-in-input-output-mapping-script/3310).

It will solve the JIRAissue CAM-4222.

Now it is configured to register in the `org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration` class, method `initScripting()`.

It could be perhaps implemented as a community extension, imolemented as a `ProcessEnginePlugin`.

Was tested with JavaScript, Groovy, the 'execution' object too is available as before.
