### PR TITLE
CAM-11143 - MessageCorrelationBuilder: deprecate correlateAll in favor of Signals

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/runtime/MessageCorrelationBuilder.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/runtime/MessageCorrelationBuilder.java
@@ -24,6 +24,7 @@ import org.camunda.bpm.engine.MismatchingMessageCorrelationException;
 import org.camunda.bpm.engine.authorization.Permissions;
 import org.camunda.bpm.engine.authorization.Resources;
 import org.camunda.bpm.engine.variable.value.SerializableValue;
+import org.camunda.bpm.engine.RuntimeService;
 
 /**
  * <p>A fluent builder for defining message correlation</p>
@@ -250,7 +251,9 @@ public interface MessageCorrelationBuilder {
    * Executes the message correlation for multiple messages.
    *
    * @see {@link #correlateAllWithResult()}
+   * @deprecated use {@link RuntimeService#signalEventReceived()} since Messages are defined as point-to-point comunication in BPMN
    */
+  @Deprecated
   void correlateAll();
 
   /**
@@ -277,7 +280,9 @@ public interface MessageCorrelationBuilder {
    * @return The result list of the message correlations. Each result contains
    * either the execution id or the start event activity id and the process definition.
    * @since 7.6
+   * @deprecated use {@link RuntimeService#signalEventReceived()} since Messages are defined as point-to-point comunication in BPMN
    */
+  @Deprecated
   List<MessageCorrelationResult> correlateAllWithResult();
 
   /**
@@ -293,7 +298,9 @@ public interface MessageCorrelationBuilder {
    * @return The result list of the message correlations. Each result contains
    *         either the execution id or the start event activity id, the process
    *         definition, and the process variables.
+   * @deprecated use {@link RuntimeService#signalEventReceived()} since Messages are defined as point-to-point comunication in BPMN
    */
+  @Deprecated
   List<MessageCorrelationResultWithVariables> correlateAllWithResultAndVariables(boolean deserializeValues);
 
   /**


### PR DESCRIPTION
[![CAM-11143](https://badgen.net/badge/JIRA/CAM-11143/0052CC)](https://app.camunda.com/jira/browse/CAM-11143)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

BPMN 2.0.2 page 91 (PDF 121) says:
> A Message represents the content of a communication between two Participants.

So the API that allows sending a message to multiple process instances at the same time violates BPMN execution semantics. Signals are explicitly designed for broadcasting use cases and should be suggested as an alternative through JavaDoc.