### PR TITLE
CAM-11456: Adjust module reference for WildFly 19.x

### DIFF
--- a/distro/wildfly/modules/src/main/modules/org/camunda/bpm/wildfly/camunda-wildfly-subsystem/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/camunda/bpm/wildfly/camunda-wildfly-subsystem/main/module.xml
@@ -28,7 +28,8 @@
     <module name="org.jboss.as.connector" />
     <module name="org.jboss.as.ee" />
     <module name="org.jboss.as.ejb3" />
-    <module name="org.jboss.metadata" />
+    <module name="org.jboss.metadata.common" />
+    <module name="org.jboss.metadata.web" />
     <module name="org.jboss.as.web" />
     <module name="org.jboss.as.web-common" />
     <module name="org.jboss.invocation" />


### PR DESCRIPTION
[![CAM-11456](https://badgen.net/badge/JIRA/CAM-11456/0052CC)](https://app.camunda.com/jira/browse/CAM-11456)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Use sub-modules org.jboss.metadata.common and org.jboss.metadata.web instead of former existing org.jboss.metadata.