### PR TITLE
CAM-10805: chore(rest): ensure correct rest exception log levels

### DIFF
--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -496,6 +496,10 @@
 
     <profile>
       <id>wink</id>
+      <properties>
+        <version.slf4j>1.5.11</version.slf4j>
+        <version.logback>0.9.20</version.logback>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>org.jboss.spec.javax.ws.rs</groupId>
@@ -511,7 +515,19 @@
         <dependency>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
-          <version>1.5.11</version>
+          <version>${version.slf4j}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>jcl-over-slf4j</artifactId>
+          <version>${version.slf4j}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+          <version>${version.logback}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -71,6 +71,12 @@
       <artifactId>camunda-engine</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.camunda.commons</groupId>
+      <artifactId>camunda-commons-logging</artifactId>
+      <scope>provided</scope>
+    </dependency>
     
     <dependency>
       <groupId>javax.activation</groupId>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -18,9 +18,6 @@
     <!-- use inherited version as default -->
     <resteasy.version>${version.resteasy}</resteasy.version>
     <resteasy.netty.version>2.3.6.Final</resteasy.netty.version>
-    <!-- http-client uses an old version of slf4j -->
-    <version.slf4j>1.5.6</version.slf4j>
-    <version.logback>0.9.15</version.logback>
     <!-- other JAX-RS implementations -->
     <wink.version>1.1.1-incubating</wink.version>
     <jersey.version>1.17.1</jersey.version>
@@ -198,6 +195,12 @@
       <artifactId>jul-to-slf4j</artifactId>
       <scope>test</scope>
    </dependency>
+
+    <dependency>
+      <groupId>org.camunda.commons</groupId>
+      <artifactId>camunda-commons-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/ExceptionHandler.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/ExceptionHandler.java
@@ -16,17 +16,9 @@
  */
 package org.camunda.bpm.engine.rest.exception;
 
-import org.camunda.bpm.engine.rest.dto.ExceptionDto;
-
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Translates any {@link Throwable} to a HTTP 500 error and a JSON response.
@@ -36,26 +28,8 @@ import java.util.logging.Logger;
 @Provider
 public class ExceptionHandler implements ExceptionMapper<Throwable> {
 
-  private static final Logger LOGGER = Logger.getLogger(ExceptionHandler.class.getSimpleName());
-
   @Override
   public Response toResponse(Throwable throwable) {
-
-    LOGGER.log(Level.WARNING, getStackTrace(throwable));
-
-    ExceptionDto exceptionDto = ExceptionHandlerHelper.getInstance().fromException(throwable);
-
-    Response.Status responseStatus = ExceptionHandlerHelper.getInstance().getStatus(throwable);
-
-    return Response.status(responseStatus).entity(exceptionDto).type(MediaType.APPLICATION_JSON_TYPE).build();
+    return ExceptionHandlerHelper.getInstance().getResponse(throwable);
   }
-  
-  protected String getStackTrace(Throwable aThrowable) {
-    final Writer result = new StringWriter();
-    final PrintWriter printWriter = new PrintWriter(result);
-    aThrowable.printStackTrace(printWriter);
-    return result.toString();
-  }
-
-  
 }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/ExceptionHandlerHelper.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/ExceptionHandlerHelper.java
