### PR TITLE
fix(engine): populate historic process instance state during migration

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/history/producer/DefaultHistoryEventProducer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/history/producer/DefaultHistoryEventProducer.java
@@ -584,6 +584,12 @@ public class DefaultHistoryEventProducer implements HistoryEventProducer {
     // initialize event
     initProcessInstanceEvent(evt, executionEntity, HistoryEventTypes.PROCESS_INSTANCE_MIGRATE);
 
+    if (executionEntity.isSuspended()) {
+      evt.setState(HistoricProcessInstance.STATE_SUSPENDED);
+    } else {
+      evt.setState(HistoricProcessInstance.STATE_ACTIVE);
+    }
+
     return evt;
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/history/MigrationHistoricProcessInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/history/MigrationHistoricProcessInstanceTest.java
@@ -104,5 +104,29 @@ public class MigrationHistoricProcessInstanceTest {
     assertEquals(instance.getProcessDefinitionKey(), targetProcessDefinition.getKey());
   }
 
+  @Test
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_ACTIVITY)
+  public void testMigrateHistoryProcessInstanceState() {
+    //given
+    HistoricProcessInstanceQuery sourceHistoryProcessInstanceQuery =
+        historyService.createHistoricProcessInstanceQuery()
+          .processDefinitionId(sourceProcessDefinition.getId());
+    HistoricProcessInstanceQuery targetHistoryProcessInstanceQuery =
+        historyService.createHistoricProcessInstanceQuery()
+          .processDefinitionId(targetProcessDefinition.getId());
+
+    HistoricProcessInstance historicProcessInstanceBeforeMigration = sourceHistoryProcessInstanceQuery.singleResult();
+    assertEquals(historicProcessInstanceBeforeMigration.getState(), HistoricProcessInstance.STATE_ACTIVE);
+
+    //when
+    ProcessInstanceQuery sourceProcessInstanceQuery = runtimeService.createProcessInstanceQuery().processDefinitionId(sourceProcessDefinition.getId());
+    runtimeService.newMigration(migrationPlan)
+      .processInstanceQuery(sourceProcessInstanceQuery)
+      .execute();
+
+    //then
+    HistoricProcessInstance instance = targetHistoryProcessInstanceQuery.singleResult();
+    assertEquals(instance.getState(), historicProcessInstanceBeforeMigration.getState());
+  }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/history/MigrationHistoricProcessInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/history/MigrationHistoricProcessInstanceTest.java
@@ -116,7 +116,7 @@ public class MigrationHistoricProcessInstanceTest {
           .processDefinitionId(targetProcessDefinition.getId());
 
     HistoricProcessInstance historicProcessInstanceBeforeMigration = sourceHistoryProcessInstanceQuery.singleResult();
-    assertEquals(historicProcessInstanceBeforeMigration.getState(), HistoricProcessInstance.STATE_ACTIVE);
+    assertEquals(HistoricProcessInstance.STATE_ACTIVE, historicProcessInstanceBeforeMigration.getState());
 
     //when
     ProcessInstanceQuery sourceProcessInstanceQuery = runtimeService.createProcessInstanceQuery().processDefinitionId(sourceProcessDefinition.getId());
@@ -126,7 +126,7 @@ public class MigrationHistoricProcessInstanceTest {
 
     //then
     HistoricProcessInstance instance = targetHistoryProcessInstanceQuery.singleResult();
-    assertEquals(instance.getState(), historicProcessInstanceBeforeMigration.getState());
+    assertEquals(historicProcessInstanceBeforeMigration.getState(), instance.getState());
   }
 
 }


### PR DESCRIPTION
[![CAM-11380](https://badgen.net/badge/JIRA/CAM-11380/0052CC)](https://app.camunda.com/jira/browse/CAM-11380)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Related to CAM-11380