### PR TITLE
Enable using the FEEL-Scala engine as script engine

### DIFF
--- a/engine-dmn/feel-scala/src/main/resources/META-INF/services/org.camunda.feel.valuemapper.CustomValueMapper
+++ b/engine-dmn/feel-scala/src/main/resources/META-INF/services/org.camunda.feel.valuemapper.CustomValueMapper
@@ -1,0 +1,1 @@
+org.camunda.feel.impl.JavaValueMapper

--- a/engine-plugins/spin-plugin/src/main/resources/META-INF/services/org.camunda.feel.valuemapper.CustomValueMapper
+++ b/engine-plugins/spin-plugin/src/main/resources/META-INF/services/org.camunda.feel.valuemapper.CustomValueMapper
@@ -1,0 +1,1 @@
+org.camunda.spin.plugin.impl.feel.integration.SpinValueMapper


### PR DESCRIPTION
Since the FEEL-Scala engine implements the script engine interface (JSR223), it can be used as a script engine in the Camunda BPM engine. 

Currently, the usage as a script engine is limited because the result can not always be used directly in an expression of an attribute. For example, if the result is a list that should be used in the `candidateUsers` attribute.

By adding these two files, it registers the value mappers for FEEL-Scala engine to transform Java objects and Camunda Spin types.
  