### PR TITLE
CAM-10798: provide process data context for logging

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -798,6 +798,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   // max results limit
   protected int queryMaxResultsLimit = Integer.MAX_VALUE;
 
+  // logging context property names (with default values)
+  protected String logginContextActivityId = "activityId";
+  protected String logginContextApplicationName = "applicationName";
+  protected String logginContextBusinessKey;// default == null => disabled by default
+  protected String logginContextProcessDefinitionId = "processDefinitionId";
+  protected String logginContextProcessInstanceId = "processInstanceId";
+  protected String logginContextTenantId = "tenantId";
+
   // buildProcessEngine ///////////////////////////////////////////////////////
 
   @Override
@@ -4358,6 +4366,60 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public ProcessEngineConfigurationImpl setQueryMaxResultsLimit(int queryMaxResultsLimit) {
     this.queryMaxResultsLimit = queryMaxResultsLimit;
+    return this;
+  }
+
+  public String getLogginContextActivityId() {
+    return logginContextActivityId;
+  }
+
+  public ProcessEngineConfigurationImpl setLogginContextActivityId(String logginContextActivityId) {
+    this.logginContextActivityId = logginContextActivityId;
+    return this;
+  }
+
+  public String getLogginContextApplicationName() {
+    return logginContextApplicationName;
+  }
+
+  public ProcessEngineConfigurationImpl setLogginContextApplicationName(String logginContextApplicationName) {
+    this.logginContextApplicationName = logginContextApplicationName;
+    return this;
+  }
+
+  public String getLogginContextBusinessKey() {
+    return logginContextBusinessKey;
+  }
+
+  public ProcessEngineConfigurationImpl setLogginContextBusinessKey(String logginContextBusinessKey) {
+    this.logginContextBusinessKey = logginContextBusinessKey;
+    return this;
+  }
+
+  public String getLogginContextProcessDefinitionId() {
+    return logginContextProcessDefinitionId;
+  }
+
+  public ProcessEngineConfigurationImpl setLogginContextProcessDefinitionId(String logginContextProcessDefinitionId) {
+    this.logginContextProcessDefinitionId = logginContextProcessDefinitionId;
+    return this;
+  }
+
+  public String getLogginContextProcessInstanceId() {
+    return logginContextProcessInstanceId;
+  }
+
+  public ProcessEngineConfigurationImpl setLogginContextProcessInstanceId(String logginContextProcessInstanceId) {
+    this.logginContextProcessInstanceId = logginContextProcessInstanceId;
+    return this;
+  }
+
+  public String getLogginContextTenantId() {
+    return logginContextTenantId;
+  }
+
+  public ProcessEngineConfigurationImpl setLogginContextTenantId(String logginContextTenantId) {
+    this.logginContextTenantId = logginContextTenantId;
     return this;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/context/Context.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/context/Context.java
@@ -77,7 +77,17 @@ public class Context {
   }
 
   public static void removeCommandInvocationContext() {
-    getStack(commandInvocationContextThreadLocal).pop();
+    Stack<CommandInvocationContext> stack = getStack(commandInvocationContextThreadLocal);
+    CommandInvocationContext currentContext = stack.pop();
+    if (stack.isEmpty()) {
+      // do not clear when called from JobExecutor, will be cleared there after logging
+      if (getJobExecutorContext() == null) {
+        currentContext.getLoggingContext().clearMdc();
+      }
+    } else {
+      // reset the MDC to the logging context of the outer command invocation
+      stack.peek().getLoggingContext().update();
+    }
   }
 
   public static ProcessEngineConfigurationImpl getProcessEngineConfiguration() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/AtomicOperationInvocation.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/AtomicOperationInvocation.java
@@ -54,7 +54,7 @@ public class AtomicOperationInvocation {
     this.performAsync = performAsync;
   }
 
-  public void execute(BpmnStackTrace stackTrace) {
+  public void execute(BpmnStackTrace stackTrace, ProcessDataLoggingContext loggingContext) {
 
     if(operation != PvmAtomicOperation.ACTIVITY_START_CANCEL_SCOPE
        && operation != PvmAtomicOperation.ACTIVITY_START_INTERRUPT_SCOPE
@@ -89,6 +89,9 @@ public class AtomicOperationInvocation {
     activityName = execution.getCurrentActivityName();
     stackTrace.add(this);
 
+
+    boolean popSection = loggingContext.pushSection(execution);
+
     try {
       Context.setExecutionContext(execution);
       if(!performAsync) {
@@ -97,6 +100,9 @@ public class AtomicOperationInvocation {
       }
       else {
         execution.scheduleAtomicOperationAsync(this);
+      }
+      if (popSection) {
+        loggingContext.popSection();
       }
     } finally {
       Context.removeExecutionContext();

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandContextInterceptor.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandContextInterceptor.java
@@ -90,7 +90,7 @@ public class CommandContextInterceptor extends CommandInterceptor {
     boolean isNew = ProcessEngineContextImpl.consume();
     boolean openNew = (context == null || isNew);
 
-    CommandInvocationContext commandInvocationContext = new CommandInvocationContext(command);
+    CommandInvocationContext commandInvocationContext = new CommandInvocationContext(command, processEngineConfiguration);
     Context.setCommandInvocationContext(commandInvocationContext);
 
     try {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandInvocationContext.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandInvocationContext.java
@@ -25,6 +25,7 @@ import org.camunda.bpm.application.InvocationContext;
 import org.camunda.bpm.application.ProcessApplicationReference;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.cmd.CommandLogger;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.context.ProcessApplicationContextUtil;
@@ -47,9 +48,11 @@ public class CommandInvocationContext {
   protected boolean isExecuting = false;
   protected List<AtomicOperationInvocation> queuedInvocations = new ArrayList<AtomicOperationInvocation>();
   protected BpmnStackTrace bpmnStackTrace = new BpmnStackTrace();
+  protected ProcessDataLoggingContext loggingContext;
 
-  public CommandInvocationContext(Command<?> command) {
+  public CommandInvocationContext(Command<?> command, ProcessEngineConfigurationImpl configuration) {
     this.command = command;
+    this.loggingContext = new ProcessDataLoggingContext(configuration);
   }
 
   public Throwable getThrowable() {
@@ -125,9 +128,8 @@ public class CommandInvocationContext {
   protected void invokeNext() {
     AtomicOperationInvocation invocation = queuedInvocations.remove(0);
     try {
-      invocation.execute(bpmnStackTrace);
-    }
-    catch(RuntimeException e) {
+      invocation.execute(bpmnStackTrace, loggingContext);
+    } catch(RuntimeException e) {
       // log bpmn stacktrace
       bpmnStackTrace.printStackTrace(Context.getProcessEngineConfiguration().isBpmnStacktraceVerbose());
       // rethrow
@@ -155,5 +157,9 @@ public class CommandInvocationContext {
         throw new ProcessEngineException("exception while executing command " + command, throwable);
       }
     }
+  }
+
+  public ProcessDataLoggingContext getLoggingContext() {
+    return loggingContext;
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/ProcessDataLoggingContext.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/ProcessDataLoggingContext.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.interceptor;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.camunda.bpm.application.ProcessApplicationReference;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.context.Context;
+import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.slf4j.MDC;
+
+/**
+ * Holds the contextual process data used in logging.<br>
+ *
+ * New context properties are always part of a section that can be started by
+ * {@link #pushSection(ExecutionEntity)}. The section keeps track of all pushed
+ * properties. Those can easily be cleared by popping the section with
+ * {@link #popSection()} afterwards, e.g. after the successful execution.<br>
+ *
+ * A property is only pushed to the logging context if there is a configured
+ * non-empty context name for it in the {@link ProcessEngineConfigurationImpl
+ * process engine configuration}. The following configuration options are
+ * available:
+ * <ul>
+ * <li>logginContextActivityId - the context property for the activity id</li>
+ * <li>logginContextApplicationName - the context property for the application name</li>
+ * <li>logginContextBusinessKey - the context property for the business key</li>
+ * <li>logginContextDefinitionId - the context property for the definition id</li>
+ * <li>logginContextProcessInstanceId - the context property for the instance id</li>
+ * <li>logginContextTenantId - the context property for the tenant id</li>
+ * </ul>
+ */
+public class ProcessDataLoggingContext {
+
+  private static final String NULL_VALUE = "~NULL_VALUE~";
+
+  private String propertyActivityId;
+  private String propertyApplicationName;
+  private String propertyBusinessKey;
+  private String propertyDefinitionId;
+  private String propertyInstanceId;
+  private String propertyTenantId;
+
+  private List<String> propertyNames = new ArrayList<>();
+
+  private Map<String, Deque<String>> propertyValues = new HashMap<>();
+
+  private boolean startNewSection = false;
+  private Deque<List<String>> sections = new ArrayDeque<>();
+
+  public ProcessDataLoggingContext(ProcessEngineConfigurationImpl configuration) {
+    propertyActivityId = configuration.getLogginContextActivityId();
+    if (isNotBlank(propertyActivityId)) {
+      propertyNames.add(propertyActivityId);
+    }
+    propertyApplicationName = configuration.getLogginContextApplicationName();
+    if (isNotBlank(propertyApplicationName)) {
+      propertyNames.add(propertyApplicationName);
+    }
+    propertyBusinessKey = configuration.getLogginContextBusinessKey();
+    if (isNotBlank(propertyBusinessKey)) {
+      propertyNames.add(propertyBusinessKey);
+    }
+    propertyDefinitionId = configuration.getLogginContextProcessDefinitionId();
+    if (isNotBlank(propertyDefinitionId)) {
+      propertyNames.add(propertyDefinitionId);
+    }
+    propertyInstanceId = configuration.getLogginContextProcessInstanceId();
+    if (isNotBlank(propertyInstanceId)) {
+      propertyNames.add(propertyInstanceId);
+    }
+    propertyTenantId = configuration.getLogginContextTenantId();
+    if (isNotBlank(propertyTenantId)) {
+      propertyNames.add(propertyTenantId);
+    }
+  }
+
+  /**
+   * Start a new section that keeps track of the pushed properties and update
+   * the MDC. This also includes clearing the MDC for the first section that is
+   * pushed for the logging context so that only the current properties will be
+   * present in the MDC (might be less than previously present in the MDC). The
+   * previous logging context needs to be reset in the MDC when this one is
+   * closed. This can be achieved by using {@link #updateMdc(String)} with the
+   * previous logging context.
+   *
+   * @param execution
+   *          the execution to retrieve the logging context data from
+   *
+   * @return <code>true</code> if the section contains any updates for the MDC
+   *         and therefore should be popped later by {@link #popSection()}
+   */
+  public boolean pushSection(ExecutionEntity execution) {
+    if (!propertyNames.isEmpty()) {
+      if (propertyValues.isEmpty()) {
+        clearMdc();
+      }
+      startNewSection = true;
+      addToStackAndMdc(execution.getActivityId(), propertyActivityId);
+      addToStackAndMdc(execution.getProcessDefinitionId(), propertyDefinitionId);
+      addToStackAndMdc(execution.getProcessInstanceId(), propertyInstanceId);
+      addToStackAndMdc(execution.getTenantId(), propertyTenantId);
+
+      if (isNotBlank(propertyApplicationName)) {
+        ProcessApplicationReference currentPa = Context.getCurrentProcessApplication();
+        if (currentPa != null) {
+          addToStackAndMdc(currentPa.getName(), propertyApplicationName);
+        }
+      }
+
+      if (isNotBlank(propertyBusinessKey)) {
+        addToStackAndMdc(execution.getBusinessKey(), propertyBusinessKey);
+      }
+
+      if (!startNewSection) {
+        // a new section was started
+        return true;
+      }
+      startNewSection = false;
+    }
+    return false;
+  }
+
+  /**
+   * Pop the latest section, remove all pushed properties of that section and
+   * update the MDC accordingly
+   */
+  public void popSection() {
+    if (!propertyNames.isEmpty()) {
+      List<String> section = sections.pollFirst();
+      if (section != null) {
+        for (String property : section) {
+          removeFromStackAndUpdateMdc(property);
+        }
+      }
+    }
+  }
+
+  /** Remove all logging context properties from the MDC */
+  public void clearMdc() {
+    for (String property : propertyNames) {
+      MDC.remove(property);
+    }
+  }
+
+  /** Update the MDC with the current values of this logging context */
+  public void update() {
+    if (!propertyValues.isEmpty()) {
+      // only update MDC if this context has set anything as well
+      for (String property : propertyNames) {
+        updateMdc(property);
+      }
+    }
+  }
+
+  /** Preserve the current MDC values and store them in the logging context */
+  public void fetchCurrentContext() {
+    if (!propertyNames.isEmpty()) {
+      startNewSection = true;
+      for (String property : propertyNames) {
+        addToStack(MDC.get(property), property, false);
+      }
+      startNewSection = false;
+    }
+  }
+
+  protected void addToStackAndMdc(String value, String property) {
+    addToStack(value, property, true);
+  }
+
+  protected void addToStack(String value, String property, boolean addToMdc) {
+    if (!isNotBlank(property)) {
+      return;
+    }
+    Deque<String> deque = getDeque(property);
+    String current = deque.peekFirst();
+    if (valuesEqual(current, value)) {
+      return;
+    }
+    addToCurrentSection(property);
+    if (value == null) {
+      deque.addFirst(NULL_VALUE);
+      if (addToMdc) {
+        MDC.remove(property);
+      }
+    } else {
+      deque.addFirst(value);
+      if (addToMdc) {
+        MDC.put(property, value);
+      }
+    }
+  }
+
+  protected void removeFromStackAndUpdateMdc(String property) {
+    if (property == null) {
+      return;
+    }
+    getDeque(property).removeFirst();
+    updateMdc(property);
+  }
+
+  protected Deque<String> getDeque(String property) {
+    Deque<String> deque = propertyValues.get(property);
+    if (deque == null) {
+      deque = new ArrayDeque<>();
+      propertyValues.put(property, deque);
+    }
+    return deque;
+  }
+
+  protected void addToCurrentSection(String property) {
+    List<String> section = sections.peekFirst();
+    if (startNewSection) {
+      section = new ArrayList<>();
+      sections.addFirst(section);
+      startNewSection = false;
+    }
+    section.add(property);
+  }
+
+  protected void updateMdc(String property) {
+    String previousValue = propertyValues.containsKey(property) ? propertyValues.get(property).peekFirst() : null;
+    if (isNull(previousValue)) {
+      MDC.remove(property);
+    } else {
+      MDC.put(property, previousValue);
+    }
+  }
+
+  protected static boolean isNotBlank(String property) {
+    return property != null && !property.trim().isEmpty();
+  }
+
+  protected static boolean valuesEqual(String val1, String val2) {
+    if (isNull(val1)) {
+      return val2 == null;
+    }
+    return val1.equals(val2);
+  }
+
+  protected static boolean isNull(String value) {
+    return value == null || NULL_VALUE.equals(value);
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/test/TestHelper.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/test/TestHelper.java
@@ -154,7 +154,7 @@ public abstract class TestHelper {
 
   public static void deleteDeployment(ProcessEngine processEngine, String deploymentId) {
     if(deploymentId != null) {
-      processEngine.getRepositoryService().deleteDeployment(deploymentId, true);
+      processEngine.getRepositoryService().deleteDeployment(deploymentId, true, true, true);
     }
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/logging/ProcessDataLoggingContextTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/logging/ProcessDataLoggingContextTest.java
@@ -1,0 +1,861 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.logging;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.camunda.bpm.container.RuntimeContainerDelegate;
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.DelegateTask;
+import org.camunda.bpm.engine.delegate.ExecutionListener;
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.camunda.bpm.engine.delegate.TaskListener;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.util.ClockUtil;
+import org.camunda.bpm.engine.repository.DeploymentBuilder;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.WatchLogger;
+import org.camunda.bpm.engine.test.util.ProcessEngineBootstrapRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineLoggingRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public class ProcessDataLoggingContextTest {
+
+  private static final String PROCESS = "process";
+  private static final String B_KEY = "businessKey1";
+  private static final String B_KEY2 = "businessKey2";
+  private static final String FAILING_PROCESS = "failing-process";
+  private static final String TENANT_ID = "testTenant";
+
+  private static final String CMD_LOGGER = "org.camunda.bpm.engine.cmd";
+  private static final String CONTEXT_LOGGER = "org.camunda.bpm.engine.context";
+  private static final String JOBEXEC_LOGGER = "org.camunda.bpm.engine.jobexecutor";
+  private static final String PVM_LOGGER = "org.camunda.bpm.engine.pvm";
+
+  private static final String LOG_IDENT_FAILURE = "ENGINE-16004";
+
+  private RuntimeContainerDelegate runtimeContainerDelegate = RuntimeContainerDelegate.INSTANCE.get();
+  private boolean defaultEngineRegistered;
+
+  @ClassRule
+  public static ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
+    public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      return configuration.setLogginContextBusinessKey("businessKey");
+    }
+  };
+
+  @Rule
+  public ProcessEngineRule engineRule = new ProvidedProcessEngineRule(bootstrapRule);
+
+  @Rule
+  public ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
+
+  @Rule
+  public ProcessEngineLoggingRule loggingRule = new ProcessEngineLoggingRule();
+
+  private RuntimeService runtimeService;
+  private TaskService taskService;
+
+  @Before
+  public void setupServices() {
+    runtimeService = engineRule.getRuntimeService();
+    taskService = engineRule.getTaskService();
+    defaultEngineRegistered = false;
+  }
+
+  @After
+  public void resetClock() {
+    ClockUtil.reset();
+  }
+
+  @After
+  public void tearDown() {
+    if (defaultEngineRegistered) {
+      runtimeContainerDelegate.unregisterProcessEngine(engineRule.getProcessEngine());
+    }
+  }
+
+  @After
+  public void resetLogConfiguration() {
+    engineRule.getProcessEngineConfiguration()
+      .setLogginContextActivityId("activityId")
+      .setLogginContextApplicationName("applicationName")
+      .setLogginContextBusinessKey("businessKey")
+      .setLogginContextProcessDefinitionId("processDefinitionId")
+      .setLogginContextProcessInstanceId("processInstanceId")
+      .setLogginContextTenantId("tenantId");
+  }
+
+  @Test
+  @WatchLogger(loggerNames = PVM_LOGGER, level = "DEBUG")
+  public void shouldNotLogBusinessKeyIfNotConfigured() {
+    // given
+    engineRule.getProcessEngineConfiguration().setLogginContextBusinessKey(null);
+    manageDeployment(modelOneTaskProcess());
+    // when
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    taskService.complete(taskService.createTaskQuery().singleResult().getId());
+    // then
+    assertActivityLogs(instance, "ENGINE-200", Arrays.asList("start", "waitState", "end"), true, false, true, true);
+  }
+
+  @Test
+  @WatchLogger(loggerNames = PVM_LOGGER, level = "DEBUG")
+  public void shouldNotLogDisabledProperties() {
+    // given
+    engineRule.getProcessEngineConfiguration()
+      .setLogginContextActivityId(null)
+      .setLogginContextBusinessKey(null)
+      .setLogginContextProcessDefinitionId("");
+    manageDeployment(modelOneTaskProcess());
+    // when
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    taskService.complete(taskService.createTaskQuery().singleResult().getId());
+    // then
+    assertActivityLogs(instance, "ENGINE-200", null, true, false, false, false);
+  }
+
+  @Test
+  @WatchLogger(loggerNames = {PVM_LOGGER, CMD_LOGGER}, level = "DEBUG")
+  public void shouldLogMdcPropertiesOnlyInActivityContext() {
+    // given
+    manageDeployment(modelOneTaskProcess());
+    // when
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    taskService.complete(taskService.createTaskQuery().singleResult().getId());
+    // then activity context logs are present
+    assertActivityLogsPresent(instance, Arrays.asList("start", "waitState", "end"));
+    // other logs do not contain MDC properties
+    assertActivityLogsPresentWithoutMdc("ENGINE-130");
+  }
+
+  @Test
+  @WatchLogger(loggerNames = {PVM_LOGGER, CMD_LOGGER}, level = "DEBUG")
+  public void shouldLogCustomMdcPropertiesOnlyInActivityContext() {
+    // given
+    engineRule.getProcessEngineConfiguration()
+      .setLogginContextActivityId("actId")
+      .setLogginContextApplicationName("appName")
+      .setLogginContextBusinessKey("busKey")
+      .setLogginContextProcessDefinitionId("defId")
+      .setLogginContextProcessInstanceId("instId")
+      .setLogginContextTenantId("tenId");
+    manageDeployment(modelOneTaskProcess());
+    // when
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    taskService.complete(taskService.createTaskQuery().singleResult().getId());
+    // then activity context logs are present
+    assertActivityLogsPresent(instance, Arrays.asList("start", "waitState", "end"), "actId", "appName", "busKey", "defId", "instId", "tenId");
+  }
+
+  @Test
+  @WatchLogger(loggerNames = PVM_LOGGER, level = "DEBUG")
+  public void shouldLogMdcPropertiesForAsyncBeforeInTaskContext() {
+    // given
+    manageDeployment(Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .userTask("waitState").camundaAsyncBefore()
+        .endEvent("end")
+        .done());
+    // when
+    ProcessInstance pi = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    testRule.waitForJobExecutorToProcessAllJobs();
+    taskService.complete(taskService.createTaskQuery().singleResult().getId());
+    // then
+    assertActivityLogsPresent(pi, Arrays.asList("start", "waitState", "end"));
+  }
+
+  @Test
+  @WatchLogger(loggerNames = PVM_LOGGER, level = "DEBUG")
+  public void shouldLogMdcPropertiesForAsyncAfterInTaskContext() {
+    // given
+    manageDeployment(Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .userTask("waitState").camundaAsyncAfter()
+        .endEvent("end")
+        .done());
+    // when
+    ProcessInstance pi = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    taskService.complete(taskService.createTaskQuery().singleResult().getId());
+    testRule.waitForJobExecutorToProcessAllJobs();
+    // then
+    assertActivityLogsPresent(pi, Arrays.asList("start", "waitState", "end"));
+  }
+
+  @Test
+  @WatchLogger(loggerNames = {JOBEXEC_LOGGER, PVM_LOGGER}, level = "DEBUG")
+  public void shouldLogMdcPropertiesForTimerInTaskContext() {
+    // given
+    manageDeployment(Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .intermediateCatchEvent("timer").timerWithDuration("PT10S")
+        .userTask("waitState")
+        .endEvent("end")
+        .done());
+    // when
+    ProcessInstance pi = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    ClockUtil.offset(TimeUnit.MINUTES.toMillis(2L));
+    testRule.waitForJobExecutorToProcessAllJobs();
+    taskService.complete(taskService.createTaskQuery().singleResult().getId());
+    // then
+    assertActivityLogsPresent(pi, Arrays.asList("start", "timer", "waitState", "end"));
+    // job executor logs do not contain MDC properties
+    assertActivityLogsPresentWithoutMdc("ENGINE-140");
+  }
+
+  @Test
+  @WatchLogger(loggerNames = CONTEXT_LOGGER, level = "ERROR")
+  public void shouldLogFailureFromDelegateInTaskContext() {
+    // given
+    manageDeployment(modelDelegateFailure());
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    // when
+    try {
+      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      fail("Exception expected");
+    } catch (Exception e) {
+      // expected exception in the task listener that is not caught
+    }
+    // then
+    assertFailureLogPresent(instance, "failingTask");
+  }
+
+  @Test
+  @WatchLogger(loggerNames = CONTEXT_LOGGER, level = "ERROR")
+  public void shouldLogFailureFromDelegateInTaskContextWithChangedBusinessKey() {
+    // given
+    manageDeployment(Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .userTask("waitState")
+        .serviceTask("bkeyChangingTask")
+          .camundaClass(BusinessKeyChangeDelegate.class)
+        .serviceTask("failingTask")
+          .camundaClass(FailingDelegate.class)
+        .endEvent("end")
+        .done());
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    // when
+    try {
+      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      fail("Exception expected");
+    } catch (Exception e) {
+      // expected exception in the task listener that is not caught
+    }
+    // then
+    assertFailureLogPresent(instance, LOG_IDENT_FAILURE, "failingTask", null, B_KEY2, 1);
+  }
+
+  @Test
+  @WatchLogger(loggerNames = CONTEXT_LOGGER, level = "ERROR")
+  public void shouldLogFailureFromCreateTaskListenerInTaskContext() {
+    // given
+    manageDeployment(Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .userTask("waitState")
+        .userTask("failingTask")
+          .camundaTaskListenerClass(TaskListener.EVENTNAME_CREATE, FailingTaskListener.class)
+        .endEvent("end")
+        .done());
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    // when
+    try {
+      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      fail("Exception expected");
+    } catch (Exception e) {
+      // expected exception in the task listener that is not caught
+    }
+    assertFailureLogPresent(instance, "failingTask");
+  }
+
+  @Test
+  @WatchLogger(loggerNames = CONTEXT_LOGGER, level = "ERROR")
+  public void shouldLogFailureFromAssignTaskListenerInTaskContext() {
+    // given
+    manageDeployment(Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .userTask("failingTask")
+          .camundaTaskListenerClass(TaskListener.EVENTNAME_ASSIGNMENT, FailingTaskListener.class)
+        .endEvent("end")
+        .done());
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    // when
+    try {
+      taskService.setAssignee(taskService.createTaskQuery().singleResult().getId(), "testUser");
+      fail("Exception expected");
+    } catch (Exception e) {
+      // expected exception in the task listener that is not caught
+    }
+    assertFailureLogPresent(instance, "failingTask");
+  }
+
+  @Test
+  @WatchLogger(loggerNames = CONTEXT_LOGGER, level = "ERROR")
+  public void shouldLogFailureFromCompleteTaskListenerInTaskContext() {
+    // given
+    manageDeployment(Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .userTask("failingTask")
+          .camundaTaskListenerClass(TaskListener.EVENTNAME_COMPLETE, FailingTaskListener.class)
+        .endEvent("end")
+        .done());
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    // when
+    try {
+      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      fail("Exception expected");
+    } catch (Exception e) {
+      // expected exception in the task listener that is not caught
+    }
+    assertFailureLogPresent(instance, "failingTask");
+  }
+
+  @Test
+  @WatchLogger(loggerNames = CONTEXT_LOGGER, level = "ERROR")
+  public void shouldLogFailureFromDeleteTaskListenerInTaskContext() {
+    // given
+    manageDeployment(Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .userTask("failingTask")
+          .camundaTaskListenerClass(TaskListener.EVENTNAME_DELETE, FailingTaskListener.class)
+        .endEvent("end")
+        .done());
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    // when
+    try {
+      runtimeService.deleteProcessInstance(instance.getId(), "cancel it");
+      fail("Exception expected");
+    } catch (Exception e) {
+      // expected exception in the task listener that is not caught
+    }
+    assertFailureLogPresent(instance, "failingTask");
+  }
+
+  @Test
+  @WatchLogger(loggerNames = CONTEXT_LOGGER, level = "ERROR")
+  public void shouldLogFailureFromExecutionListenerInTaskContext() {
+    // given
+    manageDeployment(modelExecutionListenerFailure());
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    // when
+    try {
+      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      fail("Exception expected");
+    } catch (Exception e) {
+      // expected exception in the execution listener that is not caught
+    }
+    // then
+    assertFailureLogPresent(instance, "failingTask");
+  }
+
+  @Test
+  @WatchLogger(loggerNames = {CONTEXT_LOGGER, JOBEXEC_LOGGER}, level = "WARN")
+  public void shouldLogFailureFromTimeoutTaskListenerInTaskContext() {
+    // given
+    manageDeployment(Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .userTask("failingTask")
+          .camundaTaskListenerClassTimeoutWithDuration("failure-listener", FailingTaskListener.class, "PT10S")
+        .endEvent("end")
+        .done());
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    // when
+    ClockUtil.offset(TimeUnit.MINUTES.toMillis(2L));
+    testRule.waitForJobExecutorToProcessAllJobs();
+    // then
+    assertFailureLogPresent(instance, "failingTask", 3);
+    assertFailureLogPresent(instance, "ENGINE-14006", "failingTask", null, instance.getBusinessKey(), 3);
+  }
+
+  @Test
+  @WatchLogger(loggerNames = CONTEXT_LOGGER, level = "ERROR")
+  public void shouldLogFailureFromParallelTasksInCorrectTaskContext() {
+    // given
+    manageDeployment(Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .userTask("waitState")
+        .parallelGateway("pSplit")
+          .serviceTask("task")
+            .camundaClass(NoneDelegate.class)
+          .endEvent("end")
+        .moveToLastGateway()
+          .serviceTask("failingTask")
+            .camundaClass(FailingDelegate.class)
+          .endEvent("failingEnd")
+        .done());
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    // when
+    try {
+      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      fail("Exception expected");
+    } catch (Exception e) {
+      // expected exception in the service task that is not caught
+    }
+    // then
+    assertFailureLogPresent(instance, "failingTask");
+  }
+
+  @Test
+  @WatchLogger(loggerNames = CONTEXT_LOGGER, level = "ERROR")
+  public void shouldLogFailureFromNestedDelegateInOuterContext() {
+    // given
+    manageDeployment("failing.bpmn", Bpmn.createExecutableProcess(FAILING_PROCESS)
+        .startEvent("failing_start")
+        .serviceTask("failing_task")
+          .camundaClass(FailingDelegate.class)
+        .endEvent("failing_end")
+        .done());
+    manageDeployment(Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .userTask("waitState")
+        .serviceTask("startProcess")
+          .camundaClass(NestedStartDelegate.class.getName())
+        .endEvent("end")
+        .done());
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    // when
+    try {
+      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      fail("Exception expected");
+    } catch (Exception e) {
+      // expected exception in the nested delegate that is not caught
+    }
+    // then
+    assertFailureLogPresent(instance, "startProcess");
+    assertBpmnStacktraceLogPresent(instance);
+  }
+
+  @Test
+  @WatchLogger(loggerNames = CONTEXT_LOGGER, level = "ERROR")
+  public void shouldLogFailureFromNestedExecutionListenerInOuterContext() {
+    // given
+    manageDeployment("failing.bpmn", Bpmn.createExecutableProcess(FAILING_PROCESS)
+        .startEvent("failing_start")
+        .serviceTask("failing_task")
+          .camundaClass(NoneDelegate.class.getName())
+          .camundaExecutionListenerClass("end", FailingExecutionListener.class)
+        .endEvent("failing_end")
+        .done());
+    manageDeployment(Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .userTask("waitState")
+        .serviceTask("startProcess")
+          .camundaClass(NestedStartDelegate.class.getName())
+        .endEvent("end")
+        .done());
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    // when
+    try {
+      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      fail("Exception expected");
+    } catch (Exception e) {
+      // expected exception in the nested delegate that is not caught
+    }
+    // then
+    assertFailureLogPresent(instance, "startProcess");
+    assertBpmnStacktraceLogPresent(instance);
+  }
+
+  @Test
+  @WatchLogger(loggerNames = CONTEXT_LOGGER, level = "ERROR")
+  public void shouldLogFailureFromMessageCorrelationListenerInEventContext() {
+    // given
+    manageDeployment(Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .intermediateCatchEvent("message")
+          .message("testMessage")
+          .camundaExecutionListenerClass("end", FailingExecutionListener.class)
+        .endEvent("end")
+        .done());
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    // when
+    try {
+      runtimeService.correlateMessage("testMessage");
+      fail("Exception expected");
+    } catch (Exception e) {
+      // expected exception in the task listener that is not caught
+    }
+    // then
+    assertFailureLogPresent(instance, "message");
+  }
+
+  @Test
+  @WatchLogger(loggerNames = CONTEXT_LOGGER, level = "ERROR")
+  public void shouldLogFailureFromEventSubprocessInSubprocessTaskContext() {
+    // given
+    testRule.deployForTenant(TENANT_ID, "org/camunda/bpm/engine/test/logging/ProcessDataLoggingContextTest.shouldLogFailureFromEventSubprocessInSubprocessTaskContext.bpmn20.xml");
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS);
+    // when
+    try {
+      runtimeService.correlateMessage("testMessage");
+      fail("Exception expected");
+    } catch (Exception e) {
+      // expected exception in the delegate that is not caught
+    }
+    // then
+    assertFailureLogPresent(instance, "sub_failingTask");
+  }
+
+  @Test
+  @WatchLogger(loggerNames = CONTEXT_LOGGER, level = "ERROR")
+  public void shouldLogInternalFailureInTaskContext() {
+    // given
+    manageDeployment(Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .userTask("waitState")
+        .serviceTask("failingTask")
+          .camundaDelegateExpression("${foo}")
+        .endEvent("end")
+        .done());
+    ProcessInstance pi = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    // when
+    try {
+      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      fail("Exception expected");
+    } catch (Exception e) {
+      // expected exception in the delegate resolution that is not caught
+    }
+    // then
+    assertFailureLogPresent(pi, "failingTask");
+  }
+
+  @Test
+  @WatchLogger(loggerNames = CONTEXT_LOGGER, level = "ERROR")
+  public void shouldLogInputOutputMappingFailureInTaskContext() {
+    // given
+    manageDeployment(Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .userTask("waitState")
+        .serviceTask("failingTask")
+          .camundaClass(NoneDelegate.class)
+          .camundaInputParameter("foo", "${foooo}")
+        .endEvent("end")
+        .done());
+    ProcessInstance pi = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    // when
+    try {
+      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      fail("Exception expected");
+    } catch (Exception e) {
+      // expected exception in the delegate resolution that is not caught
+    }
+    // then
+    assertFailureLogPresent(pi, "failingTask");
+  }
+
+  @Test
+  @WatchLogger(loggerNames = CONTEXT_LOGGER, level = "ERROR")
+  public void shouldLogFailureFromDelegateInTaskContextInPa() {
+    // given
+    registerProcessEngine();
+    TestApplicationReusingExistingEngine application = new TestApplicationReusingExistingEngine() {
+      @Override
+      public void createDeployment(String processArchiveName, DeploymentBuilder deploymentBuilder) {
+        deploymentBuilder.addModelInstance("test.bpmn", modelDelegateFailure()).tenantId(TENANT_ID);
+      }
+    };
+    application.deploy();
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    // when
+    try {
+      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      fail("Exception expected");
+    } catch (Exception e) {
+      // expected exception in the task listener that is not caught
+    }
+    application.undeploy();
+    assertFailureLogInApplication(instance, "failingTask", application.getName());
+  }
+
+  @Test
+  @WatchLogger(loggerNames = CONTEXT_LOGGER, level = "ERROR")
+  public void shouldLogFailureFromExecutionListenerInTaskContextInPa() {
+    // given
+    registerProcessEngine();
+    TestApplicationReusingExistingEngine application = new TestApplicationReusingExistingEngine() {
+      @Override
+      public void createDeployment(String processArchiveName, DeploymentBuilder deploymentBuilder) {
+        deploymentBuilder.addModelInstance("test.bpmn", modelExecutionListenerFailure()).tenantId(TENANT_ID);
+      }
+    };
+    application.deploy();
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    // when
+    try {
+      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      fail("Exception expected");
+    } catch (Exception e) {
+      // expected exception in the execution listener that is not caught
+    }
+    application.undeploy();
+    // then
+    assertFailureLogInApplication(instance, "failingTask", application.getName());
+  }
+
+  protected void assertActivityLogsPresent(ProcessInstance instance, List<String> expectedActivities) {
+    assertActivityLogs(instance, "ENGINE-200", expectedActivities, true, true, true, true);
+  }
+
+  protected void assertActivityLogsPresentWithoutMdc(String filter) {
+    assertActivityLogs(null, filter, null, false, false, false, false);
+  }
+
+  protected void assertActivityLogs(ProcessInstance instance, String filter, List<String> expectedActivities, boolean isMdcPresent,
+      boolean isBusinessKeyPresent, boolean isActivityIdPresent, boolean isDefinitionIdPresent) {
+    assertActivityLogs(instance, filter, isActivityIdPresent ? expectedActivities : null, null,
+        isBusinessKeyPresent ? instance.getBusinessKey() : null, isDefinitionIdPresent ? instance.getProcessDefinitionId() : null,
+        isMdcPresent, null);
+  }
+
+  protected void assertActivityLogsPresent(ProcessInstance instance, List<String> expectedActivities, String activityIdProperty,
+      String appNameProperty, String businessKeyProperty, String definitionIdProperty, String instanceIdProperty, String tenantIdProperty) {
+    assertLogs(instance, "ENGINE-200", expectedActivities, null, instance.getBusinessKey(), instance.getProcessDefinitionId(), true, null,
+        activityIdProperty, appNameProperty, businessKeyProperty, definitionIdProperty, instanceIdProperty, tenantIdProperty);
+  }
+
+  protected void assertFailureLogPresent(ProcessInstance instance, String activityId) {
+    assertFailureLogPresent(instance, activityId, 1);
+  }
+
+  protected void assertFailureLogPresent(ProcessInstance instance, String activityId, int numberOfFailureLogs) {
+    assertFailureLogPresent(instance, LOG_IDENT_FAILURE, activityId, null, instance.getBusinessKey(), numberOfFailureLogs);
+  }
+
+  protected void assertFailureLogInApplication(ProcessInstance instance, String activityId, String application) {
+    assertFailureLogPresent(instance, LOG_IDENT_FAILURE, activityId, application, instance.getBusinessKey(), 1);
+  }
+
+  protected void assertFailureLogPresent(ProcessInstance instance, String filter, String activityId, String appName,
+      String businessKey, int numberOfFailureLogs) {
+    assertActivityLogs(instance, filter, Arrays.asList(activityId), appName, businessKey, instance.getProcessDefinitionId(), true,
+        numberOfFailureLogs);
+  }
+
+  protected void assertActivityLogs(ProcessInstance instance, String filter, List<String> expectedActivities, String appName,
+      String businessKey, String definitionId, boolean isMdcPresent, Integer numberOfLogs) {
+    assertLogs(instance, filter, expectedActivities, appName, businessKey, definitionId, isMdcPresent, numberOfLogs,
+        "activityId", "applicationName", "businessKey", "processDefinitionId", "processInstanceId", "tenantId");
+  }
+
+  protected void assertLogs(ProcessInstance instance, String filter, List<String> expectedActivities, String appName,
+      String businessKey, String definitionId, boolean isMdcPresent, Integer numberOfLogs, String activityIdProperty, String appNameProperty,
+      String businessKeyProperty, String definitionIdProperty, String instanceIdProperty, String tenantIdProperty) {
+    boolean foundLogEntries = false;
+    Set<String> passedActivities = new HashSet<>();
+    List<ILoggingEvent> filteredLog = loggingRule.getFilteredLog(filter);
+    if (numberOfLogs != null) {
+      assertEquals(numberOfLogs.intValue(), filteredLog.size());
+    }
+    for (ILoggingEvent logEvent : filteredLog) {
+      Map<String, String> mdcPropertyMap = logEvent.getMDCPropertyMap();
+      if (isMdcPresent) {
+        // PVM log contains MDC properties
+        String activityIdMdc = mdcPropertyMap.get(activityIdProperty);
+        String appNameMdc = mdcPropertyMap.get(appNameProperty);
+        String businessKeyMdc = mdcPropertyMap.get(businessKeyProperty);
+        String definitionIdMdc = mdcPropertyMap.get(definitionIdProperty);
+        String instanceIdMdc = mdcPropertyMap.get(instanceIdProperty);
+        String tenantIdMdc = mdcPropertyMap.get(tenantIdProperty);
+
+        if (expectedActivities != null) {
+          assertNotNull(activityIdMdc);
+          assertTrue(expectedActivities.contains(activityIdMdc));
+          passedActivities.add(activityIdMdc);
+        } else {
+          assertNull(activityIdMdc);
+        }
+
+        if (appName != null) {
+          assertEquals(appName, appNameMdc);
+        } else {
+          assertNull(appNameMdc);
+        }
+
+        if (businessKey != null) {
+          assertEquals(businessKey, businessKeyMdc);
+        } else {
+          assertNull(businessKeyMdc);
+        }
+
+        if (definitionId != null) {
+          assertEquals(definitionId, definitionIdMdc);
+        } else {
+          assertNull(definitionIdMdc);
+        }
+
+        assertNotNull(instanceIdMdc);
+        assertEquals(instance.getId(), instanceIdMdc);
+
+        assertNotNull(tenantIdMdc);
+        assertEquals(instance.getTenantId(), tenantIdMdc);
+
+      } else {
+        assertTrue(mdcPropertyMap.isEmpty());
+      }
+      foundLogEntries = true;
+    }
+    assertTrue(foundLogEntries);
+    if (expectedActivities != null) {
+      assertTrue(passedActivities.equals(new HashSet<>(expectedActivities)));
+    }
+  }
+
+  protected void assertBpmnStacktraceLogPresent(ProcessInstance instance) {
+    List<ILoggingEvent> bpmnStacktraceLog = loggingRule.getFilteredLog("ENGINE-16006");
+    assertEquals(2, bpmnStacktraceLog.size());
+    for (int i = 0; i < bpmnStacktraceLog.size(); i++) {
+      ILoggingEvent logEvent = bpmnStacktraceLog.get(i);
+      Map<String, String> mdcPropertyMap = logEvent.getMDCPropertyMap();
+      assertTrue(mdcPropertyMap.containsKey("activityId"));
+      assertFalse(mdcPropertyMap.containsKey("applicationName"));
+      assertTrue(mdcPropertyMap.containsKey("processDefinitionId"));
+      assertTrue(mdcPropertyMap.containsKey("processInstanceId"));
+      assertTrue(mdcPropertyMap.containsKey("tenantId"));
+      if (i == 0) {
+        // first BPMN stack trace log corresponds to nested service task
+        assertFalse(mdcPropertyMap.containsKey("businessKey"));
+        assertEquals("failing_task", mdcPropertyMap.get("activityId"));
+        assertNotEquals(instance.getProcessDefinitionId(), mdcPropertyMap.get("processDefinitionId"));
+        assertNotEquals(instance.getId(), mdcPropertyMap.get("processInstanceId"));
+        assertEquals(instance.getTenantId(), mdcPropertyMap.get("tenantId"));
+      } else {
+        // second BPMN stack trace log corresponds to outer service task
+        assertTrue(mdcPropertyMap.containsKey("businessKey"));
+        assertEquals("startProcess", mdcPropertyMap.get("activityId"));
+        assertEquals(instance.getBusinessKey(), mdcPropertyMap.get("businessKey"));
+        assertEquals(instance.getProcessDefinitionId(), mdcPropertyMap.get("processDefinitionId"));
+        assertEquals(instance.getId(), mdcPropertyMap.get("processInstanceId"));
+        assertEquals(instance.getTenantId(), mdcPropertyMap.get("tenantId"));
+      }
+    }
+  }
+
+  protected void manageDeployment(BpmnModelInstance model) {
+    manageDeployment("test.bpmn", model);
+  }
+
+  protected void manageDeployment(String name, BpmnModelInstance model) {
+    testRule.deployForTenant(TENANT_ID, model);
+  }
+
+  protected void registerProcessEngine() {
+    runtimeContainerDelegate.registerProcessEngine(engineRule.getProcessEngine());
+    defaultEngineRegistered = true;
+  }
+
+  protected BpmnModelInstance modelOneTaskProcess() {
+    return Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .userTask("waitState")
+        .endEvent("end")
+        .done();
+  }
+
+  protected BpmnModelInstance modelDelegateFailure() {
+    return Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .userTask("waitState")
+        .serviceTask("failingTask")
+          .camundaClass(FailingDelegate.class)
+        .endEvent("end")
+        .done();
+  }
+
+  protected BpmnModelInstance modelExecutionListenerFailure() {
+    return Bpmn.createExecutableProcess(PROCESS)
+        .startEvent("start")
+        .userTask("failingTask")
+          .camundaExecutionListenerClass("end", FailingExecutionListener.class)
+        .endEvent("end")
+        .done();
+  }
+
+  public static class NestedStartDelegate implements JavaDelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) throws Exception {
+      RuntimeService runtimeService = execution.getProcessEngine().getRuntimeService();
+      runtimeService.startProcessInstanceByKey(FAILING_PROCESS, (String) null);
+    }
+  }
+
+  public static class FailingDelegate implements JavaDelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) throws Exception {
+      throw new IllegalArgumentException("I am always failing!");
+    }
+  }
+
+  public static class NoneDelegate implements JavaDelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) throws Exception {
+      // nothing to do
+    }
+  }
+
+  public static class BusinessKeyChangeDelegate implements JavaDelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) throws Exception {
+      execution.setProcessBusinessKey(B_KEY2);
+    }
+  }
+
+  public static class FailingTaskListener implements TaskListener {
+
+    @Override
+    public void notify(DelegateTask delegateTask) {
+      throw new IllegalArgumentException("I am failing!");
+    }
+  }
+
+  public static class FailingExecutionListener implements ExecutionListener {
+
+    @Override
+    public void notify(DelegateExecution execution) {
+      throw new IllegalArgumentException("I am failing!");
+    }
+  }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/logging/TestApplicationReusingExistingEngine.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/logging/TestApplicationReusingExistingEngine.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.logging;
+
+import org.camunda.bpm.application.ProcessApplication;
+import org.camunda.bpm.application.impl.EmbeddedProcessApplication;
+
+@ProcessApplication(
+    name="test-app",
+    deploymentDescriptors={"org/camunda/bpm/engine/test/logging/deployment-reusing-existing-engine.xml"}
+)
+public class TestApplicationReusingExistingEngine extends EmbeddedProcessApplication {
+  // nothing to add here
+}

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/logging/ProcessDataLoggingContextTest.shouldLogFailureFromEventSubprocessInSubprocessTaskContext.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/logging/ProcessDataLoggingContextTest.shouldLogFailureFromEventSubprocessInSubprocessTaskContext.bpmn20.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1p689a6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.1">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>SequenceFlow_16gobwy</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_16gobwy" sourceRef="start" targetRef="waitState" />
+    <bpmn:userTask id="waitState">
+      <bpmn:incoming>SequenceFlow_16gobwy</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1uh0emz</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>SequenceFlow_1uh0emz</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1uh0emz" sourceRef="waitState" targetRef="end" />
+    <bpmn:subProcess id="subprocess" triggeredByEvent="true">
+      <bpmn:endEvent id="sub_end">
+        <bpmn:incoming>SequenceFlow_1jfwjy5</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_1t7qsgf" sourceRef="sub_start" targetRef="sub_failingTask" />
+      <bpmn:sequenceFlow id="SequenceFlow_1jfwjy5" sourceRef="sub_failingTask" targetRef="sub_end" />
+      <bpmn:startEvent id="sub_start" isInterrupting="false">
+        <bpmn:outgoing>SequenceFlow_1t7qsgf</bpmn:outgoing>
+        <bpmn:messageEventDefinition messageRef="Message_1auh2zd" />
+      </bpmn:startEvent>
+      <bpmn:serviceTask id="sub_failingTask" camunda:class="org.camunda.bpm.engine.test.logging.ProcessDataLoggingContextTest.FailingDelegate">
+        <bpmn:incoming>SequenceFlow_1t7qsgf</bpmn:incoming>
+        <bpmn:outgoing>SequenceFlow_1jfwjy5</bpmn:outgoing>
+      </bpmn:serviceTask>
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmn:message id="Message_1auh2zd" name="testMessage" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="194" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_16gobwy_di" bpmnElement="SequenceFlow_16gobwy">
+        <di:waypoint x="230" y="121" />
+        <di:waypoint x="285" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_0y300p2_di" bpmnElement="waitState">
+        <dc:Bounds x="285" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1ck4sns_di" bpmnElement="end">
+        <dc:Bounds x="447" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1uh0emz_di" bpmnElement="SequenceFlow_1uh0emz">
+        <di:waypoint x="385" y="121" />
+        <di:waypoint x="447" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1t7qsgf_di" bpmnElement="SequenceFlow_1t7qsgf">
+        <di:waypoint x="236" y="294" />
+        <di:waypoint x="290" y="294" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1p1lzwq_di" bpmnElement="sub_end">
+        <dc:Bounds x="452" y="276" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1jfwjy5_di" bpmnElement="SequenceFlow_1jfwjy5">
+        <di:waypoint x="390" y="294" />
+        <di:waypoint x="452" y="294" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="SubProcess_1iy5k2r_di" bpmnElement="subprocess" isExpanded="true">
+        <dc:Bounds x="160" y="194" width="370" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1yhew7a_di" bpmnElement="sub_start">
+        <dc:Bounds x="200" y="276" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0iq44b2_di" bpmnElement="sub_failingTask">
+        <dc:Bounds x="290" y="254" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/logging/deployment-reusing-existing-engine.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/logging/deployment-reusing-existing-engine.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<process-application
+  xmlns="http://www.camunda.org/schema/1.0/ProcessApplication"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.camunda.org/schema/1.0/ProcessApplication http://www.camunda.org/schema/1.0/ProcessApplication ">
+
+  <process-archive name="pa1">
+
+    <process-engine>default</process-engine>
+  
+    <properties>
+        <property name="isScanForProcessDefinitions">false</property>
+        <property name="isDeleteUponUndeploy">true</property>
+    </properties>
+    
+  </process-archive>    
+
+</process-application>


### PR DESCRIPTION
* log activityId, applicationName, businessKey, processInstanceId,
  definitionId, and tenantId for process-related executions
* preserve context for logging in JobExecutor in exception case
* make context properties configurable (all but businessKey enabled by default)

related to [CAM-10798](https://app.camunda.com/jira/browse/CAM-10798)