### PR TITLE
CAM-10583: chore(typed-values): adjust old version for clirr comparison check

### DIFF
--- a/typed-values/pom.xml
+++ b/typed-values/pom.xml
@@ -13,12 +13,6 @@
     <version>7.13.0-SNAPSHOT</version>
   </parent>
 
-  <properties>
-    <!-- on 7.12 release this property should be removed and
-    camunda.version.old from camunda-database-settigns used -->
-    <version.old>1.7.1</version.old>
-  </properties>
-
   <dependencies>
 
     <dependency>
@@ -52,9 +46,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
         <configuration>
-          <!-- After 7.12 release, use camunda.version.old -->
-          <!--<comparisonVersion>${camunda.version.old}</comparisonVersion>-->
-          <comparisonVersion>${version.old}</comparisonVersion>
+          <comparisonVersion>${camunda.version.old}</comparisonVersion>
           <logResults>true</logResults>
           <excludes>
             <exclude>org/camunda/bpm/engine/impl/**</exclude>


### PR DESCRIPTION
[![CAM-10583](https://badgen.net/badge/JIRA/CAM-10583/0052CC)](https://app.camunda.com/jira/browse/CAM-10583)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

typed values moved to platform in 7.12.0 version
so the version changed from 1.x.y/commons to 7.z/platform

Keep in mind that during the creation of the PR, the `camunda.version.old` is still `7.11.0` ([CAM-11032](https://jira.camunda.com/browse/CAM-11032)) so the check finishes with a warning since 7.11.0 version doesn't exist for `typed-values`. This will be resolved when the version is adjusted to `7.12.0`
```
---- current
[INFO] --- clirr-maven-plugin:2.8:check-no-fork (all) @ camunda-commons-typed-values ---
[INFO] Comparing to version: 7.11.0
Downloading: https://app.camunda.com/nexus/content/groups/internal/org/camunda/commons/camunda-commons-typed-values/7.11.0/camunda-commons-typed-values-7.11.0.jar
[WARNING] Impossible to find previous version
[INFO] Succeeded with 0 errors; 0 warnings; and 0 other changes.

---- expected after resolving of CAM-11032
[INFO] --- clirr-maven-plugin:2.8:check-no-fork (all) @ camunda-commons-typed-values ---
[INFO] Comparing to version: 7.12.0
[INFO] Succeeded with 0 errors; 0 warnings; and 0 other changes.
```