### PR TITLE
CAM-6554: feat(rest): query historic queries without tenant id

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricActivityInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricActivityInstanceQueryDto.java
@@ -16,6 +16,8 @@
  */
 package org.camunda.bpm.engine.rest.dto.history;
 
+import static java.lang.Boolean.TRUE;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -35,20 +37,20 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class HistoricActivityInstanceQueryDto extends AbstractQueryDto<HistoricActivityInstanceQuery> {
 
-  private static final String SORT_BY_HISTORIC_ACTIVITY_INSTANCE_ID_VALUE = "activityInstanceId";
-  private static final String SORT_BY_PROCESS_INSTANCE_ID_VALUE = "instanceId";
-  private static final String SORT_BY_EXECUTION_ID_VALUE = "executionId";
-  private static final String SORT_BY_ACTIVITY_ID_VALUE = "activityId";
-  private static final String SORT_BY_ACTIVITY_NAME_VALUE = "activityName";
-  private static final String SORT_BY_ACTIVITY_TYPE_VALUE = "activityType";
-  private static final String SORT_BY_HISTORIC_ACTIVITY_INSTANCE_START_TIME_VALUE = "startTime";
-  private static final String SORT_BY_HISTORIC_ACTIVITY_INSTANCE_END_TIME_VALUE = "endTime";
-  private static final String SORT_BY_HISTORIC_ACTIVITY_INSTANCE_DURATION_VALUE = "duration";
-  private static final String SORT_BY_PROCESS_DEFINITION_ID_VALUE = "definitionId";
-  private static final String SORT_PARTIALLY_BY_OCCURRENCE = "occurrence";
-  private static final String SORT_BY_TENANT_ID = "tenantId";
+  protected static final String SORT_BY_HISTORIC_ACTIVITY_INSTANCE_ID_VALUE = "activityInstanceId";
+  protected static final String SORT_BY_PROCESS_INSTANCE_ID_VALUE = "instanceId";
+  protected static final String SORT_BY_EXECUTION_ID_VALUE = "executionId";
+  protected static final String SORT_BY_ACTIVITY_ID_VALUE = "activityId";
+  protected static final String SORT_BY_ACTIVITY_NAME_VALUE = "activityName";
+  protected static final String SORT_BY_ACTIVITY_TYPE_VALUE = "activityType";
+  protected static final String SORT_BY_HISTORIC_ACTIVITY_INSTANCE_START_TIME_VALUE = "startTime";
+  protected static final String SORT_BY_HISTORIC_ACTIVITY_INSTANCE_END_TIME_VALUE = "endTime";
+  protected static final String SORT_BY_HISTORIC_ACTIVITY_INSTANCE_DURATION_VALUE = "duration";
+  protected static final String SORT_BY_PROCESS_DEFINITION_ID_VALUE = "definitionId";
+  protected static final String SORT_PARTIALLY_BY_OCCURRENCE = "occurrence";
+  protected static final String SORT_BY_TENANT_ID = "tenantId";
 
-  private static final List<String> VALID_SORT_BY_VALUES;
+  protected static final List<String> VALID_SORT_BY_VALUES;
   static {
     VALID_SORT_BY_VALUES = new ArrayList<String>();
     VALID_SORT_BY_VALUES.add(SORT_BY_HISTORIC_ACTIVITY_INSTANCE_ID_VALUE);
@@ -65,23 +67,24 @@ public class HistoricActivityInstanceQueryDto extends AbstractQueryDto<HistoricA
     VALID_SORT_BY_VALUES.add(SORT_BY_TENANT_ID);
   }
 
-  private String activityInstanceId;
-  private String processInstanceId;
-  private String processDefinitionId;
-  private String executionId;
-  private String activityId;
-  private String activityName;
-  private String activityType;
-  private String taskAssignee;
-  private Boolean finished;
-  private Boolean unfinished;
-  private Boolean completeScope;
-  private Boolean canceled;
-  private Date startedBefore;
-  private Date startedAfter;
-  private Date finishedBefore;
-  private Date finishedAfter;
-  private List<String> tenantIds;
+  protected String activityInstanceId;
+  protected String processInstanceId;
+  protected String processDefinitionId;
+  protected String executionId;
+  protected String activityId;
+  protected String activityName;
+  protected String activityType;
+  protected String taskAssignee;
+  protected Boolean finished;
+  protected Boolean unfinished;
+  protected Boolean completeScope;
+  protected Boolean canceled;
+  protected Date startedBefore;
+  protected Date startedAfter;
+  protected Date finishedBefore;
+  protected Date finishedAfter;
+  protected List<String> tenantIds;
+  protected Boolean withoutTenantId;
 
   public HistoricActivityInstanceQueryDto() {
   }
@@ -175,6 +178,11 @@ public class HistoricActivityInstanceQueryDto extends AbstractQueryDto<HistoricA
     this.tenantIds = tenantIds;
   }
 
