### PR TITLE
CAM-11471: chore(feel): move feel-scala version property

### DIFF
--- a/engine-dmn/pom.xml
+++ b/engine-dmn/pom.xml
@@ -16,7 +16,6 @@
 
   <properties>
     <version.juel>2.2.7</version.juel>
-    <version.feel-scala>1.11.0-SNAPSHOT</version.feel-scala>
     <version.log4j>2.9.0</version.log4j>
   </properties>
 
@@ -85,11 +84,6 @@
           <configuration>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
           </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.scalatest</groupId>
-          <artifactId>scalatest-maven-plugin</artifactId>
-          <version>1.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <version.camunda.template-engines>2.0.0</version.camunda.template-engines>
     <version.camunda.ee.xslt-plugin>1.1.0</version.camunda.ee.xslt-plugin>
     <version.spring-boot>2.2.1.RELEASE</version.spring-boot>
+    <version.feel-scala>1.11.0-SNAPSHOT</version.feel-scala>
   </properties>
 
   <build>


### PR DESCRIPTION
[![CAM-11471](https://badgen.net/badge/JIRA/CAM-11471/0052CC)](https://app.camunda.com/jira/browse/CAM-11471)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* Move the `feel-scala` version property to the root pom of the platform project, so that it is grouped together with other Camunda-maintained side-projects;
* Remove unused `scalatest-maven-plugin` in the DMN root pom's plugin management section.

Related to CAM-11471