### PR TITLE
CAM-11665: make integration tests run on Unix systems

### DIFF
--- a/distro/run/assembly/resources/start.sh
+++ b/distro/run/assembly/resources/start.sh
@@ -21,7 +21,7 @@ webappsPath=$BASEDIR/internal/webapps/
 restPath=$BASEDIR/internal/rest/
 classPath=$BASEDIR/configuration/userlib/,$BASEDIR/configuration/keystore/
 optionalComponentChosen=false
-configuration=$BASEDIR/configuration/application.yml
+configuration=$BASEDIR/configuration/default.yml
 
 
 # inspect arguments

--- a/distro/run/core/src/main/java/org/camunda/bpm/run/CamundaBpmRunConfiguration.java
+++ b/distro/run/core/src/main/java/org/camunda/bpm/run/CamundaBpmRunConfiguration.java
@@ -18,29 +18,19 @@ package org.camunda.bpm.run;
 
 import java.util.List;
 
-import javax.servlet.Filter;
-import javax.servlet.ServletException;
-
-import org.apache.catalina.filters.CorsFilter;
 import org.camunda.bpm.engine.impl.cfg.CompositeProcessEnginePlugin;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.cfg.ProcessEnginePlugin;
-import org.camunda.bpm.engine.rest.security.auth.ProcessEngineAuthenticationFilter;
 import org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration;
 import org.camunda.bpm.identity.impl.ldap.plugin.LdapIdentityProviderPlugin;
-import org.camunda.bpm.run.property.CamundaBpmRunAuthenticationProperties;
-import org.camunda.bpm.run.property.CamundaBpmRunCorsProperty;
 import org.camunda.bpm.run.property.CamundaBpmRunLdapProperties;
 import org.camunda.bpm.run.property.CamundaBpmRunProperties;
 import org.camunda.bpm.spring.boot.starter.CamundaBpmAutoConfiguration;
 import org.camunda.bpm.spring.boot.starter.configuration.CamundaDeploymentConfiguration;