+  @CamundaQueryParam(value = "withoutTenantId", converter = BooleanConverter.class)
+  public void setWithoutTenantId(Boolean withoutTenantId) {
+    this.withoutTenantId = withoutTenantId;
+  }
+
   @Override
   protected boolean isValidSortByValue(String value) {
     return VALID_SORT_BY_VALUES.contains(value);
@@ -237,6 +245,9 @@ public class HistoricActivityInstanceQueryDto extends AbstractQueryDto<HistoricA
     }
     if (tenantIds != null && !tenantIds.isEmpty()) {
       query.tenantIdIn(tenantIds.toArray(new String[tenantIds.size()]));
+    }
+    if (TRUE.equals(withoutTenantId)) {
+      query.withoutTenantId();
     }
   }
 

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricCaseActivityInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricCaseActivityInstanceQueryDto.java
@@ -16,6 +16,8 @@
  */
 package org.camunda.bpm.engine.rest.dto.history;
 
+import static java.lang.Boolean.TRUE;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -86,6 +88,7 @@ public class HistoricCaseActivityInstanceQueryDto extends AbstractQueryDto<Histo
   protected Boolean completed;
   protected Boolean terminated;
   protected List<String> tenantIds;
+  protected Boolean withoutTenantId;
 
   public HistoricCaseActivityInstanceQueryDto() {
   }
@@ -209,6 +212,11 @@ public class HistoricCaseActivityInstanceQueryDto extends AbstractQueryDto<Histo
     this.tenantIds = tenantIds;
   }
 
+  @CamundaQueryParam(value = "withoutTenantId", converter = BooleanConverter.class)
+  public void setWithoutTenantId(Boolean withoutTenantId) {
+    this.withoutTenantId = withoutTenantId;
+  }
+
   @Override
   protected boolean isValidSortByValue(String value) {
     return VALID_SORT_BY_VALUES.contains(value);
@@ -289,6 +297,9 @@ public class HistoricCaseActivityInstanceQueryDto extends AbstractQueryDto<Histo
     }
     if (tenantIds != null && !tenantIds.isEmpty()) {
       query.tenantIdIn(tenantIds.toArray(new String[tenantIds.size()]));
+    }
+    if (TRUE.equals(withoutTenantId)) {
+      query.withoutTenantId();
     }
   }
 

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricDecisionInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricDecisionInstanceQueryDto.java
@@ -80,6 +80,7 @@ public class HistoricDecisionInstanceQueryDto extends AbstractQueryDto<HistoricD
   protected String decisionRequirementsDefinitionId;
   protected String decisionRequirementsDefinitionKey;
   protected List<String> tenantIds;
+  protected Boolean withoutTenantId;
 
   public HistoricDecisionInstanceQueryDto() {
   }
@@ -228,6 +229,11 @@ public class HistoricDecisionInstanceQueryDto extends AbstractQueryDto<HistoricD
     this.tenantIds = tenantIds;
   }
 
+  @CamundaQueryParam(value = "withoutTenantId", converter = BooleanConverter.class)
+  public void setWithoutTenantId(Boolean withoutTenantId) {
+    this.withoutTenantId = withoutTenantId;
+  }
+
   @Override
   protected boolean isValidSortByValue(String value) {
     return VALID_SORT_BY_VALUES.contains(value);
@@ -323,6 +329,9 @@ public class HistoricDecisionInstanceQueryDto extends AbstractQueryDto<HistoricD
     }
     if (tenantIds != null && !tenantIds.isEmpty()) {
       query.tenantIdIn(tenantIds.toArray(new String[tenantIds.size()]));
+    }
+    if (TRUE.equals(withoutTenantId)) {
+      query.withoutTenantId();
     }
   }
 

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricDetailQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricDetailQueryDto.java
@@ -16,6 +16,8 @@
  */
 package org.camunda.bpm.engine.rest.dto.history;
 
+import static java.lang.Boolean.TRUE;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -77,6 +79,7 @@ public class HistoricDetailQueryDto extends AbstractQueryDto<HistoricDetailQuery
   protected Boolean variableUpdates;
   protected Boolean excludeTaskDetails;
   protected List<String> tenantIds;
+  protected Boolean withoutTenantId;
   protected String[] processInstanceIdIn;
   protected String userOperationId;
   private Date occurredBefore;
@@ -149,11 +152,15 @@ public class HistoricDetailQueryDto extends AbstractQueryDto<HistoricDetailQuery
     this.tenantIds = tenantIds;
   }
 
+  @CamundaQueryParam(value = "withoutTenantId", converter = BooleanConverter.class)
+  public void setWithoutTenantId(Boolean withoutTenantId) {
+    this.withoutTenantId = withoutTenantId;
+  }
+
   @CamundaQueryParam(value="processInstanceIdIn", converter = StringArrayConverter.class)
   public void setProcessInstanceIdIn(String[] processInstanceIdIn) {
     this.processInstanceIdIn = processInstanceIdIn;
   }
