### PR TITLE
[CAM-11725] Allow to specify the cause exception when creating a BpmnError

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/delegate/BpmnError.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/delegate/BpmnError.java
@@ -43,14 +43,36 @@ public class BpmnError extends ProcessEngineException {
   private String errorMessage;
 
   public BpmnError(String errorCode) {
-    super("");
+    super(exceptionMessage(errorCode, null));
     setErrorCode(errorCode);
   }
           
   public BpmnError(String errorCode, String message) {
-    super(message + " (errorCode='" + errorCode + "')");
+    super(exceptionMessage(errorCode, message));
     setErrorCode(errorCode);
     setMessage(message);
+  }
+
+  public BpmnError(String errorCode, String message, Throwable cause) {
+    super(exceptionMessage(errorCode, message), cause);
+    setErrorCode(errorCode);
+    setMessage(exceptionMessage(errorCode, message) + (cause != null ? "; details: " + cause.getMessage() : ""));
+  }
+
+  public BpmnError(String errorCode, Throwable cause) {
+    super(exceptionMessage(errorCode, null), cause);
+    setErrorCode(errorCode);
+    if (cause != null) {
+      setMessage(cause.getMessage());
+    }
+  }
+
+  private static String exceptionMessage(String errorCode, String message) {
+    if (message == null) {
+      return "errorCode='" + errorCode + "'";
+    } else {
+      return message + " (errorCode='" + errorCode + "')";
+    }
   }
 
   protected void setErrorCode(String errorCode) {
@@ -62,6 +84,7 @@ public class BpmnError extends ProcessEngineException {
     return errorCode;
   }
 
+  @Override
   public String toString() {
     return super.toString() + " (errorCode='" + errorCode + "')";
   }
@@ -71,6 +94,7 @@ public class BpmnError extends ProcessEngineException {
     this.errorMessage = errorMessage;
   }
 
+  @Override
   public String getMessage() {
     return errorMessage;
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/delegate/BpmnErrorTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/delegate/BpmnErrorTest.java
@@ -1,0 +1,49 @@
+package org.camunda.bpm.engine.delegate;
+
+import junit.framework.TestCase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BpmnErrorTest extends TestCase {
+
+    /** Error code used when creating BpmnError instances */
+    private static final String ERROR_CODE = "testErrorCode";
+
+    /** Error message used when creating BpmnError instances */
+    private static final String ERROR_MESSAGE = "testErrorMessage";
+
+    /** Cause object used when creating BpmnError instances with a cause */
+    private static final Throwable CAUSE = new IllegalArgumentException("causeMessage");
+
+
+    public void testCreation_ErrorCodeOnly_BpmnMessageContainsErrorCode() {
+        BpmnError bpmnError = new BpmnError(ERROR_CODE);
+        assertThat(bpmnError).hasMessageContaining(ERROR_CODE);
+    }
+
+    public void testCreation_ErrorMessagePresent_BpmnMessageContainsErrorCodeAndMessage() {
+        BpmnError bpmnError = new BpmnError(ERROR_CODE, ERROR_MESSAGE);
+        assertThat(bpmnError) //
+                .hasMessageContaining(ERROR_CODE) //
+                .hasMessageContaining(ERROR_MESSAGE);
+    }
+
+    public void testCreation_ErrorCodeOnlyWithCause_BpmnMessageIsCopiedFromCause() {
+        BpmnError bpmnError = new BpmnError(ERROR_CODE, CAUSE);
+        assertThat(bpmnError) //
+                .hasMessage(CAUSE.getMessage()) //
+                .hasCause(CAUSE);
+        assertThat(bpmnError.getErrorCode()).isEqualTo(ERROR_CODE);
+    }
+
+    public void testCreation_ErrorMessageAndCausePresent_BpmnMessageContainsCause() {
+        BpmnError bpmnError = new BpmnError(ERROR_CODE, ERROR_MESSAGE, CAUSE);
+        assertThat(bpmnError) //
+                .hasMessageContaining(ERROR_CODE) //
+                .hasMessageContaining(ERROR_MESSAGE) //
+                .hasMessageContaining(CAUSE.getMessage()) //
+                .hasCause(CAUSE);
+        assertThat(bpmnError.getErrorCode()).isEqualTo(ERROR_CODE);
+    }
+
+}


### PR DESCRIPTION
See https://jira.camunda.com/browse/CAM-11725