### PR TITLE
CAM-11551: feat(open-api): add task attachment endpoints

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/main.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/main.ftl
@@ -40,6 +40,7 @@
     {"name": "Signal"},
     {"name": "Schema Log"},
     {"name": "Task"},
+    {"name": "Task Attachment"},
     {"name": "Task Comment"},
     {"name": "Task Identity Link"},
     {"name": "Version"}

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/task/AttachmentDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/task/AttachmentDto.ftl
@@ -1,0 +1,56 @@
+<@lib.dto extends = "LinkableDto" >
+
+    <@lib.property
+        name = "id"
+        type = "string"
+        desc = "The id of the task attachment." />
+
+    <@lib.property
+        name = "name"
+        type = "string"
+        desc = "The name of the task attachment." />
+
+    <@lib.property
+        name = "description"
+        type = "string"
+        desc = "The description of the task attachment." />
+
+    <@lib.property
+        name = "taskId"
+        type = "string"
+        desc = "The id of the task to which the attachment belongs." />
+
+    <@lib.property
+        name = "type"
+        type = "string"
+        desc = "Indication of the type of content that this attachment refers to.
+                Can be MIME type or any other indication." />
+
+    <@lib.property
+        name = "url"
+        type = "string"
+        desc = "The url to the remote content of the task attachment." />
+
+    <@lib.property
+        name = "createTime"
+        type = "string"
+        format = "date-time"
+        desc = "The time the variable was inserted.
+                [Default format](${docsUrl}/reference/rest/overview/date-format/)
+                `yyyy-MM-dd'T'HH:mm:ss.SSSZ`." />
+
+    <@lib.property
+        name = "removalTime"
+        type = "string"
+        format = "date-time"
+        desc = "The time after which the attachment should be removed by the History Cleanup job.
+                [Default format](${docsUrl}/reference/rest/overview/date-format/)
+                `yyyy-MM-dd'T'HH:mm:ss.SSSZ`." />
+
+    <@lib.property
+        name = "rootProcessInstanceId"
+        type = "string"
+        last = true
+        desc = "The process instance id of the root process instance that initiated the process containing the task." />
+
+</@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/task/MultiFormAttachmentDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/task/MultiFormAttachmentDto.ftl
@@ -1,0 +1,30 @@
+<@lib.dto>
+
+    <@lib.property
+        name = "attachment-name"
+        type = "string"
+        desc = "The name of the attachment." />
+
+    <@lib.property
+        name = "attachment-description"
+        type = "string"
+        desc = "The description of the attachment." />
+
+    <@lib.property
+        name = "attachment-type"
+        type = "string"
+        desc = "The type of the attachment." />
+
+    <@lib.property
+        name = "url"
+        type = "string"
+        desc = "The url to the remote content of the attachment." />
+
+    <@lib.property
+        name = "content"
+        type = "string"
+        format = "binary"
+        last = true
+        desc = "The content of the attachment." />
+
+</@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/create/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/create/post.ftl
@@ -2,7 +2,7 @@
 
   <@lib.endpointInfo
       id = "addAttachment"