-
 
   @CamundaQueryParam(value = "userOperationId")
   public void setUserOperationId(String userOperationId) {
@@ -237,6 +244,9 @@ public class HistoricDetailQueryDto extends AbstractQueryDto<HistoricDetailQuery
     }
     if (tenantIds != null && !tenantIds.isEmpty()) {
       query.tenantIdIn(tenantIds.toArray(new String[tenantIds.size()]));
+    }
+    if (TRUE.equals(withoutTenantId)) {
+      query.withoutTenantId();
     }
     if (processInstanceIdIn != null && processInstanceIdIn.length > 0) {
       query.processInstanceIdIn(processInstanceIdIn);

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricExternalTaskLogQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricExternalTaskLogQueryDto.java
@@ -16,6 +16,8 @@
  */
 package org.camunda.bpm.engine.rest.dto.history;
 
+import static java.lang.Boolean.TRUE;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.history.HistoricExternalTaskLogQuery;
@@ -79,6 +81,7 @@ public class HistoricExternalTaskLogQueryDto extends AbstractQueryDto<HistoricEx
   protected Long priorityHigherThanOrEquals;
   protected Long priorityLowerThanOrEquals;
   protected String[] tenantIds;
+  protected Boolean withoutTenantId;
   protected Boolean creationLog;
   protected Boolean failureLog;
   protected Boolean successLog;
@@ -158,6 +161,11 @@ public class HistoricExternalTaskLogQueryDto extends AbstractQueryDto<HistoricEx
   @CamundaQueryParam(value = "tenantIdIn", converter = StringArrayConverter.class)
   public void setTenantIdIn(String[] tenantIds) {
     this.tenantIds = tenantIds;
+  }
+
+  @CamundaQueryParam(value = "withoutTenantId", converter = BooleanConverter.class)
+  public void setWithoutTenantId(Boolean withoutTenantId) {
+    this.withoutTenantId = withoutTenantId;
   }
 
   @CamundaQueryParam(value="creationLog", converter = BooleanConverter.class)
@@ -262,6 +270,9 @@ public class HistoricExternalTaskLogQueryDto extends AbstractQueryDto<HistoricEx
     }
     if (tenantIds != null && tenantIds.length > 0) {
       query.tenantIdIn(tenantIds);
+    }
+    if (TRUE.equals(withoutTenantId)) {
+      query.withoutTenantId();
     }
   }
 

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricIdentityLinkLogQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricIdentityLinkLogQueryDto.java
@@ -16,6 +16,8 @@
  */
 package org.camunda.bpm.engine.rest.dto.history;
 
+import static java.lang.Boolean.TRUE;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -27,6 +29,7 @@ import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.history.HistoricIdentityLinkLogQuery;
 import org.camunda.bpm.engine.rest.dto.AbstractQueryDto;
 import org.camunda.bpm.engine.rest.dto.CamundaQueryParam;
+import org.camunda.bpm.engine.rest.dto.converter.BooleanConverter;
 import org.camunda.bpm.engine.rest.dto.converter.DateConverter;
 import org.camunda.bpm.engine.rest.dto.converter.StringListConverter;
 
@@ -76,6 +79,7 @@ public class HistoricIdentityLinkLogQueryDto extends AbstractQueryDto<HistoricId
   protected String operationType;
   protected String assignerId;
   protected List<String> tenantIds;
+  protected Boolean withoutTenantId;
 
   public HistoricIdentityLinkLogQueryDto() {
   }
@@ -149,6 +153,11 @@ public class HistoricIdentityLinkLogQueryDto extends AbstractQueryDto<HistoricId
     this.tenantIds = tenantIds;
   }
 
+  @CamundaQueryParam(value = "withoutTenantId", converter = BooleanConverter.class)
+  public void setWithoutTenantId(Boolean withoutTenantId) {
+    this.withoutTenantId = withoutTenantId;
+  }
+
   @Override
   protected void applyFilters(HistoricIdentityLinkLogQuery query) {
     if (dateBefore != null) {
@@ -183,6 +192,9 @@ public class HistoricIdentityLinkLogQueryDto extends AbstractQueryDto<HistoricId
     }
     if (tenantIds != null && !tenantIds.isEmpty()) {
       query.tenantIdIn(tenantIds.toArray(new String[tenantIds.size()]));
+    }
+    if (TRUE.equals(withoutTenantId)) {
+      query.withoutTenantId();
     }
   }
 

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricIncidentQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricIncidentQueryDto.java
@@ -16,6 +16,8 @@
  */
 package org.camunda.bpm.engine.rest.dto.history;
 
