### PR TITLE
CAM-11217: feat(engine): set default composite history event handler 

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -182,6 +182,8 @@ import org.camunda.bpm.engine.impl.history.DefaultHistoryRemovalTimeProvider;
 import org.camunda.bpm.engine.impl.history.HistoryLevel;
 import org.camunda.bpm.engine.impl.history.HistoryRemovalTimeProvider;
 import org.camunda.bpm.engine.impl.history.event.HistoricDecisionInstanceManager;
+import org.camunda.bpm.engine.impl.history.handler.CompositeDbHistoryEventHandler;
+import org.camunda.bpm.engine.impl.history.handler.CompositeHistoryEventHandler;
 import org.camunda.bpm.engine.impl.history.handler.DbHistoryEventHandler;
 import org.camunda.bpm.engine.impl.history.handler.HistoryEventHandler;
 import org.camunda.bpm.engine.impl.history.parser.HistoryParseListener;
@@ -630,7 +632,23 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected DmnHistoryEventProducer dmnHistoryEventProducer;
 
+  /**
+   * As an instance of {@link org.camunda.bpm.engine.impl.history.handler.CompositeHistoryEventHandler}
+   * it contains all the provided history event handlers that process history events.
+   */
   protected HistoryEventHandler historyEventHandler;
+
+  /**
+   *  Allows users to add additional {@link HistoryEventHandler}
+   *  instances to process history events.
+   */
+  protected List<HistoryEventHandler> customHistoryEventHandlers = new ArrayList<>();
+
+  /**
+   * If true, the default {@link DbHistoryEventHandler} will be included in the list
+   * of history event handlers.
+   */
+  protected boolean enableDefaultDbHistoryEventHandler = true;
 
   protected PermissionProvider permissionProvider;
 
@@ -2371,7 +2389,11 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initHistoryEventHandler() {
     if (historyEventHandler == null) {
-      historyEventHandler = new DbHistoryEventHandler();
+      if (enableDefaultDbHistoryEventHandler) {
+        historyEventHandler = new CompositeDbHistoryEventHandler(customHistoryEventHandlers);
+      } else {
+        historyEventHandler = new CompositeHistoryEventHandler(customHistoryEventHandlers);
+      }
     }
   }
 
@@ -3370,6 +3392,22 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public HistoryEventHandler getHistoryEventHandler() {
     return historyEventHandler;
+  }
+
+  public boolean isEnableDefaultDbHistoryEventHandler() {
+    return enableDefaultDbHistoryEventHandler;
+  }
+
+  public void setEnableDefaultDbHistoryEventHandler(boolean enableDefaultDbHistoryEventHandler) {
+    this.enableDefaultDbHistoryEventHandler = enableDefaultDbHistoryEventHandler;
+  }
+
+  public List<HistoryEventHandler> getCustomHistoryEventHandlers() {
+    return customHistoryEventHandlers;
+  }
+
+  public void setCustomHistoryEventHandlers(List<HistoryEventHandler> customHistoryEventHandlers) {
+    this.customHistoryEventHandlers = customHistoryEventHandlers;
   }
 
   public IncidentHandler getIncidentHandler(String incidentType) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/history/handler/CompositeHistoryEventHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/history/handler/CompositeHistoryEventHandler.java
