### PR TITLE
CAM-10374: add JAXB to webapp-standalone

### DIFF
--- a/distro/tomcat/webapp-standalone/pom.xml
+++ b/distro/tomcat/webapp-standalone/pom.xml
@@ -145,6 +145,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
     </dependency>
+    <!-- CAM-10374  -->
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
* module `java.xml.bind` removed from Java 9+
* add dependency on JAXB to webapp-standalone so it is provided
  for the application on Tomcat

related to [CAM-10374](https://app.camunda.com/jira/browse/CAM-10374)