### PR TITLE
CAM-10779: Fixed Illegal reflective access exception for MyBatis 

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -32,7 +32,7 @@
   </organization>
 
   <properties>
-    <version.mybatis>3.4.4</version.mybatis>
+    <version.mybatis>3.5.3</version.mybatis>
     <version.joda-time>2.1</version.joda-time>
     <version.uuid-generator>3.2.0</version.uuid-generator>
     <version.camunda.commons>1.8.2</version.camunda.commons>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Attachment.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Attachment.xml
@@ -204,7 +204,7 @@
   </select>
 
   <sql id="selectAttachmentsProcessInstanceByIdsSql">
-    <if test="processInstanceIds != null &amp;&amp; processInstanceIds.size() > 0">
+    <if test="processInstanceIds != null &amp;&amp; processInstanceIds.size > 0">
       and
         <bind name="listOfIds" value="processInstanceIds"/>
         <bind name="fieldName" value="'PROC_INST_ID_'"/>
@@ -213,7 +213,7 @@
   </sql>
 
   <sql id="selectAttachmentsTaskProcessAndCaseInstanceByIdsSql">
-    <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size() > 0">
+    <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size > 0">
       and TASK_ID_ in (
       select ID_
       from ${prefix}ACT_HI_TASKINST
@@ -223,7 +223,7 @@
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.applyInForPaginatedCollection"/>
       )
     </if>
