### PR TITLE
CAM-11819 improve ProcessEngineException message

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/application/impl/ProcessApplicationLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/application/impl/ProcessApplicationLogger.java
@@ -47,9 +47,6 @@ public class ProcessApplicationLogger extends ProcessEngineLogger {
   }
 
   public ProcessEngineException exceptionWhileNotifyingPaTaskListener(Exception e) {
-    if (e instanceof ProcessEngineException) {
-      return (ProcessEngineException)e;
-    }
     return new ProcessEngineException(exceptionMessage(
         "002",
         "Exception while notifying process application task listener: " + e.getMessage()), e);

--- a/engine/src/main/java/org/camunda/bpm/application/impl/ProcessApplicationLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/application/impl/ProcessApplicationLogger.java
@@ -47,9 +47,12 @@ public class ProcessApplicationLogger extends ProcessEngineLogger {
   }
 
   public ProcessEngineException exceptionWhileNotifyingPaTaskListener(Exception e) {
+    if (e instanceof ProcessEngineException) {
+      return (ProcessEngineException)e;
+    }
     return new ProcessEngineException(exceptionMessage(
         "002",
-        "Exception while notifying process application task listener."), e);
+        "Exception while notifying process application task listener: " + e.getMessage()), e);
   }
 
   public void noTargetProcessApplicationForExecution(DelegateExecution execution) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/EnginePersistenceLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/EnginePersistenceLogger.java
@@ -445,6 +445,9 @@ public class EnginePersistenceLogger extends ProcessEngineLogger {
   }
 
   public ProcessEngineException invokeTaskListenerException(Throwable cause) {
+    if (cause instanceof ProcessEngineException) {
+      return (ProcessEngineException)cause;
+    }
     return new ProcessEngineException(exceptionMessage(
       "051",
       "There was an exception while invoking the TaskListener. Message: '{}'",

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/EnginePersistenceLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/EnginePersistenceLogger.java
@@ -445,9 +445,6 @@ public class EnginePersistenceLogger extends ProcessEngineLogger {
   }
 
   public ProcessEngineException invokeTaskListenerException(Throwable cause) {
-    if (cause instanceof ProcessEngineException) {
-      return (ProcessEngineException)cause;
-    }
     return new ProcessEngineException(exceptionMessage(
       "051",
       "There was an exception while invoking the TaskListener. Message: '{}'",


### PR DESCRIPTION
Currently when a task listener throws an exception, Camunda displays a message something like:

"ENGINE-03051 There was an exception while invoking the TaskListener. Message: 'ENGINE-07002 Exception while notifying process application task listener."

This gives the user no clue what went wrong because it throws away the message from the original exception and it includes duplicated information which is meaningless to the end user.

This change request prevents the duplicated information and includes the message from the original exception in the new exception, so that it may display something meaningful to the user.