### PR TITLE
CAM-11760: chore(engine): set default transaction isolation level

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/ProcessEngineConfiguration.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/ProcessEngineConfiguration.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import javax.sql.DataSource;
 
+import org.apache.ibatis.session.TransactionIsolationLevel;
 import org.camunda.bpm.engine.authorization.Authorization;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.camunda.bpm.engine.identity.PasswordPolicy;
@@ -231,6 +232,7 @@ public abstract class ProcessEngineConfiguration {
 
   protected String databaseType;
   protected String databaseSchemaUpdate = DB_SCHEMA_UPDATE_FALSE;
+  protected int dbTransactionIsolationLevel = TransactionIsolationLevel.READ_COMMITTED.getLevel();
   protected String jdbcDriver = "org.h2.Driver";
   protected String jdbcUrl = "jdbc:h2:tcp://localhost/activiti";
   protected String jdbcUsername = "sa";
@@ -625,6 +627,14 @@ public abstract class ProcessEngineConfiguration {
   public ProcessEngineConfiguration setJdbcPassword(String jdbcPassword) {
     this.jdbcPassword = jdbcPassword;
     return this;
+  }
+
+  public int getDbTransactionIsolationLevel() {
+    return dbTransactionIsolationLevel;
+  }
+
+  public void setDbTransactionIsolationLevel(int dbTransactionIsolationLevel) {
+    this.dbTransactionIsolationLevel = dbTransactionIsolationLevel;
   }
 
   public boolean isTransactionsExternallyManaged() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -1360,6 +1360,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         PooledDataSource pooledDataSource =
             new PooledDataSource(ReflectUtil.getClassLoader(), jdbcDriver, jdbcUrl, jdbcUsername, jdbcPassword);
 
+        // Set default Transaction Isolation Level to READ_COMMITTED
+        pooledDataSource.setDefaultTransactionIsolationLevel(getDbTransactionIsolationLevel());
+
         if (jdbcMaxActiveConnections > 0) {
           pooledDataSource.setPoolMaximumActiveConnections(jdbcMaxActiveConnections);
         }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/db/DbTransactionIsolationLevelTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/db/DbTransactionIsolationLevelTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.standalone.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.sql.SQLException;
+
+import org.apache.ibatis.session.TransactionIsolationLevel;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DbTransactionIsolationLevelTest {
+
+  @Rule
+  public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
+
+  protected ProcessEngineConfigurationImpl processEngineConfiguration;
+
+  @Before
+  public void setUp() {
+    processEngineConfiguration = engineRule.getProcessEngineConfiguration();
+  }
+
+  @Test
+  public void shouldBeReadCommitted() {
+    try {
+      // when
+      int transactionIsolationLevel = processEngineConfiguration.getDataSource()
+          .getConnection()
+          .getTransactionIsolation();
+
+      // then
+      assertThat(transactionIsolationLevel)
+          .isEqualTo(TransactionIsolationLevel.READ_COMMITTED.getLevel());
+    } catch (SQLException throwables) {
+      fail("Connection expected");
+    }
+  }
+}


### PR DESCRIPTION
Related to CAM-11760

The fix removes the issues when a database uses a non-`READ_COMMITTED` Transaction Isolation Level by default, by setting the Session's connection preference from our side. This is the case for MySQL and MariaDB.