### PR TITLE
CAM-10801: filtering by candidateUser in an OR query

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
@@ -954,7 +954,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
     if (candidateUser != null) {
       List<String> groupsForCandidateUser = getGroupsForCandidateUser(candidateUser);
 
-      if (cachedCandidateGroups == null) { // if not an 'or' query, it is always empty here
+      if (cachedCandidateGroups == null) {
         cachedCandidateGroups = groupsForCandidateUser;
       } else {
         for (String group : groupsForCandidateUser) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
@@ -929,13 +929,12 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   }
 
   public List<String> getCandidateGroups() {
-
     if (cachedCandidateGroups != null) {
       return cachedCandidateGroups;
     }
 
     if (candidateGroup != null && candidateGroups != null) {
-      cachedCandidateGroups = new ArrayList<String>(candidateGroups);
+      cachedCandidateGroups = new ArrayList<>(candidateGroups);
       if (!isOrQueryActive) {
         // get intersection of candidateGroups and candidateGroup
         cachedCandidateGroups.retainAll(Arrays.asList(candidateGroup));
@@ -1013,28 +1012,31 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   }
 
   protected List<String> getGroupsForCandidateUser(String candidateUser) {
-    HashMap<String, List<String>> cachedGroups = getCachedUserGroups();
-
-    if (cachedGroups.containsKey(candidateUser)) {
-      return cachedGroups.get(candidateUser);
+    HashMap<String, List<String>> cachedUserGroups = getCachedUserGroups();
+    if (cachedUserGroups.containsKey(candidateUser)) {
+      return cachedUserGroups.get(candidateUser);
     }
 
-    List<Group> groups = Context.getCommandContext().getReadOnlyIdentityProvider().createGroupQuery()
-        .groupMember(candidateUser).list();
-    List<String> groupIds = new ArrayList<String>();
+    List<Group> groups = Context
+        .getCommandContext()
+        .getReadOnlyIdentityProvider()
+        .createGroupQuery()
+        .groupMember(candidateUser)
+        .list();
+    
+    List<String> groupIds = new ArrayList<>();
     for (Group group : groups) {
       groupIds.add(group.getId());
     }
-
-    cachedGroups.put(candidateUser, groupIds);
+    cachedUserGroups.put(candidateUser, groupIds);
 
     return groupIds;
   }
 
-  private HashMap<String, List<String>> getCachedUserGroups() {
-    // store and retrieve cached user groups always from the first (root) query
+  protected HashMap<String, List<String>> getCachedUserGroups() {
+    // store and retrieve cached user groups always from the first query
     if (queries.get(0).cachedUserGroups == null) {
-      queries.get(0).cachedUserGroups = new HashMap<String, List<String>>();
+      queries.get(0).cachedUserGroups = new HashMap<>();
     }
     return queries.get(0).cachedUserGroups;
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/usertask/TaskCandidateTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/usertask/TaskCandidateTest.java
@@ -84,6 +84,12 @@ public class TaskCandidateTest extends PluggableProcessEngineTestCase {
     Task task = tasks.get(0);
     assertEquals("Pay out expenses", task.getName());
 
+    // The above query again, now between 'or' and 'endOr'
+    tasks = taskService.createTaskQuery().or().taskCandidateUser(KERMIT).endOr().list();
+    assertEquals(1, tasks.size());
+    task = tasks.get(0);
+    assertEquals("Pay out expenses", task.getName());
+    
     // Claim the task
     taskService.claim(task.getId(), KERMIT);
 


### PR DESCRIPTION
The [TaskQueryImpl.java](https://github.com/camunda/camunda-bpm-platform/blob/7.12.0-alpha3/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java) class changed, and the [TaskCandidateTest.java](https://github.com/camunda/camunda-bpm-platform/blob/7.12.0-alpha3/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/usertask/TaskCandidateTest.java) class got a new testcase.

* the `getCandidateGroups()` method now resolves the `candidateUser`'s groups in case of an 'or' query too, so the TaskQuery returns correct results.
* the `getCandidateGroups()` is working for non 'or' queries exactly the same way as before.
* the `getGroupsForCandidateUser(...)` method caches it's results now, as suggested in the implementation notes.

Solves [CAM-10801](https://app.camunda.com/jira/browse/CAM-10801).