+import static java.lang.Boolean.TRUE;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -90,6 +92,7 @@ public class HistoricIncidentQueryDto extends AbstractQueryDto<HistoricIncidentQ
   protected Boolean resolved;
   protected Boolean deleted;
   protected List<String> tenantIds;
+  protected Boolean withoutTenantId;
   protected List<String> jobDefinitionIds;
 
 
@@ -179,6 +182,11 @@ public class HistoricIncidentQueryDto extends AbstractQueryDto<HistoricIncidentQ
     this.tenantIds = tenantIds;
   }
 
+  @CamundaQueryParam(value = "withoutTenantId", converter = BooleanConverter.class)
+  public void setWithoutTenantId(Boolean withoutTenantId) {
+    this.withoutTenantId = withoutTenantId;
+  }
+
   @CamundaQueryParam(value = "jobDefinitionIdIn", converter = StringListConverter.class)
   public void setJobDefinitionIdIn(List<String> jobDefinitionIds) {
     this.jobDefinitionIds = jobDefinitionIds;
@@ -243,6 +251,9 @@ public class HistoricIncidentQueryDto extends AbstractQueryDto<HistoricIncidentQ
     }
     if (tenantIds != null && !tenantIds.isEmpty()) {
       query.tenantIdIn(tenantIds.toArray(new String[tenantIds.size()]));
+    }
+    if (TRUE.equals(withoutTenantId)) {
+      query.withoutTenantId();
     }
     if (jobDefinitionIds != null && !jobDefinitionIds.isEmpty()) {
       query.jobDefinitionIdIn(jobDefinitionIds.toArray(new String[jobDefinitionIds.size()]));

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricJobLogQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricJobLogQueryDto.java
@@ -16,6 +16,8 @@
  */
 package org.camunda.bpm.engine.rest.dto.history;
 
+import static java.lang.Boolean.TRUE;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -93,6 +95,7 @@ public class HistoricJobLogQueryDto extends AbstractQueryDto<HistoricJobLogQuery
   protected Long jobPriorityHigherThanOrEquals;
   protected Long jobPriorityLowerThanOrEquals;
   protected List<String> tenantIds;
+  protected Boolean withoutTenantId;
 
   public HistoricJobLogQueryDto() {}
 
@@ -195,6 +198,11 @@ public class HistoricJobLogQueryDto extends AbstractQueryDto<HistoricJobLogQuery
     this.tenantIds = tenantIds;
   }
 
+  @CamundaQueryParam(value = "withoutTenantId", converter = BooleanConverter.class)
+  public void setWithoutTenantId(Boolean withoutTenantId) {
+    this.withoutTenantId = withoutTenantId;
+  }
+
   @Override
   protected boolean isValidSortByValue(String value) {
     return VALID_SORT_BY_VALUES.contains(value);
@@ -280,6 +288,9 @@ public class HistoricJobLogQueryDto extends AbstractQueryDto<HistoricJobLogQuery
     }
     if (tenantIds != null && !tenantIds.isEmpty()) {
       query.tenantIdIn(tenantIds.toArray(new String[tenantIds.size()]));
+    }
+    if (TRUE.equals(withoutTenantId)) {
+      query.withoutTenantId();
     }
   }
 

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricTaskInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricTaskInstanceQueryDto.java
@@ -16,6 +16,8 @@
  */
 package org.camunda.bpm.engine.rest.dto.history;
 
+import static java.lang.Boolean.TRUE;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -131,7 +133,8 @@ public class HistoricTaskInstanceQueryDto extends AbstractQueryDto<HistoricTaskI
   protected Date taskFollowUpDate;
   protected Date taskFollowUpDateBefore;
   protected Date taskFollowUpDateAfter;
-  private List<String> tenantIds;
+  protected List<String> tenantIds;
+  protected Boolean withoutTenantId;
 
   protected Date startedBefore;
   protected Date startedAfter;
@@ -398,6 +401,11 @@ public class HistoricTaskInstanceQueryDto extends AbstractQueryDto<HistoricTaskI
     this.tenantIds = tenantIds;
   }
 
+  @CamundaQueryParam(value = "withoutTenantId", converter = BooleanConverter.class)
+  public void setWithoutTenantId(Boolean withoutTenantId) {
+    this.withoutTenantId = withoutTenantId;
+  }
+
   @CamundaQueryParam("taskInvolvedUser")
   public void setTaskInvolvedUser(String taskInvolvedUser) {
     this.taskInvolvedUser = taskInvolvedUser;
@@ -598,6 +606,9 @@ public class HistoricTaskInstanceQueryDto extends AbstractQueryDto<HistoricTaskI
     if (tenantIds != null && !tenantIds.isEmpty()) {
       query.tenantIdIn(tenantIds.toArray(new String[tenantIds.size()]));
     }
+    if (TRUE.equals(withoutTenantId)) {
+      query.withoutTenantId();
+    }
     if(taskInvolvedUser != null){
       query.taskInvolvedUser(taskInvolvedUser);
     }
@@ -633,11 +644,11 @@ public class HistoricTaskInstanceQueryDto extends AbstractQueryDto<HistoricTaskI
       query.startedBefore(startedBefore);
     }
 
