### PR TITLE
fix(rest-openapi): fix docsVersion for alpha releases

### DIFF
--- a/engine-rest/engine-rest-openapi-generator/src/main/java/org/camunda/bpm/engine/rest/openapi/generator/impl/TemplateParser.java
+++ b/engine-rest/engine-rest-openapi-generator/src/main/java/org/camunda/bpm/engine/rest/openapi/generator/impl/TemplateParser.java
@@ -126,6 +126,8 @@ public class TemplateParser {
   
       if (version.contains("SNAPSHOT")) {
         templateData.put("docsVersion", "develop");
+      } else if (version.contains("alpha")) {
+        templateData.put("docsVersion", "latest");
       } else {
         // docsVersion = 7.X
         templateData.put("docsVersion", version.substring(0, version.lastIndexOf(".")));


### PR DESCRIPTION
7.X(.0-alphaY) version doesn't exist in the manual docs during
development of a new version =>
the docs links are built with `latest` version

Related to CAM-11715