@@ -17,6 +17,7 @@
 package org.camunda.bpm.engine.rest.exception;
 
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.BadUserRequestException;
@@ -33,13 +34,27 @@ import org.camunda.bpm.engine.rest.dto.migration.MigrationPlanValidationExceptio
  */
 public class ExceptionHandlerHelper {
 
-  private static ExceptionHandlerHelper INSTANCE = new ExceptionHandlerHelper();
+  protected static final ExceptionLogger LOGGER = ExceptionLogger.REST_LOGGER;
+  protected static ExceptionHandlerHelper INSTANCE = new ExceptionHandlerHelper();
 
   private ExceptionHandlerHelper() {
   }
 
   public static ExceptionHandlerHelper getInstance(){
     return INSTANCE;
+  }
+
+  public Response getResponse(Throwable throwable) {
+    LOGGER.log(throwable);
+
+    Response.Status responseStatus = getStatus(throwable);
+    ExceptionDto exceptionDto = fromException(throwable);
+
+    return Response
+        .status(responseStatus)
+        .entity(exceptionDto)
+        .type(MediaType.APPLICATION_JSON_TYPE)
+        .build();
   }
 
   public ExceptionDto fromException(Throwable e) {

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/ExceptionLogger.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/ExceptionLogger.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.rest.exception;
+
+import javax.ws.rs.core.Response;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.logging.Level;
+
+import org.camunda.commons.logging.BaseLogger;
+
+public class ExceptionLogger extends BaseLogger {
+
+  public static final String PROJECT_CODE = "ENGINE-REST";
+  public static final String REST_API = "org.camunda.bpm.engine.rest.exception";
+  public static final ExceptionLogger REST_LOGGER = BaseLogger.createLogger(ExceptionLogger.class,
+                                                                               PROJECT_CODE,
+                                                                               REST_API,
+                                                                               "HTTP");
+
+  public void log(Throwable throwable) {
+    Response.Status status = ExceptionHandlerHelper.getInstance().getStatus(throwable);
+    int statusCode = status.getStatusCode();
+
+    if ( statusCode >= 500) {
+      logWarn(String.valueOf(statusCode), getStackTrace(throwable));
+    } else {
+      logDebug(String.valueOf(statusCode), getStackTrace(throwable));
+    }
+  }
+
+  protected String getStackTrace(Throwable aThrowable) {
+
+    final Writer      result      = new StringWriter();
+    final PrintWriter printWriter = new PrintWriter(result);
+    aThrowable.printStackTrace(printWriter);
+
+    return result.toString();
+  }
+}

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/JsonMappingExceptionHandler.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/JsonMappingExceptionHandler.java
@@ -16,14 +16,12 @@
  */
 package org.camunda.bpm.engine.rest.exception;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
-import org.camunda.bpm.engine.rest.dto.ExceptionDto;
-
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
 
 /**
  * @author Thorben Lindhauer
@@ -34,7 +32,8 @@ public class JsonMappingExceptionHandler implements ExceptionMapper<JsonMappingE
 
   @Override
   public Response toResponse(JsonMappingException exception) {
-    ExceptionDto dto = ExceptionDto.fromException(exception);
-    return Response.status(Status.BAD_REQUEST).entity(dto).type(MediaType.APPLICATION_JSON_TYPE).build();
+    InvalidRequestException badRequestException = new InvalidRequestException(Status.BAD_REQUEST,
+                                                                              exception, "");
+    return ExceptionHandlerHelper.getInstance().getResponse(badRequestException);
   }
 }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/JsonParseExceptionHandler.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/JsonParseExceptionHandler.java
@@ -34,7 +34,8 @@ public class JsonParseExceptionHandler implements ExceptionMapper<JsonParseExcep
 
   @Override
   public Response toResponse(JsonParseException exception) {
-    ExceptionDto dto = ExceptionDto.fromException(exception);
-    return Response.status(Status.BAD_REQUEST).entity(dto).type(MediaType.APPLICATION_JSON_TYPE).build();
+    InvalidRequestException badRequestException = new InvalidRequestException(Status.BAD_REQUEST,
+                                                                              exception, "");
+    return ExceptionHandlerHelper.getInstance().getResponse(badRequestException);
   }
 }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/ProcessEngineExceptionHandler.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/ProcessEngineExceptionHandler.java
@@ -16,20 +16,12 @@
  */
 package org.camunda.bpm.engine.rest.exception;
 
-import org.camunda.bpm.engine.AuthorizationException;
-import org.camunda.bpm.engine.ProcessEngineException;
-import org.camunda.bpm.engine.rest.dto.ExceptionDto;
-
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
+import org.camunda.bpm.engine.AuthorizationException;
+import org.camunda.bpm.engine.ProcessEngineException;
 
 /**
  * <p>Translates any {@link ProcessEngineException} to a HTTP 500 error and a JSON response.
@@ -47,28 +39,8 @@ import java.util.logging.Logger;
 @Provider
 public class ProcessEngineExceptionHandler implements ExceptionMapper<ProcessEngineException> {
 
-  private static final Logger LOGGER = Logger.getLogger(ExceptionHandler.class.getSimpleName());
-
+  @Override
   public Response toResponse(ProcessEngineException exception) {
-
-    LOGGER.log(Level.WARNING, getStackTrace(exception));
-
-    Status responseStatus = ExceptionHandlerHelper.getInstance().getStatus(exception);
-
-    ExceptionDto exceptionDto = ExceptionHandlerHelper.getInstance().fromException(exception);
-
-    return Response
-      .status(responseStatus)
-      .entity(exceptionDto)
-      .type(MediaType.APPLICATION_JSON_TYPE)
-      .build();
-
-  }
-
-  protected String getStackTrace(Throwable aThrowable) {
-    final Writer result = new StringWriter();
-    final PrintWriter printWriter = new PrintWriter(result);
-    aThrowable.printStackTrace(printWriter);
-    return result.toString();
+    return ExceptionHandlerHelper.getInstance().getResponse(exception);
   }
 }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/RestExceptionHandler.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/RestExceptionHandler.java
@@ -16,17 +16,9 @@
  */
 package org.camunda.bpm.engine.rest.exception;
 
-import org.camunda.bpm.engine.rest.dto.ExceptionDto;
-
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Translates {@link RestException}s to error responses according to the status that is set in the exception.
@@ -37,27 +29,8 @@ import java.util.logging.Logger;
 @Provider
 public class RestExceptionHandler implements ExceptionMapper<RestException> {
 
-  private static final Logger LOGGER = Logger.getLogger(ExceptionHandler.class.getSimpleName());
-
   @Override
   public Response toResponse(RestException exception) {
-
-    Response.Status responseStatus = ExceptionHandlerHelper.getInstance().getStatus(exception);
-    ExceptionDto exceptionDto = ExceptionHandlerHelper.getInstance().fromException(exception);
-
-    LOGGER.log(Level.WARNING, getStackTrace(exception));
-
-    return Response
-      .status(responseStatus)
-      .entity(exceptionDto)
-      .type(MediaType.APPLICATION_JSON_TYPE)
-      .build();
-  }
-  
-  protected String getStackTrace(Throwable aThrowable) {
-    final Writer result = new StringWriter();
-    final PrintWriter printWriter = new PrintWriter(result);
-    aThrowable.printStackTrace(printWriter);
-    return result.toString();
+    return ExceptionHandlerHelper.getInstance().getResponse(exception);
   }
 }


### PR DESCRIPTION
* Add a Camunda Commons `BaseLogger` based Exception logger for the engine Rest API;
* Refactor and cleanup rest exception logging;
* Add a dependency to camunda-commons-testing in the engine-rest project;
* Add logging rule test coverage in engine-rest.
* Remove old `slf4j` and `logback` versions. They are not needed since the `httpclient` was bumped to a newer version (reason for having them).

Related to [CAM-10805](https://app.camunda.com/jira/browse/CAM-10805)