### PR TITLE
CAM-8724: fix(engine): timer jobs are executed on time

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/JobManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/JobManager.java
@@ -150,8 +150,8 @@ public class JobManager extends AbstractManager {
       job.setLockOwner(jobExecutor.getLockOwner());
       transactionListener = new ExclusiveJobAddedNotification(job.getId(), jobExecutorContext);
     } else {
-      // schedule job for the next processor and reset Acquisition strategy
-      // notify job executor:
+      // reset Acquisition strategy and notify the JobExecutor that
+      // a new Job is available for execution on future runs
       transactionListener = new MessageAddedNotification(jobExecutor);
     }
     Context.getCommandContext()


### PR DESCRIPTION
[![CAM-8724](https://badgen.net/badge/JIRA/CAM-8724/0052CC)](https://app.camunda.com/jira/browse/CAM-8724)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* Fix bug that executes Timer jobs whose DueDate is earlier than the sum of the Current Time and the JobExecutor wait time.

Related to CAM-8724