### PR TITLE
CAM-11412: chore(dmn): add limitation on date transformer

### DIFF
--- a/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/type/DateDataTypeTransformer.java
+++ b/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/type/DateDataTypeTransformer.java
@@ -25,6 +25,7 @@ import org.camunda.bpm.dmn.engine.impl.spi.type.DmnDataTypeTransformer;
 import org.camunda.bpm.engine.variable.Variables;
 import org.camunda.bpm.engine.variable.value.DateValue;
 import org.camunda.bpm.engine.variable.value.TypedValue;
+import org.camunda.feel.syntaxtree.ZonedTime;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -81,6 +82,9 @@ public class DateDataTypeTransformer implements DmnDataTypeTransformer {
       throw unsupportedType(value);
 
     } else if (value instanceof Period) {
+      throw unsupportedType(value);
+
+    } else if (value instanceof ZonedTime) {
       throw unsupportedType(value);
 
     } else {

--- a/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/type/DmnDataTypeTransformerTest.java
+++ b/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/type/DmnDataTypeTransformerTest.java
@@ -24,6 +24,7 @@ import org.camunda.bpm.dmn.engine.impl.spi.type.DmnDataTypeTransformerRegistry;
 import org.camunda.bpm.dmn.engine.test.DmnEngineTest;
 import org.camunda.bpm.engine.variable.Variables;
 import org.camunda.bpm.engine.variable.value.TypedValue;
+import org.camunda.feel.syntaxtree.ZonedTime;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,6 +40,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
+import static com.sun.org.apache.xalan.internal.lib.ExsltDatetime.time;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -293,6 +295,22 @@ public class DmnDataTypeTransformerTest extends DmnEngineTest {
 
     // when
     typeTransformer.transform(localDate);
+  }
+
+  @Test
+  public void shouldThrowExceptionDueToUnsupportedType_ZonedTime() {
+    // given
+    DmnDataTypeTransformer typeTransformer = registry.getTransformer("date");
+
+    ZonedTime zonedTime = ZonedTime.parse("22:22:22@Europe/Berlin");
+
+    // then
+    thrown.expect(DmnEngineException.class);
+    thrown.expectMessage("Unsupported type: 'org.camunda.feel.syntaxtree.ZonedTime' " +
+                           "cannot be converted to 'java.util.Date'");
+
+    // when
+    typeTransformer.transform(zonedTime);
   }
 
   @Test

--- a/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/type/DmnDataTypeTransformerTest.java
+++ b/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/type/DmnDataTypeTransformerTest.java
@@ -40,7 +40,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
-import static com.sun.org.apache.xalan.internal.lib.ExsltDatetime.time;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 


### PR DESCRIPTION
[![CAM-11412](https://badgen.net/badge/JIRA/CAM-11412/0052CC)](https://app.camunda.com/jira/browse/CAM-11412)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

An exception is thrown when there is an attempt to convert a (Scala FEEL) `ZonedTime` data type to `java.util.DateTime`.

Related to CAM-11412