### PR TITLE
CAM-11116: fix(db): set correct oracle db column type

### DIFF
--- a/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.oracle.create.decision.history.sql
+++ b/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.oracle.create.decision.history.sql
@@ -55,7 +55,7 @@ create table ACT_HI_DEC_IN (
     TEXT2_ NVARCHAR2(2000),
     TENANT_ID_ NVARCHAR2(64),
     CREATE_TIME_ TIMESTAMP(6),
-    ROOT_PROC_INST_ID_ varchar(64),
+    ROOT_PROC_INST_ID_ NVARCHAR2(64),
     REMOVAL_TIME_ TIMESTAMP(6),
     primary key (ID_)
 );
@@ -77,7 +77,7 @@ create table ACT_HI_DEC_OUT (
     TEXT2_ NVARCHAR2(2000),
     TENANT_ID_ NVARCHAR2(64),
     CREATE_TIME_ TIMESTAMP(6),
-    ROOT_PROC_INST_ID_ varchar(64),
+    ROOT_PROC_INST_ID_ NVARCHAR2(64),
     REMOVAL_TIME_ TIMESTAMP(6),
     primary key (ID_)
 );

--- a/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.oracle.create.engine.sql
+++ b/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.oracle.create.engine.sql
@@ -50,7 +50,7 @@ create table ACT_GE_BYTEARRAY (
     TENANT_ID_ NVARCHAR2(64),
     TYPE_ INTEGER,
     CREATE_TIME_ TIMESTAMP(6),
-    ROOT_PROC_INST_ID_ varchar(64),
+    ROOT_PROC_INST_ID_ NVARCHAR2(64),
     REMOVAL_TIME_ TIMESTAMP(6),
     primary key (ID_)
 );


### PR DESCRIPTION
* Set NVARCHAR as the data type for the ROOT_PROCESS_INSTANCE_ID_ columns in ACT_GE_BYTEARRAY, ACT_HI_DEC_IN and ACT_HI_DEC_OUT.

Related to CAM-11116