### PR TITLE
CAM-10962: prevent task op log on instance modification

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AssignTaskCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AssignTaskCmd.java
@@ -34,7 +34,7 @@ public class AssignTaskCmd extends AddIdentityLinkCmd {
   @Override
   public Void execute(CommandContext commandContext) {
     super.execute(commandContext);
-    task.createHistoricTaskDetails(UserOperationLogEntry.OPERATION_TYPE_ASSIGN);
+    task.logUserOperation(UserOperationLogEntry.OPERATION_TYPE_ASSIGN);
     return null;
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/ClaimTaskCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/ClaimTaskCmd.java
@@ -68,7 +68,7 @@ public class ClaimTaskCmd implements Command<Void>, Serializable {
       task.setAssignee(null);
     }
     task.triggerUpdateEvent();
-    task.createHistoricTaskDetails(UserOperationLogEntry.OPERATION_TYPE_CLAIM);
+    task.logUserOperation(UserOperationLogEntry.OPERATION_TYPE_CLAIM);
 
     return null;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/CompleteTaskCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/CompleteTaskCmd.java
@@ -21,6 +21,7 @@ import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 import java.io.Serializable;
 import java.util.Map;
 
+import org.camunda.bpm.engine.history.UserOperationLogEntry;
 import org.camunda.bpm.engine.impl.cfg.CommandChecker;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
@@ -95,6 +96,7 @@ public class CompleteTaskCmd implements Command<VariableMap>, Serializable {
   }
 
   protected void completeTask(TaskEntity task) {
+    task.logUserOperation(UserOperationLogEntry.OPERATION_TYPE_COMPLETE);
     task.complete();
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DelegateTaskCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DelegateTaskCmd.java
@@ -55,7 +55,7 @@ public class DelegateTaskCmd implements Command<Object>, Serializable {
     task.delegate(userId);
 
     task.triggerUpdateEvent();
-    task.createHistoricTaskDetails(UserOperationLogEntry.OPERATION_TYPE_DELEGATE);
+    task.logUserOperation(UserOperationLogEntry.OPERATION_TYPE_DELEGATE);
 
     return null;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteTaskCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteTaskCmd.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.util.Collection;
 
 import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.history.UserOperationLogEntry;
 import org.camunda.bpm.engine.impl.cfg.CommandChecker;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.interceptor.Command;
@@ -78,6 +79,7 @@ public class DeleteTaskCmd implements Command<Void>, Serializable {
       }
 
       checkDeleteTask(task, commandContext);
+      task.logUserOperation(UserOperationLogEntry.OPERATION_TYPE_DELETE);
 
       String reason = (deleteReason == null || deleteReason.length() == 0) ? TaskEntity.DELETE_REASON_DELETED : deleteReason;
       task.delete(reason, cascade);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/ResolveTaskCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/ResolveTaskCmd.java
@@ -37,6 +37,6 @@ public class ResolveTaskCmd extends CompleteTaskCmd {
   protected void completeTask(TaskEntity task) {
     task.resolve();
     task.triggerUpdateEvent();
-    task.createHistoricTaskDetails(UserOperationLogEntry.OPERATION_TYPE_RESOLVE);
+    task.logUserOperation(UserOperationLogEntry.OPERATION_TYPE_RESOLVE);
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SaveTaskCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SaveTaskCmd.java
@@ -73,7 +73,7 @@ public class SaveTaskCmd implements Command<Void>, Serializable {
       task.triggerUpdateEvent();
     }
 
-    task.createHistoricTaskDetails(operation);
+    task.logUserOperation(operation);
 
     return null;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SetTaskOwnerCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SetTaskOwnerCmd.java
@@ -34,7 +34,7 @@ public class SetTaskOwnerCmd extends AddIdentityLinkCmd {
   @Override
   public Void execute(CommandContext commandContext) {
     super.execute(commandContext);
-    task.createHistoricTaskDetails(UserOperationLogEntry.OPERATION_TYPE_SET_OWNER);
+    task.logUserOperation(UserOperationLogEntry.OPERATION_TYPE_SET_OWNER);
     return null;
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SetTaskPriorityCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SetTaskPriorityCmd.java
@@ -55,7 +55,7 @@ public class SetTaskPriorityCmd implements Command<Void>, Serializable {
     task.setPriority(priority);
 
     task.triggerUpdateEvent();
-    task.createHistoricTaskDetails(UserOperationLogEntry.OPERATION_TYPE_SET_PRIORITY);
+    task.logUserOperation(UserOperationLogEntry.OPERATION_TYPE_SET_PRIORITY);
 
     return null;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SubmitTaskFormCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SubmitTaskFormCmd.java
@@ -87,11 +87,11 @@ public class SubmitTaskFormCmd implements Command<VariableMap>, Serializable {
     // complete or resolve the task
     if (DelegationState.PENDING.equals(task.getDelegationState())) {
       task.resolve();
-      task.createHistoricTaskDetails(UserOperationLogEntry.OPERATION_TYPE_RESOLVE);
+      task.logUserOperation(UserOperationLogEntry.OPERATION_TYPE_RESOLVE);
       task.triggerUpdateEvent();
     } else {
+      task.logUserOperation(UserOperationLogEntry.OPERATION_TYPE_COMPLETE);
       task.complete();
-      task.createHistoricTaskDetails(UserOperationLogEntry.OPERATION_TYPE_COMPLETE);
     }
 
     if (returnVariables)

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmmn/cmd/CompleteCaseExecutionCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmmn/cmd/CompleteCaseExecutionCmd.java
@@ -19,9 +19,11 @@ package org.camunda.bpm.engine.impl.cmmn.cmd;
 import java.util.Collection;
 import java.util.Map;
 
+import org.camunda.bpm.engine.history.UserOperationLogEntry;
 import org.camunda.bpm.engine.impl.cmmn.CaseExecutionCommandBuilderImpl;
 import org.camunda.bpm.engine.impl.cmmn.entity.runtime.CaseExecutionEntity;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
 
 /**
  * @author Roman Smirnov
@@ -41,6 +43,11 @@ public class CompleteCaseExecutionCmd extends StateTransitionCaseExecutionCmd {
   }
 
   protected void performStateTransition(CommandContext commandContext, CaseExecutionEntity caseExecution) {
+    TaskEntity task = caseExecution.getTask();
+    if (task != null) {
+      task.logUserOperation(UserOperationLogEntry.OPERATION_TYPE_COMPLETE);
+    }
+
     caseExecution.manualComplete();
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/TaskManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/TaskManager.java
@@ -84,7 +84,7 @@ public class TaskManager extends AbstractManager {
         ((TaskEntity) subTask).delete(deleteReason, cascade, skipCustomListeners);
       }
 
-      task.deleteIdentityLinks(false);
+      task.deleteIdentityLinks();
 
       commandContext
         .getVariableInstanceManager()
@@ -98,11 +98,6 @@ public class TaskManager extends AbstractManager {
         commandContext
           .getHistoricTaskInstanceManager()
           .markTaskInstanceEnded(taskId, deleteReason);
-        if (TaskEntity.DELETE_REASON_COMPLETED.equals(deleteReason)) {
-          task.createHistoricTaskDetails(UserOperationLogEntry.OPERATION_TYPE_COMPLETE);
-        } else {
-          task.createHistoricTaskDetails(UserOperationLogEntry.OPERATION_TYPE_DELETE);
-        }
       }
 
       deleteAuthorizations(Resources.TASK, taskId);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/useroperationlog/UserOperationLogTaskServiceAndBeanTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/useroperationlog/UserOperationLogTaskServiceAndBeanTest.java
@@ -134,7 +134,6 @@ public class UserOperationLogTaskServiceAndBeanTest extends AbstractUserOperatio
     Map<String, PropertyChange> changes = entity.getPropertyChanges();
     assertEquals("er", changes.get(ASSIGNEE).getNewValue());
     assertSame(DelegationState.PENDING, changes.get(DELEGATION).getNewValue());
-    assertTrue((Boolean) changes.get(DELETE).getNewValue());
     assertEquals("a description", changes.get(DESCRIPTION).getNewValue());
     assertEquals(tomorrow, changes.get(DUE_DATE).getNewValue());
     assertEquals(yesterday, changes.get(FOLLOW_UP_DATE).getNewValue());
@@ -142,6 +141,8 @@ public class UserOperationLogTaskServiceAndBeanTest extends AbstractUserOperatio
     assertEquals("icke", changes.get(OWNER).getNewValue());
     assertEquals("parent", changes.get(PARENT_TASK).getNewValue());
     assertEquals(73, changes.get(PRIORITY).getNewValue());
+
+    // DELETE property is not validated here; it is set directly on task deletion
   }
 
   public void testDeleteTask() {


### PR DESCRIPTION
[![CAM-10962](https://badgen.net/badge/JIRA/CAM-10962/0052CC)](https://app.camunda.com/jira/browse/CAM-10962)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixes the problem that task deletion would always generate an op log entry, regardless by which user command it is triggered. There should only be a dedicated task delete op log entry if the triggering command is the task deletion command. If a task gets deleted "indirectly", e.g. via instance modification, then only the op log of the triggering command should be written.