### PR TITLE
CAM-11749: adjust async operation ids

### DIFF
--- a/engine-rest/engine-rest-openapi/README.md
+++ b/engine-rest/engine-rest-openapi/README.md
@@ -126,6 +126,7 @@ then the path parameters (`id` and `varName`) should always be included in the e
 * endpoints that are almost similar but have a different paths (e.g. [Get Activity Instance Statistics](https://docs.camunda.org/manual/7.12/reference/rest/process-definition/get-activity-statistics/)) needs to be separated in different files. A unique `operationId` should be assigne to each of them. You can consider adding the common parts of the endpoints in [lib/commons](#commons).
 * the name of the method's request (GET, POST, PUT, DELETE, OPTIONS) is the name of the template file (get.ftl, post.frl, etc.).
 * each endpoint definition has a unique `operationId` that will be used for the generation of clients.
+* for async endpoints make sure to add `Operation` suffix to prevent collisions in generated C# clients, e.g. `setExternalTaskRetriesAsync` -> `setExternalTaskRetriesAsyncOperation`, `modifyProcessInstanceAsync` -> `modifyProcessInstanceAsyncOperation`
 In most of the cases, the java method name should be used (e.g. `deleteProcessInstancesAsync`). When this is not possible, please define it according to the Java conventions.
 * each endpoint definition contains a tag of its resource (e.g. `Process instance`, `Deployment`).
 * each endpoint definition contains a description.

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/retries-async/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/retries-async/post.ftl
@@ -1,7 +1,7 @@
 {
 
   <@lib.endpointInfo
-      id = "setExternalTaskRetriesAsync"
+      id = "setExternalTaskRetriesAsyncOperation"
       tag = "External Task"
       desc = "Sets the number of retries left to execute external tasks by id asynchronously. If retries are set to 0,
               an incident is created." />

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/process-instance/delete/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/process-instance/delete/post.ftl
@@ -1,6 +1,6 @@
 {
   <@lib.endpointInfo
-      id = "deleteProcessInstancesAsync"
+      id = "deleteProcessInstancesAsyncOperation"
       tag = "Process instance"
       desc = "Deletes multiple process instances asynchronously (batch)." />
 

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/process-instance/suspended-async/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/process-instance/suspended-async/post.ftl
@@ -1,6 +1,6 @@
 {
   <@lib.endpointInfo
-      id = "updateSuspensionStateAsync"
+      id = "updateSuspensionStateAsyncOperation"
       tag = "Process instance"
       desc = "Activates or suspends process instances asynchronously with a list of process instance ids,
               a process instance query, and/or a historical process instance query." />

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/process-instance/{id}/modification-async/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/process-instance/{id}/modification-async/post.ftl
@@ -1,7 +1,7 @@
 {
 
   <@lib.endpointInfo
-      id = "modifyProcessInstanceAsync"
+      id = "modifyProcessInstanceAsyncOperation"
       tag = "Process instance"
       desc = "Submits a list of modification instructions to change a process instance's execution state async.
               A modification instruction is one of the following:

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/delegate/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/delegate/post.ftl
@@ -1,7 +1,7 @@
 {
 
   <@lib.endpointInfo
-      id = "delegate"
+      id = "delegateTask"
       tag = "Task"
       desc = "Delegates a task to another user." />
 


### PR DESCRIPTION
* rename async operations to prevent collisions with generated C# clients
* rename delegate operation as `delegate` is reserved word in C# clients

Related to CAM-11749