@@ -35,7 +35,7 @@ public class CompositeHistoryEventHandler implements HistoryEventHandler {
   /**
    * The list of {@link HistoryEventHandler} which consume the event.
    */
-  protected final List<HistoryEventHandler> historyEventHandlers = new ArrayList<HistoryEventHandler>();
+  protected final List<HistoryEventHandler> historyEventHandlers = new ArrayList<>();
 
   /**
    * Non-argument constructor for default initialization.

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/AbstractCompositeHistoryEventHandlerTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/AbstractCompositeHistoryEventHandlerTest.java
@@ -18,16 +18,32 @@ package org.camunda.bpm.engine.test.history;
 
 import java.util.List;
 
+import org.camunda.bpm.engine.HistoryService;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.history.event.HistoricVariableUpdateEventEntity;
 import org.camunda.bpm.engine.impl.history.event.HistoryEvent;
 import org.camunda.bpm.engine.impl.history.handler.HistoryEventHandler;
-import org.camunda.bpm.engine.impl.test.PluggableProcessEngineTestCase;
 import org.camunda.bpm.engine.task.Task;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.RequiredHistoryLevel;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
-public abstract class AbstractCompositeHistoryEventHandlerTest extends PluggableProcessEngineTestCase {
+public abstract class AbstractCompositeHistoryEventHandlerTest {
+
+  @Rule
+  public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
+
+  protected ProcessEngineConfigurationImpl processEngineConfiguration;
+  protected RuntimeService runtimeService;
+  protected TaskService taskService;
+  protected HistoryService historyService;
 
   protected HistoryEventHandler originalHistoryEventHandler;
 
@@ -39,18 +55,21 @@ public abstract class AbstractCompositeHistoryEventHandlerTest extends Pluggable
   /**
    * Perform common setup.
    */
-  @Override
-  protected void setUp() throws Exception {
-    super.setUp();
+  @Before
+  public void setUp() throws Exception {
+    processEngineConfiguration = engineRule.getProcessEngineConfiguration();
+    runtimeService = engineRule.getRuntimeService();
+    taskService = engineRule.getTaskService();
+    historyService = engineRule.getHistoryService();
+
     // save current history event handler
     originalHistoryEventHandler = processEngineConfiguration.getHistoryEventHandler();
     // clear the event counter
     countCustomHistoryEventHandler = 0;
   }
 
-  @Override
-  protected void tearDown() throws Exception {
-    super.tearDown();
+  @After
+  public void tearDown() throws Exception {
     // reset original history event handler
     processEngineConfiguration.setHistoryEventHandler(originalHistoryEventHandler);
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/CompositeDbHistoryEventHandlerTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/CompositeDbHistoryEventHandlerTest.java
@@ -16,6 +16,9 @@
  */
 package org.camunda.bpm.engine.test.history;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,6 +26,7 @@ import org.camunda.bpm.engine.exception.NullValueException;
 import org.camunda.bpm.engine.impl.history.handler.CompositeDbHistoryEventHandler;
 import org.camunda.bpm.engine.impl.history.handler.HistoryEventHandler;
 import org.camunda.bpm.engine.test.Deployment;
+import org.junit.Test;
 
 /**
  * @author Alexander Tyatenkov
@@ -30,40 +34,44 @@ import org.camunda.bpm.engine.test.Deployment;
  */
 public class CompositeDbHistoryEventHandlerTest extends AbstractCompositeHistoryEventHandlerTest {
 
+  @Test
   @Deployment(resources = {"org/camunda/bpm/engine/test/history/HistoryLevelTest.bpmn20.xml"})
-  public void testCompositeDbHistoryEventHandlerNonArgumentConstructor() {
+  public void shouldUseCompositeDbHistoryEventHandlerNonArgumentConstructor() {
     processEngineConfiguration.setHistoryEventHandler(new CompositeDbHistoryEventHandler());
 
     startProcessAndCompleteUserTask();
 
-    assertEquals(0, countCustomHistoryEventHandler);
-    assertEquals(2, historyService.createHistoricDetailQuery().count());
+    assertThat(countCustomHistoryEventHandler).isZero();
+    assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(2L);
   }
 
-  public void testCompositeDbHistoryEventHandlerNonArgumentConstructorAddNullEvent() {
+  @Test
+  public void shouldUseCompositeDbHistoryEventHandlerNonArgumentConstructorAddNullEvent() {
     CompositeDbHistoryEventHandler compositeDbHistoryEventHandler = new CompositeDbHistoryEventHandler();
     try {
       compositeDbHistoryEventHandler.add(null);
       fail("NullValueException expected");
     } catch (NullValueException e) {
-      assertTextPresent("History event handler is null", e.getMessage());
+      assertThat(e.getMessage()).containsIgnoringCase("History event handler is null");
     }
   }
 
+  @Test
   @Deployment(resources = {"org/camunda/bpm/engine/test/history/HistoryLevelTest.bpmn20.xml"})
-  public void testCompositeDbHistoryEventHandlerNonArgumentConstructorAddNotNullEvent() {
+  public void shouldUseCompositeDbHistoryEventHandlerNonArgumentConstructorAddNotNullEvent() {
     CompositeDbHistoryEventHandler compositeDbHistoryEventHandler = new CompositeDbHistoryEventHandler();
     compositeDbHistoryEventHandler.add(new CustomDbHistoryEventHandler());
     processEngineConfiguration.setHistoryEventHandler(compositeDbHistoryEventHandler);
 
     startProcessAndCompleteUserTask();
 
-    assertEquals(2, countCustomHistoryEventHandler);
-    assertEquals(2, historyService.createHistoricDetailQuery().count());
+    assertThat(countCustomHistoryEventHandler).isEqualTo(2);
+    assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(2L);
   }
 
+  @Test
   @Deployment(resources = { "org/camunda/bpm/engine/test/history/HistoryLevelTest.bpmn20.xml" })
-  public void testCompositeDbHistoryEventHandlerNonArgumentConstructorAddTwoNotNullEvents() {
+  public void shouldUseCompositeDbHistoryEventHandlerNonArgumentConstructorAddTwoNotNullEvents() {
     CompositeDbHistoryEventHandler compositeDbHistoryEventHandler = new CompositeDbHistoryEventHandler();
     compositeDbHistoryEventHandler.add(new CustomDbHistoryEventHandler());
     compositeDbHistoryEventHandler.add(new CustomDbHistoryEventHandler());
@@ -71,63 +79,69 @@ public class CompositeDbHistoryEventHandlerTest extends AbstractCompositeHistory
 
     startProcessAndCompleteUserTask();
 
-    assertEquals(4, countCustomHistoryEventHandler);
-    assertEquals(2, historyService.createHistoricDetailQuery().count());
+    assertThat(countCustomHistoryEventHandler).isEqualTo(4);
+    assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(2L);
   }
 
-  public void testCompositeDbHistoryEventHandlerArgumentConstructorWithNullVarargs() {
+  @Test
+  public void shouldUseCompositeDbHistoryEventHandlerArgumentConstructorWithNullVarargs() {
     HistoryEventHandler historyEventHandler = null;
     try {
       new CompositeDbHistoryEventHandler(historyEventHandler);
       fail("NullValueException expected");
     } catch (NullValueException e) {
-      assertTextPresent("History event handler is null", e.getMessage());
+      assertThat(e.getMessage()).containsIgnoringCase("History event handler is null");
     }
   }
 
-  public void testCompositeDbHistoryEventHandlerArgumentConstructorWithNullTwoVarargs() {
+  @Test
+  public void shouldUseCompositeDbHistoryEventHandlerArgumentConstructorWithNullTwoVarargs() {
     try {
       new CompositeDbHistoryEventHandler(null, null);
       fail("NullValueException expected");
     } catch (NullValueException e) {
-      assertTextPresent("History event handler is null", e.getMessage());
+      assertThat(e.getMessage()).containsIgnoringCase("History event handler is null");
     }
   }
 
+  @Test
   @Deployment(resources = { "org/camunda/bpm/engine/test/history/HistoryLevelTest.bpmn20.xml" })
-  public void testCompositeDbHistoryEventHandlerArgumentConstructorWithNotNullVarargsOneEvent() {
+  public void shouldUseCompositeDbHistoryEventHandlerArgumentConstructorWithNotNullVarargsOneEvent() {
     CompositeDbHistoryEventHandler compositeDbHistoryEventHandler = new CompositeDbHistoryEventHandler(new CustomDbHistoryEventHandler());
     processEngineConfiguration.setHistoryEventHandler(compositeDbHistoryEventHandler);
 
     startProcessAndCompleteUserTask();
 
-    assertEquals(2, countCustomHistoryEventHandler);
-    assertEquals(2, historyService.createHistoricDetailQuery().count());
+    assertThat(countCustomHistoryEventHandler).isEqualTo(2);
+    assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(2L);
   }
 
+  @Test
   @Deployment(resources = { "org/camunda/bpm/engine/test/history/HistoryLevelTest.bpmn20.xml" })
-  public void testCompositeDbHistoryEventHandlerArgumentConstructorWithNotNullVarargsTwoEvents() {
+  public void shouldUseCompositeDbHistoryEventHandlerArgumentConstructorWithNotNullVarargsTwoEvents() {
     CompositeDbHistoryEventHandler compositeDbHistoryEventHandler = new CompositeDbHistoryEventHandler(new CustomDbHistoryEventHandler(), new CustomDbHistoryEventHandler());
     processEngineConfiguration.setHistoryEventHandler(compositeDbHistoryEventHandler);
 
     startProcessAndCompleteUserTask();
 
-    assertEquals(4, countCustomHistoryEventHandler);
-    assertEquals(2, historyService.createHistoricDetailQuery().count());
+    assertThat(countCustomHistoryEventHandler).isEqualTo(4);
+    assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(2L);
   }
 
+  @Test
   @Deployment(resources = {"org/camunda/bpm/engine/test/history/HistoryLevelTest.bpmn20.xml"})
-  public void testCompositeDbHistoryEventHandlerArgumentConstructorWithEmptyList() {
+  public void shouldUseCompositeDbHistoryEventHandlerArgumentConstructorWithEmptyList() {
     CompositeDbHistoryEventHandler compositeDbHistoryEventHandler = new CompositeDbHistoryEventHandler(new ArrayList<HistoryEventHandler>());
     processEngineConfiguration.setHistoryEventHandler(compositeDbHistoryEventHandler);
 
     startProcessAndCompleteUserTask();
 
-    assertEquals(0, countCustomHistoryEventHandler);
-    assertEquals(2, historyService.createHistoricDetailQuery().count());
+    assertThat(countCustomHistoryEventHandler).isZero();
+    assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(2L);
   }
 
-  public void testCompositeDbHistoryEventHandlerArgumentConstructorWithNotEmptyListNullTwoEvents() {
+  @Test
+  public void shouldUseCompositeDbHistoryEventHandlerArgumentConstructorWithNotEmptyListNullTwoEvents() {
     // prepare the list with two null events
     List<HistoryEventHandler> historyEventHandlers = new ArrayList<HistoryEventHandler>();
     historyEventHandlers.add(null);
@@ -137,12 +151,13 @@ public class CompositeDbHistoryEventHandlerTest extends AbstractCompositeHistory
       new CompositeDbHistoryEventHandler(historyEventHandlers);
       fail("NullValueException expected");
     } catch (NullValueException e) {
-      assertTextPresent("History event handler is null", e.getMessage());
+      assertThat(e.getMessage()).containsIgnoringCase("History event handler is null");
     }
   }
 
+  @Test
   @Deployment(resources = {"org/camunda/bpm/engine/test/history/HistoryLevelTest.bpmn20.xml"})
-  public void testCompositeDbHistoryEventHandlerArgumentConstructorWithNotEmptyListNotNullTwoEvents() {
+  public void shouldUseCompositeDbHistoryEventHandlerArgumentConstructorWithNotEmptyListNotNullTwoEvents() {
     // prepare the list with two events
     List<HistoryEventHandler> historyEventHandlers = new ArrayList<HistoryEventHandler>();
     historyEventHandlers.add(new CustomDbHistoryEventHandler());
@@ -153,8 +168,8 @@ public class CompositeDbHistoryEventHandlerTest extends AbstractCompositeHistory
 
     startProcessAndCompleteUserTask();
 
-    assertEquals(4, countCustomHistoryEventHandler);
-    assertEquals(2, historyService.createHistoricDetailQuery().count());
+    assertThat(countCustomHistoryEventHandler).isEqualTo(4);
+    assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(2L);
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/CompositeHistoryEventHandlerTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/CompositeHistoryEventHandlerTest.java
@@ -16,6 +16,9 @@
  */
 package org.camunda.bpm.engine.test.history;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,6 +27,7 @@ import org.camunda.bpm.engine.impl.history.handler.CompositeHistoryEventHandler;
 import org.camunda.bpm.engine.impl.history.handler.DbHistoryEventHandler;
 import org.camunda.bpm.engine.impl.history.handler.HistoryEventHandler;
 import org.camunda.bpm.engine.test.Deployment;
+import org.junit.Test;
 
 /**
  * @author Alexander Tyatenkov
@@ -31,51 +35,56 @@ import org.camunda.bpm.engine.test.Deployment;
  */
 public class CompositeHistoryEventHandlerTest extends AbstractCompositeHistoryEventHandlerTest {
 
+  @Test
   @Deployment(resources = { "org/camunda/bpm/engine/test/history/HistoryLevelTest.bpmn20.xml" })
-  public void testDefaultHistoryEventHandler() {
+  public void shouldUseCompositeHistoryEventHandlerNonArgumentConstructor() {
+    processEngineConfiguration.setHistoryEventHandler(new CompositeHistoryEventHandler());
+
+    startProcessAndCompleteUserTask();
+
+    assertThat(countCustomHistoryEventHandler).isZero();
+    assertThat(historyService.createHistoricDetailQuery().count()).isZero();
+  }
+
+  @Test
+  @Deployment(resources = { "org/camunda/bpm/engine/test/history/HistoryLevelTest.bpmn20.xml" })
+  public void shouldUseDefaultHistoryEventHandler() {
     // use default DbHistoryEventHandler
     processEngineConfiguration.setHistoryEventHandler(new DbHistoryEventHandler());
 
     startProcessAndCompleteUserTask();
 
-    assertEquals(0, countCustomHistoryEventHandler);
-    assertEquals(2, historyService.createHistoricDetailQuery().count());
+    assertThat(countCustomHistoryEventHandler).isZero();
+    assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(2L);
   }
 
-  @Deployment(resources = { "org/camunda/bpm/engine/test/history/HistoryLevelTest.bpmn20.xml" })
-  public void testCompositeHistoryEventHandlerNonArgumentConstructor() {
-    processEngineConfiguration.setHistoryEventHandler(new CompositeHistoryEventHandler());
-
-    startProcessAndCompleteUserTask();
-
-    assertEquals(0, countCustomHistoryEventHandler);
-    assertEquals(0, historyService.createHistoricDetailQuery().count());
-  }
-
-  public void testCompositeHistoryEventHandlerNonArgumentConstructorAddNullEvent() {
+  @Test
+  public void shouldUseCompositeHistoryEventHandlerNonArgumentConstructorAddNullEvent() {
     CompositeHistoryEventHandler compositeHistoryEventHandler = new CompositeHistoryEventHandler();
     try {
       compositeHistoryEventHandler.add(null);
       fail("NullValueException expected");
     } catch (NullValueException e) {
-      assertTextPresent("History event handler is null", e.getMessage());
+      assertThat(e.getMessage()).containsIgnoringCase("History event handler is null");
     }
   }
 
+  @Test
   @Deployment(resources = { "org/camunda/bpm/engine/test/history/HistoryLevelTest.bpmn20.xml" })
-  public void testCompositeHistoryEventHandlerNonArgumentConstructorAddNotNullEvent() {
+  public void shouldUseCompositeHistoryEventHandlerNonArgumentConstructorAddNotNullEvent() {
     CompositeHistoryEventHandler compositeHistoryEventHandler = new CompositeHistoryEventHandler();
     compositeHistoryEventHandler.add(new CustomDbHistoryEventHandler());
     processEngineConfiguration.setHistoryEventHandler(compositeHistoryEventHandler);
 
     startProcessAndCompleteUserTask();
 
-    assertEquals(2, countCustomHistoryEventHandler);
-    assertEquals(0, historyService.createHistoricDetailQuery().count());
+    assertThat(countCustomHistoryEventHandler).isEqualTo(2);
+    assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(0);
   }
 
+  @Test
   @Deployment(resources = { "org/camunda/bpm/engine/test/history/HistoryLevelTest.bpmn20.xml" })
-  public void testCompositeHistoryEventHandlerNonArgumentConstructorAddNotNullTwoEvents() {
+  public void shouldUseCompositeHistoryEventHandlerNonArgumentConstructorAddNotNullTwoEvents() {
     CompositeHistoryEventHandler compositeHistoryEventHandler = new CompositeHistoryEventHandler();
     compositeHistoryEventHandler.add(new CustomDbHistoryEventHandler());
     compositeHistoryEventHandler.add(new DbHistoryEventHandler());
@@ -83,63 +92,69 @@ public class CompositeHistoryEventHandlerTest extends AbstractCompositeHistoryEv
 
     startProcessAndCompleteUserTask();
 
-    assertEquals(2, countCustomHistoryEventHandler);
-    assertEquals(2, historyService.createHistoricDetailQuery().count());
+    assertThat(countCustomHistoryEventHandler).isEqualTo(2);
+    assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(2);
   }
 
-  public void testCompositeHistoryEventHandlerArgumentConstructorWithNullVarargs() {
+  @Test
+  public void shouldUseCompositeHistoryEventHandlerArgumentConstructorWithNullVarargs() {
     HistoryEventHandler historyEventHandler = null;
     try {
       new CompositeHistoryEventHandler(historyEventHandler);
       fail("NullValueException expected");
     } catch (NullValueException e) {
-      assertTextPresent("History event handler is null", e.getMessage());
+      assertThat(e.getMessage()).containsIgnoringCase("History event handler is null");
     }
   }
 
-  public void testCompositeHistoryEventHandlerArgumentConstructorWithNullTwoVarargs() {
+  @Test
+  public void shouldUseCompositeHistoryEventHandlerArgumentConstructorWithNullTwoVarargs() {
     try {
       new CompositeHistoryEventHandler(null, null);
       fail("NullValueException expected");
     } catch (NullValueException e) {
-      assertTextPresent("History event handler is null", e.getMessage());
+      assertThat(e.getMessage()).containsIgnoringCase("History event handler is null");
     }
   }
 
+  @Test
   @Deployment(resources = { "org/camunda/bpm/engine/test/history/HistoryLevelTest.bpmn20.xml" })
-  public void testCompositeHistoryEventHandlerArgumentConstructorWithNotNullVarargsOneEvent() {
+  public void shouldUseCompositeHistoryEventHandlerArgumentConstructorWithNotNullVarargsOneEvent() {
     CompositeHistoryEventHandler compositeHistoryEventHandler = new CompositeHistoryEventHandler(new CustomDbHistoryEventHandler());
     processEngineConfiguration.setHistoryEventHandler(compositeHistoryEventHandler);
 
     startProcessAndCompleteUserTask();
 
-    assertEquals(2, countCustomHistoryEventHandler);
-    assertEquals(0, historyService.createHistoricDetailQuery().count());
+    assertThat(countCustomHistoryEventHandler).isEqualTo(2);
+    assertThat(historyService.createHistoricDetailQuery().count()).isZero();
   }
 
+  @Test
   @Deployment(resources = { "org/camunda/bpm/engine/test/history/HistoryLevelTest.bpmn20.xml" })
-  public void testCompositeHistoryEventHandlerArgumentConstructorWithNotNullVarargsTwoEvents() {
+  public void shouldUseCompositeHistoryEventHandlerArgumentConstructorWithNotNullVarargsTwoEvents() {
     CompositeHistoryEventHandler compositeHistoryEventHandler = new CompositeHistoryEventHandler(new CustomDbHistoryEventHandler(), new DbHistoryEventHandler());
     processEngineConfiguration.setHistoryEventHandler(compositeHistoryEventHandler);
 
     startProcessAndCompleteUserTask();
 
-    assertEquals(2, countCustomHistoryEventHandler);
-    assertEquals(2, historyService.createHistoricDetailQuery().count());
+    assertThat(countCustomHistoryEventHandler).isEqualTo(2);
+    assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(2);
   }
 
+  @Test
   @Deployment(resources = { "org/camunda/bpm/engine/test/history/HistoryLevelTest.bpmn20.xml" })
-  public void testCompositeHistoryEventHandlerArgumentConstructorWithEmptyList() {
+  public void shouldUseCompositeHistoryEventHandlerArgumentConstructorWithEmptyList() {
     CompositeHistoryEventHandler compositeHistoryEventHandler = new CompositeHistoryEventHandler(new ArrayList<HistoryEventHandler>());
     processEngineConfiguration.setHistoryEventHandler(compositeHistoryEventHandler);
 
     startProcessAndCompleteUserTask();
 
-    assertEquals(0, countCustomHistoryEventHandler);
-    assertEquals(0, historyService.createHistoricDetailQuery().count());
+    assertThat(countCustomHistoryEventHandler).isZero();
+    assertThat(historyService.createHistoricDetailQuery().count()).isZero();
   }
 
-  public void testCompositeHistoryEventHandlerArgumentConstructorWithNotEmptyListNullTwoEvents() {
+  @Test
+  public void shouldUseCompositeHistoryEventHandlerArgumentConstructorWithNotEmptyListNullTwoEvents() {
     // prepare the list with two null events
     List<HistoryEventHandler> historyEventHandlers = new ArrayList<HistoryEventHandler>();
     historyEventHandlers.add(null);
@@ -149,12 +164,13 @@ public class CompositeHistoryEventHandlerTest extends AbstractCompositeHistoryEv
       new CompositeHistoryEventHandler(historyEventHandlers);
       fail("NullValueException expected");
     } catch (NullValueException e) {
-      assertTextPresent("History event handler is null", e.getMessage());
+      assertThat(e.getMessage()).containsIgnoringCase("History event handler is null");
     }
   }
 
+  @Test
   @Deployment(resources = { "org/camunda/bpm/engine/test/history/HistoryLevelTest.bpmn20.xml" })
-  public void testCompositeHistoryEventHandlerArgumentConstructorWithNotEmptyListNotNullTwoEvents() {
+  public void shouldUseCompositeHistoryEventHandlerArgumentConstructorWithNotEmptyListNotNullTwoEvents() {
     // prepare the list with two events
     List<HistoryEventHandler> historyEventHandlers = new ArrayList<HistoryEventHandler>();
     historyEventHandlers.add(new CustomDbHistoryEventHandler());
@@ -165,8 +181,8 @@ public class CompositeHistoryEventHandlerTest extends AbstractCompositeHistoryEv
 
     startProcessAndCompleteUserTask();
 
-    assertEquals(2, countCustomHistoryEventHandler);
-    assertEquals(2, historyService.createHistoricDetailQuery().count());
+    assertThat(countCustomHistoryEventHandler).isEqualTo(2);
+    assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(2);
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/DefaultHistoryEventHandlerTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/DefaultHistoryEventHandlerTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.history;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.history.event.HistoryEvent;
+import org.camunda.bpm.engine.impl.history.handler.CompositeDbHistoryEventHandler;
+import org.camunda.bpm.engine.impl.history.handler.CompositeHistoryEventHandler;
+import org.camunda.bpm.engine.impl.history.handler.HistoryEventHandler;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineBootstrapRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class DefaultHistoryEventHandlerTest {
+
+  @Parameterized.Parameters
+  public static Iterable<Object> parameters() {
+    return Arrays.asList(new Object[]{
+        true, false
+    });
+  }
+
+  @Parameterized.Parameter
+  public boolean isDefaultHandlerEnabled;
+
+  @Rule
+  public ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule() {
+    @Override
+    public ProcessEngineConfiguration configureEngine(ProcessEngineConfigurationImpl configuration) {
+      // given
+      configuration.setEnableDefaultDbHistoryEventHandler(isDefaultHandlerEnabled);
+      configuration.setCustomHistoryEventHandlers(Collections.<HistoryEventHandler>singletonList(new CustomHistoryEventHandler()));
+
+      return configuration;
+    }
+  };
+  @Rule
+  public ProcessEngineRule engineRule = new ProvidedProcessEngineRule(bootstrapRule);
+
+  @Test
+  public void shouldUseInstanceOfCompositeHistoryEventHandler() {
+    // when
+    boolean useDefaultDbHandler = engineRule.getProcessEngineConfiguration()
+        .isEnableDefaultDbHistoryEventHandler();
+    HistoryEventHandler defaultHandler = engineRule.getProcessEngineConfiguration()
+        .getHistoryEventHandler();
+
+    // then
+    assertThat(useDefaultDbHandler).isNotNull();
+    if (useDefaultDbHandler) {
+      assertThat(defaultHandler).isInstanceOf(CompositeDbHistoryEventHandler.class);
+    } else {
+      assertThat(defaultHandler).isInstanceOf(CompositeHistoryEventHandler.class);
+    }
+  }
+
+  @Test
+  public void shouldProvideCustomHistoryEventHandlers() {
+    // when
+    List<HistoryEventHandler> eventHandlers = engineRule.getProcessEngineConfiguration().getCustomHistoryEventHandlers();
+
+    // then
+    assertThat(eventHandlers).hasSize(1);
+    assertThat(eventHandlers.get(0)).isInstanceOf(CustomHistoryEventHandler.class);
+  }
+
+  public class CustomHistoryEventHandler implements HistoryEventHandler {
+
+    @Override
+    public void handleEvent(HistoryEvent historyEvent) {
+    }
+
+    @Override
+    public void handleEvents(List<HistoryEvent> historyEvents) {
+    }
+  }
+}


### PR DESCRIPTION
[![CAM-10650](https://badgen.net/badge/JIRA/CAM-10650/0052CC)](https://app.camunda.com/jira/browse/CAM-10650)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* Use an instance of `CompositeHistoryEventHandler` as the default `HistoryEventHandler`;
* Provide a list property for adding custom HistoryEventHandlers;
* Provide a flag property to enable/disable the `DbHistoryEventHandler`;

Related to [CAM-11217](https://jira.camunda.com/browse/CAM-11217)

Note: I originally implemented this in the scope of the main ticket (CAM-10650). However, separating it makes more sense.