### PR TITLE
CAM-11669: use OpenJPA 1 for old-engine tests

### DIFF
--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -139,6 +139,7 @@
         <dependency>
           <groupId>org.apache.openjpa</groupId>
           <artifactId>openjpa</artifactId>
+          <version>1.2.3</version>
           <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
- this suite uses the tests at tag 7.12.0 which are not adapted
  to OpenJPA 2 yet
- this change can be reverted as soon as we move the old engine version
  to 7.13.0

related to CAM-11669