-    if (Boolean.TRUE.equals(variableNamesIgnoreCase)) {
+    if (TRUE.equals(variableNamesIgnoreCase)) {
       query.matchVariableNamesIgnoreCase();
     }
 
-    if (Boolean.TRUE.equals(variableValuesIgnoreCase)) {
+    if (TRUE.equals(variableValuesIgnoreCase)) {
       query.matchVariableValuesIgnoreCase();
     }
 

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricVariableInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricVariableInstanceQueryDto.java
@@ -16,6 +16,8 @@
  */
 package org.camunda.bpm.engine.rest.dto.history;
 
+import static java.lang.Boolean.TRUE;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +67,7 @@ public class HistoricVariableInstanceQueryDto extends AbstractQueryDto<HistoricV
   protected String[] caseActivityIdIn;
   protected String[] processInstanceIdIn;
   protected List<String> tenantIds;
+  protected Boolean withoutTenantId;
   protected boolean includeDeleted;
 
   public HistoricVariableInstanceQueryDto() {
@@ -159,6 +162,11 @@ public class HistoricVariableInstanceQueryDto extends AbstractQueryDto<HistoricV
     this.tenantIds = tenantIds;
   }
 
+  @CamundaQueryParam(value = "withoutTenantId", converter = BooleanConverter.class)
+  public void setWithoutTenantId(Boolean withoutTenantId) {
+    this.withoutTenantId = withoutTenantId;
+  }
+
   public boolean isIncludeDeleted() {
     return includeDeleted;
   }
@@ -209,10 +217,10 @@ public class HistoricVariableInstanceQueryDto extends AbstractQueryDto<HistoricV
     if (variableTypeIn != null && variableTypeIn.length > 0) {
       query.variableTypeIn(variableTypeIn);
     }
-    if (Boolean.TRUE.equals(variableNamesIgnoreCase)) {
+    if (TRUE.equals(variableNamesIgnoreCase)) {
       query.matchVariableNamesIgnoreCase();
     }
-    if (Boolean.TRUE.equals(variableValuesIgnoreCase)) {
+    if (TRUE.equals(variableValuesIgnoreCase)) {
       query.matchVariableValuesIgnoreCase();
     }
     if (executionIdIn != null && executionIdIn.length > 0) {
@@ -235,6 +243,9 @@ public class HistoricVariableInstanceQueryDto extends AbstractQueryDto<HistoricV
     }
     if (tenantIds != null && !tenantIds.isEmpty()) {
       query.tenantIdIn(tenantIds.toArray(new String[tenantIds.size()]));
+    }
+    if (TRUE.equals(withoutTenantId)) {
+      query.withoutTenantId();
     }
     if (includeDeleted) {
       query.includeDeleted();

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricActivityInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricActivityInstanceRestServiceQueryTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -824,6 +825,60 @@ public class HistoricActivityInstanceRestServiceQueryTest extends AbstractRestSe
 
     assertThat(returnedTenantId1).isEqualTo(MockProvider.EXAMPLE_TENANT_ID);
     assertThat(returnedTenantId2).isEqualTo(MockProvider.ANOTHER_EXAMPLE_TENANT_ID);
+  }
+
+  @Test
+  public void testQueryFilterWithoutTenantIdParameter() {
+    // given
+    HistoricActivityInstance activityInstance = MockProvider.createMockHistoricActivityInstance(null);
+    mockedQuery = setUpMockHistoricActivityInstanceQuery(Collections.singletonList(activityInstance));
+
+    // when
+    Response response = given()
+        .queryParam("withoutTenantId", true)
+        .then().expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .get(HISTORIC_ACTIVITY_INSTANCE_RESOURCE_URL);
+
+    // then
+    verify(mockedQuery).withoutTenantId();
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(1);
+
+    String returnedTenantId = from(content).getString("[0].tenantId");
+    assertThat(returnedTenantId).isEqualTo(null);
+  }
+
+  @Test
+  public void testQueryFilterWithoutTenantIdPostParameter() {
+    // given
+    HistoricActivityInstance activityInstance = MockProvider.createMockHistoricActivityInstance(null);
+    mockedQuery = setUpMockHistoricActivityInstanceQuery(Collections.singletonList(activityInstance));
+    Map<String, Object> queryParameters = Collections.singletonMap("withoutTenantId", (Object) true);
+
+    // when
+    Response response = given()
+        .contentType(POST_JSON_CONTENT_TYPE)
+        .body(queryParameters)
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .post(HISTORIC_ACTIVITY_INSTANCE_RESOURCE_URL);
+
+    // then
+    verify(mockedQuery).withoutTenantId();
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(1);
+
+    String returnedTenantId = from(content).getString("[0].tenantId");
+    assertThat(returnedTenantId).isEqualTo(null);
   }
 
   private List<HistoricActivityInstance> createMockHistoricActivityInstancesTwoTenants() {

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricDecisionInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricDecisionInstanceRestServiceQueryTest.java
@@ -520,6 +520,31 @@ public class HistoricDecisionInstanceRestServiceQueryTest extends AbstractRestSe
     assertThat(returnedTenantId2).isEqualTo(MockProvider.ANOTHER_EXAMPLE_TENANT_ID);
   }
 
+  @Test
+  public void testWithoutTenantIdQueryParameter() {
+    // given
+    mockedQuery = setUpMockHistoricDecisionInstanceQuery(Collections.singletonList(MockProvider.createMockHistoricDecisionInstanceBase(null)));
+
+    // when
+    Response response = given()
+          .queryParam("withoutTenantId", true)
+        .then().expect()
+          .statusCode(Status.OK.getStatusCode())
+        .when()
+          .get(HISTORIC_DECISION_INSTANCE_RESOURCE_URL);
+
+    // then
+    verify(mockedQuery).withoutTenantId();
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(1);
+
+    String returnedTenantId1 = from(content).getString("[0].tenantId");
+    assertThat(returnedTenantId1).isEqualTo(null);
+  }
+
   private List<HistoricDecisionInstance> createMockHistoricDecisionInstancesTwoTenants() {
     return Arrays.asList(
         MockProvider.createMockHistoricDecisionInstanceBase(MockProvider.EXAMPLE_TENANT_ID),

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricDetailRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricDetailRestServiceQueryTest.java
@@ -1155,6 +1155,76 @@ public class HistoricDetailRestServiceQueryTest extends AbstractRestServiceTest 
     verifyTenantIdListParameterResponse(response);
   }
 
+  @Test
+  public void testQueryWithoutTenantIdQueryParameter() {
+    // given
+    List<HistoricDetail> details = new ArrayList<HistoricDetail>();
+
+    historicUpdateBuilder = MockProvider.mockHistoricVariableUpdate(null);
+    historicUpdateMock = historicUpdateBuilder.build();
+    historicFormFieldMock = MockProvider.createMockHistoricFormField(null);
+
+    details.add(historicUpdateMock);
+    details.add(historicFormFieldMock);
+
+    mockedQuery = setUpMockedDetailsQuery(details);
+
+    // when
+    Response response = given()
+        .queryParam("withoutTenantId", true)
+        .then().expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .get(HISTORIC_DETAIL_RESOURCE_URL);
+
+    // then
+    verify(mockedQuery).withoutTenantId();
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(2);
+
+    String returnedTenantId = from(content).getString("[0].tenantId");
+    assertThat(returnedTenantId).isEqualTo(null);
+  }
+
+  @Test
+  public void testQueryWithoutTenantIdPostParameter() {
+    // given
+    List<HistoricDetail> details = new ArrayList<HistoricDetail>();
+
+    historicUpdateBuilder = MockProvider.mockHistoricVariableUpdate(null);
+    historicUpdateMock = historicUpdateBuilder.build();
+    historicFormFieldMock = MockProvider.createMockHistoricFormField(null);
+
+    details.add(historicUpdateMock);
+    details.add(historicFormFieldMock);
+
+    mockedQuery = setUpMockedDetailsQuery(details);
+    Map<String, Object> queryParameters = Collections.singletonMap("withoutTenantId", (Object) true);
+
+    // when
+    Response response = given()
+        .contentType(POST_JSON_CONTENT_TYPE)
+        .body(queryParameters)
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .post(HISTORIC_DETAIL_RESOURCE_URL);
+
+    // then
+    verify(mockedQuery).withoutTenantId();
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(2);
+
+    String returnedTenantId = from(content).getString("[0].tenantId");
+    assertThat(returnedTenantId).isEqualTo(null);
+  }
+
   private void verifyTenantIdListParameterResponse(Response response) {
     String content = response.asString();
     List<String> historicDetails = from(content).getList("");

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricExternalTaskLogRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricExternalTaskLogRestServiceQueryTest.java
@@ -35,6 +35,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -791,11 +792,62 @@ public class HistoricExternalTaskLogRestServiceQueryTest extends AbstractRestSer
     assertThat(returnedTenantId2).isEqualTo(MockProvider.ANOTHER_EXAMPLE_TENANT_ID);
   }
 
+  @Test
+  public void testQueryWithoutTenantIdQueryParameter() {
+    // given
+    mockedQuery = setUpMockHistoricExternalTaskLogQuery(Collections.singletonList(MockProvider.createMockHistoricExternalTaskLog(null)));
+
+    // when
+    Response response = given()
+        .queryParam("withoutTenantId", true)
+        .then().expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .get(HISTORIC_EXTERNAL_TASK_LOG_RESOURCE_URL);
+
+    // then
+    verify(mockedQuery).withoutTenantId();
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(1);
+
+    String returnedTenantId = from(content).getString("[0].tenantId");
+    assertThat(returnedTenantId).isEqualTo(null);
+  }
+
+  @Test
+  public void testQueryWithoutTenantIdPostParameter() {
+    // given
+    mockedQuery = setUpMockHistoricExternalTaskLogQuery(Collections.singletonList(MockProvider.createMockHistoricExternalTaskLog(null)));
+    Map<String, Object> queryParameters = Collections.singletonMap("withoutTenantId", (Object) true);
+
+    // when
+    Response response = given()
+        .contentType(POST_JSON_CONTENT_TYPE)
+        .body(queryParameters)
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .post(HISTORIC_EXTERNAL_TASK_LOG_RESOURCE_URL);
+
+    // then
+    verify(mockedQuery).withoutTenantId();
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(1);
+
+    String returnedTenantId = from(content).getString("[0].tenantId");
+    assertThat(returnedTenantId).isEqualTo(null);
+  }
+
   private List<HistoricExternalTaskLog> createMockHistoricExternalTaskLogsTwoTenants() {
     return Arrays.asList(
       MockProvider.createMockHistoricExternalTaskLog(MockProvider.EXAMPLE_TENANT_ID),
       MockProvider.createMockHistoricExternalTaskLog(MockProvider.ANOTHER_EXAMPLE_TENANT_ID));
   }
-
 
 }

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricIncidentRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricIncidentRestServiceQueryTest.java
@@ -31,8 +31,10 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.core.Response.Status;
 
@@ -604,6 +606,31 @@ public class HistoricIncidentRestServiceQueryTest extends AbstractRestServiceTes
 
     assertThat(returnedTenantId1).isEqualTo(MockProvider.EXAMPLE_TENANT_ID);
     assertThat(returnedTenantId2).isEqualTo(MockProvider.ANOTHER_EXAMPLE_TENANT_ID);
+  }
+
+  @Test
+  public void testQueryWithoutTenantIdQueryParameter() {
+    // given
+    mockedQuery = setUpMockHistoricIncidentQuery(Collections.singletonList(MockProvider.createMockHistoricIncident(null)));
+
+    // when
+    Response response = given()
+        .queryParam("withoutTenantId", true)
+        .then().expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .get(HISTORY_INCIDENT_QUERY_URL);
+
+    // then
+    verify(mockedQuery).withoutTenantId();
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(1);
+
+    String returnedTenantId = from(content).getString("[0].tenantId");
+    assertThat(returnedTenantId).isEqualTo(null);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricJobLogRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricJobLogRestServiceQueryTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -769,6 +770,60 @@ public class HistoricJobLogRestServiceQueryTest extends AbstractRestServiceTest 
 
     assertThat(returnedTenantId1).isEqualTo(MockProvider.EXAMPLE_TENANT_ID);
     assertThat(returnedTenantId2).isEqualTo(MockProvider.ANOTHER_EXAMPLE_TENANT_ID);
+  }
+
+  @Test
+  public void testQueryWithoutTenantIdQueryParameter() {
+    // given
+    HistoricJobLog jobLog = MockProvider.createMockHistoricJobLog(null);
+    mockedQuery = setUpMockHistoricJobLogQuery(Collections.singletonList(jobLog));
+
+    // when
+    Response response = given()
+        .queryParam("withoutTenantId", true)
+        .then().expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .get(HISTORIC_JOB_LOG_RESOURCE_URL);
+
+    // then
+    verify(mockedQuery).withoutTenantId();
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(1);
+
+    String returnedTenantId = from(content).getString("[0].tenantId");
+    assertThat(returnedTenantId).isEqualTo(null);
+  }
+
+  @Test
+  public void testQueryWithoutTenantIdPostParameter() {
+    // given
+    HistoricJobLog jobLog = MockProvider.createMockHistoricJobLog(null);
+    mockedQuery = setUpMockHistoricJobLogQuery(Collections.singletonList(jobLog));
+    Map<String, Object> queryParameters = Collections.singletonMap("withoutTenantId", (Object) true);
+
+    // when
+    Response response = given()
+        .contentType(POST_JSON_CONTENT_TYPE)
+        .body(queryParameters)
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .post(HISTORIC_JOB_LOG_RESOURCE_URL);
+
+    // then
+    verify(mockedQuery).withoutTenantId();
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(1);
+
+    String returnedTenantId = from(content).getString("[0].tenantId");
+    assertThat(returnedTenantId).isEqualTo(null);
   }
 
   private List<HistoricJobLog> createMockHistoricJobLogsTwoTenants() {

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricTaskInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricTaskInstanceRestServiceQueryTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -46,6 +47,7 @@ import org.camunda.bpm.engine.impl.calendar.DateTimeUtil;
 import org.camunda.bpm.engine.rest.AbstractRestServiceTest;
 import org.camunda.bpm.engine.rest.exception.InvalidRequestException;
 import org.camunda.bpm.engine.rest.helper.MockProvider;
+import org.camunda.bpm.engine.rest.spi.impl.MockedProcessEngineProvider;
 import org.camunda.bpm.engine.rest.util.OrderingBuilder;
 import org.camunda.bpm.engine.rest.util.container.TestContainerRule;
 import org.junit.Assert;
@@ -2247,6 +2249,58 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
 
     assertThat(returnedTenantId1).isEqualTo(MockProvider.EXAMPLE_TENANT_ID);
     assertThat(returnedTenantId2).isEqualTo(MockProvider.ANOTHER_EXAMPLE_TENANT_ID);
+  }
+
+  @Test
+  public void testQueryWithoutTenantIdQueryParameter() {
+    // given
+    mockedQuery = setUpMockHistoricTaskInstanceQuery(Collections.singletonList(MockProvider.createMockHistoricTaskInstance(null)));
+
+    // when
+    Response response = given()
+          .queryParam("withoutTenantId", true)
+        .then().expect()
+          .statusCode(Status.OK.getStatusCode())
+        .when()
+          .get(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
+
+    // then
+    verify(mockedQuery).withoutTenantId();
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(1);
+
+    String returnedTenantId = from(content).getString("[0].tenantId");
+    assertThat(returnedTenantId).isEqualTo(null);
+  }
+
+  @Test
+  public void testQueryWithoutTenantIdPostParameter() {
+    // given
+    mockedQuery = setUpMockHistoricTaskInstanceQuery(Collections.singletonList(MockProvider.createMockHistoricTaskInstance(null)));
+    Map<String, Object> queryParameters = Collections.singletonMap("withoutTenantId", (Object) true);
+
+    // when
+    Response response = given()
+          .contentType(POST_JSON_CONTENT_TYPE)
+          .body(queryParameters)
+        .expect()
+          .statusCode(Status.OK.getStatusCode())
+        .when()
+          .post(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
+
+    // then
+    verify(mockedQuery).withoutTenantId();
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(1);
+
+    String returnedTenantId = from(content).getString("[0].tenantId");
+    assertThat(returnedTenantId).isEqualTo(null);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricVariableInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricVariableInstanceRestServiceQueryTest.java
@@ -41,6 +41,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -807,6 +808,64 @@ public class HistoricVariableInstanceRestServiceQueryTest extends AbstractRestSe
 
     assertThat(returnedTenantId1).isEqualTo(MockProvider.EXAMPLE_TENANT_ID);
     assertThat(returnedTenantId2).isEqualTo(MockProvider.ANOTHER_EXAMPLE_TENANT_ID);
+  }
+
+  @Test
+  public void testQueryFilterWithoutTenantIdParameter() {
+    // given
+    HistoricVariableInstance historicVariableInstance = MockProvider
+        .mockHistoricVariableInstance(null)
+        .build();
+    mockedQuery = setUpMockHistoricVariableInstanceQuery(Collections.singletonList(historicVariableInstance));
+
+    // when
+    Response response = given()
+        .queryParam("withoutTenantId", true)
+        .then().expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .get(HISTORIC_VARIABLE_INSTANCE_RESOURCE_URL);
+
+    // then
+    verify(mockedQuery).withoutTenantId();
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(1);
+
+    String returnedTenantId = from(content).getString("[0].tenantId");
+    assertThat(returnedTenantId).isEqualTo(null);
+  }
+
+  @Test
+  public void testQueryFilterWithoutTenantIdPostParameter() {
+    // given
+    HistoricVariableInstance historicVariableInstance = MockProvider
+        .mockHistoricVariableInstance(null)
+        .build();
+    mockedQuery = setUpMockHistoricVariableInstanceQuery(Collections.singletonList(historicVariableInstance));
+    Map<String, Object> queryParameters = Collections.singletonMap("withoutTenantId", (Object) true);
+
+    // when
+    Response response = given()
+        .contentType(POST_JSON_CONTENT_TYPE)
+        .body(queryParameters)
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .post(HISTORIC_VARIABLE_INSTANCE_RESOURCE_URL);
+
+    // then
+    verify(mockedQuery).withoutTenantId();
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(1);
+
+    String returnedTenantId = from(content).getString("[0].tenantId");
+    assertThat(returnedTenantId).isEqualTo(null);
   }
 
   @Test


### PR DESCRIPTION
Related to [CAM-6554](https://app.camunda.com/jira/browse/CAM-6554)