### PR TITLE
CAM-10714: use whitelist for JSON deserialization

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -37,7 +37,7 @@
     <version.uuid-generator>3.2.0</version.uuid-generator>
     <version.camunda.commons>1.8.2</version.camunda.commons>
     <version.camunda.connect>1.2.1</version.camunda.connect>
-    <version.camunda.spin>1.7.3</version.camunda.spin>
+    <version.camunda.spin>1.8.0-SNAPSHOT</version.camunda.spin>
     <version.camunda.template-engines>1.1.0</version.camunda.template-engines>
     <version.camunda.ee.xslt-plugin>1.1.0</version.camunda.ee.xslt-plugin>
   </properties>

--- a/engine-plugins/spin-plugin/pom.xml
+++ b/engine-plugins/spin-plugin/pom.xml
@@ -19,6 +19,14 @@
     </dependency>
 
     <dependency>
+      <groupId>org.camunda.bpm</groupId>
+      <artifactId>camunda-engine</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
       <scope>test</scope>

--- a/engine-plugins/spin-plugin/src/main/java/org/camunda/spin/plugin/impl/SpinObjectValueSerializer.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/camunda/spin/plugin/impl/SpinObjectValueSerializer.java
@@ -23,11 +23,13 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.util.IoUtil;
 import org.camunda.bpm.engine.impl.variable.serializer.AbstractObjectValueSerializer;
 import org.camunda.bpm.engine.impl.variable.serializer.TypedValueSerializer;
 import org.camunda.bpm.engine.variable.value.ObjectValue;
+import org.camunda.spin.DeserializationTypeValidator;
 import org.camunda.spin.spi.DataFormat;
 import org.camunda.spin.spi.DataFormatMapper;
 import org.camunda.spin.spi.DataFormatReader;
