### PR TITLE
[CAM-10748] feat(engine-cdi): add JobExecutor using managed threads

### DIFF
--- a/engine-cdi/pom.xml
+++ b/engine-cdi/pom.xml
@@ -141,6 +141,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>javax.enterprise.concurrent</groupId>
+      <artifactId>javax.enterprise.concurrent-api</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
@@ -154,6 +159,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>jul-to-slf4j</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
   </dependencies>
 

--- a/engine-cdi/src/main/java/org/camunda/bpm/engine/cdi/impl/ManagedJobExecutor.java
+++ b/engine-cdi/src/main/java/org/camunda/bpm/engine/cdi/impl/ManagedJobExecutor.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.cdi.impl;
+
+import org.camunda.bpm.engine.impl.ProcessEngineImpl;
+import org.camunda.bpm.engine.impl.jobexecutor.JobExecutor;
+import org.camunda.bpm.engine.impl.jobexecutor.ThreadPoolJobExecutor;
+
+import javax.annotation.Resource;
+import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.enterprise.concurrent.ManagedThreadFactory;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * {@link JobExecutor} implementation that utilises an application server's managed thread pool to acquire and execute jobs.
+ */
+@ApplicationScoped
+public class ManagedJobExecutor extends ThreadPoolJobExecutor {
+
+    @Resource
+    private ManagedExecutorService managedExecutorService;
+
+    @Resource
+    private ManagedThreadFactory managedThreadFactory;
+
+    /**
+     * Constructs a new ManagedJobExecutor.
+     */
+    public ManagedJobExecutor() {
+    }
+
+    /**
+     * Constructs a new ManagedJobExecutor with the provided {@link ManagedExecutorService} and {@link ManagedThreadFactory}.
+     */
+    public ManagedJobExecutor(final ManagedExecutorService managedExecutorService, final ManagedThreadFactory managedThreadFactory) {
+        this.managedExecutorService = managedExecutorService;
+        this.managedThreadFactory = managedThreadFactory;
+    }
+
+    @Override
+    public void executeJobs(List<String> jobIds, ProcessEngineImpl processEngine) {
+        try {
+            managedExecutorService.execute(getExecuteJobsRunnable(jobIds, processEngine));
+        } catch (RejectedExecutionException e) {
+            logRejectedExecution(processEngine, jobIds.size());
+            rejectedJobsHandler.jobsRejected(jobIds, processEngine, this);
+        }
+    }
+
+    @Override
+    protected void startJobAcquisitionThread() {
+        if (jobAcquisitionThread == null) {
+            jobAcquisitionThread = managedThreadFactory.newThread(acquireJobsRunnable);
+            jobAcquisitionThread.start();
+        }
+    }
+}

--- a/engine-cdi/src/test/java/org/camunda/bpm/engine/cdi/test/impl/ManagedJobExecutorTest.java
+++ b/engine-cdi/src/test/java/org/camunda/bpm/engine/cdi/test/impl/ManagedJobExecutorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.cdi.test.impl;
+
+import com.google.common.collect.Lists;
+import org.camunda.bpm.engine.cdi.impl.ManagedJobExecutor;
+import org.camunda.bpm.engine.impl.ProcessEngineImpl;
+import org.camunda.bpm.engine.impl.jobexecutor.AcquireJobsRunnable;
+import org.camunda.bpm.engine.impl.jobexecutor.ExecuteJobsRunnable;
+import org.camunda.bpm.engine.impl.jobexecutor.JobExecutor;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.Mockito;
+
+import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.enterprise.concurrent.ManagedThreadFactory;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+public class ManagedJobExecutorTest {
+
+    @Test
+    public void testUsesManagedExecutorService() {
+        final ManagedExecutorService managedExecutorServiceMock = Mockito.mock(ManagedExecutorService.class);
+        final ManagedThreadFactory managedThreadFactoryMock = Mockito.mock(ManagedThreadFactory.class);
+        final ProcessEngineImpl processEngineImplMock = Mockito.mock(ProcessEngineImpl.class, Answers.RETURNS_DEEP_STUBS.get());
+        final JobExecutor jobExecutor = new ManagedJobExecutor(managedExecutorServiceMock, managedThreadFactoryMock);
+
+        when(processEngineImplMock.getProcessEngineConfiguration().getJobExecutor()).thenReturn(jobExecutor);
+
+        jobExecutor.executeJobs(Lists.newArrayList(UUID.randomUUID().toString()), processEngineImplMock);
+        verify(managedExecutorServiceMock, times(1)).execute(isA(ExecuteJobsRunnable.class));
+    }
+
+    @Test
+    public void testUsesManagedThreadFactory() {
+        final ManagedExecutorService managedExecutorServiceMock = Mockito.mock(ManagedExecutorService.class);
+        final ManagedThreadFactory managedThreadFactoryMock = Mockito.mock(ManagedThreadFactory.class);
+        final Thread managedThreadMock = mock(Thread.class);
+        final JobExecutor jobExecutor = new ManagedJobExecutor(managedExecutorServiceMock, managedThreadFactoryMock);
+
+        when(managedThreadFactoryMock.newThread(isA(AcquireJobsRunnable.class))).thenReturn(managedThreadMock);
+
+        jobExecutor.start();
+        verify(managedThreadFactoryMock, times(1)).newThread(isA(AcquireJobsRunnable.class));
+    }
+
+}


### PR DESCRIPTION
[![CAM-10748](https://badgen.net/badge/JIRA/CAM-10748/0052CC)](https://app.camunda.com/jira/browse/CAM-10748)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Add a JobExecutor that can be configured for a ProcessEngine that uses managed
threads provided by the application server. From Java EE 7 and up, a standardised
API for interacting with the application servers scoped was introduced, providing
access to the ManagedExecutorService and ManagedThreadFactory for use in
applications.

implements CAM-10748