### PR TITLE
fix(run): fix CORS with authentication behavior

### DIFF
--- a/distro/run/core/src/main/java/org/camunda/bpm/run/property/CamundaBpmRunCorsProperty.java
+++ b/distro/run/core/src/main/java/org/camunda/bpm/run/property/CamundaBpmRunCorsProperty.java
@@ -20,6 +20,7 @@ public class CamundaBpmRunCorsProperty {
 
   public static final String PREFIX = CamundaBpmRunProperties.PREFIX + ".cors";
   public static final String DEFAULT_ORIGINS = "*";
+  public static final String DEFAULT_HTTP_METHODS = "GET,POST,HEAD,OPTIONS,PUT,DELETE";
 
   boolean enabled;
   String allowedOrigins;

--- a/distro/run/core/src/test/java/org/camunda/bpm/run/test/AbstractRestTest.java
+++ b/distro/run/core/src/test/java/org/camunda/bpm/run/test/AbstractRestTest.java
@@ -35,6 +35,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ActiveProfiles(profiles = { "test-auth-disabled" })
 public abstract class AbstractRestTest {
 
+  public static String CONTEXT_PATH = "/engine-rest";
+  
   @Autowired
   protected TestRestTemplate testRestTemplate;
 

--- a/distro/run/core/src/test/java/org/camunda/bpm/run/test/config/cors/CorsAccessControlHeadersTest.java
+++ b/distro/run/core/src/test/java/org/camunda/bpm/run/test/config/cors/CorsAccessControlHeadersTest.java
@@ -18,10 +18,10 @@ package org.camunda.bpm.run.test.config.cors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
-
+import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.run.test.AbstractRestTest;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -31,45 +31,37 @@ import org.springframework.test.context.ActiveProfiles;
 
 /**
  * Note: To run this test via an IDE you must set the system property
- * {@code sun.net.http.allowRestrictedHeaders} to {@code true}.
- * (e.g. System.setProperty("sun.net.http.allowRestrictedHeaders", "true");)
+ * {@code sun.net.http.allowRestrictedHeaders} to {@code true}. (e.g.
+ * System.setProperty("sun.net.http.allowRestrictedHeaders", "true");)
  * 
  * @see https://jira.camunda.com/browse/CAM-11290
  */
 @ActiveProfiles(profiles = { "test-cors-enabled" }, inheritProfiles = true)
-public class CorsConfigurationEnabledWildcardTest extends AbstractRestTest {
+public class CorsAccessControlHeadersTest extends AbstractRestTest {
+
+  @Autowired
+  ProcessEngine processEngine;
 
   @Test
-  public void shouldPassSameOriginRequest() {
+  public void shouldRespondWithAccessControlHeaders() {
     // given
-    // same origin
-    String origin = "http://localhost:" + localPort;
-
-    HttpHeaders headers = new HttpHeaders();
-    headers.add(HttpHeaders.ORIGIN, origin);
-
-    // when
-    ResponseEntity<List> response = testRestTemplate.exchange(CONTEXT_PATH + "/task", HttpMethod.GET, new HttpEntity<>(headers), List.class);
-
-    // then
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getHeaders().getAccessControlAllowOrigin()).contains("*");
-  }
-
-  @Test
-  public void shouldPassCrossOriginRequest() {
-    // given
-    // cross origin but allowed through wildcard
+    // preflight request
     String origin = "http://other.origin";
 
     HttpHeaders headers = new HttpHeaders();
-    headers.add("Origin", origin);
+    headers.add(HttpHeaders.HOST, "localhost");
+    headers.add(HttpHeaders.ORIGIN, origin);
+    headers.add(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.PUT.name());
+    headers.add(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, HttpHeaders.ORIGIN);
 
     // when
-    ResponseEntity<List> response = testRestTemplate.exchange(CONTEXT_PATH + "/task", HttpMethod.GET, new HttpEntity<>(headers), List.class);
+    ResponseEntity<String> response = testRestTemplate.exchange(CONTEXT_PATH + "/task", HttpMethod.OPTIONS, new HttpEntity<>(headers), String.class);
 
     // then
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getHeaders().getAccessControlAllowOrigin()).contains("*");
+    assertThat(response.getHeaders().getAccessControlAllowMethods()).containsExactlyInAnyOrder(HttpMethod.GET, HttpMethod.POST, HttpMethod.HEAD,
+        HttpMethod.OPTIONS, HttpMethod.PUT, HttpMethod.DELETE);
+    assertThat(response.getHeaders().getAccessControlAllowHeaders()).containsExactlyInAnyOrder("origin", "accept", "x-requested-with", "content-type",
+        "access-control-request-method", "access-control-request-headers");
   }
 }

--- a/distro/run/core/src/test/java/org/camunda/bpm/run/test/config/cors/CorsAuthenticationTest.java
+++ b/distro/run/core/src/test/java/org/camunda/bpm/run/test/config/cors/CorsAuthenticationTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.run.test.config.cors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.identity.Group;
+import org.camunda.bpm.engine.impl.persistence.entity.GroupEntity;
+import org.camunda.bpm.run.test.AbstractRestTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Note: To run this test via an IDE you must set the system property
+ * {@code sun.net.http.allowRestrictedHeaders} to {@code true}.
+ * (e.g. System.setProperty("sun.net.http.allowRestrictedHeaders", "true");)
+ * 
+ * @see https://jira.camunda.com/browse/CAM-11290
+ */
+@ActiveProfiles(profiles = { "test-cors-enabled", "test-auth-enabled", "test-demo-user" }, inheritProfiles = false)
+public class CorsAuthenticationTest extends AbstractRestTest {
+
+  TestRestTemplate authTestRestTemplate;
+
+  @Autowired
+  ProcessEngine processEngine;
+
+  @Before
+  public void init() {
+    authTestRestTemplate = testRestTemplate.withBasicAuth("demo", "demo");
+  }
+
+  @After
+  public void tearDown() {
+    processEngine.getIdentityService().deleteGroup("groupId");
+  }
+
+  @Test
+  public void shouldPassAuthenticatedSimpleCorsRequest() {
+    // given
+    // cross origin but allowed through wildcard
+    String origin = "http://other.origin";
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(HttpHeaders.ORIGIN, origin);
+
+    // when
+    ResponseEntity<List> response = authTestRestTemplate.exchange(CONTEXT_PATH + "/task", HttpMethod.GET, new HttpEntity<>(headers), List.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getHeaders().getAccessControlAllowOrigin()).contains("*");
+  }
+
+  @Test
+  public void shouldPassAuthenticatedCorsRequest() {
+    // given
+    // cross origin but allowed through wildcard
+    String origin = "http://other.origin";
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(HttpHeaders.ORIGIN, origin);
+
+    Group group = new GroupEntity("groupId");
+    
+    // create group
+    processEngine.getIdentityService().saveGroup(new GroupEntity("groupId"));
+
+    group.setName("updatedGroupName");
+
+    // when
+    ResponseEntity<String> response = authTestRestTemplate.exchange(CONTEXT_PATH + "/group/" + group.getId(), HttpMethod.PUT, new HttpEntity<>(group, headers),
+        String.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    assertThat(response.getHeaders().getAccessControlAllowOrigin()).contains("*");
+  }
+
+  @Test
+  public void shouldNotPassNonAuthenticatedCorsRequest() {
+    // given
+    // cross origin but allowed through wildcard
+    String origin = "http://other.origin";
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(HttpHeaders.ORIGIN, origin);
+
+    // when
+    ResponseEntity<List> response = testRestTemplate.exchange(CONTEXT_PATH + "/task", HttpMethod.GET, new HttpEntity<>(headers), List.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    assertThat(response.getHeaders().get("WWW-Authenticate")).containsExactly("Basic realm=\"default\"");
+  }
+
+  @Test
+  public void shouldPassNonAuthenticatedPreflightRequest() {
+    // given
+    // cross origin but allowed through wildcard
+    String origin = "http://other.origin";
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add(HttpHeaders.HOST, "localhost");
+    headers.add(HttpHeaders.ORIGIN, origin);
+    headers.add(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, HttpMethod.PUT.name());
+    headers.add(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, HttpHeaders.ORIGIN);
+
+    // when
+    ResponseEntity<String> response = testRestTemplate.exchange(CONTEXT_PATH + "/task", HttpMethod.OPTIONS, new HttpEntity<>(headers), String.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+}

--- a/distro/run/core/src/test/java/org/camunda/bpm/run/test/config/cors/CorsConfigurationDisabledTest.java
+++ b/distro/run/core/src/test/java/org/camunda/bpm/run/test/config/cors/CorsConfigurationDisabledTest.java
@@ -35,6 +35,7 @@ import org.springframework.test.context.TestPropertySource;
 /**
  * Note: To run this test via an IDE you must set the system property
  * {@code sun.net.http.allowRestrictedHeaders} to {@code true}.
+ * (e.g. System.setProperty("sun.net.http.allowRestrictedHeaders", "true");)
  * 
  * @see https://jira.camunda.com/browse/CAM-11290
  */
@@ -52,7 +53,7 @@ public class CorsConfigurationDisabledTest extends AbstractRestTest {
     headers.add(HttpHeaders.ORIGIN, origin);
 
     // when
-    ResponseEntity<List> response = testRestTemplate.exchange("/engine-rest/task", HttpMethod.GET, new HttpEntity<>(headers), List.class);
+    ResponseEntity<List> response = testRestTemplate.exchange(CONTEXT_PATH + "/task", HttpMethod.GET, new HttpEntity<>(headers), List.class);
 
     // then
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -73,7 +74,7 @@ public class CorsConfigurationDisabledTest extends AbstractRestTest {
     headers.add("Origin", origin);
 
     // when
-    ResponseEntity<List> response = testRestTemplate.exchange("/engine-rest/task", HttpMethod.GET, new HttpEntity<>(headers), List.class);
+    ResponseEntity<List> response = testRestTemplate.exchange(CONTEXT_PATH + "/task", HttpMethod.GET, new HttpEntity<>(headers), List.class);
 
     // then
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);

--- a/distro/run/core/src/test/java/org/camunda/bpm/run/test/config/cors/CorsConfigurationEnabledAllowedOriginConfiguredTest.java
+++ b/distro/run/core/src/test/java/org/camunda/bpm/run/test/config/cors/CorsConfigurationEnabledAllowedOriginConfiguredTest.java
@@ -34,6 +34,7 @@ import org.springframework.test.context.TestPropertySource;
 /**
  * Note: To run this test via an IDE you must set the system property
  * {@code sun.net.http.allowRestrictedHeaders} to {@code true}.
+ * (e.g. System.setProperty("sun.net.http.allowRestrictedHeaders", "true");)
  * 
  * @see https://jira.camunda.com/browse/CAM-11290
  */
@@ -51,7 +52,7 @@ public class CorsConfigurationEnabledAllowedOriginConfiguredTest extends Abstrac
     headers.add(HttpHeaders.ORIGIN, origin);
 
     // when
-    ResponseEntity<List> response = testRestTemplate.exchange("/engine-rest/task", HttpMethod.GET, new HttpEntity<>(headers), List.class);
+    ResponseEntity<List> response = testRestTemplate.exchange(CONTEXT_PATH + "/task", HttpMethod.GET, new HttpEntity<>(headers), List.class);
 
     // then
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -68,7 +69,7 @@ public class CorsConfigurationEnabledAllowedOriginConfiguredTest extends Abstrac
     headers.add("Origin", origin);
 
     // when
-    ResponseEntity<List> response = testRestTemplate.exchange("/engine-rest/task", HttpMethod.GET, new HttpEntity<>(headers), List.class);
+    ResponseEntity<List> response = testRestTemplate.exchange(CONTEXT_PATH + "/task", HttpMethod.GET, new HttpEntity<>(headers), List.class);
 
     // then
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
@@ -85,7 +86,7 @@ public class CorsConfigurationEnabledAllowedOriginConfiguredTest extends Abstrac
     headers.add("Origin", origin);
 
     // when
-    ResponseEntity<List> response = testRestTemplate.exchange("/engine-rest/task", HttpMethod.GET, new HttpEntity<>(headers), List.class);
+    ResponseEntity<List> response = testRestTemplate.exchange(CONTEXT_PATH + "/task", HttpMethod.GET, new HttpEntity<>(headers), List.class);
 
     // then
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/distro/run/core/src/test/java/org/camunda/bpm/run/test/config/https/HttpsConfigurationEnabledTest.java
+++ b/distro/run/core/src/test/java/org/camunda/bpm/run/test/config/https/HttpsConfigurationEnabledTest.java
@@ -51,7 +51,7 @@ public class HttpsConfigurationEnabledTest extends AbstractRestTest {
   @Test
   public void shouldConnectWithHttps() {
     // given
-    String url = "https://localhost:" + localPort + "/engine-rest/task";
+    String url = "https://localhost:" + localPort + CONTEXT_PATH + "/task";
 
     // when
     ResponseEntity<List> response = testRestTemplate.exchange(url, HttpMethod.GET, new HttpEntity<>(null), List.class);
@@ -63,7 +63,7 @@ public class HttpsConfigurationEnabledTest extends AbstractRestTest {
   @Test
   public void shouldNotRedirect() {
     // given
-    String url = "http://localhost:" + 8080 + "/engine-rest/task";
+    String url = "http://localhost:" + 8080 + CONTEXT_PATH + "/task";
 
     // then
     exceptionRule.expect(ResourceAccessException.class);


### PR DESCRIPTION
* execute CORS filter before authentication filter
* do not forward CORS preflight request to succeding filter
* allow all HTTP methods that are used by Camunda REST API

Related to CAM-11840, CAM-11885