### PR TITLE
CAM-11709: feat(rest): add external task operation openapi endpoints

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/PriorityDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/PriorityDto.ftl
@@ -1,0 +1,10 @@
+<@lib.dto>
+
+  <@lib.property
+      name = "priority"
+      type = "integer"
+      format = "int64"
+      last = true
+      desc = "The priority of the resource." />
+
+</@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/RetriesDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/RetriesDto.ftl
@@ -1,0 +1,13 @@
+<@lib.dto>
+
+  <@lib.property
+      name = "retries"
+      type = "integer"
+      format = "int32"
+      last = true
+      desc = "The number of retries to set for the resource.  Must be >= 0. If this is 0, an incident is created
+              and the task, or job, cannot be fetched, or acquired anymore unless the retries are increased again.
+              Can not be null." />
+
+
+</@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/CompleteExternalTaskDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/CompleteExternalTaskDto.ftl
@@ -1,0 +1,23 @@
+<@lib.dto>
+
+  <@lib.property
+      name = "workerId"
+      type = "string"
+      desc = "The id of the worker that completes the task. Must match the id of the worker who has most recently locked the task." />
+
+  <@lib.property
+      name = "variables"
+      type = "object"
+      additionalProperties = true
+      dto = "VariableValueDto"
+      desc = "A JSON object containing variable key-value pairs. Each key is a variable name and each value a JSON variable value object with the following properties:" />
+
+  <@lib.property
+      name = "localVariables"
+      type = "object"
+      additionalProperties = true
+      last = true
+      dto = "VariableValueDto"
+      desc = "A JSON object containing local variable key-value pairs. Local variables are set only in the scope of external task. Each key is a variable name and each value a JSON variable value object with the following properties:" />
+
+</@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/ExtendLockOnExternalTaskDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/ExtendLockOnExternalTaskDto.ftl
@@ -1,0 +1,15 @@
+<@lib.dto>
+
+  <@lib.property
+      name = "workerId"
+      type = "string"
+      desc = "The ID of a worker who is locking the external task." />
+
+  <@lib.property
+      name = "newDuration"
+      type = "integer"
+      format = "int64"
+      last = true
+      desc = "An amount of time (in milliseconds). This is the new lock duration starting from the current moment." />
+
+</@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/ExternalTaskBpmnError.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/ExternalTaskBpmnError.ftl
@@ -1,0 +1,11 @@
+<@lib.dto
+    extends = "TaskBpmnErrorDto" >
+
+  <@lib.property
+      name = "workerId"
+      type = "string"
+      last = true
+      desc = "The id of the worker that reports the failure. Must match the id of the worker who has most recently
+              locked the task." />
+
+</@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/ExternalTaskFailureDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/ExternalTaskFailureDto.ftl
@@ -1,0 +1,34 @@
+<@lib.dto>
+
+  <@lib.property
+    name = "workerId"
+    type = "string"
+    desc = "The id of the worker that reports the failure. Must match the id of the worker who has most recently
+            locked the task." />
+
+  <@lib.property
+      name = "errorMessage"
+      type = "string"
+      desc = "An message indicating the reason of the failure." />
+
+  <@lib.property
+      name = "errorDetails"
+      type = "string"
+      desc = "A detailed error description." />
+
+  <@lib.property
+      name = "retries"
+      type = "integer"
+      format = "int32"
+      desc = "A number of how often the task should be retried. Must be >= 0. If this is 0, an incident is created and
+              the task cannot be fetched anymore unless the retries are increased again. The incident's message is set
+              to the `errorMessage` parameter." />
+
+  <@lib.property
+      name = "retryTimeout"
+      type = "integer"
+      format = "int64"
+      last = true
+      desc = "A timeout in milliseconds before the external task becomes available again for fetching. Must be >= 0." />
+
+</@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/FetchExternalTaskTopicDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/FetchExternalTaskTopicDto.ftl
@@ -1,0 +1,97 @@
+<@lib.dto
+    required = [ "topicName", "lockDuration" ] >
+
+    <@lib.property
+        name = "topicName"
+        type = "string"
+        desc = "**Mandatory.** The topic's name." />
+
+    <@lib.property
+        name = "lockDuration"
+        type = "integer"
+        format = "int64"
+        desc = "**Mandatory.** The duration to lock the external tasks for in milliseconds." />
+
+    <@lib.property
+        name = "variables"
+        type = "array"
+        itemType = "string"
+        desc = "A JSON array of `String` values that represent variable names. For each result task belonging to this
+                topic, the given variables are returned as well if they are accessible from the external task's
+                execution. If not provided - all variables will be fetched." />
+
+    <@lib.property
+        name = "localVariables"
+        type = "boolean"
+        defaultValue = 'false'
+        desc = "If `true` only local variables will be fetched." />
+
+    <@lib.property
+        name = "businessKey"
+        type = "string"
+        desc = "A `String` value which enables the filtering of tasks based on process instance business key." />
+
+    <@lib.property
+        name = "processDefinitionId"
+        type = "string"
+        desc = "Filter tasks based on process definition id." />
+
+    <@lib.property
+        name = "processDefinitionIdIn"
+        type = "array"
+        itemType = "string"
+        desc = "Filter tasks based on process definition ids." />
+
+    <@lib.property
+        name = "processDefinitionKey"
+        type = "string"
+        desc = "Filter tasks based on process definition key." />
+
+    <@lib.property
+        name = "processDefinitionKeyIn"
+        type = "array"
+        itemType = "string"
+        desc = "Filter tasks based on process definition keys." />
+
+    <@lib.property
+        name = "processDefinitionVersionTag"
+        type = "string"
+        desc = "Filter tasks based on process definition version tag." />
+
+    <@lib.property
+        name = "withoutTenantId"
+        type = "boolean"
+        defaultValue = 'false'
+        desc = "Filter tasks without tenant id." />
+
+    <@lib.property
+        name = "tenantIdIn"
+        type = "array"
+        itemType = "string"
+        desc = "Filter tasks based on tenant ids." />
+
+    <@lib.property
+        name = "processVariables"
+        type = "object"
+        addProperty = "\"additionalProperties\": true"
+        desc = "A `JSON` object used for filtering tasks based on process instance variable values. A property name of
+                the object represents a process variable name, while the property value represents the process variable
+                value to filter tasks by." />
+
+    <@lib.property
+        name = "deserializeValues"
+        type = "boolean"
+        defaultValue = 'false'
+        last = true
+        desc = "Determines whether serializable variable values (typically variables that store custom Java objects)
+                should be deserialized on server side (default `false`).
+
+                If set to `true`, a serializable variable will be deserialized on server side and transformed to JSON
+                using [Jackson's](https://github.com/FasterXML/jackson) POJO/bean property introspection feature. Note
+                that this requires the Java classes of the variable value to be on the REST API's classpath.
+
+                If set to `false`, a serializable variable will be returned in its serialized format. For example, a
+                variable that is serialized as XML will be returned as a JSON string containing XML." />
+
+
+</@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/FetchExternalTasksDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/FetchExternalTasksDto.ftl
@@ -1,0 +1,40 @@
+<@lib.dto
+    title = ""
+    required = [ "workerId", "maxTasks" ] >
+
+    <@lib.property
+        name = "workerId"
+        type = "string"
+        desc = "**Mandatory.** The id of the worker on which behalf tasks are fetched. The returned tasks are locked for
+                that worker and can only be completed when providing the same worker id." />
+
+    <@lib.property
+        name = "maxTasks"
+        type = "integer"
+        format = "int32"
+        desc = "**Mandatory.** The maximum number of tasks to return." />
+
+    <@lib.property
+        name = "usePriority"
+        type = "boolean"
+        desc = "A `boolean` value, which indicates whether the task should be fetched based on its priority
+                or arbitrarily." />
+
+    <@lib.property
+        name = "asyncResponseTimeout"
+        type = "integer"
+        format = "int64"
+        desc = "The [Long Polling](${docsUrl}/user-guide/process-engine/external-tasks/#long-polling-to-fetch-and-lock-external-tasks)
+                timeout in milliseconds.
+
+                **Note:** The value cannot be set larger than 1.800.000 milliseconds (corresponds to 30 minutes)." />
+
+    <@lib.property
+        name = "topics"
+        type = "array"
+        dto = "FetchExternalTaskTopicDto"
+        last = true
+        desc = "A JSON array of topic objects for which external tasks should be fetched. The returned tasks may be
+                arbitrarily distributed among these topics. Each topic object has the following properties:" />
+
+</@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/LockedExternalTaskDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/LockedExternalTaskDto.ftl
@@ -1,0 +1,108 @@
+<@lib.dto
+    title = "LockedExternalTaskDto" >
+
+  <@lib.property
+      name = "activityId"
+      type = "string"
+      desc = "The id of the activity that this external task belongs to." />
+
+  <@lib.property
+      name = "activityInstanceId"
+      type = "string"
+      desc = "The id of the activity instance that the external task belongs to." />
+
+  <@lib.property
+      name = "errorMessage"
+      type = "string"
+      desc = "The full error message submitted with the latest reported failure executing this task;`null` if no failure
+              was reported previously or if no error message was submitted" />
+
+  <@lib.property
+      name = "errorDetails"
+      type = "string"
+      desc = "The error details submitted with the latest reported failure executing this task.`null` if no failure was
+              reported previously or if no error details was submitted" />
+
+  <@lib.property
+      name = "executionId"
+      type = "string"
+      desc = "The id of the execution that the external task belongs to." />
+
+  <@lib.property
+      name = "id"
+      type = "string"
+      desc = "The id of the external task." />
+
+  <@lib.property
+      name = "lockExpirationTime"
+      type = "string"
+      format = "date-time"
+      desc = "The date that the task's most recent lock expires or has expired." />
+
+  <@lib.property
+      name = "processDefinitionId"
+      type = "string"
+      desc = "The id of the process definition the external task is defined in." />
+
+  <@lib.property
+      name = "processDefinitionKey"
+      type = "string"
+      desc = "The key of the process definition the external task is defined in." />
+
+  <@lib.property
+      name = "processDefinitionVersionTag"
+      type = "string"
+      desc = "The version tag of the process definition the external task is defined in." />
+
+  <@lib.property
+      name = "processInstanceId"
+      type = "string"
+      desc = "The id of the process instance the external task belongs to." />
+
+  <@lib.property
+      name = "tenantId"
+      type = "string"
+      desc = "The id of the tenant the external task belongs to." />
+
+  <@lib.property
+      name = "retries"
+      type = "integer"
+      format = "int32"
+      desc = "The number of retries the task currently has left." />
+
+  <@lib.property
+      name = "suspended"
+      type = "boolean"
+      desc = "Whether the process instance the external task belongs to is suspended." />
+
+  <@lib.property
+      name = "workerId"
+      type = "string"
+      desc = "The id of the worker that posesses or posessed the most recent lock." />
+
+  <@lib.property
+      name = "priority"
+      type = "integer"
+      format = "int64"
+      desc = "The priority of the external task." />
+
+  <@lib.property
+      name = "topicName"
+      type = "string"
+      desc = "The topic name of the external task." />
+
+  <@lib.property
+      name = "businessKey"
+      type = "string"
+      desc = "The business key of the process instance the external task belongs to." />
+
+  <@lib.property
+      name = "variables"
+      type = "object"
+      dto = "VariableValueDto"
+      additionalProperties = true
+      last = true
+      desc = "A JSON object containing a property for each of the requested variables. The key is the variable name,
+              the value is a JSON object of serialized variable values with the following properties:" />
+
+</@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/SetRetriesForExternalTasksDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/SetRetriesForExternalTasksDto.ftl
@@ -1,0 +1,42 @@
+<@lib.dto>
+
+  <@lib.property
+      name = "retries"
+      type = "integer"
+      format = "int32"
+      desc = "The number of retries to set for the external task.  Must be >= 0. If this is 0, an incident is created
+              and the task cannot be fetched anymore unless the retries are increased again. Can not be null." />
+
+  <@lib.property
+      name = "externalTaskIds"
+      type = "array"
+      itemType = "string"
+      desc = "The ids of the external tasks to set the number of retries for." />
+
+  <@lib.property
+      name = "processInstanceIds"
+      type = "array"
+      itemType = "string"
+      desc = "The ids of process instances containing the tasks to set the number of retries for." />
+
+  <@lib.property
+      name = "externalTaskQuery"
+      type = "ref"
+      dto = "ExternalTaskQueryDto"
+      desc = "Query for the external tasks to set the number of retries for." />
+
+  <@lib.property
+      name = "processInstanceQuery"
+      type = "ref"
+      dto = "ProcessInstanceQueryDto"
+      desc = "Query for the process instances containing the tasks to set the number of retries for." />
+
+  <@lib.property
+      name = "historicProcessInstanceQuery"
+      type = "ref"
+      dto = "HistoricProcessInstanceQueryDto"
+      last = true
+      desc = "Query for the historic process instances containing the tasks to set the number of retries for." />
+
+
+</@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/fetchAndLock/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/fetchAndLock/post.ftl
@@ -1,0 +1,177 @@
+{
+
+  <@lib.endpointInfo
+      id = "fetchAndLock"
+      tag = "External Task"
+      desc = "Fetches and locks a specific number of external tasks for execution by a worker. Query can be restricted
+              to specific task topics and for each task topic an individual lock time can be provided." />
+
+  <@lib.requestBody
+      mediaType = "application/json"
+      dto = "FetchExternalTasksDto"
+      examples = ['"example-1": {
+                       "summary": "POST /external-task/fetchAndLock (1)",
+                       "description": "Request with variable filtering",
+                       "value": {
+                         "workerId": "aWorkerId",
+                         "maxTasks": 2,
+                         "usePriority": true,
+                         "topics": [
+                           {
+                             "topicName": "createOrder",
+                             "lockDuration": 10000,
+                             "variables": [
+                               "orderId"
+                             ]
+                           }
+                         ]
+                       }
+                     }',
+                    '"example-2": {
+                       "summary": "POST /external-task/fetchAndLock (2)",
+                       "description": "Request with all variables included",
+                       "value": {
+                         "workerId": "aWorkerId",
+                         "maxTasks": 2,
+                         "usePriority": true,
+                         "topics": [
+                           {
+                             "topicName": "createOrder",
+                             "lockDuration": 10000,
+                             "processDefinitionId": "aProcessDefinitionId",
+                             "tenantIdIn": "tenantOne"
+                           }
+                         ]
+                       }
+                     }'
+      ] />
+
+  "responses" : {
+
+    <@lib.response
+        code = "200"
+        dto = "LockedExternalTaskDto"
+        array = true
+        desc = "Request successful."
+        examples = ['"example-1": {
+                       "summary": "POST /external-task/fetchAndLock (1)",
+                       "description": "Request with variable filtering",
+                       "value": [
+                         {
+                           "activityId": "anActivityId",
+                           "activityInstanceId": "anActivityInstanceId",
+                           "errorMessage": "anErrorMessage",
+                           "errorDetails": "anErrorDetails",
+                           "executionId": "anExecutionId",
+                           "id": "anExternalTaskId",
+                           "lockExpirationTime": "2015-10-06T16:34:42.000+0200",
+                           "processDefinitionId": "aProcessDefinitionId",
+                           "processDefinitionKey": "aProcessDefinitionKey",
+                           "processInstanceId": "aProcessInstanceId",
+                           "tenantId": null,
+                           "retries": 3,
+                           "workerId": "aWorkerId",
+                           "priority": 4,
+                           "topicName": "createOrder",
+                           "variables": {
+                             "orderId": {
+                               "type": "String",
+                               "value": "1234",
+                               "valueInfo": {}
+                             }
+                           }
+                         },
+                         {
+                           "activityId": "anActivityId",
+                           "activityInstanceId": "anActivityInstanceId",
+                           "errorMessage": "anErrorMessage",
+                           "errorDetails": "anotherErrorDetails",
+                           "executionId": "anExecutionId",
+                           "id": "anExternalTaskId",
+                           "lockExpirationTime": "2015-10-06T16:34:42.000+0200",
+                           "processDefinitionId": "aProcessDefinitionId",
+                           "processDefinitionKey": "aProcessDefinitionKey",
+                           "processInstanceId": "aProcessInstanceId",
+                           "tenantId": null,
+                           "retries": 3,
+                           "workerId": "aWorkerId",
+                           "priority": 0,
+                           "topicName": "createOrder",
+                           "variables": {
+                             "orderId": {
+                               "type": "String",
+                               "value": "3456",
+                               "valueInfo": {}
+                             }
+                           }
+                         }
+                       ]
+                     }',
+                    '"example-2": {
+                       "summary": "POST /external-task/fetchAndLock (2)",
+                       "description": "Request with all variables included",
+                       "value": [
+                         {
+                           "activityId": "anActivityId",
+                           "activityInstanceId": "anActivityInstanceId",
+                           "errorMessage": "anErrorMessage",
+                           "errorDetails": "anErrorDetails",
+                           "executionId": "anExecutionId",
+                           "id": "anExternalTaskId",
+                           "lockExpirationTime": "2015-10-06T16:34:42.00+0200",
+                           "processDefinitionId": "aProcessDefinitionId",
+                           "processDefinitionKey": "aProcessDefinitionKey",
+                           "processInstanceId": "aProcessInstanceId",
+                           "tenantId": "tenantOne",
+                           "retries": 3,
+                           "workerId": "aWorkerId",
+                           "priority": 4,
+                           "topicName": "createOrder",
+                           "businessKey": "aBusinessKey",
+                           "variables": {
+                             "orderId": {
+                               "type": "String",
+                               "value": "1234",
+                               "valueInfo": {}
+                             }
+                           }
+                         },
+                         {
+                           "activityId": "anActivityId",
+                           "activityInstanceId": "anActivityInstanceId",
+                           "errorMessage": "anErrorMessage",
+                           "errorDetails": "anotherErrorDetails",
+                           "executionId": "anExecutionId",
+                           "id": "anExternalTaskId",
+                           "lockExpirationTime": "2015-10-06T16:34:42.000+0200",
+                           "processDefinitionId": "aProcessDefinitionId",
+                           "processDefinitionKey": "aProcessDefinitionKey",
+                           "processInstanceId": "aProcessInstanceId",
+                           "tenantId": null,
+                           "retries": 3,
+                           "workerId": "aWorkerId",
+                           "priority": 0,
+                           "topicName": "createOrder",
+                           "businessKey": "aBusinessKey",
+                           "variables": {
+                             "orderId": {
+                               "type": "String",
+                               "value": "3456",
+                               "valueInfo": {}
+                             }
+                           }
+                         }
+                       ]
+                     }'
+        ] />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        last = true
+        desc = "Bad Request. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+  }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/retries-async/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/retries-async/post.ftl
@@ -1,0 +1,64 @@
+{
+
+  <@lib.endpointInfo
+      id = "setExternalTaskRetriesAsync"
+      tag = "External Task"
+      desc = "Sets the number of retries left to execute external tasks by id asynchronously. If retries are set to 0,
+              an incident is created." />
+
+  <@lib.requestBody
+      mediaType = "application/json"
+      dto = "SetRetriesForExternalTasksDto"
+      examples = ['"example-1": {
+                       "summary": "POST /external-task/retries-async",
+                       "value": {
+                         "retries": 123,
+                         "externalTaskIds": [
+                           "anExternalTask",
+                           "anotherExternalTask"
+                         ]
+                       }
+                     }'] />
+
+  "responses" : {
+
+    <@lib.response
+        code = "200"
+        dto = "BatchDto"
+        desc = "Request successful."
+        examples = ['"example-1": {
+                       "summary": "Status 200 Response",
+                       "value": {
+                         "id": "aBatchId",
+                         "type": "aBatchType",
+                         "totalJobs": 10,
+                         "batchJobsPerSeed": 100,
+                         "invocationsPerBatchJob": 1,
+                         "seedJobDefinitionId": "aSeedJobDefinitionId",
+                         "monitorJobDefinitionId": "aMonitorJobDefinitionId",
+                         "batchJobDefinitionId": "aBatchJobDefinitionId",
+                         "tenantId": "aTenantId",
+                         "suspended": false,
+                         "createUserId": "demo"
+                       }
+                     }'] />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "If neither externalTaskIds nor externalTaskQuery are present or externalTaskIds contains null value or 
+                the number of retries is negative or null, an exception of type `InvalidRequestException` is returned.
+                See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        last = true
+        desc = "Returned if the task does not exist. This could indicate a wrong task id as well as a cancelled task, 
+                e.g., due to a caught BPMN boundary event. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+  }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/retries/put.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/retries/put.ftl
@@ -1,0 +1,46 @@
+{
+
+  <@lib.endpointInfo
+      id = "setExternalTaskRetries"
+      tag = "External Task"
+      desc = "Sets the number of retries left to execute external tasks by id synchronously. If retries are set to 0, 
+              an incident is created." />
+
+  <@lib.requestBody
+      mediaType = "application/json"
+      dto = "SetRetriesForExternalTasksDto"
+      examples = ['"example-1": {
+                       "summary": "PUT /external-task/retries",
+                       "value": {
+                         "retries": 123,
+                         "externalTaskIds": [
+                           "anExternalTask",
+                           "anotherExternalTask"
+                         ]
+                       }
+                     }'] />
+
+  "responses" : {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful." />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "In case the number of retries is negative or null, an exception of type `InvalidRequestException` is
+                returned. See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        last = true
+        desc = "Returned if the task does not exist. This could indicate a wrong task id as well as a cancelled task, 
+                e.g., due to a caught BPMN boundary event. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+  }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/bpmnError/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/bpmnError/post.ftl
@@ -1,0 +1,76 @@
+{
+
+  <@lib.endpointInfo
+      id = "handleExternalTaskBpmnError"
+      tag = "External Task"
+      desc = "Reports a business error in the context of a running external task by id. The error code must be specified
+              to identify the BPMN error handler." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the external task in which context a BPMN error is reported."/>
+
+  ],
+
+  <@lib.requestBody
+      mediaType = "application/json"
+      dto = "ExternalTaskBpmnError"
+      examples = ['"example-1": {
+                       "summary": "POST /external-task/anId/bpmnError",
+                       "value": {
+                         "workerId": "aWorker",
+                         "errorCode": "bpmn-error",
+                         "errorMessage": "anErrorMessage",
+                         "variables": {
+                           "aVariable": {
+                             "value": "aStringValue",
+                             "type": "String"
+                           },
+                           "anotherVariable": {
+                             "value": true,
+                             "type": "Boolean"
+                           }
+                         }
+                       }
+                     }'] />
+
+  "responses" : {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful." />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "Returned if the task's most recent lock was not acquired by the provided worker.
+
+                See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        desc = "Returned if the task does not exist. This could indicate a wrong task id as well as a cancelled task,
+                e.g., due to a caught BPMN boundary event.
+
+                See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+    <@lib.response
+        code = "500"
+        dto = "ExceptionDto"
+        last = true
+        desc = "Returned if the corresponding process instance could not be resumed successfully.
+
+                See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+  }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/complete/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/complete/post.ftl
@@ -1,0 +1,76 @@
+{
+
+  <@lib.endpointInfo
+      id = "completeExternalTaskResource"
+      tag = "External Task"
+      desc = "Completes an external task by id and updates process variables." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the task to complete." />
+
+  ],
+
+  <@lib.requestBody
+      mediaType = "application/json"
+      dto = "CompleteExternalTaskDto"
+      examples = ['"example-1": {
+                       "summary": "POST /external-task/anId/complete",
+                       "value": {
+                         "workerId": "aWorker",
+                         "variables": {
+                           "aVariable": {
+                             "value": "aStringValue"
+                           },
+                           "anotherVariable": {
+                             "value": 42
+                           },
+                           "aThirdVariable": {
+                             "value": true
+                           }
+                         },
+                         "localVariables": {
+                           "aLocalVariable": {
+                             "value": "aStringValue"
+                           }
+                         }
+                       }
+                     }'] />
+
+  "responses" : {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful." />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "Returned if the task's most recent lock was not acquired by the provided worker. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        desc = "Returned if the task does not exist. This could indicate a wrong task id as well as a cancelled task,
+                e.g., due to a caught BPMN boundary event. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+    <@lib.response
+        code = "500"
+        dto = "ExceptionDto"
+        last = true
+        desc = "Returned if the corresponding process instance could not be resumed successfully. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+  }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/errorDetails/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/errorDetails/get.ftl
@@ -1,0 +1,59 @@
+{
+
+  <@lib.endpointInfo
+      id = "getExternalTaskErrorDetails"
+      tag = "External Task"
+      desc = "Retrieves the error details in the context of a running external task by id." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the external task for which the error details should be retrieved."/>
+
+  ],
+
+  "responses" : {
+
+    "200": {
+      "description": "Request successful.",
+      "content": {
+        "text/plain": {
+          "schema": {
+            "type": "string",
+            "description": "The error details for the external task."
+          },
+          "examples": {
+            "example-1": {
+              "value": "org.apache.ibatis.jdbc.RuntimeSqlException: org.apache.ibatis.jdbc.RuntimeSqlException: test cause
+                  at org.camunda.bpm.engine.test.api.externaltask.ExternalTaskServiceTest.testHandleFailureWithErrorDetails(ExternalTaskServiceTest.java:1424)
+                  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+                  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+                  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+                "
+            }
+          }
+        }
+      }
+    },
+
+
+  <@lib.response
+      code = "204"
+      desc = "Request successful. In case the external task has no error details." />
+
+
+    <@lib.response
+        code = "500"
+        dto = "ExceptionDto"
+        last = true
+        desc = "An external task with the given id does not exist. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+  }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/extendLock/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/extendLock/post.ftl
@@ -1,0 +1,55 @@
+{
+
+  <@lib.endpointInfo
+      id = "extendLock"
+      tag = "External Task"
+      desc = "Extends the timeout of the lock by a given amount of time." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the external task."/>
+
+  ],
+
+  <@lib.requestBody
+      mediaType = "application/json"
+      dto = "ExtendLockOnExternalTaskDto"
+      examples = ['"example-1": {
+                     "summary": "POST /external-task/anId/extendLock",
+                     "value": {
+                       "workerId": "anId",
+                       "newDuration": 100000
+                     }
+                   }'] />
+
+  "responses" : {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful." />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "In case the new lock duration is negative or the external task is not locked by the given worker or not 
+                locked at all, an exception of type `InvalidRequestException` is returned. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        last = true
+        desc = "Returned if the task does not exist. This could indicate a wrong task id as well as a cancelled task,
+                e.g., due to a caught BPMN boundary event. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+  }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/failure/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/failure/post.ftl
@@ -1,0 +1,63 @@
+{
+
+  <@lib.endpointInfo
+      id = "handleFailure"
+      tag = "External Task"
+      desc = "Reports a failure to execute an external task by id. A number of retries and a timeout until the task can
+              be retried can be specified. If retries are set to 0, an incident for this task is created." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the external task to report a failure for."/>
+
+  ],
+
+  <@lib.requestBody
+      mediaType = "application/json"
+      dto = "ExternalTaskFailureDto"
+      examples = ['"example-1": {
+                     "summary": "POST /external-task/anId/failure",
+                     "value": {
+                       "workerId": "aWorker",
+                       "errorMessage": "Does not compute",
+                       "retries": 3,
+                       "retryTimeout": 60000
+                       }
+                   }'] />
+
+  "responses" : {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful." />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "Returned if the task's most recent lock was not acquired by the provided worker. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        desc = "Returned if the task does not exist. This could indicate a wrong task id as well as a cancelled task,
+                e.g., due to a caught BPMN boundary event. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+    <@lib.response
+        code = "500"
+        dto = "ExceptionDto"
+        last = true
+        desc = "Returned if the corresponding process instance could not be resumed successfully. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+  }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/get.ftl
@@ -1,0 +1,58 @@
+{
+
+  <@lib.endpointInfo
+      id = "getExternalTask"
+      tag = "External Task"
+      desc = "Retrieves an external task by id, corresponding to the `ExternalTask` interface in the engine." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the external task to be retrieved." />
+
+  ],
+
+  "responses" : {
+
+    <@lib.response
+        code = "200"
+        dto = "ExternalTaskDto"
+        desc = "Request successful."
+        examples = ['"example-1": {
+                       "summary": "GET /external-task/anExternalTaskId",
+                       "value": {
+                         "activityId": "anActivityId",
+                         "activityInstanceId": "anActivityInstanceId",
+                         "errorMessage": "anErrorMessage",
+                         "errorDetails": "anErrorDetails",
+                         "executionId": "anExecutionId",
+                         "id": "anExternalTaskId",
+                         "lockExpirationTime": "2015-10-06T16:34:42.000+0200",
+                         "processDefinitionId": "aProcessDefinitionId",
+                         "processDefinitionKey": "aProcessDefinitionKey",
+                         "processInstanceId": "aProcessInstanceId",
+                         "tenantId": null,
+                         "retries": 3,
+                         "suspended": false,
+                         "workerId": "aWorkerId",
+                         "priority":0,
+                         "topicName": "aTopic",
+                         "businessKey": "aBusinessKey"
+                       }
+                     }'] />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        last = true
+        desc = "External task with the given id does not exist. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+  }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/priority/put.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/priority/put.ftl
@@ -1,0 +1,46 @@
+{
+
+  <@lib.endpointInfo
+      id = "setExternalTaskResourcePriority"
+      tag = "External Task"
+      desc = "Sets the priority of an existing external task by id. The default value of a priority is 0." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the external task to set the priority for."/>
+
+  ],
+
+  <@lib.requestBody
+      mediaType = "application/json"
+      dto = "PriorityDto"
+      examples = ['"example-1": {
+                     "summary": "PUT /external-task/anId/priority",
+                     "value": {
+                      "priority": 5
+                     }
+                   }'] />
+
+  "responses" : {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful." />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        last = true
+        desc = "Returned if the task does not exist. This could indicate a wrong task id as well as a cancelled task,
+                e.g., due to a caught BPMN boundary event. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+  }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/retries/put.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/retries/put.ftl
@@ -1,0 +1,54 @@
+{
+
+  <@lib.endpointInfo
+      id = "setExternalTaskResourceRetries"
+      tag = "External Task"
+      desc = "Sets the number of retries left to execute an external task by id. If retries are set to 0, an 
+              incident is created." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the external task to set the number of retries for."/>
+
+  ],
+
+  <@lib.requestBody
+      mediaType = "application/json"
+      dto = "RetriesDto"
+      examples = ['"example-1": {
+                     "summary": "PUT /external-task/anId/retries",
+                     "value": {
+                       "retries": 123
+                     }
+                   }'] />
+
+  "responses" : {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful." />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "Returned if the task does not exist. This could indicate a wrong task id as well as a cancelled task,
+                e.g., due to a caught BPMN boundary event. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        last = true
+        desc = "In case the number of retries is negative or null, an exception of type `InvalidRequestException`
+                is returned. See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+  }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/unlock/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/unlock/post.ftl
@@ -1,0 +1,36 @@
+{
+
+  <@lib.endpointInfo
+      id = "unlock"
+      tag = "External Task"
+      desc = "Unlocks an external task by id. Clears the task's lock expiration time and worker id." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the external task to unlock." />
+
+  ],
+
+  "responses" : {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful." />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        last = true
+        desc = "Returned if the task does not exist. This could indicate a wrong task id as well as a cancelled task,
+                e.g., due to a caught BPMN boundary event. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+  }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/localVariables/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/localVariables/get.ftl
@@ -23,8 +23,8 @@
         desc = "Determines whether serializable variable values (typically variables that store custom Java objects)
                 should be deserialized on the server side (default `true`).
 
-                If set to `true`, a serializable variable will be deserialized on server side and
-                transformed to JSON using Jackson's POJO/bean property introspection feature.
+                If set to `true`, a serializable variable will be deserialized on server side and transformed to JSON
+                using [Jackson's](https://github.com/FasterXML/jackson) POJO/bean property introspection feature.
                 Note that this requires the Java classes of the variable value to be on the REST API's classpath.
 
                 If set to `false`, a serializable variable will be returned in its serialized format.

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/localVariables/{varName}/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/localVariables/{varName}/get.ftl
@@ -30,8 +30,8 @@
         desc = "Determines whether serializable variable values (typically variables that store custom Java objects)
                 should be deserialized on the server side (default `true`).
 
-                If set to `true`, a serializable variable will be deserialized on server side and
-                transformed to JSON using Jackson's POJO/bean property introspection feature.
+                If set to `true`, a serializable variable will be deserialized on server side and transformed to JSON
+                using [Jackson's](https://github.com/FasterXML/jackson) POJO/bean property introspection feature.
                 Note that this requires the Java classes of the variable value to be on the REST API's classpath.
 
                 If set to `false`, a serializable variable will be returned in its serialized format.


### PR DESCRIPTION
* Add OpenAPI documentation for operations on External Task (excluding
  querying and counting);
* Add missing Jackson links.

Related to CAM-11540, CAM-11709