-import org.camunda.bpm.spring.boot.starter.rest.CamundaBpmRestInitializer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -51,35 +41,6 @@ public class CamundaBpmRunConfiguration {
 
   @Autowired
   CamundaBpmRunProperties camundaBpmRunProperties;
-
-  @Bean
-  @ConditionalOnClass(CamundaBpmRestInitializer.class)
-  @ConditionalOnProperty(name = "enabled", havingValue = "true", prefix = CamundaBpmRunAuthenticationProperties.PREFIX)
-  public FilterRegistrationBean<Filter> processEngineAuthenticationFilter() {
-    FilterRegistrationBean<Filter> registration = new FilterRegistrationBean<>();
-    registration.setName("camunda-auth");
-    registration.setFilter(new ProcessEngineAuthenticationFilter());
-    registration.addUrlPatterns("/rest/*");
-
-    // if nothing is set, use Http Basic authentication
-    CamundaBpmRunAuthenticationProperties properties = camundaBpmRunProperties.getAuth();
-    if (properties.getAuthentication() == null || CamundaBpmRunAuthenticationProperties.DEFAULT_AUTH.equals(properties.getAuthentication())) {
-      registration.addInitParameter("authentication-provider", "org.camunda.bpm.engine.rest.security.auth.impl.HttpBasicAuthenticationProvider");
-    }
-    return registration;
-  }
-
-  @Bean
-  @ConditionalOnProperty(name = "enabled", havingValue = "true", prefix = CamundaBpmRunCorsProperty.PREFIX)
-  public FilterRegistrationBean<Filter> corsFilter() throws ServletException {
-    FilterRegistrationBean<Filter> registration = new FilterRegistrationBean<>();
-    registration.setName("camunda-cors");
-    CorsFilter corsFilter = new CorsFilter();
-    registration.setFilter(corsFilter);
-    registration.addUrlPatterns("/rest/*");
-    registration.addInitParameter(CorsFilter.PARAM_CORS_ALLOWED_ORIGINS, camundaBpmRunProperties.getCors().getAllowedOrigins());
-    return registration;
-  }
 
   @Bean
   @ConditionalOnProperty(name = "enabled", havingValue = "true", prefix = CamundaBpmRunLdapProperties.PREFIX)

--- a/distro/run/core/src/main/java/org/camunda/bpm/run/CamundaBpmRunRestConfiguration.java
+++ b/distro/run/core/src/main/java/org/camunda/bpm/run/CamundaBpmRunRestConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.run;
+
+import javax.servlet.Filter;
+import javax.servlet.ServletException;
+
+import org.apache.catalina.filters.CorsFilter;
+import org.camunda.bpm.engine.rest.security.auth.ProcessEngineAuthenticationFilter;
+import org.camunda.bpm.run.property.CamundaBpmRunAuthenticationProperties;
+import org.camunda.bpm.run.property.CamundaBpmRunCorsProperty;
+import org.camunda.bpm.run.property.CamundaBpmRunProperties;
+import org.camunda.bpm.spring.boot.starter.CamundaBpmAutoConfiguration;
+import org.camunda.bpm.spring.boot.starter.rest.CamundaBpmRestInitializer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@EnableConfigurationProperties(CamundaBpmRunProperties.class)
+@Configuration
+@AutoConfigureAfter({ CamundaBpmAutoConfiguration.class })
+@ConditionalOnClass(CamundaBpmRestInitializer.class)
+public class CamundaBpmRunRestConfiguration {
+
+  @Autowired
+  CamundaBpmRunProperties camundaBpmRunProperties;
+
+  @Bean
+  @ConditionalOnProperty(name = "enabled", havingValue = "true", prefix = CamundaBpmRunAuthenticationProperties.PREFIX)
+  public FilterRegistrationBean<Filter> processEngineAuthenticationFilter() {
+    FilterRegistrationBean<Filter> registration = new FilterRegistrationBean<>();
+    registration.setName("camunda-auth");
+    registration.setFilter(new ProcessEngineAuthenticationFilter());
+    registration.addUrlPatterns("/rest/*");
+
+    // if nothing is set, use Http Basic authentication
+    CamundaBpmRunAuthenticationProperties properties = camundaBpmRunProperties.getAuth();
+    if (properties.getAuthentication() == null || CamundaBpmRunAuthenticationProperties.DEFAULT_AUTH.equals(properties.getAuthentication())) {
+      registration.addInitParameter("authentication-provider", "org.camunda.bpm.engine.rest.security.auth.impl.HttpBasicAuthenticationProvider");
+    }
+    return registration;
+  }
+
+  @Bean
+  @ConditionalOnProperty(name = "enabled", havingValue = "true", prefix = CamundaBpmRunCorsProperty.PREFIX)
+  public FilterRegistrationBean<Filter> corsFilter() throws ServletException {
+    FilterRegistrationBean<Filter> registration = new FilterRegistrationBean<>();
+    registration.setName("camunda-cors");
+    CorsFilter corsFilter = new CorsFilter();
+    registration.setFilter(corsFilter);
+    registration.addUrlPatterns("/rest/*");
+    registration.addInitParameter(CorsFilter.PARAM_CORS_ALLOWED_ORIGINS, camundaBpmRunProperties.getCors().getAllowedOrigins());
+    return registration;
+  }
+
+}

--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -20,6 +20,11 @@
   <description>This is the root of Camunda BPM Run</description>
   <packaging>pom</packaging>
 
+  <properties>
+    <!-- keep compatible version to camunda-parent until we can directly inherit from it -->
+    <version.assertj>2.9.1</version.assertj>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
 
@@ -37,6 +42,12 @@
         <version>${project.version}</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${version.assertj}</version>
       </dependency>
 
     </dependencies>

--- a/distro/run/qa/integration-tests/pom.xml
+++ b/distro/run/qa/integration-tests/pom.xml
@@ -24,6 +24,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/AutoDeploymentIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/AutoDeploymentIT.java
@@ -17,9 +17,8 @@
 package org.camunda.bpm.run.qa;
 
 import static io.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -132,7 +131,7 @@ public class AutoDeploymentIT {
     List<String> resourceNames = extractResourceNames(resourcesResponse);
 
     // then
-    assertThat(resourceNames, contains("/form.html", "/script.js"));
+    assertThat(resourceNames).contains("/form.html", "/script.js");
   }
 
   @Test

--- a/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/ComponentAvailabilityIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/ComponentAvailabilityIT.java
@@ -18,11 +18,8 @@ package org.camunda.bpm.run.qa;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
 import static io.restassured.RestAssured.*;
 
-import java.io.File;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -43,8 +40,6 @@ import io.restassured.response.Response;
 @RunWith(Parameterized.class)
 public class ComponentAvailabilityIT {
 
-  private static final String RUN_HOME_VARIABLE = "camunda.run.home";
-  
   @Parameter(0)
   public String[] commands;
   @Parameter(1)
@@ -66,14 +61,7 @@ public class ComponentAvailabilityIT {
 
   @BeforeParam
   public static void runStartScript(String[] commands, boolean restAvailable, boolean webappsAvailable) {
-    String runHomeDirectory = System.getProperty(RUN_HOME_VARIABLE);
-    if (runHomeDirectory == null || runHomeDirectory.isEmpty()) {
-      throw new RuntimeException("System property " + RUN_HOME_VARIABLE + " not set. This property must point "
-          + "to the root directory of the run distribution to test.");
-    }
-    
-    File file = new File(runHomeDirectory);
-    container = new SpringBootManagedContainer(file.getAbsolutePath(), commands);
+    container = new SpringBootManagedContainer(commands);
     try {
       container.start();
     } catch (Exception e) {

--- a/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/ComponentAvailabilityIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/ComponentAvailabilityIT.java
@@ -43,6 +43,8 @@ import io.restassured.response.Response;
 @RunWith(Parameterized.class)
 public class ComponentAvailabilityIT {
 
+  private static final String RUN_HOME_VARIABLE = "camunda.run.home";
+  
   @Parameter(0)
   public String[] commands;
   @Parameter(1)
@@ -64,9 +66,13 @@ public class ComponentAvailabilityIT {
 
   @BeforeParam
   public static void runStartScript(String[] commands, boolean restAvailable, boolean webappsAvailable) {
-    URL distroBase = ComponentAvailabilityIT.class.getClassLoader().getResource("camunda-bpm-run-distro");
-    assertNotNull(distroBase);
-    File file = new File(distroBase.getFile());
+    String runHomeDirectory = System.getProperty(RUN_HOME_VARIABLE);
+    if (runHomeDirectory == null || runHomeDirectory.isEmpty()) {
+      throw new RuntimeException("System property " + RUN_HOME_VARIABLE + " not set. This property must point "
+          + "to the root directory of the run distribution to test.");
+    }
+    
+    File file = new File(runHomeDirectory);
     container = new SpringBootManagedContainer(file.getAbsolutePath(), commands);
     try {
       container.start();

--- a/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/ProductionConfigurationIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/ProductionConfigurationIT.java
@@ -18,12 +18,7 @@ package org.camunda.bpm.run.qa;
 
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
-
-import java.io.File;
 import java.io.IOException;
-import java.net.URL;
-
 import javax.ws.rs.core.Response.Status;
 
 import org.camunda.bpm.run.qa.util.SpringBootManagedContainer;
@@ -35,7 +30,6 @@ import io.restassured.response.Response;
 
 public class ProductionConfigurationIT {
 
-  static URL distroBase = ProductionConfigurationIT.class.getClassLoader().getResource("camunda-bpm-run-distro");
   static SpringBootManagedContainer container;
 
   @After
@@ -53,10 +47,7 @@ public class ProductionConfigurationIT {
 
   @Before
   public void runStartScript() throws IOException {
-    assertNotNull(distroBase);
-
-    File file = new File(distroBase.getFile());
-    container = new SpringBootManagedContainer(file.getAbsolutePath(), "--production");
+    container = new SpringBootManagedContainer("--production");
 
     container.createConfigurationYml("configuration/production.yml",
         ProductionConfigurationIT.class.getClassLoader().getResourceAsStream("ProductionConfigurationIntegrationTest_production.yml"));

--- a/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/SqlAvailabilityIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/SqlAvailabilityIT.java
@@ -23,13 +23,14 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.camunda.bpm.run.qa.util.SpringBootManagedContainer;
 import org.junit.Test;
 
 public class SqlAvailabilityIT {
 
   @Test
   public void shouldFindSqlResources() throws URISyntaxException {
-    Path sqlDir = Paths.get(SqlAvailabilityIT.class.getClassLoader().getResource("camunda-bpm-run-distro/configuration/sql/").toURI());
+    Path sqlDir = Paths.get(SpringBootManagedContainer.getRunHome(), "configuration", "sql");
 
     Path createDir = sqlDir.resolve("create");
     Path dropDir = sqlDir.resolve("drop");

--- a/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/util/SpringBootManagedContainer.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/util/SpringBootManagedContainer.java
@@ -46,10 +46,13 @@ import com.sun.jna.platform.win32.WinNT;
  */
 public class SpringBootManagedContainer {
 
-  private static final String BASE_TEST_APPLICATION_YML = "base-test-application.yml";
-  private static final String APPLICATION_YML_PATH = "configuration/default.yml";
-  private static final String RESOURCES_PATH = "configuration/resources";
-  private static final String RUN_HOME_VARIABLE = "camunda.run.home";
+  protected static final String BASE_TEST_APPLICATION_YML = "base-test-application.yml";
+  protected static final String APPLICATION_YML_PATH = "configuration/default.yml";
+  protected static final String RESOURCES_PATH = "configuration/resources";
+  protected static final String RUN_HOME_VARIABLE = "camunda.run.home";
+
+  protected static final long RAMP_UP_SECONDS = 40;
+  protected static final long RAMP_DOWN_SECONDS = 10;
 
   protected static final Logger log = LoggerFactory.getLogger(SpringBootManagedContainer.class.getName());
 
@@ -60,7 +63,7 @@ public class SpringBootManagedContainer {
   protected Thread shutdownThread;
   protected Process startupProcess;
 
-  private List<File> configurationFiles = new ArrayList<>();
+  protected List<File> configurationFiles = new ArrayList<>();
 
   public SpringBootManagedContainer(String... commands) {
     this.baseDirectory = getRunHome();
@@ -111,22 +114,11 @@ public class SpringBootManagedContainer {
       });
       Runtime.getRuntime().addShutdownHook(shutdownThread);
 
-      final long startupTimeoutSeconds = 20;
-      long timeout = startupTimeoutSeconds * 1000;
-      boolean serverAvailable = false;
-      while (timeout > 0 && serverAvailable == false) {
-        serverAvailable = isRunning();
-        if (!serverAvailable) {
-          Thread.sleep(100);
-          timeout -= 100;
-        }
-      }
-      if (!serverAvailable) {
+      if (!isStarted(RAMP_UP_SECONDS * 1000)) {
         killProcess(startupProcess, false);
-        throw new TimeoutException(String.format("Managed Spring Boot application was not started within [%d] s", startupTimeoutSeconds));
+        throw new TimeoutException(String.format("Managed Spring Boot application was not started within [%d] s", RAMP_UP_SECONDS));
       }
     } catch (final Exception ex) {
-
       throw new RuntimeException("Could not start managed Spring Boot application!", ex);
     }
   }
@@ -141,8 +133,7 @@ public class SpringBootManagedContainer {
       if (startupProcess != null) {
         if (isRunning()) {
           killProcess(startupProcess, false);
-          Thread.sleep(4000L);// let the application shut down
-          if (isRunning()) {
+          if (!isShutDown(RAMP_DOWN_SECONDS * 1000)) {
             throw new RuntimeException("Could not kill the application.");
           }
         }
@@ -166,6 +157,26 @@ public class SpringBootManagedContainer {
   // ---------------------------
   // determine server status
   // ---------------------------
+
+  protected boolean isStarted(long millisToWait) throws InterruptedException {
+    return waitForServerStatus(millisToWait, true);
+  }
+
+  protected boolean isShutDown(long millisToWait) throws InterruptedException {
+    return waitForServerStatus(millisToWait, false);
+  }
+
+  protected boolean waitForServerStatus(long millisToWait, boolean shouldBeRunning) throws InterruptedException {
+    boolean serverAvailable = !shouldBeRunning;
+    while (millisToWait > 0 && serverAvailable == !shouldBeRunning) {
+      serverAvailable = isRunning();
+      if (shouldBeRunning ^ serverAvailable) {
+        Thread.sleep(100);
+        millisToWait -= 100;
+      }
+    }
+    return serverAvailable == shouldBeRunning;
+  }
 
   protected boolean isRunning() {
     try {

--- a/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/util/SpringBootManagedContainer.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/util/SpringBootManagedContainer.java
@@ -141,6 +141,7 @@ public class SpringBootManagedContainer {
       if (startupProcess != null) {
         if (isRunning()) {
           killProcess(startupProcess, false);
+          Thread.sleep(4000L);// let the application shut down
           if (isRunning()) {
             throw new RuntimeException("Could not kill the application.");
           }

--- a/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/util/SpringBootManagedContainer.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/util/SpringBootManagedContainer.java
@@ -216,6 +216,9 @@ public class SpringBootManagedContainer {
     try {
       Process p = null;
       Integer pid = null;
+      
+      // must kill a hierachy of processes: the script process (which corresponds to the pid value) 
+      // and the Java process it has spawned
       if (isUnixLike()) {
         pid = unixLikeProcessId(process);
         p = new ProcessBuilder("pkill", "-TERM", "-P", String.valueOf(pid)).start();

--- a/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/util/SpringBootManagedContainer.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/util/SpringBootManagedContainer.java
@@ -51,7 +51,7 @@ public class SpringBootManagedContainer {
   protected static final String RESOURCES_PATH = "configuration/resources";
   protected static final String RUN_HOME_VARIABLE = "camunda.run.home";
 
-  protected static final long RAMP_UP_SECONDS = 40;
+  protected static final long RAMP_UP_SECONDS = 20;
   protected static final long RAMP_DOWN_SECONDS = 10;
 
   protected static final Logger log = LoggerFactory.getLogger(SpringBootManagedContainer.class.getName());
@@ -168,11 +168,11 @@ public class SpringBootManagedContainer {
 
   protected boolean waitForServerStatus(long millisToWait, boolean shouldBeRunning) throws InterruptedException {
     boolean serverAvailable = !shouldBeRunning;
-    while (millisToWait > 0 && serverAvailable == !shouldBeRunning) {
+    long targetTime = System.currentTimeMillis() + millisToWait;
+    while (System.currentTimeMillis() < targetTime && serverAvailable == !shouldBeRunning) {
       serverAvailable = isRunning();
       if (shouldBeRunning ^ serverAvailable) {
         Thread.sleep(100);
-        millisToWait -= 100;
       }
     }
     return serverAvailable == shouldBeRunning;

--- a/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/util/SpringBootManagedContainer.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/util/SpringBootManagedContainer.java
@@ -139,7 +139,7 @@ public class SpringBootManagedContainer {
     }
     try {
       if (startupProcess != null) {
-        if (!gracefullyTerminateProcess(startupProcess) || isRunning()) {
+        if (/*!gracefullyTerminateProcess(startupProcess) ||*/ isRunning()) {
           if (!killProcess(startupProcess, false)) {
             throw new RuntimeException("Could not kill the application.");
           }

--- a/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/util/SpringBootManagedContainer.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/util/SpringBootManagedContainer.java
@@ -51,8 +51,8 @@ public class SpringBootManagedContainer {
   protected static final String RESOURCES_PATH = "configuration/resources";
   protected static final String RUN_HOME_VARIABLE = "camunda.run.home";
 
-  protected static final long RAMP_UP_SECONDS = 20;
-  protected static final long RAMP_DOWN_SECONDS = 10;
+  protected static final long RAMP_UP_SECONDS = 40;
+  protected static final long RAMP_DOWN_SECONDS = 20;
 
   protected static final Logger log = LoggerFactory.getLogger(SpringBootManagedContainer.class.getName());
 

--- a/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/webapps/LoginIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/webapps/LoginIT.java
@@ -31,14 +31,11 @@ import org.junit.runners.Parameterized.Parameters;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.junit.Assert.assertNotNull;
 import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated;
 import static org.openqa.selenium.support.ui.ExpectedConditions.textToBePresentInElementLocated;
 
@@ -75,10 +72,7 @@ public class LoginIT extends AbstractWebappUiIT {
 
   @BeforeParam
   public static void runStartScript(String[] commands) {
-    URL distroBase = LoginIT.class.getClassLoader().getResource("camunda-bpm-run-distro");
-    assertNotNull(distroBase);
-    File file = new File(distroBase.getFile());
-    container = new SpringBootManagedContainer(file.getAbsolutePath(), commands);
+    container = new SpringBootManagedContainer(commands);
     try {
       container.start();
     } catch (Exception e) {

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -135,10 +135,6 @@
               <dependenciesToScan>
                 <dependenciesToScan>org.camunda.bpm.run:camunda-bpm-run-qa-integration-tests</dependenciesToScan>
               </dependenciesToScan>
-              <excludes>
-                <!-- https://jira.camunda.com/browse/CAM-11480 -->
-                <exclude>**/AutoDeploymentIT.java</exclude>
-              </excludes>
               <systemPropertyVariables>
                 <camunda.run.home>${run-home}</camunda.run.home>
               </systemPropertyVariables>

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -44,6 +44,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -14,6 +14,10 @@
   <artifactId>camunda-bpm-run-qa-runtime</artifactId>
   <name>Camunda BPM - Run - QA - Runtime</name>
   <packaging>jar</packaging>
+  
+  <properties>
+    <run-home>${project.build.directory}/run/camunda-bpm-run-distro</run-home>
+  </properties>
 
   <dependencies>
 
@@ -121,14 +125,6 @@
     <profile>
       <id>integration-test-camunda-run</id>
       <build>
-        <testResources>
-          <testResource>
-            <directory>${project.basedir}/src/test/resources</directory>
-          </testResource>
-          <testResource>
-            <directory>${project.build.directory}/test-resources</directory>
-          </testResource>
-        </testResources>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -143,6 +139,9 @@
                 <!-- https://jira.camunda.com/browse/CAM-11480 -->
                 <exclude>**/AutoDeploymentIT.java</exclude>
               </excludes>
+              <systemPropertyVariables>
+                <camunda.run.home>${run-home}</camunda.run.home>
+              </systemPropertyVariables>
             </configuration>
             <executions>
               <execution>
@@ -167,7 +166,7 @@
                   <includeArtifactIds>camunda-bpm-run</includeArtifactIds>
                   <overWriteSnapshots>true</overWriteSnapshots>
                   <excludeTransitive>true</excludeTransitive>
-                  <outputDirectory>${project.build.directory}/test-resources/camunda-bpm-run-distro</outputDirectory>
+                  <outputDirectory>${run-home}</outputDirectory>
                   <excludes>configuration/default.yml,configuration/production.yml</excludes>
                 </configuration>
               </execution>


### PR DESCRIPTION
[![CAM-11665](https://badgen.net/badge/JIRA/CAM-11665/0052CC)](https://app.camunda.com/jira/browse/CAM-11665)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- avoids copying the unpacked run distribution into the test classpath
  via the maven resources plugin
- copying lost the file permissions for the startup scripts,
  so the integration tests failed

related to CAM-11665