### PR TITLE
chore(run): exclude asm dependency from test scope

### DIFF
--- a/distro/run/core/pom.xml
+++ b/distro/run/core/pom.xml
@@ -68,6 +68,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
- the version (5.0.4) pulled in via json-smart overrid the version
  (7.1) pulled in via jersey and created an inconsistency in
  dependency versions

related to CAM-11803