### PR TITLE
CAM-9932: fix transient flag for serialized typed values

### DIFF
--- a/engine-plugins/spin-plugin/src/main/java/org/camunda/spin/plugin/impl/JsonValueSerializer.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/camunda/spin/plugin/impl/JsonValueSerializer.java
@@ -45,13 +45,17 @@ public class JsonValueSerializer extends SpinValueSerializer {
     return SpinValues.jsonValue((SpinJsonNode) untypedValue.getValue()).create();
   }
 
-  protected SpinValue createDeserializedValue(Object deserializedObject, String serializedStringValue, ValueFields valueFields) {
+  protected SpinValue createDeserializedValue(Object deserializedObject, String serializedStringValue, ValueFields valueFields, boolean asTransientValue) {
     SpinJsonNode value = (SpinJsonNode) deserializedObject;
-    return new JsonValueImpl(value, serializedStringValue, value.getDataFormatName(), true);
+    JsonValueImpl jsonValue = new JsonValueImpl(value, serializedStringValue, value.getDataFormatName(), true);
+    jsonValue.setTransient(asTransientValue);
+    return jsonValue;
   }
 
-  protected SpinValue createSerializedValue(String serializedStringValue, ValueFields valueFields) {
-    return new JsonValueImpl(serializedStringValue, serializationDataFormat);
+  protected SpinValue createSerializedValue(String serializedStringValue, ValueFields valueFields, boolean asTransientValue) {
+    JsonValueImpl jsonValue = new JsonValueImpl(serializedStringValue, serializationDataFormat);
+    jsonValue.setTransient(asTransientValue);
+    return jsonValue;
   }
 
 }

--- a/engine-plugins/spin-plugin/src/main/java/org/camunda/spin/plugin/impl/XmlValueSerializer.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/camunda/spin/plugin/impl/XmlValueSerializer.java
@@ -45,13 +45,17 @@ public class XmlValueSerializer extends SpinValueSerializer {
     return SpinValues.xmlValue((SpinXmlElement) untypedValue.getValue()).create();
   }
 
-  protected SpinValue createDeserializedValue(Object deserializedObject, String serializedStringValue, ValueFields valueFields) {
+  protected SpinValue createDeserializedValue(Object deserializedObject, String serializedStringValue, ValueFields valueFields, boolean asTransientValue) {
     SpinXmlElement value = (SpinXmlElement) deserializedObject;
-    return new XmlValueImpl(value, serializedStringValue, value.getDataFormatName(), true);
+    XmlValueImpl xmlValue = new XmlValueImpl(value, serializedStringValue, value.getDataFormatName(), true);
+    xmlValue.setTransient(asTransientValue);
+    return xmlValue;
   }
 
-  protected SpinValue createSerializedValue(String serializedStringValue, ValueFields valueFields) {
-    return new XmlValueImpl(serializedStringValue, serializationDataFormat);
+  protected SpinValue createSerializedValue(String serializedStringValue, ValueFields valueFields, boolean asTransientValue) {
+    XmlValueImpl xmlValue = new XmlValueImpl(serializedStringValue, serializationDataFormat);
+    xmlValue.setTransient(asTransientValue);
+    return xmlValue;
   }
 
 }

--- a/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/JsonDelegate.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/JsonDelegate.java
@@ -16,14 +16,14 @@
  */
 package org.camunda.spin.plugin.variables;
 
+import static org.camunda.spin.plugin.variable.SpinValues.jsonValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.camunda.bpm.engine.variable.Variables;
 import org.camunda.bpm.engine.variable.value.TypedValue;
-
-import static org.camunda.spin.plugin.variable.SpinValues.jsonValue;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author Tassilo Weidner

--- a/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/JsonValueTest.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/JsonValueTest.java
@@ -16,13 +16,10 @@
  */
 package org.camunda.spin.plugin.variables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.spin.DataFormats.json;
 import static org.camunda.spin.plugin.variable.SpinValues.jsonValue;
 import static org.camunda.spin.plugin.variable.type.SpinValueType.JSON;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.List;
@@ -223,7 +220,7 @@ public class JsonValueTest extends PluggableProcessEngineTestCase {
 
   public void testApplyValueInfoFromSerializedValue() {
     // given
-    Map<String, Object> valueInfo = new HashMap<String, Object>();
+    Map<String, Object> valueInfo = new HashMap<>();
     valueInfo.put(ValueType.VALUE_INFO_TRANSIENT, true);
 
     // when
@@ -238,35 +235,23 @@ public class JsonValueTest extends PluggableProcessEngineTestCase {
   /**
    * See https://app.camunda.com/jira/browse/CAM-9932
    */
-  public void FAILING_testTransientJsonSpinVariables() {
-    repositoryService.createDeployment()
-      .addModelInstance("model.bpmn",
-        Bpmn.createExecutableProcess("aProcess")
-          .startEvent()
-          .serviceTask()
-            .camundaClass(JsonDelegate.class)
-          .endEvent()
-          .done())
-      .deploy();
+  public void testTransientJsonSpinVariables() {
+    // given
+    BpmnModelInstance modelInstance = Bpmn.createExecutableProcess("aProcess")
+      .startEvent()
+      .serviceTask()
+        .camundaClass(JsonDelegate.class)
+      .userTask()
+      .endEvent()
+      .done();
+    deployment(modelInstance);
 
-    runtimeService.startProcessInstanceByKey("aProcess").getId();
-  }
+    // when
+    String processInstanceId = runtimeService.startProcessInstanceByKey("aProcess").getId();
 
-  /**
-   * See https://app.camunda.com/jira/browse/CAM-9932
-   */
-  public void FAILING_testTransientXmlSpinVariables() {
-    repositoryService.createDeployment()
-      .addModelInstance("model.bpmn",
-        Bpmn.createExecutableProcess("aProcess")
-          .startEvent()
-          .serviceTask()
-            .camundaClass(XmlDelegate.class)
-          .endEvent()
-          .done())
-      .deploy();
-
-    runtimeService.startProcessInstanceByKey("aProcess").getId();
+    // then
+    Object value = runtimeService.getVariable(processInstanceId, "jsonVariable");
+    assertThat(value).isNull();
   }
 
   public void testDeserializeTransientJsonValue() {

--- a/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/XmlValueTest.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/XmlValueTest.java
@@ -16,6 +16,7 @@
  */
 package org.camunda.spin.plugin.variables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.spin.DataFormats.xml;
 import static org.camunda.spin.plugin.variable.SpinValues.xmlValue;
 import static org.camunda.spin.plugin.variable.type.SpinValueType.XML;
@@ -217,6 +218,28 @@ public class XmlValueTest extends PluggableProcessEngineTestCase {
     // then
     List<VariableInstance> variableInstances = runtimeService.createVariableInstanceQuery().list();
     assertEquals(0, variableInstances.size());
+  }
+
+  /**
+   * See https://app.camunda.com/jira/browse/CAM-9932
+   */
+  public void testTransientXmlSpinVariables() {
+    // given
+    BpmnModelInstance modelInstance = Bpmn.createExecutableProcess("aProcess")
+        .startEvent()
+        .serviceTask()
+          .camundaClass(XmlDelegate.class)
+        .userTask()
+        .endEvent()
+        .done();
+      deployment(modelInstance);
+
+    // when
+    String processInstanceId = runtimeService.startProcessInstanceByKey("aProcess").getId();
+
+    // then
+    Object value = runtimeService.getVariable(processInstanceId, "xmlVariable");
+    assertThat(value).isNull();
   }
 
   public void testApplyValueInfoFromSerializedValue() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/history/event/HistoricDecisionInputInstanceEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/history/event/HistoricDecisionInputInstanceEntity.java
@@ -103,11 +103,11 @@ public class HistoricDecisionInputInstanceEntity extends HistoryEvent implements
 
   @Override
   public TypedValue getTypedValue() {
-    return typedValueField.getTypedValue();
+    return typedValueField.getTypedValue(false);
   }
 
   public TypedValue getTypedValue(boolean deserializeValue) {
-    return typedValueField.getTypedValue(deserializeValue);
+    return typedValueField.getTypedValue(deserializeValue, false);
   }
 
   @Override

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/history/event/HistoricDecisionOutputInstanceEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/history/event/HistoricDecisionOutputInstanceEntity.java
@@ -135,11 +135,11 @@ public class HistoricDecisionOutputInstanceEntity extends HistoryEvent implement
 
   @Override
   public TypedValue getTypedValue() {
-    return typedValueField.getTypedValue();
+    return typedValueField.getTypedValue(false);
   }
 
   public TypedValue getTypedValue(boolean deserializeValue) {
-    return typedValueField.getTypedValue(deserializeValue);
+    return typedValueField.getTypedValue(deserializeValue, false);
   }
 
   @Override

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricDetailVariableInstanceUpdateEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricDetailVariableInstanceUpdateEntity.java
@@ -50,11 +50,11 @@ public class HistoricDetailVariableInstanceUpdateEntity extends HistoricVariable
   }
 
   public TypedValue getTypedValue() {
-    return typedValueField.getTypedValue();
+    return typedValueField.getTypedValue(false);
   }
 
   public TypedValue getTypedValue(boolean deserializeValue) {
-    return typedValueField.getTypedValue(deserializeValue);
+    return typedValueField.getTypedValue(deserializeValue, false);
   }
 
   @Override

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricVariableInstanceEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricVariableInstanceEntity.java
@@ -130,7 +130,7 @@ public class HistoricVariableInstanceEntity implements ValueFields, HistoricVari
   }
 
   public Object getPersistentState() {
-    List<Object> state = new ArrayList<Object>(8);
+    List<Object> state = new ArrayList<>(8);
     state.add(getSerializerName());
     state.add(textValue);
     state.add(textValue2);
@@ -152,11 +152,11 @@ public class HistoricVariableInstanceEntity implements ValueFields, HistoricVari
   }
 
   public TypedValue getTypedValue() {
-    return typedValueField.getTypedValue();
+    return typedValueField.getTypedValue(false);
   }
 
   public TypedValue getTypedValue(boolean deserializeValue) {
-    return typedValueField.getTypedValue(deserializeValue);
+    return typedValueField.getTypedValue(deserializeValue, false);
   }
 
   public TypedValueSerializer<?> getSerializer() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
@@ -162,7 +162,7 @@ public class VariableInstanceEntity implements VariableInstance, CoreVariableIns
   }
 
   public Object getPersistentState() {
-    Map<String, Object> persistentState = new HashMap<String, Object>();
+    Map<String, Object> persistentState = new HashMap<>();
     if (typedValueField.getSerializerName() != null) {
       persistentState.put("serializerName", typedValueField.getSerializerName());
     }
@@ -262,11 +262,11 @@ public class VariableInstanceEntity implements VariableInstance, CoreVariableIns
   }
 
   public TypedValue getTypedValue() {
-    return typedValueField.getTypedValue();
+    return typedValueField.getTypedValue(isTransient);
   }
 
   public TypedValue getTypedValue(boolean deserializeValue) {
-    return typedValueField.getTypedValue(deserializeValue);
+    return typedValueField.getTypedValue(deserializeValue, isTransient);
   }
 
   public void setValue(TypedValue value) {
@@ -652,13 +652,13 @@ public class VariableInstanceEntity implements VariableInstance, CoreVariableIns
 
   @Override
   public Set<String> getReferencedEntityIds() {
-    Set<String> referencedEntityIds = new HashSet<String>();
+    Set<String> referencedEntityIds = new HashSet<>();
     return referencedEntityIds;
   }
 
   @Override
   public Map<String, Class> getReferencedEntitiesIdAndClass() {
-    Map<String, Class> referenceIdAndClass = new HashMap<String, Class>();
+    Map<String, Class> referenceIdAndClass = new HashMap<>();
 
     if (processInstanceId != null){
       referenceIdAndClass.put(processInstanceId, ExecutionEntity.class);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/util/TypedValueField.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/util/TypedValueField.java
@@ -94,7 +94,7 @@ public class TypedValueField implements DbEntityLifecycleAware, CommandContextLi
         }
       }
 
-      if (cachedValue != null && (asTransientValue ^ !cachedValue.isTransient())) {
+      if (cachedValue != null && (asTransientValue ^ cachedValue.isTransient())) {
         // clear cached value if the value is not transient, but a transient value is requested
         cachedValue = null;
       }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/util/TypedValueField.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/util/TypedValueField.java
@@ -94,7 +94,7 @@ public class TypedValueField implements DbEntityLifecycleAware, CommandContextLi
         }
       }
 
-      if (cachedValue != null && ((asTransientValue && !cachedValue.isTransient()) || !asTransientValue && cachedValue.isTransient())) {
+      if (cachedValue != null && (asTransientValue ^ !cachedValue.isTransient())) {
         // clear cached value if the value is not transient, but a transient value is requested
         cachedValue = null;
       }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/util/TypedValueField.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/util/TypedValueField.java
@@ -66,11 +66,11 @@ public class TypedValueField implements DbEntityLifecycleAware, CommandContextLi
   public TypedValueField(ValueFields valueFields, boolean notifyOnImplicitUpdates) {
     this.valueFields = valueFields;
     this.notifyOnImplicitUpdates = notifyOnImplicitUpdates;
-    this.updateListeners = new ArrayList<TypedValueUpdateListener>();
+    this.updateListeners = new ArrayList<>();
   }
 
   public Object getValue() {
-    TypedValue typedValue = getTypedValue();
+    TypedValue typedValue = getTypedValue(false);
     if (typedValue != null) {
       return typedValue.getValue();
     } else {
@@ -78,22 +78,31 @@ public class TypedValueField implements DbEntityLifecycleAware, CommandContextLi
     }
   }
 
-  public TypedValue getTypedValue() {
-    return getTypedValue(true);
+  public TypedValue getTypedValue(boolean asTransientValue) {
+    return getTypedValue(true, asTransientValue);
   }
 
-  public TypedValue getTypedValue(boolean deserializeValue) {
-    if (cachedValue != null && cachedValue instanceof SerializableValue && Context.getCommandContext() != null) {
-      SerializableValue serializableValue = (SerializableValue) cachedValue;
-      if(deserializeValue && !serializableValue.isDeserialized()) {
-        // clear cached value in case it is not deserialized and user requests deserialized value
+  public TypedValue getTypedValue(boolean deserializeValue, boolean asTransientValue) {
+    if (Context.getCommandContext() != null) {
+      // in some circumstances we must invalidate the cached value instead of returning it
+
+      if (cachedValue != null && cachedValue instanceof SerializableValue) {
+        SerializableValue serializableValue = (SerializableValue) cachedValue;
+        if(deserializeValue && !serializableValue.isDeserialized()) {
+          // clear cached value in case it is not deserialized and user requests deserialized value
+          cachedValue = null;
+        }
+      }
+
+      if (cachedValue != null && ((asTransientValue && !cachedValue.isTransient()) || !asTransientValue && cachedValue.isTransient())) {
+        // clear cached value if the value is not transient, but a transient value is requested
         cachedValue = null;
       }
     }
 
     if (cachedValue == null && errorMessage == null) {
       try {
-        cachedValue = getSerializer().readValue(valueFields, deserializeValue);
+        cachedValue = getSerializer().readValue(valueFields, deserializeValue, asTransientValue);
 
         if (notifyOnImplicitUpdates && isMutableValue(cachedValue)) {
           Context.getCommandContext().registerCommandContextListener(this);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/AbstractObjectValueSerializer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/AbstractObjectValueSerializer.java
@@ -69,15 +69,21 @@ public abstract class AbstractObjectValueSerializer extends AbstractSerializable
     objectValue.setSerializationDataFormat(serializationDataFormat);
   }
 
-  protected ObjectValue createDeserializedValue(Object deserializedObject, String serializedStringValue, ValueFields valueFields) {
+  protected ObjectValue createDeserializedValue(Object deserializedObject, String serializedStringValue,
+      ValueFields valueFields, boolean asTransientValue) {
     String objectTypeName = readObjectNameFromFields(valueFields);
-    return new ObjectValueImpl(deserializedObject, serializedStringValue, serializationDataFormat, objectTypeName, true);
+    ObjectValueImpl objectValue = new ObjectValueImpl(deserializedObject, serializedStringValue, serializationDataFormat, objectTypeName, true);
+    objectValue.setTransient(asTransientValue);
+    return objectValue;
   }
 
 
-  protected ObjectValue createSerializedValue(String serializedStringValue, ValueFields valueFields) {
+  protected ObjectValue createSerializedValue(String serializedStringValue, ValueFields valueFields,
+      boolean asTransientValue) {
     String objectTypeName = readObjectNameFromFields(valueFields);
-    return new ObjectValueImpl(null, serializedStringValue, serializationDataFormat, objectTypeName, false);
+    ObjectValueImpl objectValue = new ObjectValueImpl(null, serializedStringValue, serializationDataFormat, objectTypeName, false);
+    objectValue.setTransient(asTransientValue);
+    return objectValue;
   }
 
   protected String readObjectNameFromFields(ValueFields valueFields) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/AbstractSerializableValueSerializer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/AbstractSerializableValueSerializer.java
@@ -71,7 +71,7 @@ public abstract class AbstractSerializableValueSerializer<T extends Serializable
     updateTypedValue(value, serializedStringValue);
   }
 
-  public T readValue(ValueFields valueFields, boolean deserializeObjectValue) {
+  public T readValue(ValueFields valueFields, boolean deserializeObjectValue, boolean asTransientValue) {
 
     byte[] serializedByteValue = readSerializedValueFromFields(valueFields);
     String serializedStringValue = getSerializedStringValue(serializedByteValue);
@@ -85,17 +85,17 @@ public abstract class AbstractSerializableValueSerializer<T extends Serializable
           throw new ProcessEngineException("Cannot deserialize object in variable '"+valueFields.getName()+"': "+e.getMessage(), e);
         }
       }
-      T value = createDeserializedValue(deserializedObject, serializedStringValue, valueFields);
+      T value = createDeserializedValue(deserializedObject, serializedStringValue, valueFields, asTransientValue);
       return value;
     }
     else {
-      return createSerializedValue(serializedStringValue, valueFields);
+      return createSerializedValue(serializedStringValue, valueFields, asTransientValue);
     }
   }
 
-  protected abstract T createDeserializedValue(Object deserializedObject, String serializedStringValue, ValueFields valueFields);
+  protected abstract T createDeserializedValue(Object deserializedObject, String serializedStringValue, ValueFields valueFields, boolean asTransientValue);
 
-  protected abstract T createSerializedValue(String serializedStringValue, ValueFields valueFields);
+  protected abstract T createSerializedValue(String serializedStringValue, ValueFields valueFields, boolean asTransientValue);
 
   protected abstract void writeToValueFields(T value, ValueFields valueFields, byte[] serializedValue);
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/BooleanValueSerializer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/BooleanValueSerializer.java
@@ -40,7 +40,7 @@ public class BooleanValueSerializer extends PrimitiveValueSerializer<BooleanValu
     return Variables.booleanValue((Boolean) untypedValue.getValue(), untypedValue.isTransient());
   }
 
-  public BooleanValue readValue(ValueFields valueFields) {
+  public BooleanValue readValue(ValueFields valueFields, boolean asTransientValue) {
     Boolean boolValue = null;
     Long longValue = valueFields.getLongValue();
 
@@ -48,7 +48,7 @@ public class BooleanValueSerializer extends PrimitiveValueSerializer<BooleanValu
       boolValue = longValue.equals(TRUE);
     }
 
-    return Variables.booleanValue(boolValue);
+    return Variables.booleanValue(boolValue, asTransientValue);
   }
 
   public void writeValue(BooleanValue variableValue, ValueFields valueFields) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/ByteArrayValueSerializer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/ByteArrayValueSerializer.java
@@ -45,8 +45,8 @@ public class ByteArrayValueSerializer extends PrimitiveValueSerializer<BytesValu
     }
   }
 
-  public BytesValue readValue(ValueFields valueFields) {
-    return Variables.byteArrayValue(valueFields.getByteArrayValue());
+  public BytesValue readValue(ValueFields valueFields, boolean asTransientValue) {
+    return Variables.byteArrayValue(valueFields.getByteArrayValue(), asTransientValue);
   }
 
   public void writeValue(BytesValue variableValue, ValueFields valueFields) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/DateValueSerializer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/DateValueSerializer.java
@@ -40,13 +40,13 @@ public class DateValueSerializer extends PrimitiveValueSerializer<DateValue> {
     return Variables.dateValue((Date) untypedValue.getValue(), untypedValue.isTransient());
   }
 
-  public DateValue readValue(ValueFields valueFields) {
+  public DateValue readValue(ValueFields valueFields, boolean asTransientValue) {
     Long longValue = valueFields.getLongValue();
     Date dateValue = null;
     if (longValue!=null) {
       dateValue = new Date(longValue);
     }
-    return Variables.dateValue(dateValue);
+    return Variables.dateValue(dateValue, asTransientValue);
   }
 
   public void writeValue(DateValue typedValue, ValueFields valueFields) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/DoubleValueSerializer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/DoubleValueSerializer.java
@@ -39,8 +39,8 @@ public class DoubleValueSerializer extends PrimitiveValueSerializer<DoubleValue>
     valueFields.setDoubleValue(value.getValue());
   }
 
-  public DoubleValue readValue(ValueFields valueFields) {
-    return Variables.doubleValue(valueFields.getDoubleValue());
+  public DoubleValue readValue(ValueFields valueFields, boolean asTransientValue) {
+    return Variables.doubleValue(valueFields.getDoubleValue(), asTransientValue);
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/FileValueSerializer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/FileValueSerializer.java
@@ -68,7 +68,7 @@ public class FileValueSerializer extends AbstractTypedValueSerializer<FileValue>
   }
 
   @Override
-  public FileValue readValue(ValueFields valueFields, boolean deserializeValue) {
+  public FileValue readValue(ValueFields valueFields, boolean deserializeValue, boolean asTransientValue) {
     String fileName = valueFields.getTextValue();
     if (fileName == null) {
       // ensure file name is not null
@@ -88,6 +88,9 @@ public class FileValueSerializer extends AbstractTypedValueSerializer<FileValue>
       builder.mimeType(mimeType);
       builder.encoding(encoding);
     }
+
+    builder.setTransient(asTransientValue);
+
     return builder.create();
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/IntegerValueSerializer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/IntegerValueSerializer.java
@@ -48,14 +48,14 @@ public class IntegerValueSerializer extends PrimitiveValueSerializer<IntegerValu
 
   }
 
-  public IntegerValue readValue(ValueFields valueFields) {
+  public IntegerValue readValue(ValueFields valueFields, boolean asTransientValue) {
     Integer intValue = null;
 
     if(valueFields.getLongValue() != null) {
       intValue = Integer.valueOf(valueFields.getLongValue().intValue());
     }
 
-    return Variables.integerValue(intValue);
+    return Variables.integerValue(intValue, asTransientValue);
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/LongValueSerlializer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/LongValueSerlializer.java
@@ -35,8 +35,8 @@ public class LongValueSerlializer extends PrimitiveValueSerializer<LongValue> {
     return Variables.longValue((Long) untypedValue.getValue(), untypedValue.isTransient());
   }
 
-  public LongValue readValue(ValueFields valueFields) {
-    return Variables.longValue(valueFields.getLongValue());
+  public LongValue readValue(ValueFields valueFields, boolean asTransientValue) {
+    return Variables.longValue(valueFields.getLongValue(), asTransientValue);
   }
 
   public void writeValue(LongValue value, ValueFields valueFields) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/NullValueSerializer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/NullValueSerializer.java
@@ -45,7 +45,7 @@ public class NullValueSerializer extends AbstractTypedValueSerializer<NullValueI
     // nothing to do
   }
 
-  public NullValueImpl readValue(ValueFields valueFields, boolean deserialize) {
+  public NullValueImpl readValue(ValueFields valueFields, boolean deserialize, boolean asTransientValue) {
     return NullValueImpl.INSTANCE;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/PrimitiveValueSerializer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/PrimitiveValueSerializer.java
@@ -38,12 +38,12 @@ public abstract class PrimitiveValueSerializer<T extends PrimitiveValue<?>> exte
     return valueType.getName();
   }
 
-  public T readValue(ValueFields valueFields, boolean deserializeObjectValue) {
+  public T readValue(ValueFields valueFields, boolean deserializeObjectValue, boolean asTransientValue) {
     // primitive values are always deserialized
-    return readValue(valueFields);
+    return readValue(valueFields, asTransientValue);
   }
 
-  public abstract T readValue(ValueFields valueFields);
+  public abstract T readValue(ValueFields valueFields, boolean asTransientValue);
 
   public PrimitiveValueType getType() {
     return (PrimitiveValueType) super.getType();

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/ShortValueSerializer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/ShortValueSerializer.java
@@ -35,7 +35,7 @@ public class ShortValueSerializer extends PrimitiveValueSerializer<ShortValue> {
     return Variables.shortValue((Short) untypedValue.getValue(), untypedValue.isTransient());
   }
 
-  public ShortValue readValue(ValueFields valueFields) {
+  public ShortValue readValue(ValueFields valueFields, boolean asTransientValue) {
     Long longValue = valueFields.getLongValue();
     Short shortValue = null;
 
@@ -43,7 +43,7 @@ public class ShortValueSerializer extends PrimitiveValueSerializer<ShortValue> {
       shortValue = Short.valueOf(longValue.shortValue());
     }
 
-    return Variables.shortValue(shortValue);
+    return Variables.shortValue(shortValue, asTransientValue);
   }
 
   public void writeValue(ShortValue value, ValueFields valueFields) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/StringValueSerializer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/StringValueSerializer.java
@@ -36,8 +36,8 @@ public class StringValueSerializer extends PrimitiveValueSerializer<StringValue>
     return Variables.stringValue((String) untypedValue.getValue(), untypedValue.isTransient());
   }
 
-  public StringValue readValue(ValueFields valueFields) {
-    return Variables.stringValue(valueFields.getTextValue());
+  public StringValue readValue(ValueFields valueFields, boolean asTransientValue) {
+    return Variables.stringValue(valueFields.getTextValue(), asTransientValue);
   }
 
   public void writeValue(StringValue variableValue, ValueFields valueFields) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/TypedValueSerializer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/TypedValueSerializer.java
@@ -62,7 +62,7 @@ public interface TypedValueSerializer<T extends TypedValue> {
    *
    * @return the {@link TypedValue}
    */
-  T readValue(ValueFields valueFields, boolean deserializeValue);
+  T readValue(ValueFields valueFields, boolean deserializeValue, boolean isTransient);
 
   /**
    * Used for auto-detecting the value type of a variable.

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/jpa/JPAVariableSerializer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/jpa/JPAVariableSerializer.java
@@ -91,12 +91,12 @@ public class JPAVariableSerializer extends AbstractTypedValueSerializer<ObjectVa
     }
   }
 
-  public ObjectValue readValue(ValueFields valueFields, boolean deserializeObjectValue) {
+  public ObjectValue readValue(ValueFields valueFields, boolean deserializeObjectValue, boolean asTransientValue) {
     if(valueFields.getTextValue() != null && valueFields.getTextValue2() != null) {
       Object jpaEntity = mappings.getJPAEntity(valueFields.getTextValue(), valueFields.getTextValue2());
-      return Variables.objectValue(jpaEntity).create();
+      return Variables.objectValue(jpaEntity).setTransient(asTransientValue).create();
     }
-    return Variables.objectValue(null).create();
+    return Variables.objectValue(null).setTransient(asTransientValue).create();
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/variables/FileValueSerializerTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/variables/FileValueSerializerTest.java
@@ -77,14 +77,14 @@ public class FileValueSerializerTest {
     String filename = "";
     FileValue fileValue = Variables.fileValue(filename).create();
     ValueFields valueFields = new MockValueFields();
-    
+
     serializer.writeValue(fileValue, valueFields);
-    
+
     assertThat(valueFields.getByteArrayValue(), is(nullValue()));
     assertThat(valueFields.getTextValue(), is(filename));
     assertThat(valueFields.getTextValue2(), is(nullValue()));
   }
-  
+
   @Test
   public void testWriteMimetypeAndFilenameValue() {
     String filename = "test.txt";
@@ -162,7 +162,7 @@ public class FileValueSerializerTest {
     String mimeType = "text/plain";
     valueFields.setTextValue2(mimeType + SEPARATOR);
 
-    FileValue fileValue = serializer.readValue(valueFields, true);
+    FileValue fileValue = serializer.readValue(valueFields, true, false);
 
     assertThat(fileValue.getFilename(), is(filename));
     assertThat(fileValue.getMimeType(), is(mimeType));
@@ -183,7 +183,7 @@ public class FileValueSerializerTest {
     String encoding = SEPARATOR + "UTF-8";
     valueFields.setTextValue2(encoding);
 
-    FileValue fileValue = serializer.readValue(valueFields, true);
+    FileValue fileValue = serializer.readValue(valueFields, true, false);
 
     assertThat(fileValue.getFilename(), is(filename));
     assertThat(fileValue.getEncoding(), is("UTF-8"));
@@ -206,7 +206,7 @@ public class FileValueSerializerTest {
     String encoding = "UTF-16";
     valueFields.setTextValue2(mimeType + SEPARATOR + encoding);
 
-    FileValue fileValue = serializer.readValue(valueFields, true);
+    FileValue fileValue = serializer.readValue(valueFields, true, false);
 
     assertThat(fileValue.getFilename(), is(filename));
     assertThat(fileValue.getMimeType(), is(mimeType));
@@ -227,7 +227,7 @@ public class FileValueSerializerTest {
     valueFields.setTextValue(filename);
     valueFields.setByteArrayValue(data);
 
-    FileValue fileValue = serializer.readValue(valueFields, true);
+    FileValue fileValue = serializer.readValue(valueFields, true, false);
 
     assertThat(fileValue.getFilename(), is(filename));
     assertThat(fileValue.getMimeType(), is(nullValue()));
@@ -240,7 +240,7 @@ public class FileValueSerializerTest {
     String filename = "file.txt";
     valueFields.setTextValue(filename);
 
-    FileValue fileValue = serializer.readValue(valueFields, true);
+    FileValue fileValue = serializer.readValue(valueFields, true, false);
 
     assertThat(fileValue.getFilename(), is(filename));
     assertThat(fileValue.getMimeType(), is(nullValue()));
@@ -252,22 +252,22 @@ public class FileValueSerializerTest {
     MockValueFields valueFields = new MockValueFields();
     String filename = "";
     valueFields.setTextValue(filename);
-  
-    FileValue fileValue = serializer.readValue(valueFields, true);
-  
+
+    FileValue fileValue = serializer.readValue(valueFields, true, false);
+
     assertThat(fileValue.getFilename(), is(""));
     assertThat(fileValue.getMimeType(), is(nullValue()));
     assertThat(fileValue.getValue(), is(nullValue()));
   }
-  
+
   @Test
   public void testReadNullFilenameValue() {
     MockValueFields valueFields = new MockValueFields();
     String filename = null;
     valueFields.setTextValue(filename);
-  
-    FileValue fileValue = serializer.readValue(valueFields, true);
-  
+
+    FileValue fileValue = serializer.readValue(valueFields, true, false);
+
     assertThat(fileValue.getFilename(), is(""));
     assertThat(fileValue.getMimeType(), is(nullValue()));
     assertThat(fileValue.getValue(), is(nullValue()));


### PR DESCRIPTION
[![CAM-9932](https://badgen.net/badge/JIRA/CAM-9932/0052CC)](https://app.camunda.com/jira/browse/CAM-9932)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- when accessing a the deserialized value of a serialized, transient
  variable, the returned typed value was non-transient

related to CAM-9932