### PR TITLE
[CAM-11032] chore(qa): adjust old-engine dependencies

### DIFF
--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -97,34 +97,54 @@
           <dependency>
             <groupId>org.camunda.bpm</groupId>
             <artifactId>camunda-bom</artifactId>
-            <version>7.12.0</version>
+            <version>${camunda.old.engine.version}</version>
             <scope>import</scope>
             <type>pom</type>
           </dependency>
           <dependency>
             <groupId>org.camunda.bpm</groupId>
             <artifactId>camunda-engine</artifactId>
-            <version>7.12.0</version>
+            <version>${camunda.old.engine.version}</version>
+          </dependency>
+		  <dependency>
+            <groupId>org.camunda.bpm.dmn</groupId>
+            <artifactId>camunda-engine-dmn</artifactId>
+            <version>${camunda.old.engine.version}</version>
+          </dependency>
+		  <dependency>
+            <groupId>org.camunda.bpm.dmn</groupId>
+            <artifactId>camunda-engine-feel-api</artifactId>
+            <version>${camunda.old.engine.version}</version>
+          </dependency>
+		  <dependency>
+            <groupId>org.camunda.bpm.dmn</groupId>
+            <artifactId>camunda-engine-feel-juel</artifactId>
+            <version>${camunda.old.engine.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.camunda.commons</groupId>
+            <artifactId>camunda-commons-typed-values</artifactId>
+            <version>${camunda.old.engine.version}</version>
           </dependency>
           <dependency>
             <groupId>org.camunda.bpm.model</groupId>
             <artifactId>camunda-xml-model</artifactId>
-            <version>7.12.0</version>
+            <version>${camunda.old.engine.version}</version>
           </dependency>
           <dependency>
             <groupId>org.camunda.bpm.model</groupId>
             <artifactId>camunda-bpmn-model</artifactId>
-            <version>7.12.0</version>
+            <version>${camunda.old.engine.version}</version>
           </dependency>
           <dependency>
             <groupId>org.camunda.bpm.model</groupId>
             <artifactId>camunda-cmmn-model</artifactId>
-            <version>7.12.0</version>
+            <version>${camunda.old.engine.version}</version>
           </dependency>
           <dependency>
             <groupId>org.camunda.bpm.model</groupId>
             <artifactId>camunda-dmn-model</artifactId>
-            <version>7.12.0</version>
+            <version>${camunda.old.engine.version}</version>
           </dependency>
           <dependency>
             <groupId>org.mybatis</groupId>
@@ -218,7 +238,6 @@
         <dependency>
           <groupId>org.camunda.bpm</groupId>
           <artifactId>camunda-engine</artifactId>
-          <version>7.12.0</version>
           <scope>test</scope>
         </dependency>
         <dependency>
@@ -238,6 +257,12 @@
           <groupId>org.assertj</groupId>
           <artifactId>assertj-core</artifactId>
           <version>2.9.1</version>
+          <scope>test</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>org.camunda.commons</groupId>
+          <artifactId>camunda-commons-testing</artifactId>
           <scope>test</scope>
         </dependency>
       </dependencies>


### PR DESCRIPTION
[![CAM-11032](https://badgen.net/badge/JIRA/CAM-11032/0052CC)](https://app.camunda.com/jira/browse/CAM-11032)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* add commons-testing (new in 7.12)
* fix 7.12.0 versions for transitive dependencies
  (DMN and typed values)
* use `camunda.old.engine.version` property

related to CAM-11032