@@ -44,6 +46,7 @@ public class SpinObjectValueSerializer extends AbstractObjectValueSerializer {
 
   protected String name;
   protected DataFormat<?> dataFormat;
+  protected DeserializationTypeValidator validator;
 
   public SpinObjectValueSerializer(String name, DataFormat<?> dataFormat) {
     super(dataFormat.getName());
@@ -85,16 +88,17 @@ public class SpinObjectValueSerializer extends AbstractObjectValueSerializer {
   }
 
   protected Object deserializeFromByteArray(byte[] bytes, String objectTypeName) throws Exception {
+    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
     DataFormatMapper mapper = dataFormat.getMapper();
     DataFormatReader reader = dataFormat.getReader();
 
     ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-    InputStreamReader inReader = new InputStreamReader(bais, Context.getProcessEngineConfiguration().getDefaultCharset());
+    InputStreamReader inReader = new InputStreamReader(bais, processEngineConfiguration.getDefaultCharset());
     BufferedReader bufferedReader = new BufferedReader(inReader);
 
     try {
       Object mappedObject = reader.readInput(bufferedReader);
-      return mapper.mapInternalToJava(mappedObject, objectTypeName);
+      return mapper.mapInternalToJava(mappedObject, objectTypeName, getValidator(processEngineConfiguration));
     }
     finally{
       IoUtil.closeSilently(bais);
@@ -105,6 +109,18 @@ public class SpinObjectValueSerializer extends AbstractObjectValueSerializer {
 
   protected boolean canSerializeValue(Object value) {
     return dataFormat.getMapper().canMap(value);
+  }
+
+  protected DeserializationTypeValidator getValidator(final ProcessEngineConfigurationImpl processEngineConfiguration) {
+    if (validator == null && processEngineConfiguration.isDeserializationTypeValidationEnabled()) {
+      validator = new DeserializationTypeValidator() {
+          @Override
+          public boolean validate(String type) {
+            return processEngineConfiguration.getDeserializationTypeValidator().validate(type);
+          }
+      };
+    }
+    return validator;
   }
 
 }

--- a/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/HistoricVariableJsonSerializationTest.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/HistoricVariableJsonSerializationTest.java
@@ -17,26 +17,50 @@
 package org.camunda.spin.plugin.variables;
 
 import static org.camunda.bpm.engine.variable.Variables.objectValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
+import org.camunda.bpm.engine.HistoryService;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.history.HistoricVariableInstance;
 import org.camunda.bpm.engine.history.HistoricVariableUpdate;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.history.HistoryLevel;
-import org.camunda.bpm.engine.impl.test.PluggableProcessEngineTestCase;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.variable.type.ValueType;
 import org.camunda.bpm.engine.variable.value.ObjectValue;
 import org.camunda.spin.DataFormats;
 import org.json.JSONException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-public class HistoricVariableJsonSerializationTest extends PluggableProcessEngineTestCase {
+public class HistoricVariableJsonSerializationTest {
 
   protected static final String ONE_TASK_PROCESS = "org/camunda/spin/plugin/oneTaskProcess.bpmn20.xml";
 
   protected static final String JSON_FORMAT_NAME = DataFormats.json().getName();
 
+  @Rule
+  public ProcessEngineRule engineRule = new ProcessEngineRule(true);
+
+  protected HistoryService historyService;
+  protected ProcessEngineConfigurationImpl processEngineConfiguration;
+  protected RuntimeService runtimeService;
+
+  @Before
+  public void setUp() {
+    historyService = engineRule.getHistoryService();
+    processEngineConfiguration = engineRule.getProcessEngineConfiguration();
+    runtimeService = engineRule.getRuntimeService();
+  }
+
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testSelectHistoricVariableInstances() throws JSONException {
     if (processEngineConfiguration.getHistoryLevel().getId() >=
@@ -60,6 +84,7 @@ public class HistoricVariableJsonSerializationTest extends PluggableProcessEngin
     }
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testSelectHistoricSerializedValues() throws JSONException {
     if (processEngineConfiguration.getHistoryLevel().getId() >=
@@ -82,6 +107,7 @@ public class HistoricVariableJsonSerializationTest extends PluggableProcessEngin
     }
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testSelectHistoricSerializedValuesUpdate() throws JSONException {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");

--- a/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/HistoricVariableJsonSerializationWithValidationTest.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/HistoricVariableJsonSerializationWithValidationTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.spin.plugin.variables;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.camunda.bpm.engine.runtime.DeserializationTypeValidator;
+import org.junit.Before;
+
+public class HistoricVariableJsonSerializationWithValidationTest extends HistoricVariableJsonSerializationTest {
+
+  @Before
+  public void setUpValidator() {
+    DeserializationTypeValidator validatorMock = mock(DeserializationTypeValidator.class);
+    when(validatorMock.validate(anyString())).thenReturn(true);
+    processEngineConfiguration.setDeserializationTypeValidationEnabled(true);
+    processEngineConfiguration.setDeserializationTypeValidator(validatorMock);
+  }
+
+}

--- a/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/JsonSerializationTest.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/JsonSerializationTest.java
@@ -21,18 +21,27 @@ import static org.camunda.bpm.engine.variable.Variables.serializedObjectValue;
 import static org.camunda.spin.plugin.variables.TypedValueAssert.assertObjectValueDeserializedNull;
 import static org.camunda.spin.plugin.variables.TypedValueAssert.assertObjectValueSerializedNull;
 import static org.camunda.spin.plugin.variables.TypedValueAssert.assertUntypedNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
-import org.camunda.bpm.engine.impl.test.PluggableProcessEngineTestCase;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.runtime.VariableInstance;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
 import org.camunda.bpm.engine.variable.VariableMap;
 import org.camunda.bpm.engine.variable.Variables;
 import org.camunda.bpm.engine.variable.type.ValueType;
@@ -43,17 +52,35 @@ import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.camunda.spin.DataFormats;
 import org.json.JSONException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-public class JsonSerializationTest extends PluggableProcessEngineTestCase {
+public class JsonSerializationTest {
 
   protected static final String ONE_TASK_PROCESS = "org/camunda/spin/plugin/oneTaskProcess.bpmn20.xml";
   protected static final String SERVICE_TASK_PROCESS = "org/camunda/spin/plugin/serviceTaskProcess.bpmn20.xml";
 
   protected static final String JSON_FORMAT_NAME = DataFormats.JSON_DATAFORMAT_NAME;
 
+  @Rule
+  public ProcessEngineRule engineRule = new ProcessEngineRule(true);
+
+  @Rule
+  public ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
+
+  protected RuntimeService runtimeService;
+
   protected String originalSerializationFormat;
 
+  @Before
+  public void setUp() {
+    runtimeService = engineRule.getRuntimeService();
+  }
+
+
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testSerializationAsJson() throws JSONException {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -81,11 +108,12 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
     JSONAssert.assertEquals(bean.toExpectedJsonString(), new String(typedValue.getValueSerialized()), true);
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testListSerializationAsJson() throws JSONException {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-    List<JsonSerializable> beans = new ArrayList<JsonSerializable>();
+    List<JsonSerializable> beans = new ArrayList<>();
     for (int i = 0; i < 20; i++) {
       beans.add(new JsonSerializable("a String" + i, 42 + i, true));
     }
@@ -107,6 +135,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
 
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testFailingSerialization() {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -121,6 +150,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
     }
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testFailingDeserialization() {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -156,7 +186,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
       fail("exception expected");
     }
     catch(IllegalStateException e) {
-      assertTextPresent("Object is not deserialized", e.getMessage());
+      testRule.assertTextPresent("Object is not deserialized", e.getMessage());
     }
 
     try {
@@ -164,7 +194,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
       fail("exception expected");
     }
     catch(IllegalStateException e) {
-      assertTextPresent("Object is not deserialized", e.getMessage());
+      testRule.assertTextPresent("Object is not deserialized", e.getMessage());
     }
 
     try {
@@ -172,11 +202,12 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
       fail("exception expected");
     }
     catch(IllegalStateException e) {
-      assertTextPresent("Object is not deserialized", e.getMessage());
+      testRule.assertTextPresent("Object is not deserialized", e.getMessage());
     }
 
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testFailForNonExistingSerializationFormat() {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -187,16 +218,17 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
       runtimeService.setVariable(instance.getId(), "simpleBean", objectValue(jsonSerializable).serializationDataFormat("non existing data format"));
       fail("Exception expected");
     } catch (ProcessEngineException e) {
-      assertTextPresent("Cannot find serializer for value", e.getMessage());
+      testRule.assertTextPresent("Cannot find serializer for value", e.getMessage());
       // happy path
     }
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testVariableValueCaching() {
     final ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-    processEngineConfiguration.getCommandExecutorTxRequired().execute(new Command<Void>() {
+    engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired().execute(new Command<Void>() {
 
       @Override
       public Void execute(CommandContext commandContext) {
@@ -217,6 +249,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
     assertSame(returnedBean, theSameReturnedBean);
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testGetSerializedVariableValue() throws JSONException {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -230,6 +263,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
     JSONAssert.assertEquals(bean.toExpectedJsonString(), serializedValue, true);
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testSetSerializedVariableValue() throws JSONException {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -253,6 +287,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
     assertEquals(bean.getClass().getCanonicalName(), typedValue.getObjectTypeName());
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testSetSerializedVariableValueNoTypeName() throws JSONException {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -268,10 +303,11 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
       fail("Exception expected.");
     }
     catch(Exception e) {
-      assertTextPresent("no 'objectTypeName' provided for non-null value", e.getMessage());
+      testRule.assertTextPresent("no 'objectTypeName' provided for non-null value", e.getMessage());
     }
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testSetSerializedVariableValueMismatchingTypeName() throws JSONException {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -307,7 +343,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
     }
   }
 
-
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testSetSerializedVariableValueNull() throws JSONException {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -331,6 +367,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
 
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testSetSerializedVariableValueNullNoTypeName() throws JSONException {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -353,22 +390,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
     assertNull(typedValue.getObjectTypeName());
   }
 
-  protected String toExpectedJsonArray(List<JsonSerializable> beans) {
-    StringBuilder jsonBuilder = new StringBuilder();
-
-    jsonBuilder.append("[");
-    for (int i = 0; i < beans.size(); i++) {
-      jsonBuilder.append(beans.get(i).toExpectedJsonString());
-
-      if (i != beans.size() - 1)  {
-        jsonBuilder.append(", ");
-      }
-    }
-    jsonBuilder.append("]");
-
-    return jsonBuilder.toString();
-  }
-
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testSetJavaOjectNullDeserialized() throws Exception {
 
@@ -389,6 +411,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
 
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testSetJavaOjectNullSerialized() throws Exception {
 
@@ -411,6 +434,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
     assertObjectValueSerializedNull(serializedTypedValue);
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testSetJavaOjectNullSerializedObjectTypeName() throws Exception {
 
@@ -446,6 +470,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
     assertEquals(typeName, serializedTypedValue.getObjectTypeName());
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testSetUntypedNullForExistingVariable() throws Exception {
 
@@ -471,6 +496,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
 
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testSetTypedNullForExistingVariable() throws Exception {
 
@@ -495,6 +521,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
     assertObjectValueDeserializedNull(typedValue);
   }
 
+  @Test
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testRemoveVariable() throws JSONException {
     // given a serialized json variable
@@ -517,10 +544,10 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
     assertNull(runtimeService.getVariableTyped(instance.getId(), "simpleBean", false));
   }
 
-
   /**
    * CAM-3222
    */
+  @Test
   @Deployment(resources = SERVICE_TASK_PROCESS)
   public void testImplicitlyUpdateEmptyList() {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("serviceTaskProcess",
@@ -541,6 +568,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
     assertEquals(UpdateValueDelegate.STRING_PROPERTY, list.get(0).getStringProperty());
   }
 
+  @Test
   public void testTransientJsonValue() {
     // given
     BpmnModelInstance modelInstance = Bpmn.createExecutableProcess("foo")
@@ -556,7 +584,7 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
           .endEvent()
         .done();
 
-    deployment(modelInstance);
+    testRule.deploy(modelInstance);
 
     JsonSerializable bean = new JsonSerializable("bar", 42, true);
     ObjectValue jsonValue = serializedObjectValue(bean.toExpectedJsonString(), true)
@@ -572,9 +600,25 @@ public class JsonSerializationTest extends PluggableProcessEngineTestCase {
     List<VariableInstance> variableInstances = runtimeService.createVariableInstanceQuery().list();
     assertEquals(0, variableInstances.size());
 
-    Task task = taskService.createTaskQuery().singleResult();
+    Task task = engineRule.getTaskService().createTaskQuery().singleResult();
     assertNotNull(task);
     assertEquals("userTask1", task.getTaskDefinitionKey());
+  }
+
+  protected String toExpectedJsonArray(List<JsonSerializable> beans) {
+    StringBuilder jsonBuilder = new StringBuilder();
+
+    jsonBuilder.append("[");
+    for (int i = 0; i < beans.size(); i++) {
+      jsonBuilder.append(beans.get(i).toExpectedJsonString());
+
+      if (i != beans.size() - 1)  {
+        jsonBuilder.append(", ");
+      }
+    }
+    jsonBuilder.append("]");
+
+    return jsonBuilder.toString();
   }
 
 }

--- a/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/JsonSerializationWithValidationOnMultipleEnginesTest.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/JsonSerializationWithValidationOnMultipleEnginesTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.camunda.bpm.engine.repository.Deployment;
 import org.camunda.bpm.engine.runtime.DeserializationTypeValidator;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
@@ -55,9 +54,10 @@ public class JsonSerializationWithValidationOnMultipleEnginesTest {
     public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
       DeserializationTypeValidator validatorMock = mock(DeserializationTypeValidator.class);
       when(validatorMock.validate(anyString())).thenReturn(true);
-      configuration.setDeserializationTypeValidator(validatorMock);
-      configuration.setDeserializationTypeValidationEnabled(true);
-      return configuration;
+      return configuration
+          .setDeserializationTypeValidator(validatorMock)
+          .setDeserializationTypeValidationEnabled(true)
+          .setJdbcUrl("jdbc:h2:mem:positive");
     };
   };
 
@@ -66,9 +66,10 @@ public class JsonSerializationWithValidationOnMultipleEnginesTest {
     public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
       DeserializationTypeValidator validatorMock = mock(DeserializationTypeValidator.class);
       when(validatorMock.validate(anyString())).thenReturn(false);
-      configuration.setDeserializationTypeValidator(validatorMock);
-      configuration.setDeserializationTypeValidationEnabled(true);
-      return configuration;
+      return configuration
+          .setDeserializationTypeValidator(validatorMock)
+          .setDeserializationTypeValidationEnabled(true)
+          .setJdbcUrl("jdbc:h2:mem:negative");
     };
   };
 
@@ -84,51 +85,43 @@ public class JsonSerializationWithValidationOnMultipleEnginesTest {
   @Test
   public void shouldUsePositiveValidator() {
     // given
-    Deployment deployment = engineRulePositive.getRepositoryService().createDeployment()
+    engineRulePositive.manageDeployment(engineRulePositive.getRepositoryService().createDeployment()
         .addModelInstance("foo.bpmn", getOneTaskModel())
-        .deploy();
-    try {
-      ProcessInstance instance = engineRulePositive.getRuntimeService().startProcessInstanceByKey("oneTaskProcess");
+        .deploy());
+    ProcessInstance instance = engineRulePositive.getRuntimeService().startProcessInstanceByKey("oneTaskProcess");
 
-      // add serialized values to both instances
-      JsonSerializable bean = new JsonSerializable("a String", 42, true);
-      engineRulePositive.getRuntimeService().setVariable(instance.getId(), "simpleBean",
-          objectValue(bean).serializationDataFormat(DataFormats.JSON_DATAFORMAT_NAME).create());
+    // add serialized value
+    JsonSerializable bean = new JsonSerializable("a String", 42, true);
+    engineRulePositive.getRuntimeService().setVariable(instance.getId(), "simpleBean",
+        objectValue(bean).serializationDataFormat(DataFormats.JSON_DATAFORMAT_NAME).create());
 
-      // when
-      Object value = engineRulePositive.getRuntimeService().getVariable(instance.getId(), "simpleBean");
+    // when
+    Object value = engineRulePositive.getRuntimeService().getVariable(instance.getId(), "simpleBean");
 
-      // then
-      assertEquals(bean, value);
-    } finally {
-      engineRulePositive.getRepositoryService().deleteDeployment(deployment.getId(), true);
-    }
+    // then
+    assertEquals(bean, value);
   }
 
   @Test
   public void shouldUseNegativeValidator() {
     // given
-    Deployment deployment = engineRuleNegative.getRepositoryService().createDeployment()
+    engineRuleNegative.manageDeployment(engineRuleNegative.getRepositoryService().createDeployment()
         .addModelInstance("foo.bpmn", getOneTaskModel())
-        .deploy();
-    try {
-      ProcessInstance instance = engineRuleNegative.getRuntimeService().startProcessInstanceByKey("oneTaskProcess");
+        .deploy());
+    ProcessInstance instance = engineRuleNegative.getRuntimeService().startProcessInstanceByKey("oneTaskProcess");
 
-      // add serialized values to both instances
-      JsonSerializable bean = new JsonSerializable("a String", 42, true);
-      engineRuleNegative.getRuntimeService().setVariable(instance.getId(), "simpleBean",
-          objectValue(bean).serializationDataFormat(DataFormats.JSON_DATAFORMAT_NAME).create());
+    // add serialized value
+    JsonSerializable bean = new JsonSerializable("a String", 42, true);
+    engineRuleNegative.getRuntimeService().setVariable(instance.getId(), "simpleBean",
+        objectValue(bean).serializationDataFormat(DataFormats.JSON_DATAFORMAT_NAME).create());
 
-      // then
-      thrown.expect(ProcessEngineException.class);
-      thrown.expectMessage("Cannot deserialize");
-      thrown.expectCause(isA(SpinJsonException.class));
+    // then
+    thrown.expect(ProcessEngineException.class);
+    thrown.expectMessage("Cannot deserialize");
+    thrown.expectCause(isA(SpinJsonException.class));
 
-      // when
-      engineRuleNegative.getRuntimeService().getVariable(instance.getId(), "simpleBean");
-    } finally {
-      engineRuleNegative.getRepositoryService().deleteDeployment(deployment.getId(), true);
-    }
+    // when
+    engineRuleNegative.getRuntimeService().getVariable(instance.getId(), "simpleBean");
   }
 
   protected BpmnModelInstance getOneTaskModel() {

--- a/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/JsonSerializationWithValidationOnMultipleEnginesTest.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/JsonSerializationWithValidationOnMultipleEnginesTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.spin.plugin.variables;
+
+import static org.camunda.bpm.engine.variable.Variables.objectValue;
+import static org.hamcrest.CoreMatchers.isA;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.repository.Deployment;
+import org.camunda.bpm.engine.runtime.DeserializationTypeValidator;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineBootstrapRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.camunda.spin.DataFormats;
+import org.camunda.spin.json.SpinJsonException;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Test cases for multiple engines defining different validators that do not
+ * override each other although Spin makes heavy use of the {@link DataFormats}
+ * class that holds static references regardless of the number of Spin plugins
+ * (data formats are overridden for example because they are held once in the
+ * DataFormats class)
+ */
+public class JsonSerializationWithValidationOnMultipleEnginesTest {
+
+  @ClassRule
+  public static ProcessEngineBootstrapRule bootstrapRulePositive = new ProcessEngineBootstrapRule() {
+    public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      DeserializationTypeValidator validatorMock = mock(DeserializationTypeValidator.class);
+      when(validatorMock.validate(anyString())).thenReturn(true);
+      configuration.setDeserializationTypeValidator(validatorMock);
+      configuration.setDeserializationTypeValidationEnabled(true);
+      return configuration;
+    };
+  };
+
+  @ClassRule
+  public static ProcessEngineBootstrapRule bootstrapRuleNegative = new ProcessEngineBootstrapRule() {
+    public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      DeserializationTypeValidator validatorMock = mock(DeserializationTypeValidator.class);
+      when(validatorMock.validate(anyString())).thenReturn(false);
+      configuration.setDeserializationTypeValidator(validatorMock);
+      configuration.setDeserializationTypeValidationEnabled(true);
+      return configuration;
+    };
+  };
+
+  @Rule
+  public ProcessEngineRule engineRulePositive = new ProvidedProcessEngineRule(bootstrapRulePositive);
+
+  @Rule
+  public ProcessEngineRule engineRuleNegative = new ProvidedProcessEngineRule(bootstrapRuleNegative);
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void shouldUsePositiveValidator() {
+    // given
+    Deployment deployment = engineRulePositive.getRepositoryService().createDeployment()
+        .addModelInstance("foo.bpmn", getOneTaskModel())
+        .deploy();
+    try {
+      ProcessInstance instance = engineRulePositive.getRuntimeService().startProcessInstanceByKey("oneTaskProcess");
+
+      // add serialized values to both instances
+      JsonSerializable bean = new JsonSerializable("a String", 42, true);
+      engineRulePositive.getRuntimeService().setVariable(instance.getId(), "simpleBean",
+          objectValue(bean).serializationDataFormat(DataFormats.JSON_DATAFORMAT_NAME).create());
+
+      // when
+      Object value = engineRulePositive.getRuntimeService().getVariable(instance.getId(), "simpleBean");
+
+      // then
+      assertEquals(bean, value);
+    } finally {
+      engineRulePositive.getRepositoryService().deleteDeployment(deployment.getId(), true);
+    }
+  }
+
+  @Test
+  public void shouldUseNegativeValidator() {
+    // given
+    Deployment deployment = engineRuleNegative.getRepositoryService().createDeployment()
+        .addModelInstance("foo.bpmn", getOneTaskModel())
+        .deploy();
+    try {
+      ProcessInstance instance = engineRuleNegative.getRuntimeService().startProcessInstanceByKey("oneTaskProcess");
+
+      // add serialized values to both instances
+      JsonSerializable bean = new JsonSerializable("a String", 42, true);
+      engineRuleNegative.getRuntimeService().setVariable(instance.getId(), "simpleBean",
+          objectValue(bean).serializationDataFormat(DataFormats.JSON_DATAFORMAT_NAME).create());
+
+      // then
+      thrown.expect(ProcessEngineException.class);
+      thrown.expectMessage("Cannot deserialize");
+      thrown.expectCause(isA(SpinJsonException.class));
+
+      // when
+      engineRuleNegative.getRuntimeService().getVariable(instance.getId(), "simpleBean");
+    } finally {
+      engineRuleNegative.getRepositoryService().deleteDeployment(deployment.getId(), true);
+    }
+  }
+
+  protected BpmnModelInstance getOneTaskModel() {
+    BpmnModelInstance oneTaskProcess = Bpmn.createExecutableProcess("oneTaskProcess")
+        .startEvent()
+        .userTask()
+        .endEvent()
+        .done();
+    return oneTaskProcess;
+  }
+}

--- a/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/JsonSerializationWithValidationTest.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/JsonSerializationWithValidationTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.spin.plugin.variables;
+
+import org.camunda.bpm.engine.runtime.DeserializationTypeValidator;
+import org.junit.Before;
+import org.mockito.Mockito;
+
+public class JsonSerializationWithValidationTest extends JsonSerializationTest {
+
+  @Before
+  public void setUpValidator() {
+    DeserializationTypeValidator validatorMock = Mockito.mock(DeserializationTypeValidator.class);
+    Mockito.when(validatorMock.validate(Mockito.anyString())).thenReturn(true);
+    engineRule.getProcessEngineConfiguration().setDeserializationTypeValidator(validatorMock);
+    engineRule.getProcessEngineConfiguration().setDeserializationTypeValidationEnabled(true);
+  }
+
+}

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ExecutionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ExecutionRestServiceInteractionTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -64,6 +65,7 @@ import org.camunda.bpm.engine.rest.helper.variable.EqualsPrimitiveValue;
 import org.camunda.bpm.engine.rest.helper.variable.EqualsUntypedValue;
 import org.camunda.bpm.engine.rest.util.VariablesBuilder;
 import org.camunda.bpm.engine.rest.util.container.TestContainerRule;
+import org.camunda.bpm.engine.runtime.DeserializationTypeValidator;
 import org.camunda.bpm.engine.runtime.EventSubscription;
 import org.camunda.bpm.engine.runtime.EventSubscriptionQuery;
 import org.camunda.bpm.engine.runtime.Execution;
@@ -80,7 +82,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.restassured.http.ContentType;
@@ -159,7 +160,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     String variableKey = "aKey";
     int variableValue = 123;
 
-    Map<String, Object> variablesJson = new HashMap<String, Object>();
+    Map<String, Object> variablesJson = new HashMap<>();
     Map<String, Object> variables = VariablesBuilder.create().variable(variableKey, variableValue).getVariables();
     variablesJson.put("variables", variables);
 
@@ -167,7 +168,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
       .then().expect().statusCode(Status.NO_CONTENT.getStatusCode())
       .when().post(SIGNAL_EXECUTION_URL);
 
-    Map<String, Object> expectedSignalVariables = new HashMap<String, Object>();
+    Map<String, Object> expectedSignalVariables = new HashMap<>();
     expectedSignalVariables.put(variableKey, variableValue);
 
     verify(runtimeServiceMock).signal(eq(MockProvider.EXAMPLE_EXECUTION_ID), argThat(new EqualsMap(expectedSignalVariables)));
@@ -180,7 +181,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     String variableType = "Integer";
 
 
-    Map<String, Object> variablesJson = new HashMap<String, Object>();
+    Map<String, Object> variablesJson = new HashMap<>();
     Map<String, Object> variables = VariablesBuilder.create().variable(variableKey, variableValue, variableType).getVariables();
     variablesJson.put("variables", variables);
 
@@ -199,7 +200,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     String variableType = "Short";
 
 
-    Map<String, Object> variablesJson = new HashMap<String, Object>();
+    Map<String, Object> variablesJson = new HashMap<>();
     Map<String, Object> variables = VariablesBuilder.create().variable(variableKey, variableValue, variableType).getVariables();
     variablesJson.put("variables", variables);
 
@@ -217,7 +218,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     String variableValue = "1abc";
     String variableType = "Long";
 
-    Map<String, Object> variablesJson = new HashMap<String, Object>();
+    Map<String, Object> variablesJson = new HashMap<>();
     Map<String, Object> variables = VariablesBuilder.create().variable(variableKey, variableValue, variableType).getVariables();
     variablesJson.put("variables", variables);
 
@@ -236,7 +237,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     String variableType = "Double";
 
 
-    Map<String, Object> variablesJson = new HashMap<String, Object>();
+    Map<String, Object> variablesJson = new HashMap<>();
     Map<String, Object> variables = VariablesBuilder.create().variable(variableKey, variableValue, variableType).getVariables();
     variablesJson.put("variables", variables);
 
@@ -254,7 +255,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     String variableValue = "1abc";
     String variableType = "Date";
 
-    Map<String, Object> variablesJson = new HashMap<String, Object>();
+    Map<String, Object> variablesJson = new HashMap<>();
     Map<String, Object> variables = VariablesBuilder.create().variable(variableKey, variableValue, variableType).getVariables();
     variablesJson.put("variables", variables);
 
@@ -273,7 +274,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     String variableType = "X";
 
 
-    Map<String, Object> variablesJson = new HashMap<String, Object>();
+    Map<String, Object> variablesJson = new HashMap<>();
     Map<String, Object> variables = VariablesBuilder.create().variable(variableKey, variableValue, variableType).getVariables();
     variablesJson.put("variables", variables);
 
@@ -415,7 +416,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
 
   @Test
   public void testLocalVariableModification() {
-    Map<String, Object> messageBodyJson = new HashMap<String, Object>();
+    Map<String, Object> messageBodyJson = new HashMap<>();
 
     String variableKey = "aKey";
     int variableValue = 123;
@@ -423,7 +424,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     Map<String, Object> modifications = VariablesBuilder.create().variable(variableKey, variableValue).getVariables();
     messageBodyJson.put("modifications", modifications);
 
-    List<String> deletions = new ArrayList<String>();
+    List<String> deletions = new ArrayList<>();
     deletions.add("deleteKey");
     messageBodyJson.put("deletions", deletions);
 
@@ -431,7 +432,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
       .then().expect().statusCode(Status.NO_CONTENT.getStatusCode())
       .when().post(EXECUTION_LOCAL_VARIABLES_URL);
 
-    Map<String, Object> expectedModifications = new HashMap<String, Object>();
+    Map<String, Object> expectedModifications = new HashMap<>();
     expectedModifications.put(variableKey, variableValue);
     verify(runtimeServiceMock).updateVariablesLocal(eq(MockProvider.EXAMPLE_EXECUTION_ID), argThat(new EqualsMap(expectedModifications)),
         argThat(new EqualsList(deletions)));
@@ -441,7 +442,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
   public void testLocalVariableModificationForNonExistingExecution() {
     doThrow(new ProcessEngineException("expected exception")).when(runtimeServiceMock).updateVariablesLocal(anyString(), any(Map.class), any(List.class));
 
-    Map<String, Object> messageBodyJson = new HashMap<String, Object>();
+    Map<String, Object> messageBodyJson = new HashMap<>();
 
     String variableKey = "aKey";
     int variableValue = 123;
@@ -467,7 +468,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     String message = "expected exception";
     doThrow(new AuthorizationException(message)).when(runtimeServiceMock).updateVariablesLocal(anyString(), any(Map.class), any(List.class));
 
-    Map<String, Object> messageBodyJson = new HashMap<String, Object>();
+    Map<String, Object> messageBodyJson = new HashMap<>();
 
     String variableKey = "aKey";
     int variableValue = 123;
@@ -1132,7 +1133,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
   @Test
   public void testPutSingleLocalSerializableVariableFromJson() throws Exception {
 
-    ArrayList<String> serializable = new ArrayList<String>();
+    ArrayList<String> serializable = new ArrayList<>();
     serializable.add("foo");
 
     ObjectMapper mapper = new ObjectMapper();
@@ -1155,9 +1156,80 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
   }
 
   @Test
+  public void testValidationOnPutSingleLocalSerializableVariableFromJson() throws Exception {
+    boolean previousIsValidationEnabled = processEngine.getProcessEngineConfiguration().isDeserializationTypeValidationEnabled();
+    DeserializationTypeValidator previousValidator = processEngine.getProcessEngineConfiguration().getDeserializationTypeValidator();
+
+    DeserializationTypeValidator validatorMock = mock(DeserializationTypeValidator.class);
+    when(validatorMock.validate(anyString())).thenReturn(true);
+    when(processEngine.getProcessEngineConfiguration().isDeserializationTypeValidationEnabled()).thenReturn(true);
+    when(processEngine.getProcessEngineConfiguration().getDeserializationTypeValidator()).thenReturn(validatorMock);
+
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      String jsonBytes = mapper.writeValueAsString("test");
+      String typeName = TypeFactory.defaultInstance().constructType(String.class).toCanonical();
+
+      String variableKey = "aVariableKey";
+
+      given()
+        .pathParam("id", MockProvider.EXAMPLE_EXECUTION_ID).pathParam("varId", variableKey)
+        .multiPart("data", jsonBytes, MediaType.APPLICATION_JSON)
+        .multiPart("type", typeName, MediaType.TEXT_PLAIN)
+      .expect()
+        .statusCode(Status.NO_CONTENT.getStatusCode())
+      .when()
+        .post(SINGLE_EXECUTION_LOCAL_BINARY_VARIABLE_URL);
+
+      verify(validatorMock).validate("java.lang.String");
+      verifyNoMoreInteractions(validatorMock);
+
+      verify(runtimeServiceMock).setVariableLocal(eq(MockProvider.EXAMPLE_EXECUTION_ID), eq(variableKey),
+          argThat(EqualsObjectValue.objectValueMatcher().isDeserialized().value("test")));
+    } finally {
+      when(processEngine.getProcessEngineConfiguration().isDeserializationTypeValidationEnabled()).thenReturn(previousIsValidationEnabled);
+      when(processEngine.getProcessEngineConfiguration().getDeserializationTypeValidator()).thenReturn(previousValidator);
+    }
+  }
+
+  @Test
+  public void testFailingValidationOnPutSingleLocalSerializableVariableFromJson() throws Exception {
+    boolean previousIsValidationEnabled = processEngine.getProcessEngineConfiguration().isDeserializationTypeValidationEnabled();
+    DeserializationTypeValidator previousValidator = processEngine.getProcessEngineConfiguration().getDeserializationTypeValidator();
+
+    DeserializationTypeValidator validatorMock = mock(DeserializationTypeValidator.class);
+    when(validatorMock.validate(anyString())).thenReturn(false);
+    when(processEngine.getProcessEngineConfiguration().isDeserializationTypeValidationEnabled()).thenReturn(true);
+    when(processEngine.getProcessEngineConfiguration().getDeserializationTypeValidator()).thenReturn(validatorMock);
+
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      String jsonBytes = mapper.writeValueAsString("test");
+      String typeName = TypeFactory.defaultInstance().constructType(String.class).toCanonical();
+
+      String variableKey = "aVariableKey";
+
+      given()
+        .pathParam("id", MockProvider.EXAMPLE_EXECUTION_ID).pathParam("varId", variableKey)
+        .multiPart("data", jsonBytes, MediaType.APPLICATION_JSON)
+        .multiPart("type", typeName, MediaType.TEXT_PLAIN)
+      .expect()
+        .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode())
+      .when()
+        .post(SINGLE_EXECUTION_LOCAL_BINARY_VARIABLE_URL);
+
+      verify(validatorMock).validate("java.lang.String");
+      verifyNoMoreInteractions(validatorMock);
+    } finally {
+      when(processEngine.getProcessEngineConfiguration().isDeserializationTypeValidationEnabled()).thenReturn(previousIsValidationEnabled);
+      when(processEngine.getProcessEngineConfiguration().getDeserializationTypeValidator()).thenReturn(previousValidator);
+    }
+  }
+
+  @Test
   public void testPutSingleLocalSerializableVariableUnsupportedMediaType() throws Exception {
 
-    ArrayList<String> serializable = new ArrayList<String>();
+    ArrayList<String> serializable = new ArrayList<>();
     serializable.add("foo");
 
     ObjectMapper mapper = new ObjectMapper();
@@ -1494,7 +1566,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
         .variable(variableKey1, variableValue1)
         .variable(variableKey2, variableValue2).getVariables();
 
-    Map<String, Object> variablesJson = new HashMap<String, Object>();
+    Map<String, Object> variablesJson = new HashMap<>();
     variablesJson.put("variables", variables);
 
     given().pathParam("id", MockProvider.EXAMPLE_EXECUTION_ID).pathParam("messageName", messageName)
@@ -1502,7 +1574,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
       .then().expect().statusCode(Status.NO_CONTENT.getStatusCode())
       .when().post(TRIGGER_MESSAGE_SUBSCRIPTION_URL);
 
-    Map<String, Object> expectedVariables = new HashMap<String, Object>();
+    Map<String, Object> expectedVariables = new HashMap<>();
     expectedVariables.put(variableKey1, variableValue1);
     expectedVariables.put(variableKey2, variableValue2);
 
@@ -1559,7 +1631,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
   @Test
   public void testCreateIncident() {
     when(runtimeServiceMock.createIncident(anyString(), anyString(), anyString(), anyString())).thenReturn(mock(Incident.class));
-    Map<String, Object> json = new HashMap<String, Object>();
+    Map<String, Object> json = new HashMap<>();
     json.put("incidentType", "incidentType");
     json.put("configuration", "configuration");
     json.put("message", "message");
@@ -1573,7 +1645,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
   @Test
   public void testCreateIncidentWithNullIncidentType() {
     doThrow(new BadUserRequestException()).when(runtimeServiceMock).createIncident(anyString(), anyString(), anyString(), anyString());
-    Map<String, Object> json = new HashMap<String, Object>();
+    Map<String, Object> json = new HashMap<>();
     json.put("configuration", "configuration");
     json.put("message", "message");
 

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/sub/impl/VariableDeserializationTypeValidationTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/sub/impl/VariableDeserializationTypeValidationTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.rest.sub.impl;
+
+import static org.mockito.Mockito.times;
+
+import java.util.List;
+
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.runtime.DeserializationTypeValidator;
+import org.camunda.bpm.engine.variable.VariableMap;
+import org.camunda.bpm.engine.variable.value.TypedValue;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+public class VariableDeserializationTypeValidationTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  protected AbstractVariablesResource variablesResourceSpy;
+  protected DeserializationTypeValidator validator;
+
+  @Before
+  public void setUpMocks() {
+    validator = Mockito.mock(DeserializationTypeValidator.class);
+
+    ProcessEngineConfiguration configurationMock = Mockito.mock(ProcessEngineConfiguration.class);
+    Mockito.when(configurationMock.isDeserializationTypeValidationEnabled()).thenReturn(true);
+    Mockito.when(configurationMock.getDeserializationTypeValidator()).thenReturn(validator);
+
+    variablesResourceSpy = createVariablesResourceSpy();
+    Mockito.when(variablesResourceSpy.getProcessEngineConfiguration()).thenReturn(configurationMock);
+  }
+
+  @Test
+  public void shouldValidateNothingForPrimitiveClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructType(int.class);
+    setValidatorMockResult(true);
+
+    // when
+    variablesResourceSpy.validateType(type);
+
+    // then
+    Mockito.verifyZeroInteractions(validator);
+  }
+
+  @Test
+  public void shouldValidateBaseTypeOnlyForSimpleClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructType(String.class);
+    setValidatorMockResult(true);
+
+    // when
+    variablesResourceSpy.validateType(type);
+
+    // then
+    Mockito.verify(validator).validate("java.lang.String");
+    Mockito.verifyNoMoreInteractions(validator);
+  }
+
+  @Test
+  public void shouldValidateBaseTypeOnlyForComplexClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructType(Complex.class);
+    setValidatorMockResult(true);
+
+    // when
+    variablesResourceSpy.validateType(type);
+
+    // then
+    Mockito.verify(validator).validate("org.camunda.bpm.engine.rest.sub.impl.VariableDeserializationTypeValidationTest$Complex");
+    Mockito.verifyNoMoreInteractions(validator);
+  }
+
+  @Test
+  public void shouldValidateContentTypeOnlyForArrayClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructType(Integer[].class);
+    setValidatorMockResult(true);
+
+    // when
+    variablesResourceSpy.validateType(type);
+
+    // then
+    Mockito.verify(validator).validate("java.lang.Integer");
+    Mockito.verifyNoMoreInteractions(validator);
+  }
+
+  @Test
+  public void shouldValidateCollectionAndContentTypeForCollectionClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructFromCanonical("java.util.ArrayList<java.lang.String>");
+    setValidatorMockResult(true);
+
+    // when
+    variablesResourceSpy.validateType(type);
+
+    // then
+    Mockito.verify(validator).validate("java.util.ArrayList");
+    Mockito.verify(validator).validate("java.lang.String");
+    Mockito.verifyNoMoreInteractions(validator);
+  }
+
+  @Test
+  public void shouldValidateCollectionAndContentTypeForNestedCollectionClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructFromCanonical("java.util.ArrayList<java.util.ArrayList<java.lang.String>>");
+    setValidatorMockResult(true);
+
+    // when
+    variablesResourceSpy.validateType(type);
+
+    // then
+    Mockito.verify(validator, times(2)).validate("java.util.ArrayList");
+    Mockito.verify(validator).validate("java.lang.String");
+    Mockito.verifyNoMoreInteractions(validator);
+  }
+
+  @Test
+  public void shouldValidateMapAndKeyAndContentTypeForMapClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructFromCanonical("java.util.HashMap<java.lang.String, java.lang.Integer>");
+    setValidatorMockResult(true);
+
+    // when
+    variablesResourceSpy.validateType(type);
+
+    // then
+    Mockito.verify(validator).validate("java.util.HashMap");
+    Mockito.verify(validator).validate("java.lang.String");
+    Mockito.verify(validator).validate("java.lang.Integer");
+    Mockito.verifyNoMoreInteractions(validator);
+  }
+
+  @Test
+  public void shouldFailForSimpleClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructType(String.class);
+    setValidatorMockResult(false);
+
+    // then
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("[java.lang.String]");
+
+    // when
+    variablesResourceSpy.validateType(type);
+  }
+
+  @Test
+  public void shouldFailForComplexClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructType(Complex.class);
+    setValidatorMockResult(false);
+
+    // then
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("[org.camunda.bpm.engine.rest.sub.impl.VariableDeserializationTypeValidationTest$Complex]");
+
+    // when
+    variablesResourceSpy.validateType(type);
+  }
+
+  @Test
+  public void shouldFailForArrayClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructType(Integer[].class);
+    setValidatorMockResult(false);
+
+    // then
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("[java.lang.Integer]");
+
+    // when
+    variablesResourceSpy.validateType(type);
+  }
+
+  @Test
+  public void shouldFailForCollectionClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructFromCanonical("java.util.ArrayList<java.lang.String>");
+    setValidatorMockResult(false);
+
+    // then
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("[java.util.ArrayList, java.lang.String]");
+
+    // when
+    variablesResourceSpy.validateType(type);
+  }
+
+  @Test
+  public void shouldFailForMapClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructFromCanonical("java.util.HashMap<java.lang.String, java.lang.Integer>");
+    setValidatorMockResult(false);
+
+    // then
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("[java.util.HashMap, java.lang.String, java.lang.Integer]");
+
+    // when
+    variablesResourceSpy.validateType(type);
+  }
+
+  @Test
+  public void shouldFailOnceForMapClass() {
+    // given
+    JavaType type = TypeFactory.defaultInstance().constructFromCanonical("java.util.HashMap<java.lang.String, java.lang.String>");
+    setValidatorMockResult(false);
+
+    // then
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("[java.util.HashMap, java.lang.String]");
+
+    // when
+    variablesResourceSpy.validateType(type);
+  }
+
+  public static class Complex {
+    private Nested nested;
+
+    public Nested getNested() {
+      return nested;
+    }
+  }
+
+  public static class Nested {
+    private int testInt;
+
+    public int getTestInt() {
+      return testInt;
+    }
+  }
+
+  protected void setValidatorMockResult(boolean result) {
+    Mockito.when(validator.validate(Mockito.anyString())).thenReturn(result);
+  }
+
+  protected AbstractVariablesResource createVariablesResourceSpy() {
+    return Mockito.spy(new AbstractVariablesResource(Mockito.mock(ProcessEngine.class), "test", Mockito.mock(ObjectMapper.class)) {
+
+      @Override
+      protected void updateVariableEntities(VariableMap variables, List<String> deletions) {
+      }
+
+      @Override
+      protected void setVariableEntity(String variableKey, TypedValue variableValue) {
+      }
+
+      @Override
+      protected void removeVariableEntity(String variableKey) {
+      }
+
+      @Override
+      protected TypedValue getVariableEntity(String variableKey, boolean deserializeValue) {
+        return null;
+      }
+
+      @Override
+      protected VariableMap getVariableEntities(boolean deserializeValues) {
+        return null;
+      }
+
+      @Override
+      protected String getResourceTypeName() {
+        return null;
+      }
+    });
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/ProcessEngineConfiguration.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/ProcessEngineConfiguration.java
@@ -30,8 +30,8 @@ import org.camunda.bpm.engine.impl.SchemaOperationsProcessEngineBuild;
 import org.camunda.bpm.engine.impl.cfg.BeansConfigurationHelper;
 import org.camunda.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
 import org.camunda.bpm.engine.impl.cfg.StandaloneProcessEngineConfiguration;
-import org.camunda.bpm.engine.impl.jobexecutor.ExecuteJobsRunnable;
 import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.runtime.DeserializationTypeValidator;
 import org.camunda.bpm.engine.variable.type.ValueTypeResolver;
 
 
@@ -397,6 +397,18 @@ public abstract class ProcessEngineConfiguration {
    * on logging level WARN.
    */
   protected boolean enableReducedJobExceptionLogging = false;
+
+  /** Specifies which classes are allowed for deserialization */
+  protected String deserializationAllowedClasses;
+
+  /** Specifies which packages are allowed for deserialization */
+  protected String deserializationAllowedPackages;
+
+  /** Validates types before deserialization */
+  protected DeserializationTypeValidator deserializationTypeValidator;
+
+  /** Indicates whether type validation should be done before deserialization */
+  protected boolean deserializationTypeValidationEnabled = false;
 
   /** use one of the static createXxxx methods instead */
   protected ProcessEngineConfiguration() {
@@ -1005,4 +1017,41 @@ public abstract class ProcessEngineConfiguration {
     this.enableReducedJobExceptionLogging = enableReducedJobExceptionLogging;
     return this;
   }
+
+  public String getDeserializationAllowedClasses() {
+    return deserializationAllowedClasses;
+  }
+
+  public ProcessEngineConfiguration setDeserializationAllowedClasses(String deserializationAllowedClasses) {
+    this.deserializationAllowedClasses = deserializationAllowedClasses;
+    return this;
+  }
+
+  public String getDeserializationAllowedPackages() {
+    return deserializationAllowedPackages;
+  }
+
+  public ProcessEngineConfiguration setDeserializationAllowedPackages(String deserializationAllowedPackages) {
+    this.deserializationAllowedPackages = deserializationAllowedPackages;
+    return this;
+  }
+
+  public DeserializationTypeValidator getDeserializationTypeValidator() {
+    return deserializationTypeValidator;
+  }
+
+  public ProcessEngineConfiguration setDeserializationTypeValidator(DeserializationTypeValidator deserializationTypeValidator) {
+    this.deserializationTypeValidator = deserializationTypeValidator;
+    return this;
+  }
+
+  public boolean isDeserializationTypeValidationEnabled() {
+    return deserializationTypeValidationEnabled;
+  }
+
+  public ProcessEngineConfiguration setDeserializationTypeValidationEnabled(boolean deserializationTypeValidationEnabled) {
+    this.deserializationTypeValidationEnabled = deserializationTypeValidationEnabled;
+    return this;
+  }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -40,7 +40,6 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-
 import javax.naming.InitialContext;
 import javax.sql.DataSource;
 
@@ -320,6 +319,7 @@ import org.camunda.bpm.engine.impl.runtime.ConditionHandler;
 import org.camunda.bpm.engine.impl.runtime.CorrelationHandler;
 import org.camunda.bpm.engine.impl.runtime.DefaultConditionHandler;
 import org.camunda.bpm.engine.impl.runtime.DefaultCorrelationHandler;
+import org.camunda.bpm.engine.impl.runtime.DefaultDeserializationTypeValidator;
 import org.camunda.bpm.engine.impl.scripting.ScriptFactory;
 import org.camunda.bpm.engine.impl.scripting.engine.BeansResolverFactory;
 import org.camunda.bpm.engine.impl.scripting.engine.ResolverFactory;
@@ -354,6 +354,7 @@ import org.camunda.bpm.engine.management.Metrics;
 import org.camunda.bpm.engine.repository.DeploymentBuilder;
 import org.camunda.bpm.engine.repository.DeploymentHandlerFactory;
 import org.camunda.bpm.engine.runtime.Incident;
+import org.camunda.bpm.engine.runtime.WhitelistingDeserializationTypeValidator;
 import org.camunda.bpm.engine.test.mock.MocksResolverFactory;
 import org.camunda.bpm.engine.variable.Variables;
 import org.camunda.bpm.engine.variable.type.ValueType;
@@ -852,6 +853,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     initIdentityProviderSessionFactory();
     initSessionFactories();
     initValueTypeResolver();
+    initTypeValidator();
     initSerialization();
     initJpa();
     initDelegateInterceptor();
@@ -875,6 +877,17 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     initAdminGroups();
     initPasswordPolicy();
     invokePostInit();
+  }
+
+  protected void initTypeValidator() {
+    if (deserializationTypeValidator == null) {
+      deserializationTypeValidator = new DefaultDeserializationTypeValidator();
+    }
+    if (deserializationTypeValidator instanceof WhitelistingDeserializationTypeValidator) {
+      WhitelistingDeserializationTypeValidator validator = (WhitelistingDeserializationTypeValidator) deserializationTypeValidator;
+      validator.setAllowedClasses(deserializationAllowedClasses);
+      validator.setAllowedPackages(deserializationAllowedPackages);
+    }
   }
 
   public void initHistoryRemovalTime() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/runtime/DefaultDeserializationTypeValidator.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/runtime/DefaultDeserializationTypeValidator.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.runtime;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.camunda.bpm.engine.runtime.WhitelistingDeserializationTypeValidator;
+
+/**
+ * Validate a type against a list of allowed packages and classes. Allows a basic
+ * set of packages and classes without known security issues based on Jackson
+ * Databind's <a href=
+ * "https://github.com/FasterXML/jackson-databind/blob/master/src/main/java/com/fasterxml/jackson/databind/jsontype/impl/SubTypeValidator.java">SubTypeValidator</a>.
+ */
+public class DefaultDeserializationTypeValidator implements WhitelistingDeserializationTypeValidator {
+
+  protected static final Collection<String> ALLOWED_PACKAGES = Arrays.asList("java.lang");
+  protected static final Collection<String> ALLOWED_CLASSES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+      "java.util.ArrayList", "java.util.Arrays$ArrayList", "java.util.HashMap", "java.util.HashSet",
+      "java.util.LinkedHashMap", "java.util.LinkedHashSet", "java.util.LinkedList",
+      "java.util.Properties", "java.util.TreeMap", "java.util.TreeSet")));
+
+  protected Set<String> allowedClasses = new HashSet<>(ALLOWED_CLASSES);
+  protected Set<String> allowedPackages = new HashSet<>(ALLOWED_PACKAGES);
+
+  @Override
+  public void setAllowedClasses(String deserializationAllowedClasses) {
+    extractElements(deserializationAllowedClasses, allowedClasses);
+  }
+
+  @Override
+  public void setAllowedPackages(String deserializationAllowedPackages) {
+    extractElements(deserializationAllowedPackages, allowedPackages);
+  }
+
+  @Override
+  public boolean validate(String className) {
+    if (className == null || className.trim().isEmpty()) {
+      return true;
+    }
+    return isPackageAllowed(className) || isClassNameAllowed(className);
+  }
+
+  protected boolean isPackageAllowed(String className) {
+    if (!isPackageAllowed(className, ALLOWED_PACKAGES)) {
+      return isPackageAllowed(className, allowedPackages);
+    }
+    return true;
+  }
+
+  protected boolean isPackageAllowed(String className, Collection<String> allowedPackages) {
+    for (String allowedPackage : allowedPackages) {
+      if (!allowedPackage.isEmpty() && className.startsWith(allowedPackage)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  protected boolean isClassNameAllowed(String className) {
+    if (!ALLOWED_CLASSES.contains(className)) {
+      return allowedClasses.contains(className);
+    }
+    return true;
+  }
+
+  protected void extractElements(String allowedElements, Set<String> set) {
+    if (!set.isEmpty()) {
+      set.clear();
+    }
+    if (allowedElements == null) {
+      return;
+    }
+    String allowedElementsSanitized = allowedElements.replaceAll("\\s", "");
+    if (allowedElementsSanitized.isEmpty()) {
+      return;
+    }
+    String[] classes = allowedElementsSanitized.split(",");
+    for (String className : classes) {
+      set.add(className.trim());
+    }
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/runtime/DeserializationTypeValidator.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/runtime/DeserializationTypeValidator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.runtime;
+
+/**
+ * Validate a type before deserialization
+ */
+public interface DeserializationTypeValidator {
+
+  /** Validate the class name */
+  boolean validate(String className);
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/runtime/WhitelistingDeserializationTypeValidator.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/runtime/WhitelistingDeserializationTypeValidator.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.runtime;
+
+/**
+ * Validate a type before deserialization against a whitelist of allowed types
+ */
+public interface WhitelistingDeserializationTypeValidator extends DeserializationTypeValidator {
+
+  /** Set the allowed class names */
+  void setAllowedClasses(String deserializationAllowedClasses);
+
+  /** Set the allowed package names */
+  void setAllowedPackages(String deserializationAllowedPackages);
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/impl/runtime/DefaultDeserializationTypeValidatorTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/impl/runtime/DefaultDeserializationTypeValidatorTest.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import org.camunda.bpm.engine.impl.runtime.DefaultDeserializationTypeValidator;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DefaultDeserializationTypeValidatorTest {
+
+  private static final String ANOTHER_CLASS = "another.class.Class";
+  private static final String ANOTHER_PACKAGE = "another.class";
+  private static final String SOME_CLASS = "some.class.Class";
+  private static final String SOME_PACKAGE = "some.class";
+
+  protected DefaultDeserializationTypeValidator validator;
+
+  @Before
+  public void setUp() {
+    validator = new DefaultDeserializationTypeValidator();
+  }
+
+  // SETTERS
+
+  @Test
+  public void shouldAcceptNullListOfAllowedClasses() {
+    // when
+    validator.setAllowedClasses(null);
+    // then
+    assertThat(validator.allowedClasses).isEmpty();
+  }
+
+  @Test
+  public void shouldAcceptEmptyListOfAllowedClasses() {
+    // when
+    validator.setAllowedClasses("");
+    // then
+    assertThat(validator.allowedClasses).isEmpty();
+  }
+
+  @Test
+  public void shouldAcceptListOfEmptyAllowedClasses() {
+    // when
+    validator.setAllowedClasses("\r\n  , \t , ,,\n,\r");
+    // then
+    assertThat(validator.allowedClasses).isEmpty();
+  }
+
+  @Test
+  public void shouldAcceptSingleStringOfAllowedClasses() {
+    // when
+    validator.setAllowedClasses("some.Class");
+    // then
+    assertThat(validator.allowedClasses).containsExactly("some.Class");
+  }
+
+  @Test
+  public void shouldAcceptStringListOfAllowedClasses() {
+    // when
+    validator.setAllowedClasses("  some.class.Class , another.class.Class  ");
+    // then
+    assertThat(validator.allowedClasses).containsExactlyInAnyOrder(SOME_CLASS, ANOTHER_CLASS);
+  }
+
+  @Test
+  public void shouldOverrideAllowedClasses() {
+    // given
+    validator.setAllowedClasses(SOME_CLASS);
+    // when
+    validator.setAllowedClasses(ANOTHER_CLASS);
+    // then
+    assertThat(validator.allowedClasses).containsExactly(ANOTHER_CLASS);
+  }
+
+  @Test
+  public void shouldClearAllowedClasses() {
+    // given
+    validator.setAllowedClasses(SOME_CLASS);
+    // when
+    validator.setAllowedClasses(null);
+    // then
+    assertThat(validator.allowedClasses).isEmpty();
+  }
+
+  @Test
+  public void shouldAcceptNullListOfAllowedPackages() {
+    // when
+    validator.setAllowedPackages(null);
+    // then
+    assertThat(validator.allowedPackages).isEmpty();
+  }
+
+  @Test
+  public void shouldAcceptEmptyListOfAllowedPackages() {
+    // when
+    validator.setAllowedPackages("");
+    // then
+    assertThat(validator.allowedPackages).isEmpty();
+  }
+
+  @Test
+  public void shouldAcceptListOfEmptyAllowedPackages() {
+    // when
+    validator.setAllowedPackages("\r\n  , \t , ,,\n,\r");
+    // then
+    assertThat(validator.allowedPackages).isEmpty();
+  }
+
+  @Test
+  public void shouldAcceptSingleStringOfAllowedPackages() {
+    // when
+    validator.setAllowedPackages("some.");
+    // then
+    assertThat(validator.allowedPackages).containsExactly("some.");
+  }
+
+  @Test
+  public void shouldAcceptStringListOfAllowedPackages() {
+    // when
+    validator.setAllowedPackages("  some.class , another.class  ");
+    // then
+    assertThat(validator.allowedPackages).containsExactlyInAnyOrder("some.class", "another.class");
+  }
+
+  @Test
+  public void shouldOverrideAllowedPackages() {
+    // given
+    validator.setAllowedPackages(SOME_PACKAGE);
+    // when
+    validator.setAllowedPackages(ANOTHER_PACKAGE);
+    // then
+    assertThat(validator.allowedPackages).containsExactly(ANOTHER_PACKAGE);
+  }
+
+  @Test
+  public void shouldClearAllowedPackages() {
+    // given
+    validator.setAllowedPackages(SOME_PACKAGE);
+    // when
+    validator.setAllowedPackages(null);
+    // then
+    assertThat(validator.allowedPackages).isEmpty();
+  }
+
+  // EMPTY WHITELIST
+
+  @Test
+  public void shouldForbidUnknownClassOnEmptyWhitelist() {
+    // then
+    assertThat(validator.validate(SOME_CLASS)).isFalse();
+  }
+
+  @Test
+  public void shouldAllowJavaLangClassOnEmptyWhitelist() {
+    // then
+    assertThat(validator.validate(Number.class.getName())).isTrue();
+  }
+
+  @Test
+  public void shouldAllowJavaUtilContainerClassesOnEmptyWhitelist() {
+    // then
+    assertThat(validator.validate(ArrayList.class.getName())).isTrue();
+    assertThat(validator.validate(HashMap.class.getName())).isTrue();
+    assertThat(validator.validate(Arrays.asList("a", "n").getClass().getName())).isTrue();
+  }
+
+  // ALLOWED CLASS(ES)
+
+  @Test
+  public void shouldAllowClassOnWhitelistedClass() {
+    // given
+    validator.setAllowedClasses(SOME_CLASS);
+    // then
+    assertThat(validator.validate(SOME_CLASS)).isTrue();
+  }
+
+  @Test
+  public void shouldAllowClassOnWhitelistedClasses() {
+    // given
+    validator.setAllowedClasses(SOME_CLASS + "," + ANOTHER_CLASS);
+    // then
+    assertThat(validator.validate(SOME_CLASS)).isTrue();
+  }
+
+  @Test
+  public void shouldForbidClassOnNonWhitelistedClass() {
+    // given
+    validator.setAllowedClasses(SOME_CLASS);
+    // then
+    assertThat(validator.validate(ANOTHER_CLASS)).isFalse();
+  }
+
+  @Test
+  public void shouldForbidClassOnNonWhitelistedClasses() {
+    // given
+    validator.setAllowedClasses(SOME_CLASS + "," + ANOTHER_CLASS);
+    // then
+    assertThat(validator.validate("different.Class")).isFalse();
+  }
+
+  @Test
+  public void shouldForbidClassOnEmptyClasses() {
+    // given
+    validator.setAllowedClasses(",  ,,");
+    // then
+    assertThat(validator.validate(SOME_CLASS)).isFalse();
+  }
+
+  // ALLOWED PACKAGE(S)
+
+  @Test
+  public void shouldAllowClassOnWhitelistedPackage() {
+    // given
+    validator.setAllowedPackages(SOME_PACKAGE);
+    // then
+    assertThat(validator.validate(SOME_CLASS)).isTrue();
+  }
+
+  @Test
+  public void shouldAllowClassOnWhitelistedPackages() {
+    // given
+    validator.setAllowedPackages(SOME_PACKAGE + "," + ANOTHER_PACKAGE);
+    // then
+    assertThat(validator.validate(SOME_CLASS)).isTrue();
+  }
+
+  @Test
+  public void shouldForbidClassOnNonWhitelistedPackage() {
+    // given
+    validator.setAllowedPackages(SOME_PACKAGE);
+    // then
+    assertThat(validator.validate(ANOTHER_CLASS)).isFalse();
+  }
+
+  @Test
+  public void shouldForbidClassOnNonWhitelistedPackages() {
+    // given
+    validator.setAllowedPackages(SOME_PACKAGE + "," + ANOTHER_PACKAGE);
+    // then
+    assertThat(validator.validate("different.Class")).isFalse();
+  }
+
+  @Test
+  public void shouldForbidClassOnEmptyPackages() {
+    // given
+    validator.setAllowedPackages(",  ,,");
+    // then
+    assertThat(validator.validate(SOME_CLASS)).isFalse();
+  }
+
+  // ALLOWED CLASS(ES) AND PACKAGE(S)
+
+  @Test
+  public void shouldAllowClassOnWhitelistedClassAndNonWhitelistedPackage() {
+    // given
+    validator.setAllowedClasses(SOME_CLASS);
+    validator.setAllowedPackages(ANOTHER_PACKAGE);
+    // then
+    assertThat(validator.validate(SOME_CLASS)).isTrue();
+  }
+
+  @Test
+  public void shouldAllowClassOnNonWhitelistedClassAndWhitelistedPackage() {
+    // given
+    validator.setAllowedClasses(ANOTHER_CLASS);
+    validator.setAllowedPackages(SOME_PACKAGE);
+    // then
+    assertThat(validator.validate(SOME_CLASS)).isTrue();
+  }
+
+  @Test
+  public void shouldForbidClassOnNonWhitelistedClassAndNonWhitelistedPackage() {
+    // given
+    validator.setAllowedPackages(SOME_PACKAGE);
+    validator.setAllowedClasses(SOME_CLASS);
+    // then
+    assertThat(validator.validate(ANOTHER_CLASS)).isFalse();
+  }
+}

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/spin/dataformat/FooDataFormat.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/spin/dataformat/FooDataFormat.java
@@ -21,6 +21,7 @@ import java.io.Reader;
 import java.io.Writer;
 import java.util.regex.Pattern;
 
+import org.camunda.spin.DeserializationTypeValidator;
 import org.camunda.spin.spi.DataFormat;
 import org.camunda.spin.spi.DataFormatMapper;
 import org.camunda.spin.spi.DataFormatReader;
@@ -90,11 +91,21 @@ public class FooDataFormat implements DataFormat<FooSpin> {
 
       @Override
       public <T> T mapInternalToJava(Object parameter, String typeIdentifier) {
+        return mapInternalToJava(parameter, typeIdentifier, null);
+      }
+
+      @Override
+      public <T> T mapInternalToJava(Object parameter, String typeIdentifier, DeserializationTypeValidator validator) {
         return (T) new Foo();
       }
 
       @Override
       public <T> T mapInternalToJava(Object parameter, Class<T> type) {
+        return null;
+      }
+
+      @Override
+      public <T> T mapInternalToJava(Object parameter, Class<T> type, DeserializationTypeValidator validator) {
         return null;
       }
 
@@ -107,6 +118,7 @@ public class FooDataFormat implements DataFormat<FooSpin> {
       public boolean canMap(Object parameter) {
         return parameter instanceof Foo;
       }
+
     };
   }
 


### PR DESCRIPTION
* configure type validator via engine configuration
* use validator in REST API for deprecated JSON deserialization
* pass on validator to Spin via spin-plugin's object serializers
* keep validator per spin plugin instance's serializers, not in DataFormats
  (in case of multiple engines with different whitelist configurations that would
  otherwise override each other)
* use validating Spin deserialization methods (added in Spin)
* pull-in engine test classes in spin-plugin for efficient test writing

**Note**
Tests will only run if Spin https://github.com/camunda/camunda-spin/pull/59 is merged and pushed to Nexus

related to CAM-10714