### PR TITLE
Enforce Historic Process Instance Authorizations for more queries

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/HistoryService.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/HistoryService.java
@@ -107,12 +107,8 @@ public interface HistoryService {
    * */
   HistoricProcessInstanceQuery createHistoricProcessInstanceQuery();
 
-  /** Creates a new programmatic query to search for {@link HistoricActivityInstance}s. */
-  HistoricActivityInstanceQuery createHistoricActivityInstanceQuery();
-
   /**
-   * <p>Query for the number of historic activity instances aggregated by activities of a single
-   * process definition.
+   * <p>Creates a new programmatic query to search for {@link HistoricActivityInstance}s.
    *
    * <p>The result of the query is empty in the following cases:
    * <ul>
@@ -121,7 +117,17 @@ public interface HistoryService {
    *   <li>The user has no {@link HistoricProcessInstancePermissions#READ} permission on
    *       {@link Resources#HISTORIC_PROCESS_INSTANCE} ({@code enableHistoricInstancePermissions} in
    *       {@link ProcessEngineConfigurationImpl} must be set to {@code true})
+   *
    * */
+  HistoricActivityInstanceQuery createHistoricActivityInstanceQuery();
+
+  /**
+   * <p>Query for the number of historic activity instances aggregated by activities of a single
+   * process definition.
+   *
+   * <p>The result of the query is empty when the user has no {@link Permissions#READ_HISTORY}
+   * permission on {@link Resources#PROCESS_DEFINITION}
+   */
   HistoricActivityStatisticsQuery createHistoricActivityStatisticsQuery(String processDefinitionId);
 
   /**

--- a/engine/src/main/java/org/camunda/bpm/engine/HistoryService.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/HistoryService.java
@@ -656,7 +656,16 @@ public interface HistoryService {
   HistoricDecisionInstanceStatisticsQuery createHistoricDecisionInstanceStatisticsQuery(String decisionRequirementsDefinitionId);
 
   /**
-   * Creates a new programmatic query to search for {@link HistoricExternalTaskLog historic external task logs}.
+   * <p>Creates a new programmatic query to search for
+   * {@link HistoricExternalTaskLog historic external task logs}.
+   *
+   * <p>The result of the query is empty in the following cases:
+   * <ul>
+   *   <li>The user has no {@link Permissions#READ_HISTORY} permission on
+   *   {@link Resources#PROCESS_DEFINITION} OR
+   *   <li>The user has no {@link HistoricProcessInstancePermissions#READ} permission on
+   *       {@link Resources#HISTORIC_PROCESS_INSTANCE} ({@code enableHistoricInstancePermissions} in
+   *       {@link ProcessEngineConfigurationImpl} must be set to {@code true})
    *
    * @since 7.7
    */

--- a/engine/src/main/java/org/camunda/bpm/engine/HistoryService.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/HistoryService.java
@@ -555,7 +555,15 @@ public interface HistoryService {
   NativeHistoricVariableInstanceQuery createNativeHistoricVariableInstanceQuery();
 
   /**
-   * Creates a new programmatic query to search for {@link HistoricJobLog historic job logs}.
+   * <p>Creates a new programmatic query to search for {@link HistoricJobLog historic job logs}.
+   *
+   * <p>The result of the query is empty in the following cases:
+   * <ul>
+   *   <li>The user has no {@link Permissions#READ_HISTORY} permission on
+   *   {@link Resources#PROCESS_DEFINITION} OR
+   *   <li>The user has no {@link HistoricProcessInstancePermissions#READ} permission on
+   *       {@link Resources#HISTORIC_PROCESS_INSTANCE} ({@code enableHistoricInstancePermissions} in
+   *       {@link ProcessEngineConfigurationImpl} must be set to {@code true})
    *
    * @since 7.3
    */

--- a/engine/src/main/java/org/camunda/bpm/engine/HistoryService.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/HistoryService.java
@@ -196,7 +196,17 @@ public interface HistoryService {
   /** Creates a new programmatic query to search for {@link UserOperationLogEntry} instances. */
   UserOperationLogQuery createUserOperationLogQuery();
 
-  /** Creates a new programmatic query to search for {@link HistoricIncident historic incidents}. */
+  /**
+   * <p>Creates a new programmatic query to search for {@link HistoricIncident historic incidents}.
+   *
+   * <p>The result of the query is empty in the following cases:
+   * <ul>
+   *   <li>The user has no {@link Permissions#READ_HISTORY} permission on
+   *   {@link Resources#PROCESS_DEFINITION} OR
+   *   <li>The user has no {@link HistoricProcessInstancePermissions#READ} permission on
+   *       {@link Resources#HISTORIC_PROCESS_INSTANCE} ({@code enableHistoricInstancePermissions} in
+   *       {@link ProcessEngineConfigurationImpl} must be set to {@code true})
+   * */
   HistoricIncidentQuery createHistoricIncidentQuery();
 
   /**

--- a/engine/src/main/java/org/camunda/bpm/engine/HistoryService.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/HistoryService.java
@@ -193,7 +193,17 @@ public interface HistoryService {
    * */
   HistoricVariableInstanceQuery createHistoricVariableInstanceQuery();
 
-  /** Creates a new programmatic query to search for {@link UserOperationLogEntry} instances. */
+  /** <p>Creates a new programmatic query to search for {@link UserOperationLogEntry} instances.
+   *
+   * <p>The result of the query is empty in the following cases:
+   * <ul>
+   *   <li>The user has no {@link Permissions#READ_HISTORY} permission on
+   *   {@link Resources#PROCESS_DEFINITION} OR
+   *   <li>The user has no {@link HistoricProcessInstancePermissions#READ} permission on
+   *       {@link Resources#HISTORIC_PROCESS_INSTANCE} ({@code enableHistoricInstancePermissions} in
+   *       {@link ProcessEngineConfigurationImpl} must be set to {@code true})
+   *
+   * */
   UserOperationLogQuery createUserOperationLogQuery();
 
   /**

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/AuthorizationManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/AuthorizationManager.java
@@ -821,7 +821,27 @@ public class AuthorizationManager extends AbstractManager {
   // historic incident query ////////////////////////////////
 
   public void configureHistoricIncidentQuery(HistoricIncidentQueryImpl query) {
-    configureQuery(query, PROCESS_DEFINITION, "RES.PROC_DEF_KEY_", READ_HISTORY);
+    AuthorizationCheck authCheck = query.getAuthCheck();
+
+    boolean isHistoricInstancePermissionsEnabled = isHistoricInstancePermissionsEnabled();
+    authCheck.setHistoricInstancePermissionsEnabled(isHistoricInstancePermissionsEnabled);
+
+    if (!isHistoricInstancePermissionsEnabled) {
+      configureQuery(query, PROCESS_DEFINITION, "RES.PROC_DEF_KEY_", READ_HISTORY);
+
+    } else {
+      configureQuery(query);
+
+      CompositePermissionCheck permissionCheck = new PermissionCheckBuilder()
+          .disjunctive()
+            .atomicCheck(PROCESS_DEFINITION, "RES.PROC_DEF_KEY_", READ_HISTORY)
+            .atomicCheck(HISTORIC_PROCESS_INSTANCE, "RES.PROC_INST_ID_",
+                HistoricProcessInstancePermissions.READ)
+          .build();
+
+      addPermissionCheck(authCheck, permissionCheck);
+
+    }
   }
 
   //historic identity link query ////////////////////////////////

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/AuthorizationManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/AuthorizationManager.java
@@ -925,12 +925,24 @@ public class AuthorizationManager extends AbstractManager {
 
   public void configureUserOperationLogQuery(UserOperationLogQueryImpl query) {
     configureQuery(query);
-    CompositePermissionCheck permissionCheck = new PermissionCheckBuilder()
+    PermissionCheckBuilder permissionCheckBuilder = new PermissionCheckBuilder()
         .disjunctive()
           .atomicCheck(PROCESS_DEFINITION, "RES.PROC_DEF_KEY_", READ_HISTORY)
-          .atomicCheck(Resources.OPERATION_LOG_CATEGORY, "RES.CATEGORY_", READ)
-        .build();
-    addPermissionCheck(query.getAuthCheck(), permissionCheck);
+          .atomicCheck(Resources.OPERATION_LOG_CATEGORY, "RES.CATEGORY_", READ);
+
+    AuthorizationCheck authCheck = query.getAuthCheck();
+
+    boolean isHistoricInstancePermissionsEnabled = isHistoricInstancePermissionsEnabled();
+    authCheck.setHistoricInstancePermissionsEnabled(isHistoricInstancePermissionsEnabled);
+
+    if (isHistoricInstancePermissionsEnabled) {
+      permissionCheckBuilder.atomicCheck(HISTORIC_PROCESS_INSTANCE, "RES.PROC_INST_ID_",
+              HistoricProcessInstancePermissions.READ);
+    }
+
+    CompositePermissionCheck permissionCheck = permissionCheckBuilder.build();
+
+    addPermissionCheck(authCheck, permissionCheck);
   }
 
   // batch

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/AuthorizationManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/AuthorizationManager.java
@@ -898,7 +898,27 @@ public class AuthorizationManager extends AbstractManager {
   // historic external task log query /////////////////////////////////
 
   public void configureHistoricExternalTaskLogQuery(HistoricExternalTaskLogQueryImpl query) {
-    configureQuery(query, PROCESS_DEFINITION, "RES.PROC_DEF_KEY_", READ_HISTORY);
+    AuthorizationCheck authCheck = query.getAuthCheck();
+
+    boolean isHistoricInstancePermissionsEnabled = isHistoricInstancePermissionsEnabled();
+    authCheck.setHistoricInstancePermissionsEnabled(isHistoricInstancePermissionsEnabled);
+
+    if (!isHistoricInstancePermissionsEnabled) {
+      configureQuery(query, PROCESS_DEFINITION, "RES.PROC_DEF_KEY_", READ_HISTORY);
+
+    } else {
+      configureQuery(query);
+
+      CompositePermissionCheck permissionCheck = new PermissionCheckBuilder()
+          .disjunctive()
+            .atomicCheck(PROCESS_DEFINITION, "RES.PROC_DEF_KEY_", READ_HISTORY)
+            .atomicCheck(HISTORIC_PROCESS_INSTANCE, "RES.PROC_INST_ID_",
+                HistoricProcessInstancePermissions.READ)
+          .build();
+
+      addPermissionCheck(authCheck, permissionCheck);
+
+    }
   }
 
   // user operation log query ///////////////////////////////

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricExternalTaskLog.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricExternalTaskLog.xml
@@ -269,7 +269,11 @@
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause"/>
-      AUTH ON (AUTH.RESOURCE_ID_ in (RES.PROC_DEF_KEY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ in (
+      <if test="authCheck.isHistoricInstancePermissionsEnabled">
+        RES.PROC_INST_ID_,
+      </if>
+      RES.PROC_DEF_KEY_, '*'))
     </if>
 
     <where>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricIncident.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricIncident.xml
@@ -294,7 +294,11 @@
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause"/>
-      AUTH ON (AUTH.RESOURCE_ID_ in (RES.PROC_DEF_KEY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ in (
+      <if test="authCheck.isHistoricInstancePermissionsEnabled">
+      RES.PROC_INST_ID_,
+      </if>
+      RES.PROC_DEF_KEY_, '*'))
     </if>
 
     <where>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricJobLog.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricJobLog.xml
@@ -313,7 +313,11 @@
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause"/>
-      AUTH ON (AUTH.RESOURCE_ID_ in (RES.PROCESS_DEF_KEY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ in (
+      <if test="authCheck.isHistoricInstancePermissionsEnabled">
+        RES.PROCESS_INSTANCE_ID_,
+      </if>
+      RES.PROCESS_DEF_KEY_, '*'))
     </if>
 
     <where>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
@@ -547,18 +547,11 @@
       </foreach>
 
       <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; authCheck.authUserId != null">
-        <choose>
-          <when test="authCheck.isHistoricInstancePermissionsEnabled">
-            <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.queryAuthorizationCheck"/>
-          </when>
-          <otherwise>
-            and (
-            (SELF.PROC_DEF_KEY_ is not null
-            <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.queryAuthorizationCheck"/>
-            ) or SELF.PROC_DEF_KEY_ is null
-            )
-          </otherwise>
-        </choose>
+        and (
+        (SELF.PROC_DEF_KEY_ is not null
+        <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.queryAuthorizationCheck"/>
+        ) or SELF.PROC_DEF_KEY_ is null
+        )
       </if>
 
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.TenantEntity.queryTenantCheckWithSelfPrefix"/>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/UserOperationLogEntry.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/UserOperationLogEntry.xml
@@ -244,7 +244,11 @@
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause"/>
-      AUTH ON (AUTH.RESOURCE_ID_ in (RES.PROC_DEF_KEY_, RES.CATEGORY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ in (
+      <if test="authCheck.isHistoricInstancePermissionsEnabled">
+        RES.PROC_INST_ID_,
+      </if>
+      RES.PROC_DEF_KEY_, RES.CATEGORY_, '*'))
     </if>
 
     <where>
@@ -326,7 +330,7 @@
       
       <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; authCheck.authUserId != null">
         <!-- may not exist in the context of a process definition -->
-          and ( 
+          and (
             <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.queryAuthorizationCheckWithoutPrefix"/>
             or ( RES.CATEGORY_ IS NULL AND RES.PROC_DEF_KEY_ IS NULL )
           )

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricActivityInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricActivityInstanceAuthorizationTest.java
@@ -27,7 +27,6 @@ import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.authorization.HistoricProcessInstancePermissions;
 import org.camunda.bpm.engine.authorization.ProcessDefinitionPermissions;
 import org.camunda.bpm.engine.authorization.Resources;
-import org.camunda.bpm.engine.history.HistoricActivityInstance;
 import org.camunda.bpm.engine.history.HistoricActivityInstanceQuery;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
 import org.camunda.bpm.engine.impl.AbstractQuery;
@@ -216,13 +215,11 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
         HistoricProcessInstancePermissions.NONE);
 
     // when
-    List<HistoricActivityInstance> result =
-        historyService.createHistoricActivityInstanceQuery()
-            .processInstanceId(processInstanceId)
-            .list();
+    HistoricActivityInstanceQuery query = historyService.createHistoricActivityInstanceQuery()
+        .processInstanceId(processInstanceId);
 
     // then
-    assertThat(result.size()).isEqualTo(0);
+    assertThat(query.list()).isEmpty();
   }
 
   public void testCheckReadPermissionOnHistoricProcessInstance() {
@@ -235,12 +232,13 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
         HistoricProcessInstancePermissions.READ);
 
     // when
-    List<HistoricActivityInstance> result = historyService.createHistoricActivityInstanceQuery()
-        .processInstanceId(processInstanceId)
-        .list();
+    HistoricActivityInstanceQuery query = historyService.createHistoricActivityInstanceQuery()
+        .processInstanceId(processInstanceId);
 
     // then
-    assertThat(result.size()).isEqualTo(2);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId, processInstanceId);
   }
 
   public void testCheckReadPermissionOnCompletedHistoricProcessInstance() {
@@ -257,12 +255,13 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
         HistoricProcessInstancePermissions.READ);
 
     // when
-    List<HistoricActivityInstance> result = historyService.createHistoricActivityInstanceQuery()
-        .processInstanceId(processInstanceId)
-        .list();
+    HistoricActivityInstanceQuery query = historyService.createHistoricActivityInstanceQuery()
+        .processInstanceId(processInstanceId);
 
     // then
-    assertThat(result.size()).isEqualTo(3);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId, processInstanceId, processInstanceId);
   }
 
   public void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
@@ -280,12 +279,13 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
 
     // when
-    List<HistoricActivityInstance> result = historyService.createHistoricActivityInstanceQuery()
-        .processInstanceId(processInstanceId)
-        .list();
+    HistoricActivityInstanceQuery query = historyService.createHistoricActivityInstanceQuery()
+        .processInstanceId(processInstanceId);
 
     // then
-    assertThat(result.size()).isEqualTo(3);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId, processInstanceId, processInstanceId);
   }
 
   public void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
@@ -304,12 +304,13 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
         ProcessDefinitionPermissions.NONE);
 
     // when
-    List<HistoricActivityInstance> result = historyService.createHistoricActivityInstanceQuery()
-        .processInstanceId(processInstanceId)
-        .list();
+    HistoricActivityInstanceQuery query = historyService.createHistoricActivityInstanceQuery()
+        .processInstanceId(processInstanceId);
 
     // then
-    assertThat(result.size()).isEqualTo(3);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId, processInstanceId, processInstanceId);
   }
 
   public void testHistoricProcessInstancePermissionsAuthorizationDisabled() {
@@ -321,14 +322,14 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
     disableAuthorization();
 
     // when
-    List<HistoricActivityInstance> result = historyService.createHistoricActivityInstanceQuery()
-        .processInstanceId(processInstanceId)
-        .list();
+    HistoricActivityInstanceQuery query = historyService.createHistoricActivityInstanceQuery()
+        .processInstanceId(processInstanceId);
 
     // then
-    assertThat(result.size()).isEqualTo(2);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId, processInstanceId);
   }
-
 
   // helper ////////////////////////////////////////////////////////
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricDetailAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricDetailAuthorizationTest.java
@@ -1015,11 +1015,10 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
         HistoricProcessInstancePermissions.NONE);
 
     // when
-    List<HistoricDetail> result = historyService.createHistoricDetailQuery()
-        .list();
+    HistoricDetailQuery query = historyService.createHistoricDetailQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(0);
+    assertThat(query.list()).isEmpty();
   }
 
   public void testCheckReadPermissionOnHistoricProcessInstance_GlobalVariable() {
@@ -1035,11 +1034,12 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
         HistoricProcessInstancePermissions.READ);
 
     // when
-    List<HistoricDetail> result = historyService.createHistoricDetailQuery()
-        .list();
+    HistoricDetailQuery query = historyService.createHistoricDetailQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   public void testCheckReadPermissionOnHistoricProcessInstance_LocalVariable() {
@@ -1056,11 +1056,12 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
         HistoricProcessInstancePermissions.READ);
 
     // when
-    List<HistoricDetail> result = historyService.createHistoricDetailQuery()
-        .list();
+    HistoricDetailQuery query = historyService.createHistoricDetailQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   public void testCheckReadPermissionOnCompletedHistoricProcessInstance() {
@@ -1078,11 +1079,12 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
         HistoricProcessInstancePermissions.READ);
 
     // when
-    List<HistoricDetail> result = historyService.createHistoricDetailQuery()
-        .list();
+    HistoricDetailQuery query = historyService.createHistoricDetailQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   public void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
@@ -1101,11 +1103,12 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
 
     // when
-    List<HistoricDetail> result = historyService.createHistoricDetailQuery()
-        .list();
+    HistoricDetailQuery query = historyService.createHistoricDetailQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   public void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
@@ -1125,11 +1128,12 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
         ProcessDefinitionPermissions.NONE);
 
     // when
-    List<HistoricDetail> result = historyService.createHistoricDetailQuery()
-        .list();
+    HistoricDetailQuery query = historyService.createHistoricDetailQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   // helper ////////////////////////////////////////////////////////

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricIdentityLinkLogAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricIdentityLinkLogAuthorizationTest.java
@@ -368,11 +368,10 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
         HistoricProcessInstancePermissions.NONE);
 
     // when
-    List<HistoricIdentityLinkLog> result = historyService.createHistoricIdentityLinkLogQuery()
-        .list();
+    HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(0);
+    assertThat(query.list()).isEmpty();
   }
 
   public void testCheckReadPermissionOnHistoricProcessInstance() {
@@ -385,11 +384,12 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
         HistoricProcessInstancePermissions.READ);
 
     // when
-    List<HistoricIdentityLinkLog> result = historyService.createHistoricIdentityLinkLogQuery()
-        .list();
+    HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("rootProcessInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   public void testCheckReadPermissionOnCompletedHistoricProcessInstance() {
@@ -406,11 +406,12 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
         HistoricProcessInstancePermissions.READ);
 
     // when
-    List<HistoricIdentityLinkLog> result = historyService.createHistoricIdentityLinkLogQuery()
-        .list();
+    HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("rootProcessInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   public void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
@@ -428,11 +429,12 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
     createGrantAuthorization(PROCESS_DEFINITION, ONE_PROCESS_KEY, userId, READ_HISTORY);
 
     // when
-    List<HistoricIdentityLinkLog> result = historyService.createHistoricIdentityLinkLogQuery()
-        .list();
+    HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("rootProcessInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   public void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
@@ -451,11 +453,12 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
         ProcessDefinitionPermissions.NONE);
 
     // when
-    List<HistoricIdentityLinkLog> result = historyService.createHistoricIdentityLinkLogQuery()
-        .list();
+    HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("rootProcessInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   public void createTaskAndAssignUser(String taskId) {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricTaskInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricTaskInstanceAuthorizationTest.java
@@ -977,10 +977,10 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
         HistoricProcessInstancePermissions.NONE);
 
     // when
-    List<HistoricTaskInstance> result = historyService.createHistoricTaskInstanceQuery().list();
+    HistoricTaskInstanceQuery query = historyService.createHistoricTaskInstanceQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(0);
+    assertThat(query.list()).isEmpty();
   }
 
   public void testCheckReadPermissionOnHistoricProcessInstance() {
@@ -993,10 +993,12 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
         HistoricProcessInstancePermissions.READ);
 
     // when
-    List<HistoricTaskInstance> result = historyService.createHistoricTaskInstanceQuery().list();
+    HistoricTaskInstanceQuery query = historyService.createHistoricTaskInstanceQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   public void testCheckReadPermissionOnCompletedHHistoricProcessInstance() {
@@ -1013,10 +1015,12 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
         HistoricProcessInstancePermissions.READ);
 
     // when
-    List<HistoricTaskInstance> result = historyService.createHistoricTaskInstanceQuery().list();
+    HistoricTaskInstanceQuery query = historyService.createHistoricTaskInstanceQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   public void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
@@ -1034,10 +1038,12 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
 
     // when
-    List<HistoricTaskInstance> result = historyService.createHistoricTaskInstanceQuery().list();
+    HistoricTaskInstanceQuery query = historyService.createHistoricTaskInstanceQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   public void testCheckReadPermissionOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
@@ -1056,10 +1062,12 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
         ProcessDefinitionPermissions.NONE);
 
     // when
-    List<HistoricTaskInstance> result = historyService.createHistoricTaskInstanceQuery().list();
+    HistoricTaskInstanceQuery query = historyService.createHistoricTaskInstanceQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   // helper ////////////////////////////////////////////////////////

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricVariableInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricVariableInstanceAuthorizationTest.java
@@ -987,11 +987,10 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
         HistoricProcessInstancePermissions.NONE);
 
     // when
-    List<HistoricVariableInstance> result = historyService.createHistoricVariableInstanceQuery()
-        .list();
+    HistoricVariableInstanceQuery query = historyService.createHistoricVariableInstanceQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(0);
+    assertThat(query.list()).isEmpty();
   }
 
   public void testCheckReadPermissionOnHistoricProcessInstance_GlobalVariable() {
@@ -1007,11 +1006,12 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
         HistoricProcessInstancePermissions.READ);
 
     // when
-    List<HistoricVariableInstance> result = historyService.createHistoricVariableInstanceQuery()
-        .list();
+    HistoricVariableInstanceQuery query = historyService.createHistoricVariableInstanceQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   public void testCheckReadPermissionOnHistoricProcessInstance_LocalVariable() {
@@ -1028,11 +1028,12 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
         HistoricProcessInstancePermissions.READ);
 
     // when
-    List<HistoricVariableInstance> result = historyService.createHistoricVariableInstanceQuery()
-        .list();
+    HistoricVariableInstanceQuery query = historyService.createHistoricVariableInstanceQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   public void testCheckReadPermissionOnCompletedHistoricProcessInstance() {
@@ -1050,11 +1051,12 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
         HistoricProcessInstancePermissions.READ);
 
     // when
-    List<HistoricVariableInstance> result = historyService.createHistoricVariableInstanceQuery()
-        .list();
+    HistoricVariableInstanceQuery query = historyService.createHistoricVariableInstanceQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   public void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
@@ -1073,11 +1075,12 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
 
     // when
-    List<HistoricVariableInstance> result = historyService.createHistoricVariableInstanceQuery()
-        .list();
+    HistoricVariableInstanceQuery query = historyService.createHistoricVariableInstanceQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   public void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
@@ -1097,11 +1100,12 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
         ProcessDefinitionPermissions.NONE);
 
     // when
-    List<HistoricVariableInstance> result = historyService.createHistoricVariableInstanceQuery()
-        .list();
+    HistoricVariableInstanceQuery query = historyService.createHistoricVariableInstanceQuery();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(query.list())
+        .extracting("processInstanceId")
+        .containsExactly(processInstanceId);
   }
 
   protected void setReadHistoryVariableAsDefaultReadPermission() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeNonHierarchicalTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeNonHierarchicalTest.java
@@ -25,6 +25,7 @@ import org.camunda.bpm.engine.ManagementService;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.authorization.Authorization;
+import org.camunda.bpm.engine.authorization.AuthorizationQuery;
 import org.camunda.bpm.engine.authorization.Resources;
 import org.camunda.bpm.engine.batch.Batch;
 import org.camunda.bpm.engine.batch.history.HistoricBatch;
@@ -75,6 +76,7 @@ import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.camunda.bpm.engine.ProcessEngineConfiguration.HISTORY_FULL;
 
 /**
@@ -513,6 +515,14 @@ public class BatchSetRemovalTimeNonHierarchicalTest {
 
     authorizationService.saveAuthorization(authorization);
 
+    // assume
+    AuthorizationQuery authQuery = authorizationService.createAuthorizationQuery()
+        .resourceType(Resources.HISTORIC_PROCESS_INSTANCE);
+
+    assertThat(authQuery.list())
+        .extracting("removalTime", "resourceId", "rootProcessInstanceId")
+        .containsExactly(tuple(null, processInstanceId, processInstanceId));
+
     // when
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
 
@@ -524,11 +534,12 @@ public class BatchSetRemovalTimeNonHierarchicalTest {
     );
 
     // then
-    authorization = authorizationService.createAuthorizationQuery()
-            .resourceType(Resources.HISTORIC_PROCESS_INSTANCE)
-            .singleResult();
+    authQuery = authorizationService.createAuthorizationQuery()
+        .resourceType(Resources.HISTORIC_PROCESS_INSTANCE);
 
-    assertThat(authorization.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(authQuery.list())
+        .extracting("removalTime", "resourceId", "rootProcessInstanceId")
+        .containsExactly(tuple(REMOVAL_TIME, processInstanceId, processInstanceId));
   }
 
   @Test
@@ -547,6 +558,14 @@ public class BatchSetRemovalTimeNonHierarchicalTest {
 
     authorizationService.saveAuthorization(authorization);
 
+    // assume
+    AuthorizationQuery authQuery = authorizationService.createAuthorizationQuery()
+        .resourceType(Resources.HISTORIC_PROCESS_INSTANCE);
+
+    assertThat(authQuery.list())
+        .extracting("removalTime", "resourceId", "rootProcessInstanceId")
+        .containsExactly(tuple(null, processInstanceId, processInstanceId));
+
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
 
     // when
@@ -557,12 +576,13 @@ public class BatchSetRemovalTimeNonHierarchicalTest {
             .executeAsync()
     );
 
-    authorization = authorizationService.createAuthorizationQuery()
-        .resourceType(Resources.HISTORIC_PROCESS_INSTANCE)
-        .singleResult();
-
     // then
-    assertThat(authorization.getRemovalTime()).isNull();
+    authQuery = authorizationService.createAuthorizationQuery()
+        .resourceType(Resources.HISTORIC_PROCESS_INSTANCE);
+
+    assertThat(authQuery.list())
+        .extracting("removalTime", "resourceId", "rootProcessInstanceId")
+        .containsExactly(tuple(null, processInstanceId, processInstanceId));
   }
 
   @Test

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/camunda/bpm/qa/upgrade/TestFixture.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/camunda/bpm/qa/upgrade/TestFixture.java
@@ -49,6 +49,7 @@ import org.camunda.bpm.qa.upgrade.scenarios.multiinstance.MultiInstanceReceiveTa
 import org.camunda.bpm.qa.upgrade.scenarios.multiinstance.NestedSequentialMultiInstanceSubprocessScenario;
 import org.camunda.bpm.qa.upgrade.scenarios.multiinstance.ParallelMultiInstanceSubprocessScenario;
 import org.camunda.bpm.qa.upgrade.scenarios.multiinstance.SequentialMultiInstanceSubprocessScenario;
+import org.camunda.bpm.qa.upgrade.scenarios.histperms.HistoricInstancePermissionsWithoutProcDefKeyScenario;
 import org.camunda.bpm.qa.upgrade.scenarios.task.OneScopeTaskScenario;
 import org.camunda.bpm.qa.upgrade.scenarios.task.OneTaskScenario;
 import org.camunda.bpm.qa.upgrade.scenarios.task.ParallelScopeTasksScenario;
@@ -127,6 +128,8 @@ public class TestFixture {
 
     // event-based gateway
     runner.setupScenarios(EventBasedGatewayScenario.class);
+
+    runner.setupScenarios(HistoricInstancePermissionsWithoutProcDefKeyScenario.class);
 
     processEngine.close();
   }

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/camunda/bpm/qa/upgrade/scenarios/histperms/HistoricInstancePermissionsWithoutProcDefKeyScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/camunda/bpm/qa/upgrade/scenarios/histperms/HistoricInstancePermissionsWithoutProcDefKeyScenario.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.qa.upgrade.scenarios.histperms;
+
+import org.camunda.bpm.engine.IdentityService;
+import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.qa.upgrade.DescribesScenario;
+import org.camunda.bpm.qa.upgrade.ScenarioSetup;
+
+public class HistoricInstancePermissionsWithoutProcDefKeyScenario {
+
+  @Deployment
+  public static String deploy() {
+    return "org/camunda/bpm/qa/upgrade/oneTaskProcess.bpmn20.xml";
+  }
+
+  @DescribesScenario("createProcInstancesAndOpLogs")
+  public static ScenarioSetup createProcInstancesAndOpLogs() {
+    return (engine, scenarioName) -> {
+      IdentityService identityService = engine.getIdentityService();
+      for (int i = 0; i < 5; i++) {
+        String processInstanceId = engine.getRuntimeService()
+            .startProcessInstanceByKey("oneTaskProcess",
+                "HistPermsWithoutProcDefKeyScenarioBusinessKey" + i)
+            .getId();
+
+        identityService.setAuthentication("mary02", null);
+
+        TaskService taskService = engine.getTaskService();
+
+        String taskId = taskService.createTaskQuery()
+            .processInstanceId(processInstanceId)
+            .singleResult()
+            .getId();
+
+        taskService.setAssignee(taskId, "john");
+
+        identityService.clearAuthentication();
+      }
+    };
+  }
+}

--- a/qa/test-db-instance-migration/test-migration/pom.xml
+++ b/qa/test-db-instance-migration/test-migration/pom.xml
@@ -44,6 +44,12 @@
       <artifactId>groovy-all</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7130/histperms/HistoricInstancePermissionsAuthorizationTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7130/histperms/HistoricInstancePermissionsAuthorizationTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.qa.upgrade.scenarios7130.histperms;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.camunda.bpm.engine.AuthorizationService;
+import org.camunda.bpm.engine.HistoryService;
+import org.camunda.bpm.engine.IdentityService;
+import org.camunda.bpm.engine.authorization.Authorization;
+import org.camunda.bpm.engine.authorization.HistoricProcessInstancePermissions;
+import org.camunda.bpm.engine.authorization.Resources;
+import org.camunda.bpm.engine.history.HistoricProcessInstance;
+import org.camunda.bpm.engine.history.HistoricProcessInstanceQuery;
+import org.camunda.bpm.engine.history.UserOperationLogQuery;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class HistoricInstancePermissionsAuthorizationTest {
+
+  protected final String BUSINESS_KEY = "HistPermsWithoutProcDefKeyScenarioBusinessKey";
+
+  protected final String USER_ID = getClass().getName() + "-User";
+
+  @Rule
+  public ProcessEngineRule engineRule = new ProcessEngineRule("camunda.cfg.xml");
+
+  protected HistoryService historyService;
+  protected AuthorizationService authorizationService;
+  protected IdentityService identityService;
+  protected ProcessEngineConfigurationImpl engineConfiguration;
+
+  @Before
+  public void assignServices() {
+    historyService = engineRule.getHistoryService();
+    authorizationService = engineRule.getAuthorizationService();
+    identityService = engineRule.getIdentityService();
+
+    engineConfiguration = engineRule.getProcessEngineConfiguration();
+  }
+
+  @Before
+  public void authenticate() {
+    engineRule.getIdentityService()
+        .setAuthenticatedUserId(USER_ID);
+  }
+
+  @After
+  public void tearDown() {
+    engineConfiguration
+        .setEnableHistoricInstancePermissions(false)
+        .setAuthorizationEnabled(false);
+
+    identityService.clearAuthentication();
+
+    List<Authorization> auths = authorizationService.createAuthorizationQuery()
+        .userIdIn(USER_ID)
+        .list();
+
+    for (Authorization authorization : auths) {
+      authorizationService.deleteAuthorization(authorization.getId());
+    }
+  }
+
+  @Test
+  public void shouldSkipAuthorizationChecksForOperationLogQuery() {
+    // given
+    engineConfiguration.setEnableHistoricInstancePermissions(true);
+
+    Authorization auth = authorizationService.createNewAuthorization(Authorization.AUTH_TYPE_GRANT);
+    auth.setUserId(USER_ID);
+    auth.setPermissions(new HistoricProcessInstancePermissions[] {
+        HistoricProcessInstancePermissions.READ });
+    auth.setResource(Resources.HISTORIC_PROCESS_INSTANCE);
+
+    HistoricProcessInstance historicProcessInstance =
+        historyService.createHistoricProcessInstanceQuery()
+            .processInstanceBusinessKey(BUSINESS_KEY + "0")
+            .singleResult();
+
+    String processInstanceId = historicProcessInstance.getId();
+
+    auth.setResourceId(processInstanceId);
+
+    authorizationService.saveAuthorization(auth);
+
+    engineConfiguration.setAuthorizationEnabled(true);
+
+    // when
+    String processDefinitionId = historicProcessInstance.getProcessDefinitionId();
+
+    UserOperationLogQuery query = historyService.createUserOperationLogQuery()
+        .processDefinitionId(processDefinitionId);
+
+    // then
+    assertThat(query.list())
+        .extracting("processDefinitionId")
+        .containsExactly(
+            processDefinitionId,
+            processDefinitionId,
+            processDefinitionId,
+            processDefinitionId,
+            processDefinitionId
+        );
+  }
+
+}


### PR DESCRIPTION
Enforces Historic Process Instance Authorizations for the following queries:
* Historic Incident
* Job Log
* External Task Log
* User Operation Log

Parent Ticket: CAM-11189
