### PR TITLE
CAM-11887: remove distinct from fetch and lock on postgres

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExternalTaskManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExternalTaskManager.java
@@ -33,6 +33,7 @@ import org.camunda.bpm.engine.impl.cfg.TransactionState;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.db.ListQueryParameterObject;
 import org.camunda.bpm.engine.impl.db.entitymanager.DbEntityManager;
+import org.camunda.bpm.engine.impl.db.sql.DbSqlSessionFactory;
 import org.camunda.bpm.engine.impl.externaltask.TopicFetchInstruction;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.persistence.AbstractManager;
@@ -83,6 +84,8 @@ public class ExternalTaskManager extends AbstractManager {
     List<QueryOrderingProperty> orderingProperties = new ArrayList<>();
     orderingProperties.add(EXT_TASK_PRIORITY_ORDERING_PROPERTY);
     parameters.put("orderingProperties", orderingProperties);
+    String databaseType = Context.getProcessEngineConfiguration().getDatabaseType();
+    parameters.put("usesPostgres", DbSqlSessionFactory.POSTGRES.equals(databaseType));
 
     ListQueryParameterObject parameter = new ListQueryParameterObject(parameters, 0, maxResults);
     configureQuery(parameter);

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ExternalTask.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ExternalTask.xml
@@ -167,8 +167,18 @@
   <select id="selectExternalTasksForTopics" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject" resultMap="externalTaskResultMap">
     <bind name="orderingProperties" value="parameter.orderingProperties" />
     <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.bindOrderBy"/>
+
+    <bind name="performAuthorizationCheck" value="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null" />
+
     ${limitBefore}
-    select ${distinct} RES.*
+    select 
+    <!-- Distinct can only be omitted when there are no joins with a 1:n relationship.
+      Currently this is only the case for the authorization joins. When you add a join
+      in this statement in the future, check if distinct can be omitted or not -->
+    <if test="!parameter.usesPostgres || performAuthorizationCheck">
+      ${distinct} 
+    </if>
+    RES.*
     ${limitBetween}
     from (
     select RES.*, PI.BUSINESS_KEY_, PD.VERSION_TAG_
@@ -177,7 +187,7 @@
     left join ${prefix}ACT_RU_EXECUTION PI on RES.PROC_INST_ID_ = PI.ID_
     inner join ${prefix}ACT_RE_PROCDEF PD on RES.PROC_DEF_ID_ = PD.ID_
 
-    <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
+    <if test="performAuthorizationCheck">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" /> 
       AUTH ON (
        (AUTH.RESOURCE_TYPE_ = 8 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/externaltask/FetchExternalTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/externaltask/FetchExternalTaskAuthorizationTest.java
@@ -192,6 +192,21 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
     // then
     assertEquals(2, tasks.size());
   }
+  
+
+  public void testFetchWithMultipleMatchingAuthorizations() {
+    // given
+    createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ, UPDATE);
+    createGrantAuthorization(PROCESS_INSTANCE, instance1Id, userId, READ, UPDATE);
+
+    // when
+    List<LockedExternalTask> tasks = externalTaskService.fetchAndLock(5, WORKER_ID)
+      .topic("externalTaskTopic", LOCK_TIME)
+      .execute();
+
+    // then
+    assertEquals(2, tasks.size());
+  }
 
   public void testQueryWithReadAndUpdateInstanceOnAnyProcessDefinition() {
     // given


### PR DESCRIPTION
- leads to bad query plans as the database cannot push the pagination
  much into the query plan when distinct is present
- must be applied with caution: distinct can only be omitted when we do not
  join another table

related to CAM-11887