-      tag = "Attachment"
+      tag = "Task Attachment"
       desc = "Creates an attachment for a task." />
 
   "parameters" : [

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/create/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/create/post.ftl
@@ -1,0 +1,87 @@
+{
+
+  <@lib.endpointInfo
+      id = "addAttachment"
+      tag = "Attachment"
+      desc = "Creates an attachment for a task." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the task to add the attachment to."/>
+
+  ],
+
+  <@lib.requestBody
+      mediaType = "multipart/form-data"
+      dto = "MultiFormAttachmentDto"
+      examples = ['"example-1": {
+                     "summary": "POST /task/aTaskId/attachment/create",
+                     "description": "Post data for a new task attachment.",
+                     "value": "------------------------------925df49a954b
+                        Content-Disposition: form-data; name=\\"url\\"
+
+                        http://my-attachment-content-url.de
+                        ------------------------------925df49a954b
+                        Content-Disposition: form-data; name=\\"attachment-name\\"
+
+                        attachmentName
+                        ------------------------------925df49a954b
+                        Content-Disposition: form-data; name=\\"attachment-description\\"
+
+                        attachmentDescription
+                        ------------------------------925df49a954b
+                        Content-Disposition: form-data; name=\\"attachment-type\\"
+
+                        attachmentType
+                        ------------------------------925df49a954b--"
+                   }'] />
+
+  "responses" : {
+
+    <@lib.response
+        code = "200"
+        dto = "AttachmentDto"
+        desc = "Request successful."
+        examples = ['"example-1": {
+                 "summary": "Status 200 Response",
+                 "value": {
+                   "id": "attachmentId",
+                   "name": "attachmentName",
+                   "taskId": "aTaskId",
+                   "description": "attachmentDescription",
+                   "type": "attachmentType",
+                   "url": "http://my-attachment-content-url.de",
+                   "createTime":"2017-02-10T14:33:19.000+0200",
+                   "removalTime":"2018-02-10T14:33:19.000+0200",
+                   "rootProcessInstanceId": "aRootProcessInstanceId",
+                   "links": [
+                     {
+                       "method": "GET",
+                       "href": "http://localhost:38080/rest-test/task/aTaskId/attachment/aTaskAttachmentId",
+                       "rel": "self"
+                     }
+                   ]
+                 }
+               }'] />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "The task does not exists or task id is null. No content or url to remote content exists. See the
+                [Introduction](/reference/rest/overview/#error-handling) for the error response format." />
+
+    <@lib.response
+        code = "403"
+        dto = "ExceptionDto"
+        last = true
+        desc = "The history of the engine is disabled. See the [Introduction](/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+  }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/get.ftl
@@ -2,7 +2,7 @@
 
   <@lib.endpointInfo
       id = "getAttachments"
-      tag = "Attachment"
+      tag = "Task Attachment"
       desc = "Gets the attachments for a task." />
 
   "parameters" : [

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/get.ftl
@@ -1,0 +1,74 @@
+{
+
+  <@lib.endpointInfo
+      id = "getAttachments"
+      tag = "Attachment"
+      desc = "Gets the attachments for a task." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the task to retrieve the attachments for." />
+
+  ],
+
+  "responses" : {
+
+    <@lib.response
+        code = "200"
+        dto = "AttachmentDto"
+        array = true
+        desc = "Request successful."
+        examples = ['"example-1": {
+                       "summary": "GET /task/aTaskId/attachment",
+                       "value": [
+                         {
+                           "id": "attachmentId",
+                           "name": "attachmentName",
+                           "taskId": "aTaskId",
+                           "description": "attachmentDescription",
+                           "type": "attachmentType",
+                           "url": "http://my-attachment-content-url.de",
+                           "createTime": "2017-02-10T14:33:19.000+0200",
+                           "removalTime": "2018-02-10T14:33:19.000+0200",
+                           "rootProcessInstanceId": "aRootProcessInstanceId"
+                         },
+                         {
+                           "id": "anotherAttachmentId",
+                           "name": "anotherAttachmentName",
+                           "taskId": "aTaskId",
+                           "description": "anotherAttachmentDescription",
+                           "type": "anotherAttachmentType",
+                           "url": "http://my-another-attachment-content-url.de",
+                           "createTime": "2017-02-10T14:33:19.000+0200",
+                           "removalTime": "2018-02-10T14:33:19.000+0200",
+                           "rootProcessInstanceId": "aRootProcessInstanceId"
+                         },
+                         {
+                           "id": "yetAnotherAttachmentId",
+                           "name": "yetAnotherAttachmentName",
+                           "taskId": "aTaskId",
+                           "description": "yetAnotherAttachmentDescription",
+                           "type": "yetAnotherAttachmentType",
+                           "url": "http://yet-another-attachment-content-url.de",
+                           "createTime": "2017-02-10T14:33:19.000+0200",
+                           "removalTime": "2018-02-10T14:33:19.000+0200",
+                           "rootProcessInstanceId": "aRootProcessInstanceId"
+                         }
+                       ]
+                     }'] />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        last = true
+        desc = "No task exists for the given task id. See the [Introduction](/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+  }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/{attachmentId}/data/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/{attachmentId}/data/get.ftl
@@ -2,7 +2,7 @@
 
   <@lib.endpointInfo
       id = "getAttachmentData"
-      tag = "Attachment"
+      tag = "Task Attachment"
       desc = "Retrieves the binary content of a task attachment by task id and attachment id." />
 
   "parameters" : [
@@ -31,11 +31,15 @@
       "content": {
         "application/octet-stream": {
           "schema": {
+            "type": "string",
+            "format": "binary",
             "description": "For files without any MIME type information, a byte stream is returned."
           }
         },
         "text/plain": {
           "schema": {
+            "type": "string",
+            "format": "binary",
             "description": "Files with MIME type information are returned as the saved type. Additionally, for file
                             responses, the Content-Disposition header will be set."
           }

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/{attachmentId}/data/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/{attachmentId}/data/get.ftl
@@ -1,0 +1,56 @@
+{
+
+  <@lib.endpointInfo
+      id = "getAttachmentData"
+      tag = "Attachment"
+      desc = "Retrieves the binary content of a task attachment by task id and attachment id." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        desc = "The id of the task." />
+
+    <@lib.parameter
+        name = "attachmentId"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the attachment to be retrieved." />
+
+  ],
+
+  "responses" : {
+
+    "200": {
+      "description": "Request successful.",
+      "content": {
+        "application/octet-stream": {
+          "schema": {
+            "description": "For files without any MIME type information, a byte stream is returned."
+          }
+        },
+        "text/plain": {
+          "schema": {
+            "description": "Files with MIME type information are returned as the saved type. Additionally, for file
+                            responses, the Content-Disposition header will be set."
+          }
+        }
+      }
+    },
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        last = true
+        desc = "The attachment content for the given task id and attachment id does not exist, or the history of the
+                engine is disabled.
+
+                See the [Introduction](/reference/rest/overview/#error-handling) for the error response format." />
+
+  }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/{attachmentId}/delete.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/{attachmentId}/delete.ftl
@@ -1,0 +1,48 @@
+{
+
+  <@lib.endpointInfo
+      id = "deleteAttachment"
+      tag = "Attachment"
+      desc = "Removes an attachment from a task by id." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        desc = "The id of the task." />
+
+    <@lib.parameter
+        name = "attachmentId"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the attachment to be removed." />
+
+  ],
+
+  "responses" : {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful." />
+
+    <@lib.response
+        code = "403"
+        dto = "ExceptionDto"
+        desc = "The history of the engine is disabled. See the [Introduction](/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        last = true
+        desc = "A Task Attachment for the given task id and attachment id does not exist. See the
+                [Introduction](/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+  }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/{attachmentId}/delete.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/{attachmentId}/delete.ftl
@@ -2,7 +2,7 @@
 
   <@lib.endpointInfo
       id = "deleteAttachment"
-      tag = "Attachment"
+      tag = "Task Attachment"
       desc = "Removes an attachment from a task by id." />
 
   "parameters" : [

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/{attachmentId}/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/{attachmentId}/get.ftl
@@ -2,7 +2,7 @@
 
   <@lib.endpointInfo
       id = "getAttachment"
-      tag = "Attachment"
+      tag = "Task Attachment"
       desc = "Retrieves a task attachment by task id and attachment id." />
 
   "parameters" : [

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/{attachmentId}/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/attachment/{attachmentId}/get.ftl
@@ -1,0 +1,64 @@
+{
+
+  <@lib.endpointInfo
+      id = "getAttachment"
+      tag = "Attachment"
+      desc = "Retrieves a task attachment by task id and attachment id." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        desc = "The id of the task." />
+
+    <@lib.parameter
+        name = "attachmentId"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the attachment to be retrieved." />
+  ],
+
+  "responses" : {
+
+    <@lib.response
+        code = "200"
+        dto = "AttachmentDto"
+        desc = "Request successful."
+        examples = ['"example-1": {
+                       "summary": "GET /task/aTaskId/attachment/aTaskAttachmentId",
+                       "value": {
+                         "id": "attachmentId",
+                         "name": "attachmentName",
+                         "taskId": "aTaskId",
+                         "description": "attachmentDescription",
+                         "type": "attachmentType",
+                         "url": "http://my-attachment-content-url.de",
+                         "createTime": "2017-02-10T14:33:19.000+0200",
+                         "removalTime": "2018-02-10T14:33:19.000+0200",
+                         "rootProcessInstanceId": "aRootProcessInstanceId",
+                         "links": [
+                           {
+                             "method": "GET",
+                             "href": "http://localhost:38080/rest-test/task/aTaskId/attachment/aTaskAttachmentId",
+                             "rel": "self"
+                           }
+                         ]
+                       }
+                     }'] />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        last = true
+        desc = "The attachment for the given task and attachment id does not exist or the history of the engine is
+                disabled.
+
+                See the [Introduction](/reference/rest/overview/#error-handling) for the error response format." />
+
+  }
+}


### PR DESCRIPTION
[![CAM-11551](https://badgen.net/badge/JIRA/CAM-11551/0052CC)](https://app.camunda.com/jira/browse/CAM-11551)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Related to CAM-11551

**Note**: 
1. The GET `/task/attachment/get-task-attachment-data/` produces a `byte stream`. Some feedback, if things were done correctly, would be great.
2. The POST `/task/{id}/attachment/create` endpoint should accept a `binary` parameter called `content`. This is not the case in the docs. It would be good if we can discuss what is the correct approach here.