### PR TITLE
CAM-11100: chore(database): adjust mssql jdbc driver versions

### DIFF
--- a/database/pom.xml
+++ b/database/pom.xml
@@ -27,8 +27,7 @@
     <version.mariadb>1.1.8</version.mariadb>
     <version.mariadb.galera>1.6.3</version.mariadb.galera>
     <version.mysql>5.1.21</version.mysql>
-    <version.sqlserver.oss>1.3.1</version.sqlserver.oss>
-    <version.sqlserver>4.0</version.sqlserver>
+    <version.sqlserver>4.2</version.sqlserver>
     <version.db2-11.1>11.1.1.1</version.db2-11.1>
     <version.db2-10.5>10.5.0.5</version.db2-10.5>
     <version.db2-10.1>10.1.0.4</version.db2-10.1>
@@ -76,11 +75,6 @@
         <groupId>mysql</groupId>
         <artifactId>mysql-connector-java</artifactId>
         <version>${version.mysql}</version>
-      </dependency>
-      <dependency>
-        <groupId>net.sourceforge.jtds</groupId>
-        <artifactId>jtds</artifactId>
-        <version>${version.sqlserver.oss}</version>
       </dependency>
       <dependency>
         <groupId>com.microsoft.sqlserver</groupId>


### PR DESCRIPTION
[![CAM-11100](https://badgen.net/badge/JIRA/CAM-11100/0052CC)](https://app.camunda.com/jira/browse/CAM-11100)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I adjusted the following:

1. Bumped the `com.microsoft.sqlserver:sqljdbc4` dependency, to version 4.2. 
2. Removed the `net.sourceforge.jtds:jdts` dependency. According to their official page, JDTS supports Microsoft SqlServer versions up to 2012 (http://jtds.sourceforge.net/)

Related to CAM-11100