-    <if test="caseInstanceIds != null &amp;&amp; caseInstanceIds.size() > 0">
+    <if test="caseInstanceIds != null &amp;&amp; caseInstanceIds.size > 0">
       and TASK_ID_ in (
       select ID_ from
       ${prefix}ACT_HI_TASKINST
@@ -236,7 +236,7 @@
   </sql>
 
   <sql id="selectAttachmentsTaskProcessAndCaseInstanceByIdsSql_mysql">
-    <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size() > 0">
+    <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size > 0">
       inner join ${prefix}ACT_HI_TASKINST T
         on TASK_ID_ = T.ID_
         and
@@ -244,7 +244,7 @@
           <bind name="fieldName" value="'T.PROC_INST_ID_'"/>
           <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.applyInForPaginatedCollection"/>
     </if>
-    <if test="caseInstanceIds != null &amp;&amp; caseInstanceIds.size() > 0">
+    <if test="caseInstanceIds != null &amp;&amp; caseInstanceIds.size > 0">
       inner join ${prefix}ACT_HI_TASKINST T
         on TASK_ID_ = T.ID_
         and

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Authorization.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Authorization.xml
@@ -133,7 +133,7 @@
       WHERE TYPE_ = 2
       AND (
         USER_ID_ IN (#{userId, jdbcType=VARCHAR}, '*')
-        <if test="authGroupIds != null &amp;&amp; authGroupIds.size() > 0">
+        <if test="authGroupIds != null &amp;&amp; authGroupIds.size > 0">
         OR GROUP_ID_ IN <foreach item="item" index="index" collection="authGroupIds" open="(" separator="," close=")">#{item, jdbcType=VARCHAR}</foreach>
         </if>
       )
@@ -216,13 +216,13 @@
 
   <select id="isUserAuthorizedForResource" resultType="integer">
 
-  <if test="permissionChecks != null &amp;&amp; permissionChecks.atomicChecks.size() > 1">
+  <if test="permissionChecks != null &amp;&amp; permissionChecks.atomicChecks.size > 1">
     SELECT
   </if>
 
   <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authorizationCheck" />
 
-  <if test="permissionChecks != null &amp;&amp; permissionChecks.atomicChecks.size() > 1">
+  <if test="permissionChecks != null &amp;&amp; permissionChecks.atomicChecks.size > 1">
     ${dbSpecificDummyTable}
   </if>
 
@@ -328,7 +328,7 @@
           (
           SELECT
             CASE
-              <if test="authGroupIds != null &amp;&amp; authGroupIds.size() > 0">
+              <if test="authGroupIds != null &amp;&amp; authGroupIds.size > 0">
 
                 <!-- Group GRANTS -->
                 <if test="permCheck.resourceIdQueryParam != null || (permCheck.resourceId != null &amp;&amp; !permCheck.resourceId.equals('*')) ">
@@ -527,7 +527,7 @@
                             null
                           </if>
 
-              <if test="authGroupIds != null &amp;&amp; authGroupIds.size() > 0">
+              <if test="authGroupIds != null &amp;&amp; authGroupIds.size > 0">
                         END ${dbSpecificDummyTable}
                 )
               </if>
@@ -555,7 +555,7 @@
           </when> 
           <otherwise>
             AUTH.RESOURCE_ID_ IS NOT NULL 
-            <if test="authCheck.permissionChecks.compositeChecks != null &amp;&amp; authCheck.permissionChecks.compositeChecks.size() > 0"> 
+            <if test="authCheck.permissionChecks.compositeChecks != null &amp;&amp; authCheck.permissionChecks.compositeChecks.size > 0"> 
               AND
               <foreach item="permCheck" index="index" collection="authCheck.permissionChecks.compositeChecks" separator="AND">
                 <if test="index > 0">
@@ -616,11 +616,11 @@
     FROM ${prefix}ACT_RU_AUTHORIZATION A
     WHERE A.TYPE_ &lt; 2     
     AND ( A.USER_ID_ in ( #{authCheck.authUserId, jdbcType=VARCHAR}, '*')           
-    <if test="authGroupIds != null &amp;&amp; authGroupIds.size() > 0">
+    <if test="authGroupIds != null &amp;&amp; authGroupIds.size > 0">
       OR A.GROUP_ID_ IN <foreach item="item" index="index" collection="authGroupIds" open="(" separator="," close=")">#{item}</foreach>
     </if>
     )
-    <if test="atomicChecks != null &amp;&amp; atomicChecks.size() > 0">
+    <if test="atomicChecks != null &amp;&amp; atomicChecks.size > 0">
       AND (
       <if test="disjunctive">
         <foreach item="permCheck" index="index" collection="atomicChecks" open="(" separator="OR" close=")">
@@ -641,14 +641,14 @@
    input: "permissionChecks": an instance of CompositePermissionCheck
   -->
   <sql id="atomicChecks">
-    <if test="permissionChecks.atomicChecks != null &amp;&amp; permissionChecks.atomicChecks.size() == 1">
+    <if test="permissionChecks.atomicChecks != null &amp;&amp; permissionChecks.atomicChecks.size == 1">
 
       <bind name="permCheck" value="permissionChecks.atomicChecks[0]" />
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheck"/>
 
     </if>
 
-    <if test="permissionChecks.atomicChecks != null &amp;&amp; permissionChecks.atomicChecks.size() > 1">
+    <if test="permissionChecks.atomicChecks != null &amp;&amp; permissionChecks.atomicChecks.size > 1">
       <if test="permissionChecks.disjunctive">
         <bind name="atomicChecks" value="permissionChecks.atomicChecks" />
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.disjunctiveAtomicChecks" />
@@ -664,7 +664,7 @@
    input: "permissionChecks": an instance of CompositePermissionCheck
   -->
   <sql id="compositeChecks">
-    <if test="permissionChecks.compositeChecks != null &amp;&amp; permissionChecks.compositeChecks.size() > 1">
+    <if test="permissionChecks.compositeChecks != null &amp;&amp; permissionChecks.compositeChecks.size > 1">
       <if test="permissionChecks.disjunctive">
         <bind name="compositeChecks" value="permissionChecks.compositeChecks" />
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.disjunctiveCompositeChecks"/>
@@ -776,7 +776,7 @@
           (RES.CASE_EXECUTION_ID_ IS NOT NULL)
           OR
           (AUTH.RESOURCE_ID_ IS NOT NULL)
-            <if test="authCheck.permissionChecks.compositeChecks != null &amp;&amp; authCheck.permissionChecks.compositeChecks.size() > 0"> 
+            <if test="authCheck.permissionChecks.compositeChecks != null &amp;&amp; authCheck.permissionChecks.compositeChecks.size > 0"> 
               AND
               <foreach item="permCheck" index="index" collection="authCheck.permissionChecks.compositeChecks" separator="AND">
                 <if test="index > 0">

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Comment.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Comment.xml
@@ -89,7 +89,7 @@
   <delete id="deleteCommentsByIds" parameterType="java.util.Map">
     delete from ${prefix}ACT_HI_COMMENT
     where 
-    <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size() > 0">
+    <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size > 0">
       TASK_ID_ in (
         select ID_
         from ${prefix}ACT_HI_TASKINST
@@ -99,7 +99,7 @@
           <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.applyInForPaginatedCollection"/>
       )
     </if>
-    <if test="taskCaseInstanceIds != null &amp;&amp; taskCaseInstanceIds.size() > 0">
+    <if test="taskCaseInstanceIds != null &amp;&amp; taskCaseInstanceIds.size > 0">
       TASK_ID_ in (
         select ID_
         from ${prefix}ACT_HI_TASKINST
@@ -109,7 +109,7 @@
           <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.applyInForPaginatedCollection"/>
         )
     </if>
-    <if test="processInstanceIds != null &amp;&amp; processInstanceIds.size() > 0">
+    <if test="processInstanceIds != null &amp;&amp; processInstanceIds.size > 0">
       <bind name="listOfIds" value="processInstanceIds"/>
       <bind name="fieldName" value="'PROC_INST_ID_'"/>
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.applyInForPaginatedCollection"/>
@@ -120,19 +120,19 @@
     delete CO from ${prefix}ACT_HI_COMMENT CO
     left join ${prefix}ACT_HI_TASKINST T
       on CO.TASK_ID_ = T.ID_
-      <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size() > 0">
+      <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size > 0">
         where
           <bind name="listOfIds" value="taskProcessInstanceIds"/>
           <bind name="fieldName" value="'T.PROC_INST_ID_'"/>
           <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.applyInForPaginatedCollection"/>
       </if>
-      <if test="taskCaseInstanceIds != null &amp;&amp; taskCaseInstanceIds.size() > 0">
+      <if test="taskCaseInstanceIds != null &amp;&amp; taskCaseInstanceIds.size > 0">
         where
           <bind name="listOfIds" value="taskCaseInstanceIds"/>
           <bind name="fieldName" value="'T.CASE_INST_ID_'"/>
           <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.applyInForPaginatedCollection"/>
       </if>
-      <if test="processInstanceIds != null &amp;&amp; processInstanceIds.size() > 0">
+      <if test="processInstanceIds != null &amp;&amp; processInstanceIds.size > 0">
         where
           <bind name="listOfIds" value="processInstanceIds"/>
           <bind name="fieldName" value="'CO.PROC_INST_ID_'"/>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ExternalTask.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ExternalTask.xml
@@ -198,7 +198,7 @@
       (RES.LOCK_EXP_TIME_ is null or RES.LOCK_EXP_TIME_ &lt;= #{parameter.now, jdbcType=TIMESTAMP})
       and (RES.SUSPENSION_STATE_ is null or RES.SUSPENSION_STATE_ = 1)
       and (RES.RETRIES_ is null or RES.RETRIES_ > 0)
-      <if test="parameter != null &amp;&amp; parameter.topics.size() > 0">
+      <if test="parameter != null &amp;&amp; parameter.topics.size > 0">
         and
         <foreach collection="parameter.topics" open="(" close=")" separator="or" item="topicFilters">
           RES.TOPIC_NAME_ like #{topicFilters.topicName}
@@ -237,7 +237,7 @@
               </foreach>
             </if>
           </if>
-          <if test="topicFilters.filterVariables.size() > 0">
+          <if test="topicFilters.filterVariables.size > 0">
             and RES.PROC_INST_ID_ in (
               select VAR.EXECUTION_ID_
               from ${prefix}ACT_RU_VARIABLE VAR

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Filter.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Filter.xml
@@ -123,7 +123,7 @@
       ${limitAfter}
     ) RES
     INNER JOIN ${prefix}ACT_RU_FILTER J ON RES.ID_ = J.ID_
-    <if test="orderingProperties.size() > 0">
+    <if test="orderingProperties.size > 0">
       ORDER BY
       <foreach item="orderingProperty" index="index" collection="orderingProperties" separator=",">
         ${@org.camunda.bpm.engine.impl.db.sql.MybatisJoinHelper@orderBy(orderingProperty, index)}

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricDetail.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricDetail.xml
@@ -165,7 +165,7 @@
       <include refid="selectHistoricDetailsProcessAndCaseInstanceByIdsSql"/>
       <!-- https://app.camunda.com/jira/browse/CAM-9436 -->
       <!-- null filter to speed up the history cleanup -->
-      <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size() > 0">
+      <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size > 0">
         and D.TASK_ID_ is not null
       </if>
       <include refid="selectHistoricDetailsVariableInstanceByIdSql"/>
@@ -418,13 +418,13 @@
   </sql>
 
   <sql id="selectHistoricDetailsProcessAndCaseInstanceByIdsSql">
-    <if test="processInstanceIds != null &amp;&amp; processInstanceIds.size() > 0">
+    <if test="processInstanceIds != null &amp;&amp; processInstanceIds.size > 0">
       and
         <bind name="listOfIds" value="processInstanceIds"/>
         <bind name="fieldName" value="'PROC_INST_ID_'"/>
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.applyInForPaginatedCollection"/>
     </if>
-    <if test="caseInstanceIds != null &amp;&amp; caseInstanceIds.size() > 0">
+    <if test="caseInstanceIds != null &amp;&amp; caseInstanceIds.size > 0">
       and
         <bind name="listOfIds" value="caseInstanceIds"/>
         <bind name="fieldName" value="'CASE_INST_ID_'"/>
@@ -433,7 +433,7 @@
   </sql>
 
   <sql id="selectHistoricDetailsTaskProcessAndCaseInstanceByIdsSql">
-    <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size() > 0">
+    <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size > 0">
       and TASK_ID_ in (
         select ID_
         from ${prefix}ACT_HI_TASKINST
@@ -443,7 +443,7 @@
           <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.applyInForPaginatedCollection"/>
       )
     </if>
-    <if test="taskCaseInstanceIds != null &amp;&amp; taskCaseInstanceIds.size() > 0">
+    <if test="taskCaseInstanceIds != null &amp;&amp; taskCaseInstanceIds.size > 0">
       and TASK_ID_ in (
         select ID_
         from ${prefix}ACT_HI_TASKINST
@@ -456,7 +456,7 @@
   </sql>
 
   <sql id="selectHistoricDetailsTaskProcessAndCaseInstanceByIdsSql_mysql">
-    <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size() > 0">
+    <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size > 0">
       inner join ${prefix}ACT_HI_TASKINST T
         on TASK_ID_ = T.ID_
         and
@@ -464,7 +464,7 @@
           <bind name="fieldName" value="'T.PROC_INST_ID_'"/>
           <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.applyInForPaginatedCollection"/>
     </if>
-    <if test="taskCaseInstanceIds != null &amp;&amp; taskCaseInstanceIds.size() > 0">
+    <if test="taskCaseInstanceIds != null &amp;&amp; taskCaseInstanceIds.size > 0">
       inner join ${prefix}ACT_HI_TASKINST T
         on TASK_ID_ = T.ID_
         and

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricVariableInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricVariableInstance.xml
@@ -453,13 +453,13 @@
   </select>
 
   <sql id="selectHistoricVariableProcessAndCaseInstanceByIdsSql">
-    <if test="processInstanceIds != null &amp;&amp; processInstanceIds.size() > 0">
+    <if test="processInstanceIds != null &amp;&amp; processInstanceIds.size > 0">
       and
         <bind name="listOfIds" value="processInstanceIds"/>
         <bind name="fieldName" value="'PROC_INST_ID_'"/>
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.applyInForPaginatedCollection"/>
     </if>
-    <if test="caseInstanceIds != null &amp;&amp; caseInstanceIds.size() > 0">
+    <if test="caseInstanceIds != null &amp;&amp; caseInstanceIds.size > 0">
       and CASE_INST_ID_ IN
         <foreach item="caseInstanceId" index="index" collection="caseInstanceIds" open="(" separator="," close=")">
           #{caseInstanceId}
@@ -468,7 +468,7 @@
   </sql>
 
   <sql id="selectHistoricVariableTaskInstanceByIdsSql">
-    <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size() > 0">
+    <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size > 0">
       and TASK_ID_ in (
         select ID_
         from ${prefix}ACT_HI_TASKINST
@@ -478,7 +478,7 @@
           <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.applyInForPaginatedCollection"/>
       )
     </if>
-    <if test="taskCaseInstanceIds != null &amp;&amp; taskCaseInstanceIds.size() > 0">
+    <if test="taskCaseInstanceIds != null &amp;&amp; taskCaseInstanceIds.size > 0">
       and TASK_ID_ in (
         select ID_
         from ${prefix}ACT_HI_TASKINST
@@ -491,7 +491,7 @@
   </sql>
 
   <sql id="selectHistoricVariableTaskInstanceByIdsSql_mysql">
-    <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size() > 0">
+    <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size > 0">
       inner join ${prefix}ACT_HI_TASKINST T
         on TASK_ID_ = T.ID_
         and T.PROC_INST_ID_ in
@@ -499,7 +499,7 @@
             #{processInstanceId}
           </foreach>
     </if>
-    <if test="taskCaseInstanceIds != null &amp;&amp; taskCaseInstanceIds.size() > 0">
+    <if test="taskCaseInstanceIds != null &amp;&amp; taskCaseInstanceIds.size > 0">
       inner join ${prefix}ACT_HI_TASKINST T
         on TASK_ID_ = T.ID_
         and T.CASE_INST_ID_ in

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
@@ -354,7 +354,7 @@
             <if test="query.assigneeLike != null">
               ${queryType} RES.ASSIGNEE_ like #{query.assigneeLike} ESCAPE ${escapeChar}
             </if>
-            <if test="query.assigneeIn != null &amp;&amp; query.assigneeIn.size() &gt; 0">
+            <if test="query.assigneeIn != null &amp;&amp; query.assigneeIn.size &gt; 0">
               ${queryType} RES.ASSIGNEE_ in
               <foreach item="assignee" index="index" collection="query.assigneeIn"
                        open="(" separator="," close=")">
@@ -535,10 +535,10 @@
                   <if test="query.candidateUser != null">
                     I.USER_ID_ = #{query.candidateUser}
                   </if>
-                  <if test="query.candidateUser != null &amp;&amp; query.candidateGroups != null &amp;&amp; query.candidateGroups.size() &gt; 0">
+                  <if test="query.candidateUser != null &amp;&amp; query.candidateGroups != null &amp;&amp; query.candidateGroups.size &gt; 0">
                     or
                   </if>
-                  <if test="query.candidateGroups != null &amp;&amp; query.candidateGroups.size() &gt; 0">
+                  <if test="query.candidateGroups != null &amp;&amp; query.candidateGroups.size &gt; 0">
                     I.GROUP_ID_ IN
                     <foreach item="group" index="index" collection="query.candidateGroups"
                              open="(" separator="," close=")">

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/VariableInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/VariableInstance.xml
@@ -162,7 +162,7 @@
         EXECUTION_ID_ = #{parameter.executionId, jdbcType=VARCHAR}
     AND
         TASK_ID_ is null
-    <if test="parameter.variableNames != null &amp;&amp; parameter.variableNames.size() > 0">
+    <if test="parameter.variableNames != null &amp;&amp; parameter.variableNames.size > 0">
     AND
         NAME_ IN
         <foreach item="item" index="index" collection="parameter.variableNames" open="(" separator="," close=")">
@@ -213,7 +213,7 @@
         CASE_EXECUTION_ID_ = #{parameter.caseExecutionId, jdbcType=VARCHAR}
     AND
         TASK_ID_ is null
-    <if test="parameter.variableNames != null &amp;&amp; parameter.variableNames.size() > 0">
+    <if test="parameter.variableNames != null &amp;&amp; parameter.variableNames.size > 0">
     AND
         NAME_ IN
         <foreach item="item" index="index" collection="parameter.variableNames" open="(" separator="," close=")">
@@ -241,7 +241,7 @@
 
     WHERE
         TASK_ID_ = #{parameter.taskId, jdbcType=VARCHAR}
-    <if test="parameter.variableNames != null &amp;&amp; parameter.variableNames.size() > 0">
+    <if test="parameter.variableNames != null &amp;&amp; parameter.variableNames.size > 0">
     AND
         NAME_ IN
         <foreach item="item" index="index" collection="parameter.variableNames" open="(" separator="," close=")">


### PR DESCRIPTION
[![CAM-10779](https://badgen.net/badge/JIRA/CAM-10779/0052CC)](https://app.camunda.com/jira/browse/CAM-10779)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This pull request includes changes to the MyBatis Mapper XML files for a number of entities to use ".size" to retrieve the size for array lists instead of ".size()".

This prevents the "Illegal reflective access by org.apache.ibatis.ognl.OgnlRuntime java.util.Arrays exception" under JDK 13.

Updated the version of the MyBatis dependency to 3.5.3 resolve the following error under JDK 13.

WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.apache.ibatis.reflection.Reflector (file:/Users/marcus/.m2/repository/org/mybatis/mybatis/3.4.4/mybatis-3.4.4.jar) to method java.lang.Object.finalize()
WARNING: Please consider reporting this to the maintainers of org.apache.ibatis.reflection.Reflector
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release