### PR TITLE
CAM-11764: update for 7.13

### DIFF
--- a/distro/license-book/src/main/resources/license-book.txt
+++ b/distro/license-book/src/main/resources/license-book.txt
@@ -1,41 +1,41 @@
+License Book for Camunda BPM 7.13
 
-
-
-	
-
-
-
-License Book for Camunda BPM 7.12
-
-DateAuthorReleaseDescription of Change<revision number>YYYY-MM-DD<author><release number>change1.02017-12-27Ulrike Liss7.8Final version2.02018-03-20Ulrike Liss7.9intermediate3.02018-05-16Ulrike Liss7.9Final version4.02018-11-21Ulrike Liss7.10Final version5.02019-11-18Ulrike Liss7.12Final Version
-This is a license book. It contains licensing information for third-party libraries which are included in this release of Camunda BPM 7.12
-(Document generated on: 2019-11-18)
+This is a license book. It contains licensing information for third-party libraries which are used in this release of Camunda BPM 7.13
+(Document generated on: 2020-05-12)
 
 Introduction
 This Licensing Information document is a part of the program documentation and is intended to help you understand the license terms and copyright for third-party libraries associated with the Camunda BPM software.
 
-Product License – Camunda BPM 7.12
-This is a distribution of Camunda BPM platform v7.12(visit http://docs.camunda.org/) a Java-based framework. The software is mainly published under the Apache License 2.0 and other open source licenses (Community Platform) and in parts under a commercial license agreement (additional features of the Enterprise Platform). Which components are published under an open source license is clearly stated in the license header of a source code file or a LICENSE file present in the root directory of the software code repository.
+Product License - Camunda BPM 7.13
+This is a distribution of Camunda BPM platform v7.13 (visit http://docs.camunda.org/) a Java-based framework. The software is mainly published under the Apache License 2.0 and other open source licenses (Community Platform) and in parts under a commercial license agreement (additional features of the Enterprise Platform). Which components are published under an open source license is clearly stated in the license header of a source code file or a LICENSE file present in the root directory of the software code repository.
 
 Licenses for Third-Party Libraries
-The following sections contain licensing information for third-party libraries that we distribute with the Camunda BPM source code (Community and Enterprise Platform) for your convenience. In square brackets we provide information on the specific Camunda Component to which a third-party library is linked to. None of the Libraries are modified or changed and are distributed as is. For practicability, the license text is only referenced once, and each third-party library entry is linked to the specific license text. 
+The following sections contain licensing information for third-party libraries that we distribute with the Camunda BPM source code and binaries (Community and Enterprise Platform) for your convenience. None of the Libraries are modified or changed and they are solely distributed as is. For practicality, the license text is only referenced once. Each library (whether provided in source or object form) is licensed to you by its copyright holders under the original open source license listed in this License Book. Nothing in this License Book or any license agreement we enter into with you removes or restricts any rights you may have in respect of any component under its original open source license, or makes any of the original authors or copyright holders of the component liable to you in respect of your use or distribution of that component.
 
 We are thankful to all individuals that have created these.
 
+The Libraries used within the Camunda BPM platform v7.13 are published under the following licenses:
+
 * Apache 2.0
+* bpmn.io
 * BSD-3-Clause
-* BSD-2-Clause
-* CDDL 1.0 (+GPLv2 with classpath exception)
+* CCA 
+* CC0 
+* CDDL 1.0
+* EPL 1.0 
+* EPL 2.0 
 * ISC
+* LGPL 2.1 
 * MIT
-* MPL
-* CCA (Creative Commons Attribution)
+* OFL 
 
+GNU Lesser/Library General Public License LGPL (any version)
+Where the Camunda BPM binaries contain components licensed under any version of LGPL, that licence allows you to extract the object code of the LGPL component from the binary as distributed by us (this is normally distributed as a compressed .tar.gz file which contains a number of files, such as .jar files which are themselves archives containing further components, all of which can be extracted using commonly available tools such as gzip). Using the source code of the library (which we will provide on request, or you can download it from the location specified in this license book), you can make modifications or bug fixes to the library, recompile the library (again, using commonly available tools) and replace the binary of the library you extracted with the recompiled object code. Full details of this process are available on request. This will enable you to modify any LGPL-licensed library and re-integrate that modified library into the Camunda BPM binaries (accepting that this will only work provided you have not broken the library or the interface). 
 
-
+===========================================================================================
 
 Apache 2.0
-The following license text for the Apache 2.0 license is cited only once. All libraries licenses under the Apache 2.0 will be listed after the license text together with copyright notice and link to this license text.
+The following license text for the Apache 2.0 license is cited only once. 
 
 Apache License
 Version 2.0, January 2004
@@ -58,7 +58,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 You must give any other recipients of the Work or Derivative Works a copy of this License; and
 You must cause any modified files to carry prominent notices stating that You changed the files; and
 You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
-If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. 
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.Ã¯Â¿Â½
 
 You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
 5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
@@ -67,280 +67,22 @@ You may add Your own copyright statement to Your modifications and may provide a
 8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
 9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
 END OF TERMS AND CONDITIONS
-The following third-party libraries are licensed under the Apache 2.0 license:
 
 ===========================================================================================
-[Backend / connect / http and Backend / connect / Soap and Backend / connect / all]
-Commons Codec: 1.11 (http://commons.apache.org/codec/)
-Copyright: 2002-2011 The Apache Software Foundation This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/)  and  2002 Kevin Atkinson (kevina@gnu.org). Verbatim copying and distribution of this entire article is permitted in any medium,
-provided this notice is preserved.
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / connect / http and Backend / connect / Soap and Backend / connect / all]
-Commons Logging: 1.1.1 (http://commons.apache.org/proper/commons-logging/)
-Copyright: 2003-2014 The Apache Software Foundation This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/)
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / connect / http and Backend / connect / Soap and Backend / connect / all]
-Apache HttpClient: 4.5.9 (http://hc.apache.org/)
-Copyright: 2005-2014 The Apache Software Foundation This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/)
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / connect / http and Backend / connect / Soap and Backend / connect / all]
-Apache HttpCore: 4.4.11 (http://hc.apache.org/)
-Copyright: 2005-2014 The Apache Software Foundation. This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/). This project contains annotations derived from JCIP-ANNOTATIONS and 2005 Brian Goetz and Tim Peierls. See http://www.jcip.net
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine]
-Joda time: 2.1 (http://joda-time.sourceforge.net)
-Copyright: This product includes software developed by Joda.org (http://www.joda.org/)
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine]
-Mybatis: 3.4.4 (http://www.mybatis.org/mybatis-3)
-Copyright: Copyright 2009-2016 the original author or authors 2004, Drew Davidson and Luke Blanshard
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine]
-Java UUID Generator: 3.2.0 (https://github.com/cowtowncoder/java-uuid-generator)
-Copyright: various authors (https://github.com/cowtowncoder/java-uuid-generator/blob/3.0/release-notes/CREDITS)
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / Rest and and Backend / Spin / json and Backend / Webapp]
-Jackson-annotations: 2.6.0 / 2.10.0 (https://github.com/FasterXML/jackson-annotations)
-Copyright: various authors 
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / Rest and Backend / Spin / json and Backend / Webapp]
-Jackson-core: 2.6.3 / 2.10.0 (https://github.com/FasterXML/jackson-core)
-NOTICE: Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers, as well as supported
-commercially by FasterXML.com.
-## Licensing
-Jackson core and extension components may be licensed under different licenses.
-To find the details that apply to this artifact see the accompanying LICENSE file.
-For more information, including possible other licensing options, contact
-FasterXML.com (http://fasterxml.com).
-## Credits
-A list of contributors may be found from CREDITS file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-Licensed under Apache 2.0
-===========================================================================================[Backend / Engine / Rest and Backend / Spin / json and Backend / Webapp]
-Jackson-databind: 2.6.3 / 2.10.0 (https://github.com/FasterXML/jackson-databind)
-NOTICE: Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers, as well as supported
-commercially by FasterXML.com.
-## Licensing
-Jackson core and extension components may be licensed under different licenses.
-To find the details that apply to this artifact see the accompanying LICENSE file.
-For more information, including possible other licensing options, contact
-FasterXML.com (http://fasterxml.com).
-## Credits
-A list of contributors may be found from CREDITS file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / Rest and Backend / Webapp]
-jackson-jaxrs-base:2.10.0 (https://github.com/FasterXML/jackson-databind)
-NOTICE: Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers, as well as supported
-commercially by FasterXML.com.
-## Licensing
-Jackson core and extension components may be licensed under different licenses.
-To find the details that apply to this artifact see the accompanying LICENSE file.
-For more information, including possible other licensing options, contact
-FasterXML.com (http://fasterxml.com).
-## Credits
-A list of contributors may be found from CREDITS file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / Rest and Backend / Spin / json and Backend / Webapp ]
-Jackson-jaxrs-json-provider: 2.10.0 (https://github.com/FasterXML/jackson-jaxrs-providers
-Copyright: various authors (https://github.com/FasterXML/jackson-jaxrs-providers/tree/master/release-notes)
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / Rest and Backend / Webapp]
-Jackson-module-jaxb-annotations:2.10.0 (https://github.com/FasterXML/jackson-jaxrs-providers
-NOTICE: Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers, as well as supported
-commercially by FasterXML.com.
 
-## Licensing
-Jackson core and extension components may be licensed under different licenses.
-To find the details that apply to this artifact see the accompanying LICENSE file.
-For more information, including possible other licensing options, contact
-FasterXML.com (http://fasterxml.com).
-## Credits
-A list of contributors may be found from CREDITS file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / Rest and Backend /Webapp and Backend / Webapp EE]
-commons-fileupload: 1.3.3 (https://commons.apache.org/proper/commons-fileupload/download_fileupload.cgi)
-Copyright: 2002-2017 The Apache Software Foundation This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / Rest and Backend /Webapp and Backend / Webapp EE and Backend / Webapp EE/CE Tomcat]
-Commons-io:2.0.1 (https://commons.apache.org/proper/commons-fileupload/download_fileupload.cgi)
-Copyright 2002-2010 The Apache Software Foundation
+Bpmn.io License (bpmn.io)
+The following license text for the BSD-3-Clause license is cited only once. 
+bpmn.io License
+Copyright (c) 2014-present camunda Services GmbH
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The source code responsible for displaying the bpmn.io logo (two green cogwheels in a box) that links back to http://bpmn.io as part of rendered diagrams MUST NOT be removed or changed. When this software is being used in a website or application, the logo must stay fully visible and not visually overlapped by other elements.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-This product includes software developed by The Apache Software Foundation (http://www.apache.org/).
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Webapp / Tomcat and Backend/ Engine / Rest /Tomcat]
-Resteasy-jaxrs:2.3.5/ 3.0.26 (http://docs.jboss.org/resteasy/docs/2.3.5.Final/userguide/html_single/index.html#Overview)
-Copyright: various authors 
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Webapp / EE/CE / Tomcat]
-scannotation:1.0.3 (https://sourceforge.net/p/scannotation/code/HEAD/tree/)
-Copyright: @patriot1burke and @tjordahl
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / WAS and and Backend / Webapp EE WAS]
-Bean Validation API: 1.1.0 (http://beanvalidation.org/1.1/)
-Copyright: © 2007-2013 Red Hat, Inc.
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / spring]
-Commons DBCP: 1.4 (http://commons.apache.org/proper/commons-dbcp/)
-Copyright: 2001-2010 The Apache Software Foundation This product includes software developed by The Apache Software Foundation (http://www.apache.org/).
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / spring]
-Commons Pool: 1.5.4 (http://commons.apache.org/proper/commons-pool/)
-Copyright: 2001-2012 The Apache Software Foundation This product includes software developed by The Apache Software Foundation (http://www.apache.org/).
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / spring]
-spring-aop: 3.2.18 (https://github.com/spring-projects/spring-framework/tree/master/spring-aop)
-Copyright: 2002-2017 the original author or authors 
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / spring]
-spring-beans: 3.2.18 (https://github.com/spring-projects/spring-framework/tree/master/spring-beans)
-Copyright: 2002-2017 the original author or authors 
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / spring]
-spring-context: 3.2.18 (https://github.com/spring-projects/spring-framework/tree/master/spring-context)
-Copyright: 2002-2017 the original author or authors 
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / spring]
-spring-core: 3.2.18 (https://github.com/spring-projects/spring-framework/tree/master/spring-core)
-Copyright: 2002-2017 the original author or authors 
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / spring]
-spring-expression: 3.2.18 (https://github.com/spring-projects/spring-framework/tree/master/spring-expression)
-Copyright: 2002-2017 the original author or authors 
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / spring]
-spring-jdbc: 3.2.18 (https://github.com/spring-projects/spring-framework/tree/master/spring-jdbc)
-Copyright: 2002-2017 the original author or authors 
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / spring]
-spring-orm: 3.2.18 (https://github.com/spring-projects/spring-framework/tree/master/spring-orm)
-Copyright: 2002-2017 the original author or authors 
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / spring]
-spring-tx: 3.2.18 (https://github.com/spring-projects/spring-framework/tree/master/spring-tx)
-Copyright: 2002-2017 the original author or authors 
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine / spring and Backend / EE WAS]
-Javassist: 3.20.0 / 3.12.1 (https://github.com/jboss-javassist/javassist)
-Copyright: 1999-2017 by Shigeru Chiba, All rights reserved
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Spin / json]
-json-path: 2.4.0 (https://github.com/json-path/JsonPath)
-Copyright: 2001-2011 the original author or authors (Stefan Goessner)
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Spin / json]
-net.minidev:accessors-smart: 1.2 (https://code.google.com/archive/p/json-smart/)
-Copyright: Copyright 2011 JSON-SMART authors 
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Spin / json]
-net.minidev:json-smart: 2.3
-Copyright: ?
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Template freemaker]
-Freemaker: 2.3.2 (https://freemarker.apache.org/) 
-Copyright: The Apache Software Foundation. This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/)
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / template-velocity]
-Commons Collections: 3.2.1 (http://commons.apache.org/proper/commons-collections/)
-Copyright: 2001-2015 The Apache Software Foundation. This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/)
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / template-velocity]
-Apache Velocity: 1.7 (http://velocity.apache.org/download.cgi#engine)
-Copyright: 2000-2007 The Apache Software Foundation. This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/)
-Licensed under Apache 2.0
-===========================================================================================
-[Frontend / Webapp]
-mousetrap: 1.6.3 (https://github.com/ccampbell/mousetrap)
-Copyright: 2012-2017 Craig Campbell
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Webapp Standalone]
-spring-aop: 4.3.23 (https://github.com/spring-projects/spring-framework/tree/master/spring-aop)
-Copyright: 2002-2012 the original author or authors
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Engine]
-com.google.code.gson:gson:2.8.5 (https://github.com/google/gson)
-Copyright: 2008 Google Inc.
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / DMN Engine] 
-de.odysseus.juel:juel-api:2.2.7 (https://github.com/beckchr/juel/)
-Copyright: 2006-2012 Odysseus Software
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / DMN Engine]
-de.odysseus.juel:juel-spi:2.2.7 (https://github.com/beckchr/juel/)
-Copyright: 2006-2012 Odysseus Software
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Rest / Tomcat]
-org.jboss.logging:jboss-logging:3.3.0.Final (https://github.com/jboss-logging/jboss-logging)
-Copyright: 2010 Red Hat, Inc.
-Licensed under Apache 2.0
 ===========================================================================================
 
 BSD-3-Clause
-The following license text for the BSD-3-Clause license is cited only once. All libraries licenses under the BSD-3-Clause will be listed after the license text together with copyright notice and link to this license text.
+The following license text for the BSD-3-Clause license is cited only once. 
 
 BSD-3-Clause
 Copyright <YEAR> <COPYRIGHT HOLDER>
@@ -349,68 +91,110 @@ Redistribution and use in source and binary forms, with or without modification,
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-The following third-party libraries are licensed under the BSD-3-Clause license:
 
 ===========================================================================================
-[Frontend / Webapp]
-qs: 6.9.0 (https://github.com/ljharb/qs)
-Copyright: 2014 Nathan LaFreniere and other contributors
-Licensed under BSD-3-Clause
+
+Creative Commons Attribution 2.5 (CCA)
+The following license text for the Creative Commons Attribution 2.5. license is cited only once. All 
+Creative Commons Attribution 2.5
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE TO BE BOUND BY THE TERMS OF THIS LICENSE. THE LICENSOR GRANTS YOU THE RIGHTS CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND CONDITIONS.
+1. Definitions
+"Collective Work" means a work, such as a periodical issue, anthology or encyclopedia, in which the Work in its entirety in unmodified form, along with a number of other contributions, constituting separate and independent works in themselves, are assembled into a collective whole. A work that constitutes a Collective Work will not be considered a Derivative Work (as defined below) for the purposes of this License.
+"Derivative Work" means a work based upon the Work or upon the Work and other pre-existing works, such as a translation, musical arrangement, dramatization, fictionalization, motion picture version, sound recording, art reproduction, abridgment, condensation, or any other form in which the Work may be recast, transformed, or adapted, except that a work that constitutes a Collective Work will not be considered a Derivative Work for the purpose of this License. For the avoidance of doubt, where the Work is a musical composition or sound recording, the synchronization of the Work in timed-relation with a moving image ("synching") will be considered a Derivative Work for the purpose of this License.
+"Licensor" means the individual or entity that offers the Work under the terms of this License.
+"Original Author" means the individual or entity who created the Work.
+"Work" means the copyrightable work of authorship offered under the terms of this License.
+"You" means an individual or entity exercising rights under this License who has not previously violated the terms of this License with respect to the Work, or who has received express permission from the Licensor to exercise rights under this License despite a previous violation.
+2. Fair Use Rights. Nothing in this license is intended to reduce, limit, or restrict any rights arising from fair use, first sale or other limitations on the exclusive rights of the copyright owner under copyright law or other applicable laws.
+3. License Grant. Subject to the terms and conditions of this License, Licensor hereby grants You a worldwide, royalty-free, non-exclusive, perpetual (for the duration of the applicable copyright) license to exercise the rights in the Work as stated below:
+to reproduce the Work, to incorporate the Work into one or more Collective Works, and to reproduce the Work as incorporated in the Collective Works;
+to create and reproduce Derivative Works;
+to distribute copies or phonorecords of, display publicly, perform publicly, and perform publicly by means of a digital audio transmission the Work including as incorporated in Collective Works;
+to distribute copies or phonorecords of, display publicly, perform publicly, and perform publicly by means of a digital audio transmission Derivative Works.
+For the avoidance of doubt, where the work is a musical composition:
+Performance Royalties Under Blanket Licenses. Licensor waives the exclusive right to collect, whether individually or via a performance rights society (e.g. ASCAP, BMI, SESAC), royalties for the public performance or public digital performance (e.g. webcast) of the Work.
+Mechanical Rights and Statutory Royalties. Licensor waives the exclusive right to collect, whether individually or via a music rights agency or designated agent (e.g. Harry Fox Agency), royalties for any phonorecord You create from the Work ("cover version") and distribute, subject to the compulsory license created by 17 USC Section 115 of the US Copyright Act (or the equivalent in other jurisdictions).
+Webcasting Rights and Statutory Royalties. For the avoidance of doubt, where the Work is a sound recording, Licensor waives the exclusive right to collect, whether individually or via a performance-rights society (e.g. SoundExchange), royalties for the public digital performance (e.g. webcast) of the Work, subject to the compulsory license created by 17 USC Section 114 of the US Copyright Act (or the equivalent in other jurisdictions).
+The above rights may be exercised in all media and formats whether now known or hereafter devised. The above rights include the right to make such modifications as are technically necessary to exercise the rights in other media and formats. All rights not expressly granted by Licensor are hereby reserved.
+4. Restrictions.The license granted in Section 3 above is expressly made subject to and limited by the following restrictions:
+You may distribute, publicly display, publicly perform, or publicly digitally perform the Work only under the terms of this License, and You must include a copy of, or the Uniform Resource Identifier for, this License with every copy or phonorecord of the Work You distribute, publicly display, publicly perform, or publicly digitally perform. You may not offer or impose any terms on the Work that alter or restrict the terms of this License or the recipients' exercise of the rights granted hereunder. You may not sublicense the Work. You must keep intact all notices that refer to this License and to the disclaimer of warranties. You may not distribute, publicly display, publicly perform, or publicly digitally perform the Work with any technological measures that control access or use of the Work in a manner inconsistent with the terms of this License Agreement. The above applies to the Work as incorporated in a Collective Work, but this does not require the Collective Work apart from the Work itself to be made subject to the terms of this License. If You create a Collective Work, upon notice from any Licensor You must, to the extent practicable, remove from the Collective Work any credit as required by clause 4(b), as requested. If You create a Derivative Work, upon notice from any Licensor You must, to the extent practicable, remove from the Derivative Work any credit as required by clause 4(b), as requested.
+If you distribute, publicly display, publicly perform, or publicly digitally perform the Work or any Derivative Works or Collective Works, You must keep intact all copyright notices for the Work and provide, reasonable to the medium or means You are utilizing: (i) the name of the Original Author (or pseudonym, if applicable) if supplied, and/or (ii) if the Original Author and/or Licensor designate another party or parties (e.g. a sponsor institute, publishing entity, journal) for attribution in Licensor's copyright notice, terms of service or by other reasonable means, the name of such party or parties; the title of the Work if supplied; to the extent reasonably practicable, the Uniform Resource Identifier, if any, that Licensor specifies to be associated with the Work, unless such URI does not refer to the copyright notice or licensing information for the Work; and in the case of a Derivative Work, a credit identifying the use of the Work in the Derivative Work (e.g., "French translation of the Work by Original Author," or "Screenplay based on original Work by Original Author"). Such credit may be implemented in any reasonable manner; provided, however, that in the case of a Derivative Work or Collective Work, at a minimum such credit will appear where any other comparable authorship credit appears and in a manner at least as prominent as such other comparable authorship credit.
+5. Representations, Warranties and Disclaimer
+UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR OFFERS THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING, WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY, FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF LATENT OR OTHER DEFECTS, ACCURACY, OR THE PRESENCE OF ABSENCE OF ERRORS, WHETHER OR NOT DISCOVERABLE. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF IMPLIED WARRANTIES, SO SUCH EXCLUSION MAY NOT APPLY TO YOU.
+6. Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK, EVEN IF LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+7. Termination
+This License and the rights granted hereunder will terminate automatically upon any breach by You of the terms of this License. Individuals or entities who have received Derivative Works or Collective Works from You under this License, however, will not have their licenses terminated provided such individuals or entities remain in full compliance with those licenses. Sections 1, 2, 5, 6, 7, and 8 will survive any termination of this License.
+Subject to the above terms and conditions, the license granted here is perpetual (for the duration of the applicable copyright in the Work). Notwithstanding the above, Licensor reserves the right to release the Work under different license terms or to stop distributing the Work at any time; provided, however that any such election will not serve to withdraw this License (or any other license that has been, or is required to be, granted under the terms of this License), and this License will continue in full force and effect unless terminated as stated above.
+8. Miscellaneous
+Each time You distribute or publicly digitally perform the Work or a Collective Work, the Licensor offers to the recipient a license to the Work on the same terms and conditions as the license granted to You under this License.
+Each time You distribute or publicly digitally perform a Derivative Work, Licensor offers to the recipient a license to the original Work on the same terms and conditions as the license granted to You under this License.
+If any provision of this License is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this License, and without further action by the parties to this agreement, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+No term or provision of this License shall be deemed waived and no breach consented to unless such waiver or consent shall be in writing and signed by the party to be charged with such waiver or consent.
+This License constitutes the entire agreement between the parties with respect to the Work licensed here. There are no understandings, agreements or representations with respect to the Work not specified here. Licensor shall not be bound by any additional provisions that may appear in any communication from You. This License may not be modified without the mutual written agreement of the Licensor and You.
+
 ===========================================================================================
 
-BSD2
+CC0 1.0 Universal (CC0)
+The following license text for the CCO 1.0 Universal license is cited only once. 
 
-The following license text for the BSD-3-Clause license is cited only once. All libraries licenses under the BSD-3-Clause will be listed after the license text together with copyright notice and link to this license text.
-
-BSD-2-Clause
-Copyright <YEAR> <COPYRIGHT HOLDER>
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
-The following third-party libraries are licensed under the BSD-2-Clause license:
+CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER.
+Statement of Purpose
+The laws of most jurisdictions throughout the world automatically confer exclusive Copyright and Related Rights (defined below) upon the creator and subsequent owner(s) (each and all, an "owner") of an original work of authorship and/or a database (each, a "Work").
+Certain owners wish to permanently relinquish those rights to a Work for the purpose of contributing to a commons of creative, cultural and scientific works ("Commons") that the public can reliably and without fear of later claims of infringement build upon, modify, incorporate in other works, reuse and redistribute as freely as possible in any form whatsoever and for any purposes, including without limitation commercial purposes. These owners may contribute to the Commons to promote the ideal of a free culture and the further production of creative, cultural and scientific works, or to gain reputation or greater distribution for their Work in part through the use and efforts of others.
+For these and/or other purposes and motivations, and without any expectation of additional consideration or compensation, the person associating CC0 with a Work (the "Affirmer"), to the extent that he or she is an owner of Copyright and Related Rights in the Work, voluntarily elects to apply CC0 to the Work and publicly distribute the Work under its terms, with knowledge of his or her Copyright and Related Rights in the Work and the meaning and intended legal effect of CC0 on those rights.
+1. Copyright and Related Rights. A Work made available under CC0 may be protected by copyright and related or neighboring rights ("Copyright and Related Rights"). Copyright and Related Rights include, but are not limited to, the following:
+i.	the right to reproduce, adapt, distribute, perform, display, communicate, and translate a Work;
+ii.	moral rights retained by the original author(s) and/or performer(s);
+iii.	publicity and privacy rights pertaining to a person's image or likeness depicted in a Work;
+iv.	rights protecting against unfair competition in regards to a Work, subject to the limitations in paragraph 4(a), below;
+v.	rights protecting the extraction, dissemination, use and reuse of data in a Work;
+vi.	database rights (such as those arising under Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, and under any national implementation thereof, including any amended or successor version of such directive); and
+vii.	other similar, equivalent or corresponding rights throughout the world based on applicable law or treaty, and any national implementations thereof.
+2. Waiver. To the greatest extent permitted by, but not in contravention of, applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and unconditionally waives, abandons, and surrenders all of Affirmer's Copyright and Related Rights and associated claims and causes of action, whether now known or unknown (including existing as well as future claims and causes of action), in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each member of the public at large and to the detriment of Affirmer's heirs and successors, fully intending that such Waiver shall not be subject to revocation, rescission, cancellation, termination, or any other legal or equitable action to disrupt the quiet enjoyment of the Work by the public as contemplated by Affirmer's express Statement of Purpose.
+3. Public License Fallback. Should any part of the Waiver for any reason be judged legally invalid or ineffective under applicable law, then the Waiver shall be preserved to the maximum extent permitted taking into account Affirmer's express Statement of Purpose. In addition, to the extent the Waiver is so judged Affirmer hereby grants to each affected person a royalty-free, non transferable, non sublicensable, non exclusive, irrevocable and unconditional license to exercise Affirmer's Copyright and Related Rights in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "License"). The License shall be deemed effective as of the date CC0 was applied by Affirmer to the Work. Should any part of the License for any reason be judged legally invalid or ineffective under applicable law, such partial invalidity or ineffectiveness shall not invalidate the remainder of the License, and in such case Affirmer hereby affirms that he or she will not (i) exercise any of his or her remaining Copyright and Related Rights in the Work or (ii) assert any associated claims and causes of action with respect to the Work, in either case contrary to Affirmer's express Statement of Purpose.
+4. Limitations and Disclaimers.
+a.	No trademark or patent rights held by Affirmer are waived, abandoned, surrendered, licensed or otherwise affected by this document.
+b.	Affirmer offers the Work as-is and makes no representations or warranties of any kind concerning the Work, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non infringement, or the absence of latent or other defects, accuracy, or the present or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.
+c.	Affirmer disclaims responsibility for clearing rights of other persons that may apply to the Work or any use thereof, including without limitation any person's Copyright and Related Rights in the Work. Further, Affirmer disclaims responsibility for obtaining any necessary consents, permissions or other rights required for any use of the Work.
+d.	Affirmer understands and acknowledges that Creative Commons is not a party to this document and has no duty or obligation with respect to this CC0 or use of the Work.
 
 ===========================================================================================
-[Frontend / Webapp]
-readable-stream: 3.4.0 (https://github.com/nodejs/readable-stream)
-Copyright: (c) Node.js contributors. All rights reserved, Isaac Z. Schlueter
-Licensed under MIT
-===========================================================================================
 
+Common development and distribution License Version 1.0 (CDDL 1.0)
+The following license text for the CDDL 1.0 license is cited only once. 
 
-CDDL 1.0 (+GPL with classpath exception)
-The following license text for the CDDL 1.0 (+GPL with classpath exception) license is cited only once. All libraries licenses under the CDDL 1.0 (+GPL with classpath exception) will be listed after the license text together with copyright notice and link to this license text.
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 1. Definitions.
-1.1. "Contributor" means each individual or entity that creates or contributes to the creation of Modifications.
-1.2. "Contributor Version" means the combination of the Original Software, prior Modifications used by a Contributor (if any), and the Modifications made by that particular Contributor.
-1.3. "Covered Software" means (a) the Original Software, or (b) Modifications, or (c) the combination of files containing Original Software with files containing Modifications, in each case including portions thereof.
-1.4. "Executable" means the Covered Software in any form other than Source Code.
-1.5. "Initial Developer" means the individual or entity that first makes Original Software available under this License.
-1.6. "Larger Work" means a work which combines Covered Software or portions thereof with code not governed by the terms of this License.
-1.7. "License" means this document.
-1.8. "Licensable" means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently acquired, any and all of the rights conveyed herein.
-1.9 "Modifications" means the Source Code and Executable form of any of the following:
-A. Any file that results from an addition to, deletion from or modification of the contents of a file containing Original Software or previous Modifications;
-B. Any new file that contains any part of the Original Software or previous Modification; or
-C. Any new file that is contributed or otherwise made available under the terms of this License.
-1.10. "Original Software" means the Source Code and Executable form of computer software code that is originally released under this License.
-1.11. "Patent Claims" means any patent claim(s), now owned or hereafter acquired, including without limitation, method, process, and apparatus claims, in any patent Licensable by grantor.
-1.12. "Source Code" means (a) the common form of computer software code in which modifications are made and (b) associated documentation included in or with such code.
-1.13. "You" (or "Your") means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License. For legal entities, "You" includes any entity which controls, is controlled by, or is under common control with You. For purposes of this definition, "control" means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
+1.1. "Contributor" means each individual or entity that creates or contributes to the creation of Modifications.
+1.2. "Contributor Version" means the combination of the Original Software, prior Modifications used by a Contributor (if any), and the Modifications made by that particular Contributor.
+1.3. "Covered Software" means (a) the Original Software, or (b) Modifications, or (c) the combination of files containing Original Software with files containing Modifications, in each case including portions thereof.
+1.4. "Executable" means the Covered Software in any form other than Source Code.
+1.5. "Initial Developer" means the individual or entity that first makes Original Software available under this License.
+1.6. "Larger Work" means a work which combines Covered Software or portions thereof with code not governed by the terms of this License.
+1.7. "License" means this document.
+1.8. "Licensable" means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently acquired, any and all of the rights conveyed herein.
+1.9 "Modifications" means the Source Code and Executable form of any of the following:
+A  Any file that results from an addition to, deletion from or modification of the contents of a file containing Original Software or previous Modifications;
+B. Any new file that contains any part of the Original Software or previous Modification; or
+C. Any new file that is contributed or otherwise made available under the terms of this License.
+1.10. "Original Software" means the Source Code and Executable form of computer software code that is originally released under this License.
+1.11. "Patent Claims" means any patent claim(s), now owned or hereafter acquired, including without limitation, method, process, and apparatus claims, in any patent Licensable by grantor.
+1.12. "Source Code" means (a) the common form of computer software code in which modifications are made and (b) associated documentation included in or with such code.
+1.13. "You" (or "Your") means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License. For legal entities, "You" includes any entity which controls, is controlled by, or is under common control with You. For purposes of this definition, "control" means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
 2. License Grants.
 2.1. The Initial Developer Grant.
 Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, the Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive license:
-(a) under intellectual property rights (other than patent or trademark) Licensable by Initial Developer, to use, reproduce, modify, display, perform, sublicense and distribute the Original Software (or portions thereof), with or without Modifications, and/or as part of a Larger Work; and
-(b) under Patent Claims infringed by the making, using or selling of Original Software, to make, have made, use, practice, sell, and offer for sale, and/or otherwise dispose of the Original Software (or portions thereof).
-(c) The licenses granted in Sections 2.1(a) and (b) are effective on the date Initial Developer first distributes or otherwise makes the Original Software available to a third party under the terms of this License.
-(d) Notwithstanding Section 2.1(b) above, no patent license is granted: (1) for code that You delete from the Original Software, or (2) for infringements caused by: (i) the modification of the Original Software, or (ii) the combination of the Original Software with other software or devices.
+(a) under intellectual property rights (other than patent or trademark) Licensable by Initial Developer, to use, reproduce, modify, display, perform, sublicense and distribute the Original Software (or portions thereof), with or without Modifications, and/or as part of a Larger Work; and
+(b) under Patent Claims infringed by the making, using or selling of Original Software, to make, have made, use, practice, sell, and offer for sale, and/or otherwise dispose of the Original Software (or portions thereof).
+(c) The licenses granted in Sections 2.1(a) and (b) are effective on the date Initial Developer first distributes or otherwise makes the Original Software available to a third party under the terms of this License.
+(d) Notwithstanding Section 2.1(b) above, no patent license is granted: (1) for code that You delete from the Original Software, or (2) for infringements caused by: (i) the modification of the Original Software, or (ii) the combination of the Original Software with other software or devices.
 2.2. Contributor Grant.
 Conditioned upon Your compliance with Section 3.1 below and subject to third party intellectual property claims, each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:
-(a) under intellectual property rights (other than patent or trademark) Licensable by Contributor to use, reproduce, modify, display, perform, sublicense and distribute the Modifications created by such Contributor (or portions thereof), either on an unmodified basis, with other Modifications, as Covered Software and/or as part of a Larger Work; and
-(b) under Patent Claims infringed by the making, using, or selling of Modifications made by that Contributor either alone and/or in combination with its Contributor Version (or portions of such combination), to make, use, sell, offer for sale, have made, and/or otherwise dispose of: (1) Modifications made by that Contributor (or portions thereof); and (2) the combination of Modifications made by that Contributor with its Contributor Version (or portions of such combination).
-(c) The licenses granted in Sections 2.2(a) and 2.2(b) are effective on the date Contributor first distributes or otherwise makes the Modifications available to a third party.
-(d) Notwithstanding Section 2.2(b) above, no patent license is granted: (1) for any code that Contributor has deleted from the Contributor Version; (2) for infringements caused by: (i) third party modifications of Contributor Version, or (ii) the combination of Modifications made by that Contributor with other software (except as part of the Contributor Version) or other devices; or (3) under Patent Claims infringed by Covered Software in the absence of Modifications made by that Contributor.
+(a) under intellectual property rights (other than patent or trademark) Licensable by Contributor to use, reproduce, modify, display, perform, sublicense and distribute the Modifications created by such Contributor (or portions thereof), either on an unmodified basis, with other Modifications, as Covered Software and/or as part of a Larger Work; and
+(b) under Patent Claims infringed by the making, using, or selling of Modifications made by that Contributor either alone and/or in combination with its Contributor Version (or portions of such combination), to make, use, sell, offer for sale, have made, and/or otherwise dispose of: (1) Modifications made by that Contributor (or portions thereof); and (2) the combination of Modifications made by that Contributor with its Contributor Version (or portions of such combination).
+(c) The licenses granted in Sections 2.2(a) and 2.2(b) are effective on the date Contributor first distributes or otherwise makes the Modifications available to a third party.
+(d) Notwithstanding Section 2.2(b) above, no patent license is granted: (1) for any code that Contributor has deleted from the Contributor Version; (2) for infringements caused by: (i) third party modifications of Contributor Version, or (ii) the combination of Modifications made by that Contributor with other software (except as part of the Contributor Version) or other devices; or (3) under Patent Claims infringed by Covered Software in the absence of Modifications made by that Contributor.
 3. Distribution Obligations.
 3.1. Availability of Source Code.
 Any Covered Software that You distribute or otherwise make available in Executable form must also be made available in Source Code form and that Source Code form must be distributed only under the terms of this License. You must include a copy of this License with every copy of the Source Code form of the Covered Software You distribute or otherwise make available. You must inform recipients of any such Covered Software in Executable form as to how they can obtain such Covered Software in Source Code form in a reasonable manner on or through a medium customarily used for software exchange.
@@ -434,9 +218,9 @@ When You are an Initial Developer and You want to create a new license for Your 
 5. DISCLAIMER OF WARRANTY.
 COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS" BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED SOFTWARE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED SOFTWARE IS WITH YOU. SHOULD ANY COVERED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY COVERED SOFTWARE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
 6. TERMINATION.
-6.1. This License and the rights granted hereunder will terminate automatically if You fail to comply with terms herein and fail to cure such breach within 30 days of becoming aware of the breach. Provisions which, by their nature, must remain in effect beyond the termination of this License shall survive.
-6.2. If You assert a patent infringement claim (excluding declaratory judgment actions) against Initial Developer or a Contributor (the Initial Developer or Contributor against whom You assert such claim is referred to as "Participant") alleging that the Participant Software (meaning the Contributor Version where the Participant is a Contributor or the Original Software where the Participant is the Initial Developer) directly or indirectly infringes any patent, then any and all rights granted directly or indirectly to You by such Participant, the Initial Developer (if the Initial Developer is not the Participant) and all Contributors under Sections 2.1 and/or 2.2 of this License shall, upon 60 days notice from Participant terminate prospectively and automatically at the expiration of such 60 day notice period, unless if within such 60 day period You withdraw Your claim with respect to the Participant Software against such Participant either unilaterally or pursuant to a written agreement with Participant.
-6.3. In the event of termination under Sections 6.1 or 6.2 above, all end user licenses that have been validly granted by You or any distributor hereunder prior to termination (excluding licenses granted to You by any distributor) shall survive termination.
+6.1. This License and the rights granted hereunder will terminate automatically if You fail to comply with terms herein and fail to cure such breach within 30 days of becoming aware of the breach. Provisions which, by their nature, must remain in effect beyond the termination of this License shall survive.
+6.2. If You assert a patent infringement claim (excluding declaratory judgment actions) against Initial Developer or a Contributor (the Initial Developer or Contributor against whom You assert such claim is referred to as "Participant") alleging that the Participant Software (meaning the Contributor Version where the Participant is a Contributor or the Original Software where the Participant is the Initial Developer) directly or indirectly infringes any patent, then any and all rights granted directly or indirectly to You by such Participant, the Initial Developer (if the Initial Developer is not the Participant) and all Contributors under Sections 2.1 and/or 2.2 of this License shall, upon 60 days notice from Participant terminate prospectively and automatically at the expiration of such 60 day notice period, unless if within such 60 day period You withdraw Your claim with respect to the Participant Software against such Participant either unilaterally or pursuant to a written agreement with Participant.
+6.3. In the event of termination under Sections 6.1 or 6.2 above, all end user licenses that have been validly granted by You or any distributor hereunder prior to termination (excluding licenses granted to You by any distributor) shall survive termination.
 7. LIMITATION OF LIABILITY.
 UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED SOFTWARE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOST PROFITS, LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTYS NEGLIGENCE TO THE EXTENT APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
 8. U.S. GOVERNMENT END USERS.
@@ -448,872 +232,6516 @@ As between Initial Developer and the Contributors, each party is responsible for
 NOTICE PURSUANT TO SECTION 9 OF THE COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL)
 The code released under the CDDL shall be governed by the laws of the State of California (excluding conflict-of-law provisions). Any litigation relating to this License shall be subject to the jurisdiction of the Federal Courts of the Northern District of California and the state courts of the State of California, with venue lying in Santa Clara County, California.
 
-The GNU General Public License (GPL) Version 2, June 1991
-Copyright (C) 1989, 1991 Free Software Foundation, Inc. 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
-Preamble
-The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users. This General Public License applies to most of the Free Software Foundation's software and to any other program whose authors commit to using it. (Some other Free Software Foundation software is covered by the GNU Library General Public License instead.) You can apply it to your programs, too.
-When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs; and that you know you can do these things.
-To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the software, or if you modify it.
-For example, if you distribute copies of such a program, whether gratis or for a fee, you must give the recipients all the rights that you have. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights.
-We protect your rights with two steps: (1) copyright the software, and (2) offer you this license which gives you legal permission to copy, distribute and/or modify the software.
-Also, for each author's protection and ours, we want to make certain that everyone understands that there is no warranty for this free software. If the software is modified by someone else and passed on, we want its recipients to know that what they have is not the original, so that any problems introduced by others will not reflect on the original authors' reputations.
-Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that redistributors of a free program will individually obtain patent licenses, in effect making the program proprietary. To prevent this, we have made it clear that any patent must be licensed for everyone's free use or not licensed at all.
-The precise terms and conditions for copying, distribution and modification follow.
-TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
-0. This License applies to any program or other work which contains a notice placed by the copyright holder saying it may be distributed under the terms of this General Public License. The "Program", below, refers to any such program or work, and a "work based on the Program" means either the Program or any derivative work under copyright law: that is to say, a work containing the Program or a portion of it, either verbatim or with modifications and/or translated into another language. (Hereinafter, translation is included without limitation in the term "modification".) Each licensee is addressed as "you".
-Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running the Program is not restricted, and the output from the Program is covered only if its contents constitute a work based on the Program (independent of having been made by running the Program). Whether that is true depends on what the Program does.
-1. You may copy and distribute verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and give any other recipients of the Program a copy of this License along with the Program.
-You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
-2. You may modify your copy or copies of the Program or any portion of it, thus forming a work based on the Program, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
-a) You must cause the modified files to carry prominent notices stating that you changed the files and the date of any change.
-b) You must cause any work that you distribute or publish, that in whole or in part contains or is derived from the Program or any part thereof, to be licensed as a whole at no charge to all third parties under the terms of this License.
-c) If the modified program normally reads commands interactively when run, you must cause it, when started running for such interactive use in the most ordinary way, to print or display an announcement including an appropriate copyright notice and a notice that there is no warranty (or else, saying that you provide a warranty) and that users may redistribute the program under these conditions, and telling the user how to view a copy of this License. (Exception: if the Program itself is interactive but does not normally print such an announcement, your work based on the Program is not required to print an announcement.)
-These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Program, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Program, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
-Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Program.
-In addition, mere aggregation of another work not based on the Program with the Program (or with a work based on the Program) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
-3. You may copy and distribute the Program (or a work based on it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you also do one of the following:
-a) Accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
-b) Accompany it with a written offer, valid for at least three years, to give any third party, for a charge no more than your cost of physically performing source distribution, a complete machine-readable copy of the corresponding source code, to be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange; or,
-c) Accompany it with the information you received as to the offer to distribute corresponding source code. (This alternative is allowed only for noncommercial distribution and only if you received the program in object code or executable form with such an offer, in accord with Subsection b above.)
-The source code for a work means the preferred form of the work for making modifications to it. For an executable work, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the executable. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
-If distribution of executable or object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place counts as distribution of the source code, even though third parties are not compelled to copy the source along with the object code.
-4. You may not copy, modify, sublicense, or distribute the Program except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense or distribute the Program is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
-5. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Program or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Program (or any work based on the Program), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Program or works based on it.
-6. Each time you redistribute the Program (or any work based on the Program), the recipient automatically receives a license from the original licensor to copy, distribute or modify the Program subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties to this License.
-7. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Program at all. For example, if a patent license would not permit royalty-free redistribution of the Program by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Program.
-If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply and the section as a whole is intended to apply in other circumstances.
-It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system, which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
-This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
-8. If the distribution and/or use of the Program is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Program under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
-9. The Free Software Foundation may publish revised and/or new versions of the General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
-Each version is given a distinguishing version number. If the Program specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of this License, you may choose any version ever published by the Free Software Foundation.
-10. If you wish to incorporate parts of the Program into other free programs whose distribution conditions are different, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
-NO WARRANTY
-11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-END OF TERMS AND CONDITIONS
-How to Apply These Terms to Your New Programs
-If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
-To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
-One line to give the program's name and a brief idea of what it does.
-Copyright (C)
-This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
-Also add information on how to contact you by electronic and paper mail.
-If the program is interactive, make it output a short notice like this when it starts in an interactive mode:
-Gnomovision version 69, Copyright (C) year name of author
-Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'. This is free software, and you are welcome to redistribute it under certain conditions; type `show c' for details.
-The hypothetical commands `show w' and `show c' should show the appropriate parts of the General Public License. Of course, the commands you use may be called something other than `show w' and `show c'; they could even be mouse-clicks or menu items--whatever suits your program.
-You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the program, if necessary. Here is a sample; alter the names:
-Yoyodyne, Inc., hereby disclaims all copyright interest in the program `Gnomovision' (which makes passes at compilers) written by James Hacker.
-signature of Ty Coon, 1 April 1989
-Ty Coon, President of Vice
-This General Public License does not permit incorporating your program into proprietary programs. If your program is a subroutine library, you may consider it more useful to permit linking proprietary applications with the library. If this is what you want to do, use the GNU Library General Public License instead of this License.
+===========================================================================================
 
-"CLASSPATH" EXCEPTION TO THE GPL VERSION 2
-Certain source files distributed by Oracle America, Inc. and/or its affiliates are subject to the following clarification and special exception to the GPLv2, based on the GNU Project exception for its Classpath libraries, known as the GNU Classpath Exception, but only where Oracle has expressly included in the particular source file's header the words "Oracle designates this particular file as subject to the "Classpath" exception as provided by Oracle in the LICENSE file that accompanied this code."
-You should also note that Oracle includes multiple, independent programs in this software package. Some of those programs are provided under licenses deemed incompatible with the GPLv2 by the Free Software Foundation and others. For example, the package includes programs licensed under the Apache License, Version 2.0. Such programs are licensed to you under their original licenses.
-Oracle facilitates your further distribution of this package by adding the Classpath Exception to the necessary parts of its GPLv2 code, which permits you to use that code in combination with other independent modules not licensed under the GPLv2. However, note that this would not permit you to commingle code under an incompatible license with Oracle's GPLv2 licensed code by, for example, cutting and pasting such code into a file also containing Oracle's GPLv2 licensed code and then distributing the result.
-Additionally, if you were to remove the Classpath Exception from any of the files to which it applies and distribute the result, you would likely be required to license some or all of the other code in that distribution under the GPLv2 as well, and since the GPLv2 is incompatible with the license terms of some items included in the distribution by Oracle, removing the Classpath Exception could therefore effectively compromise your ability to further distribute the package.
-Proceed with caution and we recommend that you obtain the advice of a lawyer skilled in open source matters before removing the Classpath Exception or making modifications to this package which may subsequently be redistributed and/or involve the use of third party software.
-CLASSPATH EXCEPTION
-Linking this library statically or dynamically with other modules is making a combined work based on this library. Thus, the terms and conditions of the GNU General Public License version 2 cover the whole combination.
-As a special exception, the copyright holders of this library give you permission to link this library with independent modules to produce an executable, regardless of the license terms of these independent modules, and to copy and distribute the resulting executable under terms of your choice, provided that you also meet, for each linked independent module, the terms and conditions of the license of that module. An independent module is a module which is not derived from or based on this library. If you modify this library, you may extend this exception to your version of the library, but you are not obligated to do so. If you do not wish to do so, delete this exception statement from your version.
-The following third-party libraries are licensed under the CDDL 1.0 (+GPLv2 with classpath exception)
+Eclipse Public License â€“ v 1.0 (EPL 1.0) 
+The following license text for the EPL 1.0 is cited only once. 
+
+
+Eclipse Public License - v 1.0 
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+1. DEFINITIONS
+"Contribution" means:
+a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and
+b) in the case of each subsequent Contributor:
+i) changes to the Program, and
+ii) additions to the Program;
+where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution 'originates' from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+"Licensed Patents" mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
+"Program" means the Contributions distributed in accordance with this Agreement.
+"Recipient" means anyone who receives the Program under this Agreement, including all Contributors.
+2. GRANT OF RIGHTS
+a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.
+b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
+c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.
+d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
+3. REQUIREMENTS
+A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:
+a) it complies with the terms and conditions of this Agreement; and
+b) its license agreement:
+i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
+ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
+iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and
+iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.
+When the Program is made available in source code form:
+a) it must be made available under this Agreement; and
+b) a copy of this Agreement must be included with each copy of the Program.
+Contributors may not remove or alter any copyright notices contained within the Program.
+Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor ("Commercial Contributor") hereby agrees to defend and indemnify every other Contributor ("Indemnified Contributor") against any losses, damages and costs (collectively "Losses") arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
+For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+7. GENERAL
+If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
+All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
+Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.
+This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.
 
 ===========================================================================================
-[Backend / Webapp / WAS]
-javax.annotation API: 1.2 (https://github.com/javaee/javax.annotation)
-Copyright: (c) 2005-2016 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Engine WAS and Backend / Webapp EE WAS]
-HK2 API module: 2.5.0 (https://github.com/javaee/hk2/tree/master/hk2-api)
-Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
 
-=========================================================================================
-[Backend / Engine WAS and Backend / Webapp EE WAS]
-ServiceLocator Default Implementation: 2.5.0 (https://github.com/javaee/hk2/tree/master/hk2-locator)
-Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved. 
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
+Eclipse Public License â€“ v 2.0 (EPL 2.0) 
+The following license text for the EPL 2.0 is cited only once. 
+
+Eclipse Public License - v 2.0
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (â€œAGREEMENTâ€?). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+1. DEFINITIONS
+â€œContributionâ€? means:
+a) in the case of the initial Contributor, the initial content Distributed under this Agreement, and
+b) in the case of each subsequent Contributor:
+i) changes to the Program, and
+ii) additions to the Program;
+where such changes and/or additions to the Program originate from and are Distributed by that particular Contributor. A Contribution â€œoriginatesâ€? from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include changes or additions to the Program that are not Modified Works.
+â€œContributorâ€? means any person or entity that Distributes the Program.
+â€œLicensed Patentsâ€? mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
+â€œProgramâ€? means the Contributions Distributed in accordance with this Agreement.
+â€œRecipientâ€? means anyone who receives the Program under this Agreement or any Secondary License (as applicable), including Contributors.
+â€œDerivative Worksâ€? shall mean any work, whether in Source Code or other form, that is based on (or derived from) the Program and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship.
+â€œModified Worksâ€? shall mean any work in Source Code or other form that results from an addition to, deletion from, or modification of the contents of the Program, including, for purposes of clarity any new file in Source Code form that contains any contents of the Program. Modified Works shall not include works that contain only declarations, interfaces, types, classes, structures, or files of the Program solely in each case in order to link to, bind by name, or subclass the Program or Modified Works thereof.
+â€œDistributeâ€? means the acts of a) distributing or b) making available in any manner that enables the transfer of a copy.
+â€œSource Codeâ€? means the form of a Program preferred for making modifications, including but not limited to software source code, documentation source, and configuration files.
+â€œSecondary Licenseâ€? means either the GNU General Public License, Version 2.0, or any later versions of that license, including any exceptions or additional permissions as identified by the initial Contributor.
+2. GRANT OF RIGHTS
+a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, Distribute and sublicense the Contribution of such Contributor, if any, and such Derivative Works.
+b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in Source Code or other form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
+c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to Distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.
+d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
+e) Notwithstanding the terms of any Secondary License, no Contributor makes additional grants to any Recipient (other than those set forth in this Agreement) as a result of such Recipient's receipt of the Program under the terms of a Secondary License (if permitted under the terms of Section 3).
+3. REQUIREMENTS
+3.1 If a Contributor Distributes the Program in any form, then:
+a) the Program must also be made available as Source Code, in accordance with section 3.2, and the Contributor must accompany the Program with a statement that the Source Code for the Program is available under this Agreement, and informs Recipients how to obtain it in a reasonable manner on or through a medium customarily used for software exchange; and
+b) the Contributor may Distribute the Program under a license different than this Agreement, provided that such license:
+i) effectively disclaims on behalf of all other Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
+ii) effectively excludes on behalf of all other Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
+iii) does not attempt to limit or alter the recipients' rights in the Source Code under section 3.2; and
+iv) requires any subsequent distribution of the Program by any party to be under a license that satisfies the requirements of this section 3.
+3.2 When the Program is Distributed as Source Code:
+a) it must be made available under this Agreement, or if the Program (i) is combined with other material in a separate file or files made available under a Secondary License, and (ii) the initial Contributor attached to the Source Code the notice described in Exhibit A of this Agreement, then the Program may be made available under the terms of such Secondary Licenses, and
+b) a copy of this Agreement must be included with each copy of the Program.
+3.3 Contributors may not remove or alter any copyright, patent, trademark, attribution notices, disclaimers of warranty, or limitations of liability (â€˜noticesâ€™) contained within the Program from any copy of the Program which they Distribute, provided that Contributors may add their own appropriate notices.
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor (â€œCommercial Contributorâ€?) hereby agrees to defend and indemnify every other Contributor (â€œIndemnified Contributorâ€?) against any losses, damages and costs (collectively â€œLossesâ€?) arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
+For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN â€œAS ISâ€? BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+7. GENERAL
+If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
+All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
+Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be Distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to Distribute the Program (including its Contributions) under the new version.
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved. Nothing in this Agreement is intended to be enforceable by any entity that is not a Contributor or Recipient. No third-party beneficiary rights are created under this Agreement.
+Exhibit A â€“ Form of Secondary Licenses Notice
+â€œThis Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: {name license(s), version(s), and exceptions or additional permissions here}.â€?
+Simply including a copy of this Agreement, including this Exhibit A is not sufficient to license the Source Code under Secondary Licenses.
+If it is not possible or desirable to put the notice in a particular file, then You may include the notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be likely to look for such a notice.
+You may add additional accurate notices of copyright ownership.
+
 ===========================================================================================
-[Backend / Engine WAS and Backend / Webapp EE WAS]
-HK2 Implementation Utilities: 2.5.0 (https://github.com/javaee/hk2/tree/master/hk2-utils)
-Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved. 
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Engine WAS and Backend / Webapp EE WAS]
-OSGi resource locator bundle - used by various API providers that rely on META-INF/services mechanism to locate providers: 1.0.1 (https://github.com/javaee/hk2/blob/master/hk2-core/osgi.bundle)
-Copyright: (c) 2010-2015 Oracle and/or its affiliates. All rights reserved. 
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Engine WAS and Backend / Webapp EE WAS]
-aopalliance: 1.0 (https://github.com/javaee/hk2/tree/master/hk2-api)
-Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Engine spring and Backend / Webapp EE WAS]
-javax.inject: 2.5.0 (https://github.com/javaee/hk2)
-Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Webapp / WAS]
-jersey-guava: 2.25.1 (https://github.com/javaee/hk2/tree/master/hk2-core/src/main/java/com/sun/enterprise/module/common_impl)
-Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Webapp / WAS]
-jersey-container-servlet: 2.25.1 (https://github.com/javaee/hk2)
-Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Webapp / WAS]
-jersey-container-servlet-core: 2.25.1 (https://github.com/javaee/hk2/tree/master/hk2-core)
-Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Webapp / WAS]
-jersey-client: 2.25.1 (https://github.com/javaee/hk2)
-Copyright: (c) 2010-2015 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Webapp / WAS]
-jersey-common: 2.25.1 (https://github.com/javaee/hk2)
-Copyright: (c) 2010-2015 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Webapp / WAS]
-jersey-server: 2.25.1 (https://github.com/javaee/hk2)
-Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Webapp / WAS]
-jersey-media-jaxb: 2.25.1 (https://github.com/javaee/hk2/tree/master/hk2-core)
-Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Webapp EE WAS and Backend / Engine WAS]
-javax.ws.rs-api: 2.0.1 (https://github.com/javaee/hk2)
-Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Engine Tomcat and Backend / Engine spring and Backend / Webapp EE/CE Tomcat]
-JavaBeans Activation Framework (JAF): 1.1 (https://github.com/javaee/activation)
-Copyright: (c) 1997-2017 Oracle and/or its affiliates. All rights reserved
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Engine / Rest / Tomcat]
-org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec: 1.0.0 (https://github.com/javaee/glassfish)
-Copyright: © 2017, Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Engine spring]
-activation: 1.1.1 (https://github.com/javaee/glassfish)
-Copyright: © 2017, Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Engine]
-com.sun.activation:javax.activation: 1.2.0
-(https://github.com/javaee/activation/tree/master/activation/src/main/java/javax/activation)
-Copyright: © Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Spin / Dataformat All and Backend / Webapp Standalone]
-com.sun.xml-bind:jaxb-impl: 2.2.4 (https://github.com/javaee/jaxb-v2)
-Copyright: © Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Spin / Dataformat All and Backend / Webapp Standalone]
-javax.xml.bind:jaxb-api: 2.2.3 (https://github.com/javaee/jaxb-v2)
-Copyright: © Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Spin / Dataformat All and Backend / Webapp Standalone]
-javax.xml.stream:stax-api: 1.0-2 (?)
-Copyright: © Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0
-===========================================================================================
-[Backend / Spin / Dataformat All and Backend / Webapp]
-javax.activation:activation: 1.1 (https://github.com/javaee/activation)
-Copyright: © Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Webapp / Tomcat]
-javax.annotation:jsr250-api:1.0 (http://jcp.org/aboutJava/communityprocess/final/jsr250/index.html)
-Copyright: Sun Microsystems, Inc
-Licensed under CDDL 1.0
-===========================================================================================
-[Backend / Rest / Tomcat]
-org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec:1.0.1 (https://github.com/jboss/jboss-jaxrs-api_spec)
-Copyright: 2010-2015 Oracle and/or its affiliates. All rights reserved.
-Licensed under CDDL 1.0 (+GPLv2 with classpath exception)
-===========================================================================================
-[Backend / Webapp / Tomcat]
-jaxrs-api:2.3.5 (https://github.com/resteasy/Resteasy/releases/tag/3.0.12.Final)
-Copyright: 2002-2017 The Apache Software Foundation This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-Licensed under Apache 2.0
-===========================================================================================
-[Backend / Webapp / Tomcat]
-jaxrs-api:2.3.5 (https://github.com/resteasy/Resteasy/releases/tag/3.0.12.Final)
-Copyright: 2002-2017 The Apache Software Foundation This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-Licensed under CDDL 1.0 ===========================================================================================
 
 ISC License (ISC)
-The following license text for the ISC License (ISC) is cited only once. All libraries licenses under the ISC License (ISC) be listed after the license text together with copyright notice and link to this license text.
+The following license text for the ISC License (ISC) is cited only once. 
 
 ISC License (ISC)
 Copyright <YEAR> <OWNER>
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-===========================================================================================
-[Frontend / Webapp]
-inherits: 2.0.4  (https://github.com/isaacs/inherits)
-Copyright: (c) Isaac Z. Schlueter
-Licensed under ISC
+
 ===========================================================================================
 
-MIT License
-The following license text for the MIT license (MIT) is cited only once. All libraries licenses under the MIT license (MIT) be listed after the license text together with copyright notice and link to this license text.
+GNU Lesser General Public License, Version 2.1  (LGPL 2.1)
+The following license text for the LGPL 2.1 is cited only once. 
+
+GNU LESSER GENERAL PUBLIC LICENSE
+Version 2.1, February 1999
+Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+Preamble
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public Licenses are intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users.
+This license, the Lesser General Public License, applies to some specially designated software packages--typically libraries--of the Free Software Foundation and other authors who decide to use it. You can use it too, but we suggest you first think carefully about whether this license or the ordinary General Public License is the better strategy to use in any particular case, based on the explanations below.
+When we speak of free software, we are referring to freedom of use, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish); that you receive source code or can get it if you want it; that you can change the software and use pieces of it in new free programs; and that you are informed that you can do these things.
+To protect your rights, we need to make restrictions that forbid distributors to deny you these rights or to ask you to surrender these rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library or if you modify it.
+For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you link other code with the library, you must provide complete object files to the recipients, so that they can relink them with the library after making changes to the library and recompiling it. And you must show them these terms so they know their rights.
+We protect your rights with a two-step method: (1) we copyright the library, and (2) we offer you this license, which gives you legal permission to copy, distribute and/or modify the library.
+To protect each distributor, we want to make it very clear that there is no warranty for the free library. Also, if the library is modified by someone else and passed on, the recipients should know that what they have is not the original version, so that the original author's reputation will not be affected by problems that might be introduced by others.
+Finally, software patents pose a constant threat to the existence of any free program. We wish to make sure that a company cannot effectively restrict the users of a free program by obtaining a restrictive license from a patent holder. Therefore, we insist that any patent license obtained for a version of the library must be consistent with the full freedom of use specified in this license.
+Most GNU software, including some libraries, is covered by the ordinary GNU General Public License. This license, the GNU Lesser General Public License, applies to certain designated libraries, and is quite different from the ordinary General Public License. We use this license for certain libraries in order to permit linking those libraries into non-free programs.
+When a program is linked with a library, whether statically or using a shared library, the combination of the two is legally speaking a combined work, a derivative of the original library. The ordinary General Public License therefore permits such linking only if the entire combination fits its criteria of freedom. The Lesser General Public License permits more lax criteria for linking other code with the library.
+We call this license the "Lesser" General Public License because it does Less to protect the user's freedom than the ordinary General Public License. It also provides other free software developers Less of an advantage over competing non-free programs. These disadvantages are the reason we use the ordinary General Public License for many libraries. However, the Lesser license provides advantages in certain special circumstances.
+For example, on rare occasions, there may be a special need to encourage the widest possible use of a certain library, so that it becomes a de-facto standard. To achieve this, non-free programs must be allowed to use the library. A more frequent case is that a free library does the same job as widely used non-free libraries. In this case, there is little to gain by limiting the free library to free software only, so we use the Lesser General Public License.
+In other cases, permission to use a particular library in non-free programs enables a greater number of people to use a large body of free software. For example, permission to use the GNU C Library in non-free programs enables many more people to use the whole GNU operating system, as well as its variant, the GNU/Linux operating system.
+Although the Lesser General Public License is Less protective of the users' freedom, it does ensure that the user of a program that is linked with the Library has the freedom and the wherewithal to run that program using a modified version of the Library.
+The precise terms and conditions for copying, distribution and modification follow. Pay close attention to the difference between a "work based on the library" and a "work that uses the library". The former contains code derived from the library, whereas the latter must be combined with the library in order to run.
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+0. This License Agreement applies to any software library or other program which contains a notice placed by the copyright holder or other authorized party saying it may be distributed under the terms of this Lesser General Public License (also called "this License"). Each licensee is addressed as "you".
+A "library" means a collection of software functions and/or data prepared so as to be conveniently linked with application programs (which use some of those functions and data) to form executables.
+The "Library", below, refers to any such software library or work which has been distributed under these terms. A "work based on the Library" means either the Library or any derivative work under copyright law: that is to say, a work containing the Library or a portion of it, either verbatim or with modifications and/or translated straightforwardly into another language. (Hereinafter, translation is included without limitation in the term "modification".)
+"Source code" for a work means the preferred form of the work for making modifications to it. For a library, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the library.
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running a program using the Library is not restricted, and output from such a program is covered only if its contents constitute a work based on the Library (independent of the use of the Library in a tool for writing it). Whether that is true depends on what the Library does and what the program that uses the Library does.
+1. You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and distribute a copy of this License along with the Library.
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+2. You may modify your copy or copies of the Library or any portion of it, thus forming a work based on the Library, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+ï‚§	a) The modified work must itself be a software library.
+ï‚§	b) You must cause the files modified to carry prominent notices stating that you changed the files and the date of any change.
+ï‚§	c) You must cause the whole of the work to be licensed at no charge to all third parties under the terms of this License.
+ï‚§	d) If a facility in the modified Library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful.
+(For example, a function in a library to compute square roots has a purpose that is entirely well-defined independent of the application. Therefore, Subsection 2d requires that any application-supplied function or table used by this function must be optional: if the application does not supply it, the square root function must still compute square roots.)
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Library, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Library, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Library.
+In addition, mere aggregation of another work not based on the Library with the Library (or with a work based on the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+3. You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if you wish.) Do not make any other change in these notices.
+Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU General Public License applies to all subsequent copies and derivative works made from that copy.
+This option is useful when you wish to copy part of the code of the Library into a program that is not a library.
+4. You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange.
+If distribution of object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place satisfies the requirement to distribute the source code, even though third parties are not compelled to copy the source along with the object code.
+5. A program that contains no derivative of any portion of the Library, but is designed to work with the Library by being compiled or linked with it, is called a "work that uses the Library". Such a work, in isolation, is not a derivative work of the Library, and therefore falls outside the scope of this License.
+However, linking a "work that uses the Library" with the Library creates an executable that is a derivative of the Library (because it contains portions of the Library), rather than a "work that uses the library". The executable is therefore covered by this License. Section 6 states terms for distribution of such executables.
+When a "work that uses the Library" uses material from a header file that is part of the Library, the object code for the work may be a derivative work of the Library even though the source code is not. Whether this is true is especially significant if the work can be linked without the Library, or if the work is itself a library. The threshold for this to be true is not precisely defined by law.
+If such an object file uses only numerical parameters, data structure layouts and accessors, and small macros and small inline functions (ten lines or less in length), then the use of the object file is unrestricted, regardless of whether it is legally a derivative work. (Executables containing this object code plus portions of the Library will still fall under Section 6.)
+Otherwise, if the work is a derivative of the Library, you may distribute the object code for the work under the terms of Section 6. Any executables containing that work also fall under Section 6, whether or not they are linked directly with the Library itself.
+6. As an exception to the Sections above, you may also combine or link a "work that uses the Library" with the Library to produce a work containing portions of the Library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's own use and reverse engineering for debugging such modifications.
+You must give prominent notice with each copy of the work that the Library is used in it and that the Library and its use are covered by this License. You must supply a copy of this License. If the work during execution displays copyright notices, you must include the copyright notice for the Library among them, as well as a reference directing the user to the copy of this License. Also, you must do one of these things:
+ï‚§	a) Accompany the work with the complete corresponding machine-readable source code for the Library including whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the work is an executable linked with the Library, with the complete machine-readable "work that uses the Library", as object code and/or source code, so that the user can modify the Library and then relink to produce a modified executable containing the modified Library. (It is understood that the user who changes the contents of definitions files in the Library will not necessarily be able to recompile the application to use the modified definitions.)
+ï‚§	b) Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (1) uses at run time a copy of the library already present on the user's computer system, rather than copying library functions into the executable, and (2) will operate properly with a modified version of the library, if the user installs one, as long as the modified version is interface-compatible with the version that the work was made with.
+ï‚§	c) Accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of performing this distribution.
+ï‚§	d) If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place.
+ï‚§	e) Verify that the user has already received a copy of these materials or that you have already sent this user a copy.
+For an executable, the required form of the "work that uses the Library" must include any data and utility programs needed for reproducing the executable from it. However, as a special exception, the materials to be distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+It may happen that this requirement contradicts the license restrictions of other proprietary libraries that do not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library together in an executable that you distribute.
+7. You may place library facilities that are a work based on the Library side-by-side in a single library together with other library facilities not covered by this License, and distribute such a combined library, provided that the separate distribution of the work based on the Library and of the other library facilities is otherwise permitted, and provided that you do these two things:
+ï‚§	a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities. This must be distributed under the terms of the Sections above.
+ï‚§	b) Give prominent notice with the combined library of the fact that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+8. You may not copy, modify, sublicense, link with, or distribute the Library except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or distribute the Library is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+9. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Library or works based on it.
+10. Each time you redistribute the Library (or any work based on the Library), the recipient automatically receives a license from the original licensor to copy, distribute, link with or modify the Library subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties with this License.
+11. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license would not permit royalty-free redistribution of the Library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Library.
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply, and the section as a whole is intended to apply in other circumstances.
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+12. If the distribution and/or use of the Library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Library under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+13. The Free Software Foundation may publish revised and/or new versions of the Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+Each version is given a distinguishing version number. If the Library specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Library does not specify a license version number, you may choose any version ever published by the Free Software Foundation.
+14. If you wish to incorporate parts of the Library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+NO WARRANTY
+15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+END OF TERMS AND CONDITIONS
+
+===========================================================================================
+
+MIT license (MIT)
+The following license text for the MIT license (MIT) is cited only once. 
 The MIT License
 SPDX short identifier: MIT
 Copyright <YEAR> <COPYRIGHT HOLDER>
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-===========================================================================================
-[Backend / Engine]
-org.slf4j:slf4j-api: 1.7.26 (https://www.slf4j.org/index.html)
-Copyright: (c) 2004-2017 QOS.ch
-Licensed under MIT
-===========================================================================================
-[Backend / Connect _all]
-SLF4J API Module: 1.7.7 (https://www.slf4j.org/index.html)
-Copyright: (c) 2004-2017 QOS.ch
-Licensed under MIT
-===========================================================================================
- [Frontend / Webapp]
-bootstrap: 3.4.1 (https://github.com/twbs/bootstrap)
-Copyright: 2011-2015 Twitter, Inc 
-Licensed under MIT
-===========================================================================================
- [Frontend / Webapp]
-component-event: 0.1.4 (https://github.com/component/event)
-Copyright: ?
-Licensed under MIT
-===========================================================================================
- [Frontend / Webapp]
-domify: 1.4.0 (https://github.com/component/domify)
-Copyright: (c) 2016 http://component.github.io/ 
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-didi: 4.0.0 (https://github.com/nikku/didi/blob/v4.0.0/LICENSE)
-Copyright: (c) 2013 Vojta Jína 2015-present Nico Rehwaldt
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-hammerjs: 2.0.8 (https://github.com/hammerjs/hammer.js)
-Copyright: (c) 2011-2017 by Jorik Tangelder (Eight Media)
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-selection-update: 0.1.2 (https://github.com/nikku/selection-update)
-Copyright: (c) 2015, Nico Rehwaldt
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-combined-stream: 1.0.8 (https://github.com/felixge/node-combined-stream)
-Copyright: (c) 2011 Debuggable Limited <felix@debuggable.com> 
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-component-emitter: 1.3.0 (https://github.com/component/emitter)
-Copyright: (c) 2014 Component contributors dev@component.io,
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-cookiejar: 2.1.2 (https://github.com/bmeck/node-cookiejar)
-Copyright: © 2013 Bradley Meck
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-debug: 4.1.1  (https://github.com/visionmedia/debug)
-Copyright: (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-delayed-stream: 1.0.0 (https://github.com/felixge/node-delayed-stream)
-Copyright: (c) 2011 Debuggable Limited <felix@debuggable.com>
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-events:3.0.0 (https://github.com/Gozala/events)
-Copyright (c) Joyent, Inc. and other Node contributors.
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-fast-xml-parser: 3.12.14 (https://github.com/NaturalIntelligence/fast-xml-parser)
-Copyright (c) 2017 Natural Intelligence
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-form-data: 2.5.1 (https://github.com/felixge/node-form-data)
-Copyright: (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-formidable: 1.2.1 (https://github.com/felixge/node-formidable)
-Copyright: (c) 2011 Felix Geisendörfer
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-indexof: 0.0.1 (https://www.npmjs.com/package/indexof)
-Copyright: (c) 2012 TJ Holowaychuk
 
-Licensed under MIT
 ===========================================================================================
-[Frontend / Webapp]
-methods: 1.1.2 (https://github.com/jshttp/methods)
-Copyright: 2013-2014 TJ Holowaychuk <tj@vision-media.ca> 
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-mime-db:1.40.0 (https://github.com/jshttp/mime-db)
-Copyright: 2014 Jonathan Ong me@jongleberry.com
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-mime-types: 2.1.24 (https://github.com/jshttp/mime-types
-Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
-Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
- Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-mime: 2.2.4 (https://github.com/broofa/node-mime)
-Copyright: (c) 2010 Benjamin Thomas, Robert Kieffer
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-moment: 2.24.0 (https://github.com/moment/moment)
-Copyright: (c) 2011-2014 Tim Wood, Iskren Chernev, Moment.js contributors
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-ms: 2.1.2 (https://github.com/zeit/ms)
-Copyright: (c) 2016 Zeit, Inc.
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-q: 1.5.1 (https://github.com/kriskowal/q)
-Copyright: 2009–2017 Kristopher Michael Kowal
-Licensed under MIT
-===========================================================================================
- [Frontend / Webapp]
-string_decoder: 1.3.0 (https://github.com/rvagg/string_decoder)
-Copyright: Copyright Joyent, Inc. and other Node contributors.
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-Superagent: 4.1.0 (https://github.com/visionmedia/superagent/tree/v4.1.0)
-Copyright: (c) 2014-2016 TJ Holowaychuk
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-angular-data-depend: 1.0.0 (https://github.com/Nikku/angular-data-depend)
-Copyright: (c) 2013 Nico Rehwaldt
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-angular-moment: 1.3.0 (https://github.com/urish/angular-moment)
-Copyright: (c) 2013-2016 Uri Shaked and contributors
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-angular-route: 1.7.8 (https://github.com/angular/angular.js)
-Copyright: (c) 2010-2017 Google Inc., Angular Core Team, http://angularjs.org
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-jquery-ui: 1.12.1 (https://github.com/jquery/jquery-ui)
-Copyright: jQuery Foundation and other contributors, https://jquery.org/
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-jquery: 3.4.1 (https://github.com/jquery/jquery)
-Copyright: JS Foundation and other contributors, https://js.foundation/
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-requirejs: 2.1.22 /2.3.6 (https://github.com/jrburke/r.js)
-Copyright: (c) jQuery Foundation and other contributors, https://jquery.org/ (James Burke)
-Licensed under MIT or  BSD-2-Clause
-===========================================================================================
-[Frontend / Webapp]
-requirejs-angular-define: 1.1.0 (https://github.com/Nikku/requirejs-angular-define)
-Copyright: (c) 2013 Nico Rehwaldt 
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-angular-animate: 1.7.8 (https://github.com/angular/code.angularjs.org/blob/master/1.2.29/angular-animate.js)
-Copyright: (c) 2010-2017 Google Inc., Angular Core Team, http://angularjs.org
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-angular-cookies: 1.7.8 (https://github.com/angular/code.angularjs.org/blob/master/1.2.29/angular-cookies.js)
-Copyright: (c) 2010-2017 Google Inc., Angular Core Team, http://angularjs.org
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-angular-loader: 1.7.8 (https://github.com/angular/code.angularjs.org/blob/master/1.2.29/angular-loader.js)
-Copyright: (c) 2010-2017 Google Inc., Angular Core Team, http://angularjs.org
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-angular-mocks: 1.7.8 (https://github.com/angular/angular.js)
-Copyright: (c) 2010-2014 Google, Inc. http://angularjs.org
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-angular-resource: 1.7.8 (https://www.npmjs.com/package/angular-resource/v/1.2.29)
-Copyright: (c) 2010-2017 Google Inc., Angular Core Team, http://angularjs.org
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-angular-sanitize: 1.7.8 (https://www.npmjs.com/package/angular-sanitize/v/1.2.29)
-Copyright: (c) 2010-2017 Google Inc., Angular Core Team, http://angularjs.org
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-angular-scenario: 1.7.8 (https://www.npmjs.com/package/angular-scenario/v/1.2.29)
-Copyright: (c) 2010-2017 Google Inc., Angular Core Team, http://angularjs.org
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-angular-touch: 1.7.8 (https://www.npmjs.com/package/angular-touch/v/1.2.29)
-Copyright: (c) 2010-2017 Google Inc., Angular Core Team, http://angularjs.org
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-angular-translate: 2.18.1 (https://github.com/angular-translate/angular-translate)
-Copyright: (c) 2013-2017 The angular-translate team and Pascal Precht
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-clipboard: 2.0.4 (https://github.com/zenorocha/clipboard.js)
-Copyright: Zeno Rocha 
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-delegate: 3.2.0 (https://github.com/zenorocha/delegate)
-Copyright: Zeno Rocha
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-good-listener: 1.2.2 (https://github.com/zenorocha/good-listener)
-Copyright: Zeno Rocha
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-hat: 0.0.3 (https://github.com/substack/node-hat)
-Copyright: James Halliday
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-lodash: 4.17.14 (https://github.com/lodash/lodash)
-Copyright: JS Foundation and other contributors https://js.foundation/, John-David Dalton
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-select: 1.1.2 (https://github.com/zenorocha/select)
-Copyright: Zeno Rocha
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-tiny-emitter: 2.1.0 (https://github.com/scottcorgan/tiny-emitter)
-Copyright: (c) 2017 Scott Corgan
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-Angular: 1.7.8 (https://github.com/angular/angular.js)
-Copyright: (c) 2010-2014 Google, Inc. http://angularjs.org
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-q: 1.5.1 (https://github.com/kriskowal/q)
-Copyright: (c) 2009–2018 Kristopher Michael Kowal
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-closest: 0.0.1 (https://github.com/ForbesLindesay/closest)
-Copyright: ?
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-Css.escape: 1.5.1 (https://github.com/mathiasbynens/he)
-Copyright: Mathias Bynens <https://mathiasbynens.be/>
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-Delegate-events: 1.1.1 (https://github.com/HenrikJoreteg/delegate)
-Copyright: ?
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-Matches-selector: 0.0.1 / 1.2.0 (https://github.com/ForbesLindesay/matches-selector)
-Copyright: (c) 2013 Forbes Lindesay
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-saxen: 8.1.0 (https://github.com/nikku/saxen)
-Copyright: Copyright (c) 2012 Vopilovskii Konstantin flash.vkv@gmail.com, 2017-present Nico Rehwaldt
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-Component-props: 1.1.1 (https://github.com/component/props)
-Copyright: ?
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-Component-xor: 0.0.4 (https://github.com/component/xor)
-Copyright: Matthew Mueller
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-Dom-iterator: 1.0.0 (https://github.com/MatthewMueller/dom-iterator)
-Copyright: (c) Matthew Mueller
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-Escape-html:1.0.3 (https://github.com/component/escape-html)
-Copyright: (c) 2012-2013 TJ Holowaychuk, 2015 Andreas Lubbe, 2015 Tiancheng "Timothy" Gu
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-Selection-ranges: 3.0.0 (https://github.com/nikku/selection-ranges)
-Copyright: (c) 2017-present Nico Rehwaldt
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-Inferno: 5.0.6 (https://github.com/infernojs/inferno)
-Copyright: (c) 2013-2016 Dominic Gannaway
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-asynckits: 0.4.0 (https://github.com/alexindigo/asynckit)
-Copyright: (c) 2016 Alex Indigo
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-bpmn-font: 0.8.0 (https://github.com/bpmn-io/bpmn-font)
-Copyright: (c) 2014, camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-bpmn-js: 3.4.3 (https://github.com/bpmn-io/bpmn-js)
-Copyright: (c) 2014, camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-bpmn-moddle: 5.2.0 (https://github.com/bpmn-io/bpmn-moddle)
-Copyright: (c) 2014, camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-cmmn-font: 0.5.0 (https://github.com/bpmn-io/cmmn-font)
-Copyright: (c) 2015-2018 camunda services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-cmmn-js: 0.18.1 (https://github.com/bpmn-io/cmmn-js)
-Copyright: (c) 2015-2018 camunda services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-cmmn-moddle: 5.0.0 (https://github.com/bpmn-io/cmmn-moddle)
-Copyright: (c) 2015-2018 camunda services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-diagram-js-direct-editing: 1.6.0 (https://github.com/bpmn-io/diagram-js-direct-editing)
-Copyright: (c) 2014-2017 camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-diagram-js: 3.3.1 (https://github.com/bpmn-io/diagram-js)
-Copyright: (c) 2014-present camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-dmn-js-decision-table: 6.3.3 (https://github.com/bpmn-io/dmn-js)
-Copyright: (c) 2015-present Camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-dmn-js-drd: 6.3.3 (https://github.com/bpmn-io/dmn-js)
-Copyright: (c) 2015-present Camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-dmn-js-literal-expression: 6.3.3 (https://github.com/bpmn-io/dmn-js)
-Copyright: (c) 2015-present Camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-dmn-js-shared: 6.3.3 (https://github.com/bpmn-io/dmn-js)
-Copyright: (c) 2015-present Camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-dmn-js: 6.3.3 (https://github.com/bpmn-io/dmn-js)
-Copyright: (c) 2015-present Camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-dmn-moddle: 5.0.0 (https://github.com/bpmn-io/dmn-moddle)
-Copyright: (c) 2015-2017 camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-dom4: 2.1.5 (https://github.com/WebReflection/dom4)
-Copyright: (C) 2013-2015 by Andrea Giammarchi - @WebReflection
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-ids: 0.2.2 (https://github.com/bpmn-io/ids)
-Copyright: (c) 2014 camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-min-dash: 3.5.2 (https://github.com/bpmn-io/min-dash)
-Copyright: (c) 2017-present camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-min-dom: 3.1.1 (https://github.com/bpmn-io/min-dom)
-Copyright: (c) 2014 Nico Rehwaldt and (c) 2015-present camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-moddle-xml: 7.5.0 (https://github.com/bpmn-io/moddle-xml)
-Copyright: (c) 2014-present Camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-moddle: 4.1.0 (https://github.com/bpmn-io/moddle)
-Copyright: (c) 2014-present Camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-nimn-date-parser: 1.0.0 (https://github.com/nimndata/nimnjs-date-parser)
-Copyright: (c) 2018
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-nimn_schema_builder: 1.1.0 (https://github.com/nimndata/nimnjs-schema-builder)
-Copyright: (c) 2018
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-nimnjs: 1.3.2 (https://github.com/nimndata/nimnjs-node)
-Copyright: (c) 2018 nimndata
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-object-refs: 0.3.0 (https://github.com/bpmn-io/object-refs)
-Copyright: (c) 2014-present camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-path-intersection: 1.1.1 (https://github.com/bpmn-io/path-intersection)
-Copyright: (c) 2017 camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-safe-buffer: 5.2.0 (https://github.com/feross/safe-buffer)
-Copyright: (c) Feross Aboukhadijeh
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-select: 1.1.2 (https://github.com/zenorocha/select)
-Copyright: (c) Zeno Rocha
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-table-js: 5.1.0 (https://github.com/bpmn-io/table-js)
-Copyright: (c) 2017-present camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-tiny-svg: 2.2.2 (https://github.com/bpmn-io/tiny-svg)
-Copyright: (c) 2014 Nico Rehwaldt and (c) 2015-present camunda Services GmbH
-Licensed under MIT
-===========================================================================================
-[Frontend / Webapp]
-util-deprecate: 1.0.2 (https://github.com/TooTallNate/util-deprecate)
-Copyright: (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
-Licensed under MIT
+
+SIL Open Font License, Version 1.1 (OFL)
+The following license text for the OFL is cited only once. 
+
+SIL OPEN FONT LICENSE
+Version 1.1 - 26 February 2007
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting - in part or in whole - any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
 ===========================================================================================
 
 
-MPL
-The following license text for the MPL 2.0 license is cited only once. All libraries licenses under the MPL 2.0 will be listed after the license text together with copyright notice and link to this license text.
-Mozilla Public License, Version 2.0
-1. Definitions
-1.1. “Contributor”
-means each individual or legal entity that creates, contributes to the creation of, or owns Covered Software.
-1.2. “Contributor Version”
-means the combination of the Contributions of others (if any) used by a Contributor and that particular Contributor’s Contribution.
-1.3. “Contribution”
-means Covered Software of a particular Contributor.
-1.4. “Covered Software”
-means Source Code Form to which the initial Contributor has attached the notice in Exhibit A, the Executable Form of such Source Code Form, and Modifications of such Source Code Form, in each case including portions thereof.
-1.5. “Incompatible With Secondary Licenses”
-means
-that the initial Contributor has attached the notice described in Exhibit B to the Covered Software; or
-that the Covered Software was made available under the terms of version 1.1 or earlier of the License, but not also under the terms of a Secondary License.
-1.6. “Executable Form”
-means any form of the work other than Source Code Form.
-1.7. “Larger Work”
-means a work that combines Covered Software with other material, in a separate file or files, that is not Covered Software.
-1.8. “License”
-means this document.
-1.9. “Licensable”
-means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently, any and all of the rights conveyed by this License.
-1.10. “Modifications”
-means any of the following:
-any file in Source Code Form that results from an addition to, deletion from, or modification of the contents of Covered Software; or
-any new file in Source Code Form that contains any Covered Software.
-1.11. “Patent Claims” of a Contributor
-means any patent claim(s), including without limitation, method, process, and apparatus claims, in any patent Licensable by such Contributor that would be infringed, but for the grant of the License, by the making, using, selling, offering for sale, having made, import, or transfer of either its Contributions or its Contributor Version.
-1.12. “Secondary License”
-means either the GNU General Public License, Version 2.0, the GNU Lesser General Public License, Version 2.1, the GNU Affero General Public License, Version 3.0, or any later versions of those licenses.
-1.13. “Source Code Form”
-means the form of the work preferred for making modifications.
-1.14. “You” (or “Your”)
-means an individual or a legal entity exercising rights under this License. For legal entities, “You” includes any entity that controls, is controlled by, or is under common control with You. For purposes of this definition, “control” means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
-2. License Grants and Conditions
-2.1. Grants
-Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:
-under intellectual property rights (other than patent or trademark) Licensable by such Contributor to use, reproduce, make available, modify, display, perform, distribute, and otherwise exploit its Contributions, either on an unmodified basis, with Modifications, or as part of a Larger Work; and
-under Patent Claims of such Contributor to make, use, sell, offer for sale, have made, import, and otherwise transfer either its Contributions or its Contributor Version.
-2.2. Effective Date
-The licenses granted in Section 2.1 with respect to any Contribution become effective for each Contribution on the date the Contributor first distributes such Contribution.
-2.3. Limitations on Grant Scope
-The licenses granted in this Section 2 are the only rights granted under this License. No additional rights or licenses will be implied from the distribution or licensing of Covered Software under this License. Notwithstanding Section 2.1(b) above, no patent license is granted by a Contributor:
-for any code that a Contributor has removed from Covered Software; or
-for infringements caused by: (i) Your and any other third party’s modifications of Covered Software, or (ii) the combination of its Contributions with other software (except as part of its Contributor Version); or
-under Patent Claims infringed by Covered Software in the absence of its Contributions.
-This License does not grant any rights in the trademarks, service marks, or logos of any Contributor (except as may be necessary to comply with the notice requirements in Section 3.4).
-2.4. Subsequent Licenses
-No Contributor makes additional grants as a result of Your choice to distribute the Covered Software under a subsequent version of this License (see Section 10.2) or under the terms of a Secondary License (if permitted under the terms of Section 3.3).
-2.5. Representation
-Each Contributor represents that the Contributor believes its Contributions are its original creation(s) or it has sufficient rights to grant the rights to its Contributions conveyed by this License.
-2.6. Fair Use
-This License is not intended to limit any rights You have under applicable copyright doctrines of fair use, fair dealing, or other equivalents.
-2.7. Conditions
-Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in Section 2.1.
-3. Responsibilities
-3.1. Distribution of Source Form
-All distribution of Covered Software in Source Code Form, including any Modifications that You create or to which You contribute, must be under the terms of this License. You must inform recipients that the Source Code Form of the Covered Software is governed by the terms of this License, and how they can obtain a copy of this License. You may not attempt to alter or restrict the recipients’ rights in the Source Code Form.
-3.2. Distribution of Executable Form
-If You distribute Covered Software in Executable Form then:
-such Covered Software must also be made available in Source Code Form, as described in Section 3.1, and You must inform recipients of the Executable Form how they can obtain a copy of such Source Code Form by reasonable means in a timely manner, at a charge no more than the cost of distribution to the recipient; and
-You may distribute such Executable Form under the terms of this License, or sublicense it under different terms, provided that the license for the Executable Form does not attempt to limit or alter the recipients’ rights in the Source Code Form under this License.
-3.3. Distribution of a Larger Work
-You may create and distribute a Larger Work under terms of Your choice, provided that You also comply with the requirements of this License for the Covered Software. If the Larger Work is a combination of Covered Software with a work governed by one or more Secondary Licenses, and the Covered Software is not Incompatible With Secondary Licenses, this License permits You to additionally distribute such Covered Software under the terms of such Secondary License(s), so that the recipient of the Larger Work may, at their option, further distribute the Covered Software under the terms of either this License or such Secondary License(s).
-3.4. Notices
-You may not remove or alter the substance of any license notices (including copyright notices, patent notices, disclaimers of warranty, or limitations of liability) contained within the Source Code Form of the Covered Software, except that You may alter any license notices to the extent required to remedy known factual inaccuracies.
-3.5. Application of Additional Terms
-You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Software. However, You may do so only on Your own behalf, and not on behalf of any Contributor. You must make it absolutely clear that any such warranty, support, indemnity, or liability obligation is offered by You alone, and You hereby agree to indemnify every Contributor for any liability incurred by such Contributor as a result of warranty, support, indemnity or liability terms You offer. You may include additional disclaimers of warranty and limitations of liability specific to any jurisdiction.
-4. Inability to Comply Due to Statute or Regulation
-If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Covered Software due to statute, judicial order, or regulation then You must: (a) comply with the terms of this License to the maximum extent possible; and (b) describe the limitations and the code they affect. Such description must be placed in a text file included with all distributions of the Covered Software under this License. Except to the extent prohibited by statute or regulation, such description must be sufficiently detailed for a recipient of ordinary skill to be able to understand it.
-5. Termination
-5.1. The rights granted under this License will terminate automatically if You fail to comply with any of its terms. However, if You become compliant, then the rights granted under this License from a particular Contributor are reinstated (a) provisionally, unless and until such Contributor explicitly and finally terminates Your grants, and (b) on an ongoing basis, if such Contributor fails to notify You of the non-compliance by some reasonable means prior to 60 days after You have come back into compliance. Moreover, Your grants from a particular Contributor are reinstated on an ongoing basis if such Contributor notifies You of the non-compliance by some reasonable means, this is the first time You have received notice of non-compliance with this License from such Contributor, and You become compliant prior to 30 days after Your receipt of the notice.
-5.2. If You initiate litigation against any entity by asserting a patent infringement claim (excluding declaratory judgment actions, counter-claims, and cross-claims) alleging that a Contributor Version directly or indirectly infringes any patent, then the rights granted to You by any and all Contributors for the Covered Software under Section 2.1 of this License shall terminate.
-5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user license agreements (excluding distributors and resellers) which have been validly granted by You or Your distributors under this License prior to termination shall survive termination.
-6. Disclaimer of Warranty
-Covered Software is provided under this License on an “as is” basis, without warranty of any kind, either expressed, implied, or statutory, including, without limitation, warranties that the Covered Software is free of defects, merchantable, fit for a particular purpose or non-infringing. The entire risk as to the quality and performance of the Covered Software is with You. Should any Covered Software prove defective in any respect, You (not any Contributor) assume the cost of any necessary servicing, repair, or correction. This disclaimer of warranty constitutes an essential part of this License. No use of any Covered Software is authorized under this License except under this disclaimer.
-7. Limitation of Liability
-Under no circumstances and under no legal theory, whether tort (including negligence), contract, or otherwise, shall any Contributor, or anyone who distributes Covered Software as permitted above, be liable to You for any direct, indirect, special, incidental, or consequential damages of any character including, without limitation, damages for lost profits, loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses, even if such party shall have been informed of the possibility of such damages. This limitation of liability shall not apply to liability for death or personal injury resulting from such party’s negligence to the extent applicable law prohibits such limitation. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so this exclusion and limitation may not apply to You.
-8. Litigation
-Any litigation relating to this License may be brought only in the courts of a jurisdiction where the defendant maintains its principal place of business and such litigation shall be governed by laws of that jurisdiction, without reference to its conflict-of-law provisions. Nothing in this Section shall prevent a party’s ability to bring cross-claims or counter-claims.
-9. Miscellaneous
-This License represents the complete agreement concerning the subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. Any law or regulation which provides that the language of a contract shall be construed against the drafter shall not be used to construe this License against a Contributor.
-10. Versions of the License
-10.1. New Versions
-Mozilla Foundation is the license steward. Except as provided in Section 10.3, no one other than the license steward has the right to modify or publish new versions of this License. Each version will be given a distinguishing version number.
-10.2. Effect of New Versions
-You may distribute the Covered Software under the terms of the version of the License under which You originally received the Covered Software, or under the terms of any subsequent version published by the license steward.
-10.3. Modified Versions
-If you create software not governed by this License, and you want to create a new license for such software, you may create and use a modified version of this License if you rename the license and remove any references to the name of the license steward (except to note that such modified license differs from this License).
-10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
-If You choose to distribute Source Code Form that is Incompatible With Secondary Licenses under the terms of this version of the License, the notice described in Exhibit B of this License must be attached.
-Exhibit A - Source Code Form License Notice
-This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
-If it is not possible or desirable to put the notice in a particular file, then You may include the notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be likely to look for such a notice.
-You may add additional accurate notices of copyright ownership.
-Exhibit B - “Incompatible With Secondary Licenses” Notice
-This Source Code Form is “Incompatible With Secondary Licenses”, as defined by the Mozilla Public License, v. 2.0.
-=========================================================================================== [Backend / Template XSLT]
-Saxon-HE 9.5.1-5 (http://www.saxonica.com)
-Copyright: ?
-Licensed under MPL 2.0 
 ===========================================================================================
+aopalliance:aopalliance:jar:1.0
+https://github.com/javaee/hk2/tree/master/hk2-api
+Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
 
-CCA
-The following license text for the Creative Commons Attribution 2.5. license is cited only once. All libraries licenses under the MPL 2.0 will be listed after the license text together with copyright notice and link to this license text.
-Creative Commons Attribution 2.5
-THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
-BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE TO BE BOUND BY THE TERMS OF THIS LICENSE. THE LICENSOR GRANTS YOU THE RIGHTS CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND CONDITIONS.
-1. Definitions
-"Collective Work" means a work, such as a periodical issue, anthology or encyclopedia, in which the Work in its entirety in unmodified form, along with a number of other contributions, constituting separate and independent works in themselves, are assembled into a collective whole. A work that constitutes a Collective Work will not be considered a Derivative Work (as defined below) for the purposes of this License.
-"Derivative Work" means a work based upon the Work or upon the Work and other pre-existing works, such as a translation, musical arrangement, dramatization, fictionalization, motion picture version, sound recording, art reproduction, abridgment, condensation, or any other form in which the Work may be recast, transformed, or adapted, except that a work that constitutes a Collective Work will not be considered a Derivative Work for the purpose of this License. For the avoidance of doubt, where the Work is a musical composition or sound recording, the synchronization of the Work in timed-relation with a moving image ("synching") will be considered a Derivative Work for the purpose of this License.
-"Licensor" means the individual or entity that offers the Work under the terms of this License.
-"Original Author" means the individual or entity who created the Work.
-"Work" means the copyrightable work of authorship offered under the terms of this License.
-"You" means an individual or entity exercising rights under this License who has not previously violated the terms of this License with respect to the Work, or who has received express permission from the Licensor to exercise rights under this License despite a previous violation.
-2. Fair Use Rights. Nothing in this license is intended to reduce, limit, or restrict any rights arising from fair use, first sale or other limitations on the exclusive rights of the copyright owner under copyright law or other applicable laws.
-3. License Grant. Subject to the terms and conditions of this License, Licensor hereby grants You a worldwide, royalty-free, non-exclusive, perpetual (for the duration of the applicable copyright) license to exercise the rights in the Work as stated below:
-to reproduce the Work, to incorporate the Work into one or more Collective Works, and to reproduce the Work as incorporated in the Collective Works;
-to create and reproduce Derivative Works;
-to distribute copies or phonorecords of, display publicly, perform publicly, and perform publicly by means of a digital audio transmission the Work including as incorporated in Collective Works;
-to distribute copies or phonorecords of, display publicly, perform publicly, and perform publicly by means of a digital audio transmission Derivative Works.
-For the avoidance of doubt, where the work is a musical composition:
-Performance Royalties Under Blanket Licenses. Licensor waives the exclusive right to collect, whether individually or via a performance rights society (e.g. ASCAP, BMI, SESAC), royalties for the public performance or public digital performance (e.g. webcast) of the Work.
-Mechanical Rights and Statutory Royalties. Licensor waives the exclusive right to collect, whether individually or via a music rights agency or designated agent (e.g. Harry Fox Agency), royalties for any phonorecord You create from the Work ("cover version") and distribute, subject to the compulsory license created by 17 USC Section 115 of the US Copyright Act (or the equivalent in other jurisdictions).
-Webcasting Rights and Statutory Royalties. For the avoidance of doubt, where the Work is a sound recording, Licensor waives the exclusive right to collect, whether individually or via a performance-rights society (e.g. SoundExchange), royalties for the public digital performance (e.g. webcast) of the Work, subject to the compulsory license created by 17 USC Section 114 of the US Copyright Act (or the equivalent in other jurisdictions).
-The above rights may be exercised in all media and formats whether now known or hereafter devised. The above rights include the right to make such modifications as are technically necessary to exercise the rights in other media and formats. All rights not expressly granted by Licensor are hereby reserved.
-4. Restrictions.The license granted in Section 3 above is expressly made subject to and limited by the following restrictions:
-You may distribute, publicly display, publicly perform, or publicly digitally perform the Work only under the terms of this License, and You must include a copy of, or the Uniform Resource Identifier for, this License with every copy or phonorecord of the Work You distribute, publicly display, publicly perform, or publicly digitally perform. You may not offer or impose any terms on the Work that alter or restrict the terms of this License or the recipients' exercise of the rights granted hereunder. You may not sublicense the Work. You must keep intact all notices that refer to this License and to the disclaimer of warranties. You may not distribute, publicly display, publicly perform, or publicly digitally perform the Work with any technological measures that control access or use of the Work in a manner inconsistent with the terms of this License Agreement. The above applies to the Work as incorporated in a Collective Work, but this does not require the Collective Work apart from the Work itself to be made subject to the terms of this License. If You create a Collective Work, upon notice from any Licensor You must, to the extent practicable, remove from the Collective Work any credit as required by clause 4(b), as requested. If You create a Derivative Work, upon notice from any Licensor You must, to the extent practicable, remove from the Derivative Work any credit as required by clause 4(b), as requested.
-If you distribute, publicly display, publicly perform, or publicly digitally perform the Work or any Derivative Works or Collective Works, You must keep intact all copyright notices for the Work and provide, reasonable to the medium or means You are utilizing: (i) the name of the Original Author (or pseudonym, if applicable) if supplied, and/or (ii) if the Original Author and/or Licensor designate another party or parties (e.g. a sponsor institute, publishing entity, journal) for attribution in Licensor's copyright notice, terms of service or by other reasonable means, the name of such party or parties; the title of the Work if supplied; to the extent reasonably practicable, the Uniform Resource Identifier, if any, that Licensor specifies to be associated with the Work, unless such URI does not refer to the copyright notice or licensing information for the Work; and in the case of a Derivative Work, a credit identifying the use of the Work in the Derivative Work (e.g., "French translation of the Work by Original Author," or "Screenplay based on original Work by Original Author"). Such credit may be implemented in any reasonable manner; provided, however, that in the case of a Derivative Work or Collective Work, at a minimum such credit will appear where any other comparable authorship credit appears and in a manner at least as prominent as such other comparable authorship credit.
-5. Representations, Warranties and Disclaimer
-UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR OFFERS THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY KIND CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE, INCLUDING, WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY, FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF LATENT OR OTHER DEFECTS, ACCURACY, OR THE PRESENCE OF ABSENCE OF ERRORS, WHETHER OR NOT DISCOVERABLE. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF IMPLIED WARRANTIES, SO SUCH EXCLUSION MAY NOT APPLY TO YOU.
-6. Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK, EVEN IF LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-7. Termination
-This License and the rights granted hereunder will terminate automatically upon any breach by You of the terms of this License. Individuals or entities who have received Derivative Works or Collective Works from You under this License, however, will not have their licenses terminated provided such individuals or entities remain in full compliance with those licenses. Sections 1, 2, 5, 6, 7, and 8 will survive any termination of this License.
-Subject to the above terms and conditions, the license granted here is perpetual (for the duration of the applicable copyright in the Work). Notwithstanding the above, Licensor reserves the right to release the Work under different license terms or to stop distributing the Work at any time; provided, however that any such election will not serve to withdraw this License (or any other license that has been, or is required to be, granted under the terms of this License), and this License will continue in full force and effect unless terminated as stated above.
-8. Miscellaneous
-Each time You distribute or publicly digitally perform the Work or a Collective Work, the Licensor offers to the recipient a license to the Work on the same terms and conditions as the license granted to You under this License.
-Each time You distribute or publicly digitally perform a Derivative Work, Licensor offers to the recipient a license to the original Work on the same terms and conditions as the license granted to You under this License.
-If any provision of this License is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this License, and without further action by the parties to this agreement, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
-No term or provision of this License shall be deemed waived and no breach consented to unless such waiver or consent shall be in writing and signed by the party to be charged with such waiver or consent.
-This License constitutes the entire agreement between the parties with respect to the Work licensed here. There are no understandings, agreements or representations with respect to the Work not specified here. Licensor shall not be bound by any additional provisions that may appear in any communication from You. This License may not be modified without the mutual written agreement of the Licensor and You.
 ===========================================================================================
-[Backend / Webapp / Tomcat and Backend / Rest / Tomcat]
-net.jcip:jcip-annotations:1.0 (http://jcip.net/)
+ch.qos.logback:logback-classic:jar:1.2.3
+https://github.com/qos-ch/logback
+Copyright (C) 1999-2015, QOS.ch. All rights reserved.
+Licensed under EPL 1.0  							
+
+===========================================================================================
+ch.qos.logback:logback-core:jar:1.2.3
+https://github.com/qos-ch/logback
+Copyright (C) 1999-2015, QOS.ch. All rights reserved.
+Licensed under EPL 1.0  							
+
+===========================================================================================
+com.fasterxml.jackson.core:jackson-annotations:jar:2.10.0
+https://github.com/FasterXML/jackson-annotations
+Copyright: various authors 
+Licensed under Apache 2.0
+
+===========================================================================================
+com.fasterxml.jackson.core:jackson-annotations:jar:2.10.2
+https://github.com/FasterXML/jackson-annotations
+Copyright: various authors (https://github.com/FasterXML/jackson-annotations/blob/master/release-notes/VERSION-2.x)					
+Licensed under Apache 2.0
+
+===========================================================================================
+com.fasterxml.jackson.core:jackson-core:jar:2.10.0
+https://github.com/FasterXML/jackson-core
+NOTICE: 
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers, as well as supported
+commercially by FasterXML.com.
+## Licensing
+Jackson core and extension components may be licensed under different licenses.
+To find the details that apply to this artifact see the accompanying LICENSE file.
+For more information, including possible other licensing options, contact
+FasterXML.com (http://fasterxml.com).
+## Credits
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+Licensed under Apache 2.0
+
+
+===========================================================================================
+com.fasterxml.jackson.core:jackson-core:jar:2.10.2
+https://github.com/FasterXML/jackson-core
+Copyright: various authors (https://github.com/FasterXML/jackson-core/blob/master/release-notes/CREDITS-2.x)				
+Licensed under Apache 2.0
+
+===========================================================================================
+com.fasterxml.jackson.core:jackson-databind:jar:2.10.0
+https://github.com/FasterXML/jackson-databind
+Notice file: https://github.com/FasterXML/jackson-databind/blob/master/release-notes/CREDITS-2.x 
+NOTICE: Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers, as well as supported
+commercially by FasterXML.com.
+## Licensing
+Jackson core and extension components may be licensed under different licenses.
+To find the details that apply to this artifact see the accompanying LICENSE file.
+For more information, including possible other licensing options, contact
+FasterXML.com (http://fasterxml.com).
+## Credits
+A list of contributors may be found from CREDITS file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+Licensed under Apache 2.0
+
+
+===========================================================================================
+com.fasterxml.jackson.core:jackson-databind:jar:2.10.2
+https://github.com/FasterXML/jackson-databind
+Copyright: various authors (https://github.com/FasterXML/jackson-databind/blob/master/release-notes/CREDITS-2.x)			
+Licensed under Apache 2.0
+
+===========================================================================================
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.10.2
+https://github.com/FasterXML/jackson-modules-java8
+Copyright: various authors (https://github.com/FasterXML/jackson-modules-java8/blob/master/release-notes/CREDITS-2.x)			
+Licensed under Apache 2.0
+
+===========================================================================================
+com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.10.2
+https://github.com/FasterXML/jackson-modules-java8
+Copyright: various authors (https://github.com/FasterXML/jackson-modules-java8/blob/master/release-notes/CREDITS-2.x)			
+Licensed under Apache 2.0
+
+===========================================================================================
+com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.10.0
+https://github.com/FasterXML/jackson-jaxrs-providers
+Copyright: various authors (https://github.com/FasterXML/jackson-jaxrs-providers/blob/master/release-notes/CREDITS-2.x)			
+Licensed under Apache 2.0
+
+===========================================================================================
+com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.10.2.1
+https://github.com/FasterXML/jackson-jaxrs-providers
+Copyright: various authors (https://github.com/FasterXML/jackson-jaxrs-providers/tree/master/release-notes)				
+Licensed under Apache 2.0
+
+===========================================================================================
+com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.10.0
+https://github.com/FasterXML/jackson-jaxrs-providers
+Copyright: various authors (https://github.com/FasterXML/jackson-jaxrs-providers/tree/master/release-notes)
+Licensed under Apache 2.0
+
+===========================================================================================
+com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.10.2.1
+https://github.com/FasterXML/jackson-jaxrs-providers
+Copyright: various authors (https://github.com/FasterXML/jackson-jaxrs-providers/tree/master/release-notes)				
+Licensed under Apache 2.0
+
+===========================================================================================
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.10.0
+https://github.com/FasterXML/jackson-modules-base
+Copyright: various authors (https://github.com/FasterXML/jackson-modules-base/blob/master/release-notes/CREDITS-2.x)				
+Licensed under Apache 2.0
+
+===========================================================================================
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.10.2
+https://github.com/FasterXML/jackson-modules-base
+Copyright: various authors (https://github.com/FasterXML/jackson-modules-base/blob/master/release-notes/CREDITS-2.x)				
+Licensed under Apache 2.0
+
+===========================================================================================
+com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.10.2
+https://github.com/FasterXML/jackson-modules-java8
+Copyright: various authors (https://github.com/FasterXML/jackson-modules-java8/blob/master/release-notes/CREDITS-2.x)				
+Licensed under Apache 2.0
+
+===========================================================================================
+com.fasterxml.uuid:java-uuid-generator:jar:3.2.0
+https://github.com/cowtowncoder/java-uuid-generator
+Copyright: various authors (https://github.com/cowtowncoder/java-uuid-generator/blob/3.0/release-notes/CREDITS)
+Licensed under Apache 2.0
+
+===========================================================================================
+com.fasterxml:classmate:jar:1.5.1
+https://github.com/FasterXML/java-classmate
+Copyright: various authors (https://github.com/FasterXML/java-classmate/blob/master/VERSION.txt)						
+Licensed under Apache 2.0
+
+===========================================================================================
+com.github.stephenc.jcip:jcip-annotations:jar:1.0-1
+http://jcip.net/
 Copyright: 2005 Brian Goetz and Tim Peierls
 Licensed under Creative Commons Attribution License
+
+===========================================================================================
+com.google.code.gson:gson:jar:2.8.5
+https://github.com/google/gson
+Copyright: 2008 Google Inc.
+Licensed under Apache 2.0
+
+===========================================================================================
+com.h2database:h2:jar:1.4.190
+https://github.com/h2database/h2database
+Copyright: H2, the Java SQL database (https://h2database.com/html/main.html)         
+Licensed under EPL 1.0 
+
+
+===========================================================================================
+com.h2database:h2:jar:1.4.200
+https://github.com/h2database/h2database
+Copyright: H2, the Java SQL database (https://h2database.com/html/main.html)         
+Licensed under EPL 1.0 
+
+
+===========================================================================================
+com.jayway.jsonpath:json-path:jar:2.4.0
+https://github.com/json-path/JsonPath
+Copyright: 2001-2011 the original author or authors (Stefan Goessner)
+Licensed under Apache 2.0
+
+===========================================================================================
+com.sun.activation:jakarta.activation:jar:1.2.1
+https://github.com/eclipse-ee4j/jaf/tree/master/activation
+Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+Licensed under EPL 1.0  	
+
+===========================================================================================
+com.sun.xml.bind:jaxb-impl:jar:2.2.4
+https://github.com/javaee/jaxb-v2
+Copyright: 1997-2017 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
+
+===========================================================================================
+com.zaxxer:HikariCP:jar:3.4.2
+https://github.com/brettwooldridge/HikariCP
+Copyright (C) Brett Wooldridge
+Licensed under Apache 2.0
+
+===========================================================================================
+commons-codec:commons-codec:jar:1.11
+http://commons.apache.org/codec/
+Copyright: 2002-2011 The Apache Software Foundation This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/)  and  2002 Kevin Atkinson (kevina@gnu.org). Verbatim copying and distribution of this entire article is permitted in any medium,
+provided this notice is preserved.
+Licensed under Apache 2.0
+
+===========================================================================================
+commons-codec:commons-codec:jar:1.13
+http://commons.apache.org/codec/
+Notice file:
+======================================================================================
+Apache Commons Codec
+Copyright 2002-2020 The Apache Software Foundation
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+src/test/org/apache/commons/codec/language/DoubleMetaphoneTest.java
+contains test data from http://aspell.net/test/orig/batch0.tab.
+Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org)
+The content of package org.apache.commons.codec.language.bm has been translated
+from the original php source code available at http://stevemorse.org/phoneticinfo.htm
+with permission from the original authors.
+Original source copyright:
+Copyright (c) 2008 Alexander Beider & Stephen P. Morse.
+Copyright 2002-2020 The Apache Software Foundation											
+======================================================================================
+Licensed under Apache 2.0
+
+===========================================================================================
+commons-dbcp:commons-dbcp:jar:1.4
+http://commons.apache.org/proper/commons-dbcp/
+Copyright: 2001-2010 The Apache Software Foundation This product includes software developed by The Apache Software Foundation (http://www.apache.org/).
+Licensed under Apache 2.0
+
+===========================================================================================
+commons-fileupload:commons-fileupload:jar:1.3.3
+https://commons.apache.org/proper/commons-fileupload/download_fileupload.cgi
+Copyright: 2002-2017 The Apache Software Foundation This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+Licensed under Apache 2.0
+
+===========================================================================================
+commons-io:commons-io:jar:2.0.1
+https://commons.apache.org/proper/commons-io/
+Copyright 2002-2010 The Apache Software Foundation
+
+This product includes software developed by The Apache Software Foundation (http://www.apache.org/).
+Licensed under Apache 2.0
+
+===========================================================================================
+commons-logging:commons-logging:jar:1.1.1
+http://commons.apache.org/proper/commons-logging/
+Copyright: 2003-2014 The Apache Software Foundation This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/)
+Licensed under Apache 2.0
+
+===========================================================================================
+commons-logging:commons-logging:jar:1.2
+http://commons.apache.org/proper/commons-logging/
+Notice file:
+====================================================================
+Apache Commons Logging
+Copyright 2003-2016 The Apache Software Foundation
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+Copyright 2003-2016 The Apache Software Foundation												
+====================================================================
+Licensed under Apache 2.0
+
+===========================================================================================
+commons-pool:commons-pool:jar:1.5.4
+http://commons.apache.org/proper/commons-pool/
+Copyright: 2001-2012 The Apache Software Foundation This product includes software developed by The Apache Software Foundation (http://www.apache.org/).
+Licensed under Apache 2.0
+
+===========================================================================================
+commons-pool:commons-pool:jar:1.6
+http://commons.apache.org/proper/commons-pool/
+Notice file:
+====================================================================
+Apache Commons Logging
+Copyright 2003-2016 The Apache Software Foundation
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+Copyright 2001-2019 The Apache Software Foundation														
+===================================================================
+Licensed under Apache 2.0
+
+===========================================================================================
+de.odysseus.juel:juel-api:jar:2.2.7
+https://github.com/beckchr/juel/
+Copyright: 2006-2012 Odysseus Software
+Licensed under Apache 2.0
+
+===========================================================================================
+de.odysseus.juel:juel-impl:jar:2.2.7
+https://github.com/beckchr/juel/
+Copyright: 2006-2012 Odysseus Software
+Licensed under Apache 2.0
+
+===========================================================================================
+de.odysseus.juel:juel-spi:jar:2.2.7
+https://github.com/beckchr/juel/
+Copyright: 2006-2012 Odysseus Software
+Licensed under Apache 2.0
+
+===========================================================================================
+jakarta.activation:jakarta.activation-api:jar:1.2.2
+https://github.com/eclipse-ee4j/jaf
+Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.										
+Notice file: 
+==================================================================
+# Notices for Jakarta Activation
+This content is produced and maintained by Jakarta Activation project.
+* Project home: https://projects.eclipse.org/projects/ee4j.jaf
+## Copyright
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+## Declared Project Licenses
+This program and the accompanying materials are made available under the terms
+of the Eclipse Distribution License v. 1.0,
+which is available at http://www.eclipse.org/org/documents/edl-v10.php.
+SPDX-License-Identifier: BSD-3-Clause
+## Source Code
+The project maintains the following source code repositories:
+* https://github.com/eclipse-ee4j/jaf
+## Third-party Content
+This project leverages the following third party content.
+JUnit (4.12)
+* License: Eclipse Public License
+====================================================================										
+Licensed under BSD-3-Clause
+
+===========================================================================================
+jakarta.annotation:jakarta.annotation-api:jar:1.3.5
+https://github.com/eclipse-ee4j/common-annotations-api
+Notice file:
+==================================================================
+# Notices for Jakarta Activation
+This content is produced and maintained by Jakarta Activation project.
+* Project home: https://projects.eclipse.org/projects/ee4j.jaf
+## Copyright
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+## Declared Project Licenses
+This program and the accompanying materials are made available under the terms
+of the Eclipse Distribution License v. 1.0,
+which is available at http://www.eclipse.org/org/documents/edl-v10.php.
+SPDX-License-Identifier: BSD-3-Clause
+## Source Code
+The project maintains the following source code repositories:
+* https://github.com/eclipse-ee4j/jaf
+## Third-party Content
+This project leverages the following third party content.
+JUnit (4.12)
+* License: Eclipse Public License
+====================================================================	
+Copyright (C) Oracle and/or its affiliates. All rights reserved.																							
+Licensed under EPL 2.0
+
+===========================================================================================
+jakarta.validation:jakarta.validation-api:jar:2.0.2
+https://github.com/eclipse-ee4j/beanvalidation-api
+Copyright: various authors (https://github.com/eclipse-ee4j/beanvalidation-api/blob/master/copyright.txt)
+Licensed under Apache 2.0
+
+===========================================================================================
+jakarta.ws.rs:jakarta.ws.rs-api:jar:2.1.6
+https://github.com/eclipse-ee4j/jaxrs-api
+Notice file:
+==================================================================
+# Notices for Jakarta Activation
+This content is produced and maintained by Jakarta Activation project.
+* Project home: https://projects.eclipse.org/projects/ee4j.jaf
+## Copyright
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+## Declared Project Licenses
+This program and the accompanying materials are made available under the terms
+of the Eclipse Distribution License v. 1.0,
+which is available at http://www.eclipse.org/org/documents/edl-v10.php.
+SPDX-License-Identifier: BSD-3-Clause
+## Source Code
+The project maintains the following source code repositories:
+* https://github.com/eclipse-ee4j/jaf
+## Third-party Content
+This project leverages the following third party content.
+JUnit (4.12)
+* License: Eclipse Public License
+====================================================================	
+Copyright (C) Oracle and/or its affiliates. All rights reserved.																								
+Licensed under EPL 2.0
+
+===========================================================================================
+jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.2
+https://github.com/eclipse-ee4j/jaxb-api
+Notice file:
+==================================================================
+# Notices for Jakarta Activation
+This content is produced and maintained by Jakarta Activation project.
+* Project home: https://projects.eclipse.org/projects/ee4j.jaf
+## Copyright
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+## Declared Project Licenses
+This program and the accompanying materials are made available under the terms
+of the Eclipse Distribution License v. 1.0,
+which is available at http://www.eclipse.org/org/documents/edl-v10.php.
+SPDX-License-Identifier: BSD-3-Clause
+## Source Code
+The project maintains the following source code repositories:
+* https://github.com/eclipse-ee4j/jaf
+## Third-party Content
+This project leverages the following third party content.
+JUnit (4.12)
+* License: Eclipse Public License
+====================================================================	
+Copyright (C) Oracle and/or its affiliates. All rights reserved.																							
+Licensed under EPL 2.0
+
+===========================================================================================
+javax.activation:activation:jar:1.1
+https://github.com/javaee/activation
+Copyright: Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
+
+===========================================================================================
+javax.annotation:javax.annotation-api:jar:1.2
+https://github.com/javaee/javax.annotation
+Copyright: (c) 2005-2016 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
+
+===========================================================================================
+javax.validation:validation-api:jar:1.1.0.Final
+http://beanvalidation.org/1.1/
+Copyright: 2007-2013 Red Hat, Inc.
+Licensed under Apache 2.0
+
+===========================================================================================
+javax.ws.rs:javax.ws.rs-api:jar:2.0.1
+https://github.com/javaee/hk2
+Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
+
+===========================================================================================
+javax.xml.bind:jaxb-api:jar:2.2.3
+https://github.com/javaee/jaxb-v2
+Copyright: Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
+
+===========================================================================================
+javax.xml.stream:stax-api:jar:1.0-2
+?
+Copyright: Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
+
+===========================================================================================
+joda-time:joda-time:jar:2.1
+https://github.com/JodaOrg/joda-time
+Notice file: 
+=============================================================================
+= NOTICE file corresponding to section 4d of the Apache License Version 2.0 =
+=============================================================================
+This product includes software developed by
+Joda.org (https://www.joda.org/).
+Copyright 2001-2020 Stephen Colebourne
+Licensed under Apache 2.0
+
+
+===========================================================================================
+joda-time:joda-time:jar:2.10.5
+https://github.com/JodaOrg/joda-time
+Notice file:
+=============================================================================
+= NOTICE file corresponding to section 4d of the Apache License Version 2.0 =
+This product includes software developed by
+Joda.org (https://www.joda.org/).
+Copyright 2001-2020 Stephen Colebourne
+============================================================================
+Licensed under Apache 2.0
+
+
+===========================================================================================
+net.minidev:accessors-smart:jar:1.2
+https://code.google.com/archive/p/json-smart/
+Copyright: Copyright 2011 JSON-SMART authors 
+Licensed under Apache 2.0
+
+===========================================================================================
+net.minidev:json-smart:jar:2.3
+https://code.google.com/archive/p/json-smart/
+Copyright: Uriel Chemouni
+Licensed under Apache 2.0
+
+
+===========================================================================================
+org.apache.commons:commons-compress:jar:1.19
+https://commons.apache.org/proper/commons-compress/
+Notice file:
+============================================================================
+Apache Commons Compress
+Copyright 2002-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+---
+
+The files in the package org.apache.commons.compress.archivers.sevenz
+were derived from the LZMA SDK, version 9.20 (C/ and CPP/7zip/),
+which has been placed in the public domain:
+
+"LZMA SDK is placed in the public domain." (http://www.7-zip.org/sdk.html)
+
+---
+
+The test file lbzip2_32767.bz2 has been copied from libbzip2's source
+repository:
+
+This program, "bzip2", the associated library "libbzip2", and all
+documentation, are copyright (C) 1996-2019 Julian R Seward.  All
+rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. The origin of this software must not be misrepresented; you must 
+   not claim that you wrote the original software.  If you use this 
+   software in a product, an acknowledgment in the product 
+   documentation would be appreciated but is not required.
+
+3. Altered source versions must be plainly marked as such, and must
+   not be misrepresented as being the original software.
+
+4. The name of the author may not be used to endorse or promote 
+   products derived from this software without specific prior written 
+   permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Julian Seward, jseward@acm.org
+========================================================================
+Copyright 2002-2020 The Apache Software Foundation													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.apache.commons:commons-lang3:jar:3.9
+https://commons.apache.org/proper/commons-lang/
+Notice file:
+============================================================================
+Apache Commons Lang
+Copyright 2001-2020 The Apache Software Foundation
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+========================================================================
+Copyright 2001-2020 The Apache Software Foundation															
+Licensed under Apache 2.0
+
+===========================================================================================
+org.apache.httpcomponents:httpclient:jar:4.5.9
+http://hc.apache.org/
+Copyright: 2005-2014 The Apache Software Foundation This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/)
+Licensed under Apache 2.0
+
+===========================================================================================
+org.apache.httpcomponents:httpcore:jar:4.4.11
+http://hc.apache.org/
+Copyright: 2005-2014 The Apache Software Foundation. This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/). This project contains annotations derived from JCIP-ANNOTATIONS and 2005 Brian Goetz and Tim Peierls. See http://www.jcip.net
+Licensed under Apache 2.0
+
+===========================================================================================
+org.apache.logging.log4j:log4j-api:jar:2.12.1
+https://logging.apache.org/log4j/2.x/
+Notice file:
+=======================================================================
+Apache log4j
+Copyright 2010 The Apache Software Foundation
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+======================================================================
+Copyright 2010 The Apache Software Foundation														
+Licensed under Apache 2.0
+
+===========================================================================================
+org.apache.logging.log4j:log4j-to-slf4j:jar:2.12.1
+https://logging.apache.org/log4j/2.x/
+Copyright: The Apache Software Foundation
+Licensed under Apache 2.0
+
+
+===========================================================================================
+org.apache.tomcat.embed:tomcat-embed-core:jar:9.0.31
+https://github.com/apache/tomcat
+Notice file: 
+========================================================================
+Apache Tomcat
+Copyright 1999-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+This software contains code derived from netty-native
+developed by the Netty project
+(https://netty.io, https://github.com/netty/netty-tcnative/)
+and from finagle-native developed at Twitter
+(https://github.com/twitter/finagle).
+
+This software contains code derived from jgroups-kubernetes
+developed by the JGroups project (http://www.jgroups.org/).
+
+The Windows Installer is built with the Nullsoft
+Scriptable Install System (NSIS), which is
+open source software.  The original software and
+related information is available at
+http://nsis.sourceforge.net.
+
+Java compilation software for JSP pages is provided by the Eclipse
+JDT Core Batch Compiler component, which is open source software.
+The original software and related information is available at
+https://www.eclipse.org/jdt/core/.
+
+org.apache.tomcat.util.json.JSONParser.jj is a public domain javacc grammar
+for JSON written by Robert Fischer.
+https://github.com/RobertFischer/json-parser
+
+For portions of the Tomcat JNI OpenSSL API and the OpenSSL JSSE integration
+The org.apache.tomcat.jni and the org.apache.tomcat.net.openssl packages
+are derivative work originating from the Netty project and the finagle-native
+project developed at Twitter
+* Copyright 2014 The Netty Project
+* Copyright 2014 Twitter
+
+For portions of the Tomcat cloud support
+The org.apache.catalina.tribes.membership.cloud package contains derivative
+work originating from the jgroups project.
+https://github.com/jgroups-extras/jgroups-kubernetes
+Copyright 2002-2018 Red Hat Inc.
+
+The original XML Schemas for Java EE Deployment Descriptors:
+ - javaee_5.xsd
+ - javaee_web_services_1_2.xsd
+ - javaee_web_services_client_1_2.xsd
+ - javaee_6.xsd
+ - javaee_web_services_1_3.xsd
+ - javaee_web_services_client_1_3.xsd
+ - jsp_2_2.xsd
+ - web-app_3_0.xsd
+ - web-common_3_0.xsd
+ - web-fragment_3_0.xsd
+ - javaee_7.xsd
+ - javaee_web_services_1_4.xsd
+ - javaee_web_services_client_1_4.xsd
+ - jsp_2_3.xsd
+ - web-app_3_1.xsd
+ - web-common_3_1.xsd
+ - web-fragment_3_1.xsd
+ - javaee_8.xsd
+ - web-app_4_0.xsd
+ - web-common_4_0.xsd
+ - web-fragment_4_0.xsd
+
+may be obtained from:
+http://www.oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/index.html
+=====================================================================================
+Copyright 1999-2020 The Apache Software Foundation
+Licensed under Apache 2.0
+
+===========================================================================================
+org.apache.tomcat.embed:tomcat-embed-el:jar:9.0.31
+https://github.com/apache/tomcat
+Notice file:
+Apache Tomcat
+Copyright 1999-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+This software contains code derived from netty-native
+developed by the Netty project
+(https://netty.io, https://github.com/netty/netty-tcnative/)
+and from finagle-native developed at Twitter
+(https://github.com/twitter/finagle).
+
+This software contains code derived from jgroups-kubernetes
+developed by the JGroups project (http://www.jgroups.org/).
+
+The Windows Installer is built with the Nullsoft
+Scriptable Install System (NSIS), which is
+open source software.  The original software and
+related information is available at
+http://nsis.sourceforge.net.
+
+Java compilation software for JSP pages is provided by the Eclipse
+JDT Core Batch Compiler component, which is open source software.
+The original software and related information is available at
+https://www.eclipse.org/jdt/core/.
+
+org.apache.tomcat.util.json.JSONParser.jj is a public domain javacc grammar
+for JSON written by Robert Fischer.
+https://github.com/RobertFischer/json-parser
+
+For portions of the Tomcat JNI OpenSSL API and the OpenSSL JSSE integration
+The org.apache.tomcat.jni and the org.apache.tomcat.net.openssl packages
+are derivative work originating from the Netty project and the finagle-native
+project developed at Twitter
+* Copyright 2014 The Netty Project
+* Copyright 2014 Twitter
+
+For portions of the Tomcat cloud support
+The org.apache.catalina.tribes.membership.cloud package contains derivative
+work originating from the jgroups project.
+https://github.com/jgroups-extras/jgroups-kubernetes
+Copyright 2002-2018 Red Hat Inc.
+
+The original XML Schemas for Java EE Deployment Descriptors:
+ - javaee_5.xsd
+ - javaee_web_services_1_2.xsd
+ - javaee_web_services_client_1_2.xsd
+ - javaee_6.xsd
+ - javaee_web_services_1_3.xsd
+ - javaee_web_services_client_1_3.xsd
+ - jsp_2_2.xsd
+ - web-app_3_0.xsd
+ - web-common_3_0.xsd
+ - web-fragment_3_0.xsd
+ - javaee_7.xsd
+ - javaee_web_services_1_4.xsd
+ - javaee_web_services_client_1_4.xsd
+ - jsp_2_3.xsd
+ - web-app_3_1.xsd
+ - web-common_3_1.xsd
+ - web-fragment_3_1.xsd
+ - javaee_8.xsd
+ - web-app_4_0.xsd
+ - web-common_4_0.xsd
+ - web-fragment_4_0.xsd
+
+may be obtained from:
+http://www.oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/index.html
+=====================================================================================
+Copyright 1999-2020 The Apache Software Foundation
+Licensed under Apache 2.0
+
+===========================================================================================
+org.apache.tomcat.embed:tomcat-embed-websocket:jar:9.0.31
+https://github.com/apache/tomcat
+Notice file: 
+Apache Tomcat
+Copyright 1999-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+This software contains code derived from netty-native
+developed by the Netty project
+(https://netty.io, https://github.com/netty/netty-tcnative/)
+and from finagle-native developed at Twitter
+(https://github.com/twitter/finagle).
+
+This software contains code derived from jgroups-kubernetes
+developed by the JGroups project (http://www.jgroups.org/).
+
+The Windows Installer is built with the Nullsoft
+Scriptable Install System (NSIS), which is
+open source software.  The original software and
+related information is available at
+http://nsis.sourceforge.net.
+
+Java compilation software for JSP pages is provided by the Eclipse
+JDT Core Batch Compiler component, which is open source software.
+The original software and related information is available at
+https://www.eclipse.org/jdt/core/.
+
+org.apache.tomcat.util.json.JSONParser.jj is a public domain javacc grammar
+for JSON written by Robert Fischer.
+https://github.com/RobertFischer/json-parser
+
+For portions of the Tomcat JNI OpenSSL API and the OpenSSL JSSE integration
+The org.apache.tomcat.jni and the org.apache.tomcat.net.openssl packages
+are derivative work originating from the Netty project and the finagle-native
+project developed at Twitter
+* Copyright 2014 The Netty Project
+* Copyright 2014 Twitter
+
+For portions of the Tomcat cloud support
+The org.apache.catalina.tribes.membership.cloud package contains derivative
+work originating from the jgroups project.
+https://github.com/jgroups-extras/jgroups-kubernetes
+Copyright 2002-2018 Red Hat Inc.
+
+The original XML Schemas for Java EE Deployment Descriptors:
+ - javaee_5.xsd
+ - javaee_web_services_1_2.xsd
+ - javaee_web_services_client_1_2.xsd
+ - javaee_6.xsd
+ - javaee_web_services_1_3.xsd
+ - javaee_web_services_client_1_3.xsd
+ - jsp_2_2.xsd
+ - web-app_3_0.xsd
+ - web-common_3_0.xsd
+ - web-fragment_3_0.xsd
+ - javaee_7.xsd
+ - javaee_web_services_1_4.xsd
+ - javaee_web_services_client_1_4.xsd
+ - jsp_2_3.xsd
+ - web-app_3_1.xsd
+ - web-common_3_1.xsd
+ - web-fragment_3_1.xsd
+ - javaee_8.xsd
+ - web-app_4_0.xsd
+ - web-common_4_0.xsd
+ - web-fragment_4_0.xsd
+
+may be obtained from:
+http://www.oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/index.html
+=====================================================================================
+Copyright 1999-2020 The Apache Software Foundation
+Licensed under Apache 2.0
+
+===========================================================================================
+org.apache.tomcat:tomcat-annotations-api:jar:9.0.31
+https://github.com/apache/tomcat
+Notice file:
+Apache Tomcat
+Copyright 1999-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+This software contains code derived from netty-native
+developed by the Netty project
+(https://netty.io, https://github.com/netty/netty-tcnative/)
+and from finagle-native developed at Twitter
+(https://github.com/twitter/finagle).
+
+This software contains code derived from jgroups-kubernetes
+developed by the JGroups project (http://www.jgroups.org/).
+
+The Windows Installer is built with the Nullsoft
+Scriptable Install System (NSIS), which is
+open source software.  The original software and
+related information is available at
+http://nsis.sourceforge.net.
+
+Java compilation software for JSP pages is provided by the Eclipse
+JDT Core Batch Compiler component, which is open source software.
+The original software and related information is available at
+https://www.eclipse.org/jdt/core/.
+
+org.apache.tomcat.util.json.JSONParser.jj is a public domain javacc grammar
+for JSON written by Robert Fischer.
+https://github.com/RobertFischer/json-parser
+
+For portions of the Tomcat JNI OpenSSL API and the OpenSSL JSSE integration
+The org.apache.tomcat.jni and the org.apache.tomcat.net.openssl packages
+are derivative work originating from the Netty project and the finagle-native
+project developed at Twitter
+* Copyright 2014 The Netty Project
+* Copyright 2014 Twitter
+
+For portions of the Tomcat cloud support
+The org.apache.catalina.tribes.membership.cloud package contains derivative
+work originating from the jgroups project.
+https://github.com/jgroups-extras/jgroups-kubernetes
+Copyright 2002-2018 Red Hat Inc.
+
+The original XML Schemas for Java EE Deployment Descriptors:
+ - javaee_5.xsd
+ - javaee_web_services_1_2.xsd
+ - javaee_web_services_client_1_2.xsd
+ - javaee_6.xsd
+ - javaee_web_services_1_3.xsd
+ - javaee_web_services_client_1_3.xsd
+ - jsp_2_2.xsd
+ - web-app_3_0.xsd
+ - web-common_3_0.xsd
+ - web-fragment_3_0.xsd
+ - javaee_7.xsd
+ - javaee_web_services_1_4.xsd
+ - javaee_web_services_client_1_4.xsd
+ - jsp_2_3.xsd
+ - web-app_3_1.xsd
+ - web-common_3_1.xsd
+ - web-fragment_3_1.xsd
+ - javaee_8.xsd
+ - web-app_4_0.xsd
+ - web-common_4_0.xsd
+ - web-fragment_4_0.xsd
+
+may be obtained from:
+http://www.oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/index.html
+=====================================================================================
+Copyright 1999-2020 The Apache Software Foundation
+Licensed under Apache 2.0
+
+===========================================================================================
+org.apache.tomcat:tomcat:tar.gz:9.0.33
+https://github.com/apache/tomcat
+Notice file: 
+Apache Tomcat
+Copyright 1999-2020 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+This software contains code derived from netty-native
+developed by the Netty project
+(https://netty.io, https://github.com/netty/netty-tcnative/)
+and from finagle-native developed at Twitter
+(https://github.com/twitter/finagle).
+
+This software contains code derived from jgroups-kubernetes
+developed by the JGroups project (http://www.jgroups.org/).
+
+The Windows Installer is built with the Nullsoft
+Scriptable Install System (NSIS), which is
+open source software.  The original software and
+related information is available at
+http://nsis.sourceforge.net.
+
+Java compilation software for JSP pages is provided by the Eclipse
+JDT Core Batch Compiler component, which is open source software.
+The original software and related information is available at
+https://www.eclipse.org/jdt/core/.
+
+org.apache.tomcat.util.json.JSONParser.jj is a public domain javacc grammar
+for JSON written by Robert Fischer.
+https://github.com/RobertFischer/json-parser
+
+For portions of the Tomcat JNI OpenSSL API and the OpenSSL JSSE integration
+The org.apache.tomcat.jni and the org.apache.tomcat.net.openssl packages
+are derivative work originating from the Netty project and the finagle-native
+project developed at Twitter
+* Copyright 2014 The Netty Project
+* Copyright 2014 Twitter
+
+For portions of the Tomcat cloud support
+The org.apache.catalina.tribes.membership.cloud package contains derivative
+work originating from the jgroups project.
+https://github.com/jgroups-extras/jgroups-kubernetes
+Copyright 2002-2018 Red Hat Inc.
+
+The original XML Schemas for Java EE Deployment Descriptors:
+ - javaee_5.xsd
+ - javaee_web_services_1_2.xsd
+ - javaee_web_services_client_1_2.xsd
+ - javaee_6.xsd
+ - javaee_web_services_1_3.xsd
+ - javaee_web_services_client_1_3.xsd
+ - jsp_2_2.xsd
+ - web-app_3_0.xsd
+ - web-common_3_0.xsd
+ - web-fragment_3_0.xsd
+ - javaee_7.xsd
+ - javaee_web_services_1_4.xsd
+ - javaee_web_services_client_1_4.xsd
+ - jsp_2_3.xsd
+ - web-app_3_1.xsd
+ - web-common_3_1.xsd
+ - web-fragment_3_1.xsd
+ - javaee_8.xsd
+ - web-app_4_0.xsd
+ - web-common_4_0.xsd
+ - web-fragment_4_0.xsd
+
+may be obtained from:
+http://www.oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/index.html
+=====================================================================================
+Copyright 1999-2020 The Apache Software Foundation
+Licensed under Apache 2.0
+
+===========================================================================================
+org.codehaus.groovy:groovy-all:jar:2.4.13
+https://github.com/apache/groovy
+Notice file:
+================================================================================
+Apache Groovy
+Copyright 2003-2020 The Apache Software Foundation
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+This product bundles icons from the famfamfam.com silk icons set
+http://www.famfamfam.com/lab/icons/silk/
+Licensed under the Creative Commons Attribution Licence v2.5
+http://creativecommons.org/licenses/by/2.5/
+==================================================================================
+Copyright 2003-2020 The Apache Software Foundation
+Licensed under Apache 2.0
+
+===========================================================================================
+org.freemarker:freemarker:jar:2.3.29
+https://freemarker.apache.org/
+Copyright: The Apache Software Foundation. This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/)
+Licensed under Apache 2.0
+
+===========================================================================================
+org.glassfish.hk2.external:aopalliance-repackaged:jar:2.5.0-b32
+https://github.com/javaee/hk2/tree/master/external/aopalliance
+Copyright (c) 2013-2017 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
+
+===========================================================================================
+org.glassfish.hk2.external:aopalliance-repackaged:jar:2.6.1
+https://github.com/eclipse-ee4j/glassfish-hk2/tree/master/external/aopalliance
+Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2019 Payara Services Ltd.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.hk2.external:jakarta.inject:jar:2.6.1
+https://github.com/eclipse-ee4j/glassfish-hk2/tree/master/external/jsr330
+Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.hk2.external:javax.inject:jar:2.5.0-b32
+https://github.com/javaee/hk2
+Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
+
+===========================================================================================
+org.glassfish.hk2:class-model:jar:2.6.1
+https://github.com/eclipse-ee4j/glassfish-hk2/tree/master/class-model
+Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2019 Payara Services Ltd.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.hk2:hk2-api:jar:2.5.0-b32
+https://github.com/javaee/hk2/tree/master/hk2-api
+Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
+
+===========================================================================================
+org.glassfish.hk2:hk2-api:jar:2.6.1
+https://github.com/eclipse-ee4j/glassfish-hk2/tree/master/hk2-api
+Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2019 Payara Services Ltd.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.hk2:hk2-core:jar:2.6.1
+https://github.com/eclipse-ee4j/glassfish-hk2/tree/master/hk2-core
+Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2019 Payara Services Ltd.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.hk2:hk2-locator:jar:2.5.0-b32
+https://github.com/javaee/hk2/tree/master/hk2-locator
+Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved. 
+Licensed under CDDL 1.0
+
+===========================================================================================
+org.glassfish.hk2:hk2-locator:jar:2.6.1
+https://github.com/eclipse-ee4j/glassfish-hk2/tree/master/hk2-locator
+Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2019 Payara Services Ltd.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.hk2:hk2-runlevel:jar:2.6.1
+https://github.com/eclipse-ee4j/glassfish-hk2/tree/master/hk2-runlevel
+Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2019 Payara Services Ltd.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.hk2:hk2-utils:jar:2.5.0-b32
+https://github.com/javaee/hk2/tree/master/hk2-utils
+Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved. 
+Licensed under CDDL 1.0
+
+===========================================================================================
+org.glassfish.hk2:hk2-utils:jar:2.6.1
+https://github.com/eclipse-ee4j/glassfish-hk2/tree/master/hk2-utils
+Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2019 Payara Services Ltd.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.hk2:hk2:jar:2.6.1
+https://github.com/eclipse-ee4j/glassfish-hk2/tree/master/hk2
+Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.hk2:osgi-resource-locator:jar:1.0.1
+https://github.com/javaee/hk2/blob/master/hk2-core/osgi.bundle
+Copyright: (c) 2010-2015 Oracle and/or its affiliates. All rights reserved. 
+Licensed under CDDL 1.0
+
+===========================================================================================
+org.glassfish.hk2:osgi-resource-locator:jar:1.0.3
+https://github.com/eclipse-ee4j/glassfish-hk2-extra/tree/master/osgi-resource-locator
+Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.hk2:spring-bridge:jar:2.6.1
+https://github.com/eclipse-ee4j/glassfish-hk2/tree/master/spring-bridge
+Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2019 Payara Services Ltd.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.jersey.bundles.repackaged:jersey-guava:jar:2.25.1
+https://github.com/javaee/hk2/tree/master/hk2-core/src/main/java/com/sun/enterprise/module/common_impl
+Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
+
+===========================================================================================
+org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.25.1
+https://github.com/javaee/hk2/tree/master/hk2-core
+Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
+
+===========================================================================================
+org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.29.1
+https://github.com/eclipse-ee4j/jersey/tree/master/containers/jersey-servlet-core
+Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.jersey.containers:jersey-container-servlet:jar:2.25.1
+https://github.com/javaee/hk2
+Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
+
+===========================================================================================
+org.glassfish.jersey.containers:jersey-container-servlet:jar:2.29.1
+https://github.com/eclipse-ee4j/jersey/tree/master/containers/jersey-servlet
+Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.jersey.core:jersey-client:jar:2.25.1
+https://github.com/javaee/hk2
+Copyright: (c) 2010-2015 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
+
+===========================================================================================
+org.glassfish.jersey.core:jersey-client:jar:2.29.1
+https://github.com/eclipse-ee4j/jersey/tree/master/core-client
+Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.jersey.core:jersey-common:jar:2.25.1
+https://github.com/javaee/hk2
+Copyright: (c) 2010-2015 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
+
+===========================================================================================
+org.glassfish.jersey.core:jersey-common:jar:2.29.1
+https://github.com/eclipse-ee4j/jersey/tree/master/core-common
+Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.jersey.core:jersey-server:jar:2.25.1
+https://github.com/javaee/hk2
+Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
+
+===========================================================================================
+org.glassfish.jersey.core:jersey-server:jar:2.29.1
+https://github.com/eclipse-ee4j/jersey/tree/master/core-server
+Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.jersey.ext:jersey-bean-validation:jar:2.29.1
+https://github.com/eclipse-ee4j/jersey/tree/master/ext/bean-validation
+Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+Licensed under EPL-2.0
+
+
+===========================================================================================
+org.glassfish.jersey.ext:jersey-entity-filtering:jar:2.29.1
+https://github.com/eclipse-ee4j/jersey/tree/master/ext/entity-filtering
+Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.jersey.ext:jersey-spring5:jar:2.29.1
+https://github.com/eclipse-ee4j/jersey/tree/master/ext/spring5
+Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.jersey.inject:jersey-hk2:jar:2.29.1
+https://github.com/eclipse-ee4j/jersey/tree/master/inject/hk2
+Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.jersey.media:jersey-media-jaxb:jar:2.25.1
+https://github.com/javaee/hk2/tree/master/hk2-core
+Copyright: (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL 1.0
+
+===========================================================================================
+org.glassfish.jersey.media:jersey-media-jaxb:jar:2.29.1
+https://github.com/eclipse-ee4j/jersey/tree/master/media/jaxb
+Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.glassfish.jersey.media:jersey-media-json-jackson:jar:2.29.1
+https://github.com/eclipse-ee4j/jersey/tree/master/media/json-jackson
+Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.hibernate.validator:hibernate-validator:jar:6.0.18.Final
+https://github.com/hibernate/hibernate-validator
+Copyright (c) various authors (https://github.com/hibernate/hibernate-validator/blob/master/copyright.txt)
+Licensed under Apache 2.0
+
+===========================================================================================
+org.javassist:javassist:jar:3.20.0-GA
+https://github.com/jboss-javassist/javassist
+Copyright: 1999-2017 by Shigeru Chiba, All rights reserved
+Licensed under Apache 2.0
+
+===========================================================================================
+org.javassist:javassist:jar:3.22.0-CR2
+https://github.com/jboss-javassist/javassist
+Copyright (C) 1999-2020 by Shigeru Chiba, All rights reserved.
+Licensed under Apache 2.0
+
+===========================================================================================
+org.jboss.logging:jboss-logging:jar:3.3.2.Final
+https://github.com/jboss-logging/jboss-logging
+Copyright JBoss, Home of Professional Open Source
+Copyright 2010 Red Hat, Inc., and individual contributorsas indicated by the @author tags.
+Licensed under Apache 2.0
+
+
+===========================================================================================
+org.jboss.logging:jboss-logging:jar:3.4.1.Final
+https://github.com/jboss-logging/jboss-logging
+Copyright JBoss, Home of Professional Open Source
+Copyright 2010 Red Hat, Inc., and individual contributorsas indicated by the @author tags.
+Licensed under Apache 2.0
+
+
+===========================================================================================
+org.jboss.resteasy:resteasy-jaxrs:jar:3.10.0.Final
+https://github.com/resteasy/Resteasy
+Copyright JBoss, Home of Professional Open Source
+Licensed under Apache 2.0
+
+
+===========================================================================================
+org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec:jar:2.0.1.Final
+https://github.com/jboss/jboss-jakarta-annotations-api_spec
+Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
+Licensed under EPL-2.0
+
+===========================================================================================
+org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec:jar:2.0.1.Final
+https://github.com/jboss/jboss-jakarta-jaxrs-api_spec
+Notice file: 
+=====================================================================================
+Notices for the Jakarta RESTful Web Services Project
+This content is produced and maintained by the Jakarta RESTful Web Services project.
+
+Project home: https://projects.eclipse.org/projects/ee4j.jaxrs
+Trademarks
+Jakarta RESTful Web Services is a trademark of the Eclipse Foundation.
+
+Copyright
+All content is the property of the respective authors or their employers. 
+For more information regarding authorship of content, please 
+consult the listed source code repository logs.
+
+Declared Project Licenses
+This program and the accompanying materials are made available 
+under the terms of the Eclipse Public License v. 2.0 which is available 
+at http://www.eclipse.org/legal/epl-2.0. This Source Code may also be made 
+available under the following Secondary Licenses when the conditions for 
+such availability set forth in the Eclipse Public License v. 2.0 are 
+satisfied: GNU General Public License, version 2 with the GNU Classpath 
+Exception which is available at https://www.gnu.org/software/classpath/license.html.
+
+SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+Source Code
+The project maintains the following source code repositories:
+
+https://github.com/eclipse-ee4j/jaxrs-api
+Third-party Content
+This project leverages the following third party content.
+
+javaee-api (7.0)
+
+License: Apache-2.0 AND W3C
+JUnit (4.11)
+
+License: Common Public License 1.0
+Mockito (2.16.0)
+
+Project: http://site.mockito.org
+Source: https://github.com/mockito/mockito/releases/tag/v2.16.0
+Cryptography
+Content may contain encryption software. The country in 
+which you are currently may have restrictions on the import, 
+possession, and use, and/or re-export to another country, of encryption software. 
+BEFORE using any encryption software, please check the country's laws, 
+regulations and policies concerning the import, possession, or use, 
+and re-export of encryption software, to see if this is permitted.
+https://github.com/jboss/jboss-jakarta-jaxrs-api_spec
+===============================================================================
+Copyright: Jakarta RESTful Web Services Project, Eclipse Foundation  
+List of contributors: https://projects.eclipse.org/projects/ee4j.jaxrs/who
+Licensed under EPL-2.0
+
+
+===========================================================================================
+org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec:jar:1.0.1.Final
+https://github.com/jboss/jboss-jaxb-api_spec
+Copyright (c) 2011 Oracle and/or its affiliates. All rights reserved.
+Licensed under CDDL
+
+===========================================================================================
+org.mybatis:mybatis:jar:3.5.3
+http://www.mybatis.org/mybatis-3
+Notice file:
+=============================================================================
+iBATIS
+   This product includes software developed by
+   The Apache Software Foundation (http://www.apache.org/).
+
+   Copyright 2010 The Apache Software Foundation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+OGNL
+//--------------------------------------------------------------------------
+//  Copyright (c) 2004, Drew Davidson and Luke Blanshard
+//  All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//  Redistributions of source code must retain the above copyright notice,
+//  this list of conditions and the following disclaimer.
+//  Redistributions in binary form must reproduce the above copyright
+//  notice, this list of conditions and the following disclaimer in the
+//  documentation and/or other materials provided with the distribution.
+//  Neither the name of the Drew Davidson nor the names of its contributors
+//  may be used to endorse or promote products derived from this software
+//  without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+//  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+//  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+//  OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+//  AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+//  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+//  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+//  DAMAGE.
+//--------------------------------------------------------------------------
+
+Refactored SqlBuilder class (SQL, AbstractSQL)
+
+   This product includes software developed by
+   Adam Gent (https://gist.github.com/3650165)
+
+   Copyright 2010 Adam Gent
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+======================================================================================
+Copyright 2010 The Apache Software Foundation
+Licensed under Apache 2.0
+
+===========================================================================================
+org.ow2.asm:asm-analysis:jar:7.1
+https://asm.ow2.io/
+Copyright (c) 2000-2011 INRIA, France Telecom
+Licensed under BSD-3-Clause
+
+===========================================================================================
+org.ow2.asm:asm-commons:jar:7.1
+https://asm.ow2.io/
+Copyright (c) 2000-2011 INRIA, France Telecom
+Licensed under BSD-3-Clause
+
+===========================================================================================
+org.ow2.asm:asm-tree:jar:7.1
+https://asm.ow2.io/
+Copyright (c) 2000-2011 INRIA, France Telecom
+Licensed under BSD-3-Clause
+
+===========================================================================================
+org.ow2.asm:asm-util:jar:7.1
+https://asm.ow2.io/
+Copyright (c) 2000-2011 INRIA, France Telecom
+Licensed under BSD-3-Clause
+
+===========================================================================================
+org.ow2.asm:asm:jar:7.1
+https://asm.ow2.io/
+Copyright (c) 2000-2011 INRIA, France Telecom
+Licensed under BSD-3-Clause
+
+===========================================================================================
+org.reactivestreams:reactive-streams:jar:1.0.3
+https://github.com/reactive-streams/reactive-streams-jvm
+CopyrightWaiver:https://github.com/reactive-streams/reactive-streams-jvm/blob/master/CopyrightWaivers.txt
+Licensed under COO
+
+===========================================================================================
+org.scala-lang.modules:scala-parser-combinators_2.13:jar:1.1.2
+https://github.com/scala/scala-parser-combinators/
+Copyright (c) 2002-2020 EPFL
+Copyright (c) 2011-2020 Lightbend, Inc.
+Notice file: 
+=======================================================================
+Scala parser combinators
+Copyright (c) 2002-2020 EPFL
+Copyright (c) 2011-2020 Lightbend, Inc.
+
+Scala includes software developed at
+LAMP/EPFL (https://lamp.epfl.ch/) and
+Lightbend, Inc. (https://www.lightbend.com/).
+
+Licensed under the Apache License, Version 2.0 (the "License").
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=========================================================================
+Licensed under Apache 2.0
+
+===========================================================================================
+org.scala-lang:scala-library:jar:2.13.0
+https://github.com/scala/scala
+Copyright (c) 2002-2020 EPFL
+Copyright (c) 2011-2020 Lightbend, Inc.
+Notice file: 
+=======================================================================
+Scala parser combinators
+Copyright (c) 2002-2020 EPFL
+Copyright (c) 2011-2020 Lightbend, Inc.
+
+Scala includes software developed at
+LAMP/EPFL (https://lamp.epfl.ch/) and
+Lightbend, Inc. (https://www.lightbend.com/).
+
+Licensed under the Apache License, Version 2.0 (the "License").
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=========================================================================
+Licensed under Apache 2.0
+
+===========================================================================================
+org.slf4j:jul-to-slf4j:jar:1.7.30
+https://www.slf4j.org/index.html
+Copyright (c) 2004-2017 QOS.ch
+Licensed under MIT
+
+===========================================================================================
+org.slf4j:slf4j-api:jar:1.7.25
+https://www.slf4j.org/index.html
+Copyright (c) 2004-2017 QOS.ch
+Licensed under MIT
+
+===========================================================================================
+org.slf4j:slf4j-api:jar:1.7.26
+https://www.slf4j.org/index.html
+Copyright: (c) 2004-2017 QOS.ch
+Licensed under MIT
+
+===========================================================================================
+org.slf4j:slf4j-api:jar:1.7.30
+https://www.slf4j.org/index.html
+Copyright (c) 2004-2017 QOS.ch
+Licensed under MIT
+
+===========================================================================================
+org.slf4j:slf4j-jdk14:jar:1.7.26
+https://www.slf4j.org/index.html
+Copyright (c) 2004-2017 QOS.ch
+Licensed under MIT
+
+===========================================================================================
+org.springframework.boot:spring-boot-autoconfigure:jar:2.2.5.RELEASE
+https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-autoconfigure
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework.boot:spring-boot-loader-tools:jar:2.2.5.RELEASE
+https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-tools/spring-boot-loader-tools
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework.boot:spring-boot-starter-jdbc:jar:2.2.5.RELEASE
+https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-starters/spring-boot-starter-jdbc
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework.boot:spring-boot-starter-jersey:jar:2.2.5.RELEASE
+https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-starters/spring-boot-starter-jersey
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework.boot:spring-boot-starter-json:jar:2.2.5.RELEASE
+https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-starters/spring-boot-starter-json
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework.boot:spring-boot-starter-logging:jar:2.2.5.RELEASE
+https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-starters/spring-boot-starter-logging
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework.boot:spring-boot-starter-tomcat:jar:2.2.5.RELEASE
+https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-starters/spring-boot-starter-tomcat
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework.boot:spring-boot-starter-validation:jar:2.2.5.RELEASE
+https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-starters/spring-boot-starter-validation
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework.boot:spring-boot-starter-web:jar:2.2.5.RELEASE
+https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-starters/spring-boot-starter-web
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework.boot:spring-boot-starter:jar:2.2.5.RELEASE
+https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-starters/spring-boot-starter
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework.boot:spring-boot:jar:2.2.5.RELEASE
+https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-aop:jar:3.2.18.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-aop
+Copyright: 2002-2017 the original author or authors 
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-aop:jar:4.3.23.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-aop
+Copyright:Â 2002-2012 the original author or authors
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-aop:jar:5.2.4.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-aop
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-beans:jar:3.2.18.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-beans
+Copyright: 2002-2017 the original author or authors 
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-beans:jar:4.3.23.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-beans
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-beans:jar:5.2.4.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-beans
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-context:jar:3.2.18.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-context
+Copyright: 2002-2017 the original author or authors 
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-context:jar:4.3.23.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-context
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-context:jar:5.2.4.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-context
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-core:jar:3.2.18.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-core
+Copyright: 2002-2017 the original author or authors 
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-core:jar:4.3.23.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-core
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-core:jar:5.2.4.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-core
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-expression:jar:3.2.18.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-expression
+Copyright: 2002-2017 the original author or authors 
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-expression:jar:4.3.23.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-expression
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-expression:jar:5.2.4.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-expression
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-jcl:jar:5.2.4.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-jcl
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-jdbc:jar:3.2.18.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-jdbc
+Copyright: 2002-2017 the original author or authors 
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-jdbc:jar:4.3.23.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-jdbc
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-jdbc:jar:5.2.4.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-jdbc
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-orm:jar:3.2.18.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-orm
+Copyright: 2002-2017 the original author or authors 
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-orm:jar:5.2.4.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-orm
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-tx:jar:3.2.18.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-tx
+Copyright: 2002-2017 the original author or authors 
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-tx:jar:4.3.23.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-tx
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-tx:jar:5.2.4.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-tx
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-web:jar:4.3.23.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-web
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-web:jar:5.2.4.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-web
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.springframework:spring-webmvc:jar:5.2.4.RELEASE
+https://github.com/spring-projects/spring-framework/tree/master/spring-webmvc
+Copyright 2012-2019 the original author or authors.													
+Licensed under Apache 2.0
+
+===========================================================================================
+org.wildfly:wildfly-dist:tar.gz:19.0.0.Final
+https://github.com/wildfly/wildfly/tree/master/dist
+Copyright 2011, Red Hat, Inc., and individual contributors as indicated by the @author tags. 
+See the copyright.txt file in the distribution for a full listing of individual contributors.
+Licensed under LGPL 2.1
+
+===========================================================================================
+org.wildfly:wildfly-galleon-pack:zip:19.0.0.Final
+https://github.com/wildfly/wildfly/tree/master/galleon-pack
+Copyright 2010, Red Hat, Inc., and individual contributors as indicated by the @author tags. 
+See the copyright.txt file in the distribution for a full listing of individual contributors.
+Licensed under LGPL 2.1
+
+===========================================================================================
+org.yaml:snakeyaml:jar:1.25
+https://bitbucket.org/asomov/snakeyaml/
+Copyright Andrey Somov <public.somov@gmail.com>
+Licensed under Apache 2.0
+
 ===========================================================================================
 
 
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+Do Not Translate or Localize
+
+This project incorporates components from the projects listed below. The original copyright notices and the licenses under which Camunda received such components are set forth below.
+
+0.    @bpmn-io/dmn-migrate@0.4.3 (https://github.com/bpmn-io/dmn-migrate) 
+1.    angular-animate@1.7.9 (https://github.com/angular/angular.js) 
+2.    angular-cookies@1.7.9 (https://github.com/angular/angular.js) 
+3.    angular-data-depend@1.0.0 (https://github.com/Nikku/angular-data-depend) 
+4.    angular-loader@1.7.9 (https://github.com/angular/angular.js) 
+5.    angular-mocks@1.7.9 (https://github.com/angular/angular.js) 
+6.    angular-moment@1.3.0 (https://github.com/urish/angular-moment) 
+7.    angular-resource@1.7.9 (https://github.com/angular/angular.js) 
+8.    angular-route@1.7.9 (https://github.com/angular/angular.js) 
+9.    angular-sanitize@1.7.9 (https://github.com/angular/angular.js) 
+10.   angular-scenario@1.7.9 (https://github.com/angular/angular.js) 
+11.   angular-touch@1.7.9 (https://github.com/angular/angular.js) 
+12.   angular-translate@2.18.1 (https://github.com/angular-translate/angular-translate) 
+13.   angular@1.7.9 (https://github.com/angular/angular.js) 
+14.   ansi-escapes@1.4.0 (https://github.com/sindresorhus/ansi-escapes) 
+15.   ansi-regex@2.1.1 (https://github.com/chalk/ansi-regex) 
+16.   ansi-regex@3.0.0 (https://github.com/chalk/ansi-regex) 
+17.   ansi-styles@2.2.1 (https://github.com/chalk/ansi-styles) 
+18.   asynckit@0.4.0 (https://github.com/alexindigo/asynckit) 
+19.   babel-polyfill@6.23.0 (https://github.com/babel/babel/tree/master/packages/babel-polyfill) 
+20.   babel-runtime@6.26.0 (https://github.com/babel/babel/tree/master/packages/babel-runtime) 
+21.   bootstrap@3.4.1 (https://github.com/twbs/bootstrap) 
+22.   bpmn-font@0.8.0 (https://github.com/bpmn-io/bpmn-font) 
+23.   bpmn-js@3.4.3 (https://github.com/bpmn-io/bpmn-js) 
+24.   bpmn-moddle@5.2.0 (https://github.com/bpmn-io/bpmn-moddle) 
+25.   camunda-dmn-moddle@1.0.0 (https://github.com/camunda/camunda-dmn-moddle) 
+26.   camunda-webapp-translations@7.13.0-SNAPSHOT (https://github.com/camunda/camunda-webapp-translations) 
+27.   chalk@1.1.3 (https://github.com/chalk/chalk) 
+28.   chardet@0.4.2 (https://github.com/runk/node-chardet) 
+29.   cli-cursor@2.1.0 (https://github.com/sindresorhus/cli-cursor) 
+30.   cli-width@2.2.0 (https://github.com/knownasilya/cli-width) 
+31.   clipboard@2.0.4 (https://github.com/zenorocha/clipboard.js) 
+32.   closest@0.0.1 (https://github.com/ForbesLindesay/closest) 
+33.   cmmn-font@0.5.0 (https://github.com/bpmn-io/cmmn-font) 
+34.   cmmn-js@0.18.1 (https://github.com/bpmn-io/cmmn-js) 
+35.   cmmn-moddle@5.0.0 (https://github.com/bpmn-io/cmmn-moddle) 
+36.   combined-stream@1.0.8 (https://github.com/felixge/node-combined-stream) 
+37.   component-emitter@1.3.0 (https://github.com/component/emitter) 
+38.   component-event@0.1.4 (https://github.com/component/event) 
+39.   component-props@1.1.1 (https://github.com/component/props) 
+40.   component-xor@0.0.4 (https://github.com/component/xor) 
+41.   cookiejar@2.1.2 (https://github.com/bmeck/node-cookiejar) 
+42.   core-js@2.6.11 (https://github.com/zloirock/core-js) 
+43.   css.escape@1.5.1 (https://github.com/mathiasbynens/CSS.escape) 
+44.   debug@4.1.1 (https://github.com/visionmedia/debug) 
+45.   delayed-stream@1.0.0 (https://github.com/felixge/node-delayed-stream) 
+46.   delegate-events@1.1.1 (https://github.com/HenrikJoreteg/delegate) 
+47.   delegate@3.2.0 (https://github.com/zenorocha/delegate) 
+48.   diagram-js-direct-editing@1.6.1 (https://github.com/bpmn-io/diagram-js-direct-editing) 
+49.   diagram-js@3.3.1 (https://github.com/bpmn-io/diagram-js) 
+50.   diagram-js@6.4.1 (https://github.com/bpmn-io/diagram-js) 
+51.   didi@4.0.0 (https://github.com/nikku/didi) 
+52.   dmn-js-decision-table@8.0.2 (https://github.com/bpmn-io/dmn-js) 
+53.   dmn-js-drd@8.0.2 (https://github.com/bpmn-io/dmn-js) 
+54.   dmn-js-literal-expression@8.0.2 (https://github.com/bpmn-io/dmn-js) 
+55.   dmn-js-shared@8.0.2 (https://github.com/bpmn-io/dmn-js) 
+56.   dmn-js@8.0.2 (https://github.com/bpmn-io/dmn-js) 
+57.   dmn-moddle@8.0.4 (https://github.com/bpmn-io/dmn-moddle) 
+58.   dom-iterator@1.0.0 (https://github.com/MatthewMueller/dom-iterator) 
+59.   dom4@2.1.5 (https://github.com/WebReflection/dom4) 
+60.   domify@1.4.0 (https://github.com/component/domify) 
+61.   encoding@0.1.12 (https://github.com/andris9/encoding) 
+62.   escape-html@1.0.3 (https://github.com/component/escape-html) 
+63.   escape-string-regexp@1.0.5 (https://github.com/sindresorhus/escape-string-regexp) 
+64.   events@3.0.0 (https://github.com/Gozala/events) 
+65.   external-editor@2.2.0 (https://github.com/mrkmg/node-external-editor) 
+66.   fast-xml-parser@3.16.0 (https://github.com/NaturalIntelligence/fast-xml-parser) 
+67.   figures@2.0.0 (https://github.com/sindresorhus/figures) 
+68.   form-data@2.5.1 (https://github.com/form-data/form-data) 
+69.   formidable@1.2.2 (https://github.com/node-formidable/formidable) 
+70.   good-listener@1.2.2 (https://github.com/zenorocha/good-listener) 
+71.   hammerjs@2.0.8 (https://github.com/hammerjs/hammer.js) 
+72.   has-ansi@2.0.0 (https://github.com/sindresorhus/has-ansi) 
+73.   hat@0.0.3 (https://github.com/substack/node-hat) 
+74.   iconv-lite@0.4.24 (https://github.com/ashtuchkin/iconv-lite) 
+75.   ids@0.2.2 (https://github.com/bpmn-io/ids) 
+76.   ids@1.0.0 (https://github.com/bpmn-io/ids) 
+77.   indexof@0.0.1 (undefined) 
+78.   inferno-vnode-flags@5.0.6 (https://github.com/infernojs/inferno) 
+79.   inferno@5.0.6 (https://github.com/infernojs/inferno) 
+80.   inherits@2.0.4 (https://github.com/isaacs/inherits) 
+81.   inquirer@3.0.6 (https://github.com/SBoudrias/Inquirer.js) 
+82.   is-fullwidth-code-point@2.0.0 (https://github.com/sindresorhus/is-fullwidth-code-point) 
+83.   is-promise@2.1.0 (https://github.com/then/is-promise) 
+84.   is-stream@1.1.0 (https://github.com/sindresorhus/is-stream) 
+85.   jquery-ui@1.12.1 (https://github.com/jquery/jquery-ui) 
+86.   jquery@3.4.1 (https://github.com/jquery/jquery) 
+87.   lodash@4.17.14 (https://github.com/lodash/lodash) 
+88.   matches-selector@0.0.1 (https://github.com/ForbesLindesay/matches-selector) 
+89.   matches-selector@1.2.0 (https://github.com/ForbesLindesay/matches-selector) 
+90.   methods@1.1.2 (https://github.com/jshttp/methods) 
+91.   mime-db@1.43.0 (https://github.com/jshttp/mime-db) 
+92.   mime-types@2.1.26 (https://github.com/jshttp/mime-types) 
+93.   mime@2.4.4 (https://github.com/broofa/node-mime) 
+94.   mimic-fn@1.2.0 (https://github.com/sindresorhus/mimic-fn) 
+95.   min-dash@3.5.2 (https://github.com/bpmn-io/min-dash) 
+96.   min-dom@3.1.2 (https://github.com/bpmn-io/min-dom) 
+97.   minimist@1.2.0 (https://github.com/substack/minimist) 
+98.   moddle-xml@7.5.0 (https://github.com/bpmn-io/moddle-xml) 
+99.   moddle-xml@8.0.2 (https://github.com/bpmn-io/moddle-xml) 
+100.  moddle@4.1.0 (https://github.com/bpmn-io/moddle) 
+101.  moddle@5.0.1 (https://github.com/bpmn-io/moddle) 
+102.  moment@2.24.0 (https://github.com/moment/moment) 
+103.  mousetrap@1.6.3 (https://github.com/ccampbell/mousetrap) 
+104.  ms@2.1.2 (https://github.com/zeit/ms) 
+105.  mute-stream@0.0.7 (https://github.com/isaacs/mute-stream) 
+106.  node-fetch@1.6.3 (https://github.com/bitinn/node-fetch) 
+107.  object-assign@4.1.1 (https://github.com/sindresorhus/object-assign) 
+108.  object-refs@0.3.0 (https://github.com/bpmn-io/object-refs) 
+109.  onetime@2.0.1 (https://github.com/sindresorhus/onetime) 
+110.  opencollective@1.0.3 (https://github.com/opencollective/opencollective-cli) 
+111.  opn@4.0.2 (https://github.com/sindresorhus/opn) 
+112.  os-tmpdir@1.0.2 (https://github.com/sindresorhus/os-tmpdir) 
+113.  path-intersection@1.1.1 (https://github.com/bpmn-io/path-intersection) 
+114.  path-intersection@2.2.0 (https://github.com/bpmn-io/path-intersection) 
+115.  pinkie-promise@2.0.1 (https://github.com/floatdrop/pinkie-promise) 
+116.  pinkie@2.0.4 (https://github.com/floatdrop/pinkie) 
+117.  q@1.5.1 (https://github.com/kriskowal/q) 
+118.  qs@6.9.1 (https://github.com/ljharb/qs) 
+119.  readable-stream@3.6.0 (https://github.com/nodejs/readable-stream) 
+120.  regenerator-runtime@0.10.5 (https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime) 
+121.  regenerator-runtime@0.11.1 (https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime) 
+122.  requirejs-angular-define@1.1.0 (https://github.com/Nikku/requirejs-angular-define) 
+123.  requirejs@2.1.22 (https://github.com/jrburke/r.js) 
+124.  requirejs@2.3.6 (https://github.com/jrburke/r.js) 
+125.  restore-cursor@2.0.0 (https://github.com/sindresorhus/restore-cursor) 
+126.  run-async@2.4.0 (https://github.com/SBoudrias/run-async) 
+127.  rx@4.1.0 (https://github.com/Reactive-Extensions/RxJS) 
+128.  safe-buffer@5.2.0 (https://github.com/feross/safe-buffer) 
+129.  safer-buffer@2.1.2 (https://github.com/ChALkeR/safer-buffer) 
+130.  saxen@8.1.0 (https://github.com/nikku/saxen) 
+131.  select@1.1.2 (https://github.com/zenorocha/select) 
+132.  selection-ranges@3.0.3 (https://github.com/nikku/selection-ranges) 
+133.  selection-update@0.1.2 (https://github.com/nikku/selection-update) 
+134.  signal-exit@3.0.2 (https://github.com/tapjs/signal-exit) 
+135.  string-width@2.1.1 (https://github.com/sindresorhus/string-width) 
+136.  string_decoder@1.3.0 (https://github.com/nodejs/string_decoder) 
+137.  strip-ansi@3.0.1 (https://github.com/chalk/strip-ansi) 
+138.  strip-ansi@4.0.0 (https://github.com/chalk/strip-ansi) 
+139.  superagent@4.1.0 (https://github.com/visionmedia/superagent) 
+140.  supports-color@2.0.0 (https://github.com/chalk/supports-color) 
+141.  table-js@6.0.3 (https://github.com/bpmn-io/table-js) 
+142.  through@2.3.8 (https://github.com/dominictarr/through) 
+143.  tiny-emitter@2.1.0 (https://github.com/scottcorgan/tiny-emitter) 
+144.  tiny-svg@2.2.2 (https://github.com/bpmn-io/tiny-svg) 
+145.  tmp@0.0.33 (https://github.com/raszi/node-tmp) 
+146.  util-deprecate@1.0.2 (https://github.com/TooTallNate/util-deprecate) 
 
 
 
-2
+@bpmn-io/dmn-migrate@0.4.3 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2020-present Camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF @bpmn-io/dmn-migrate@0.4.3 NOTICES AND INFORMATION
+
+
+
+angular-animate@1.7.9 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 Angular
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF angular-animate@1.7.9 NOTICES AND INFORMATION
+
+
+
+angular-cookies@1.7.9 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 Angular
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF angular-cookies@1.7.9 NOTICES AND INFORMATION
+
+
+
+angular-data-depend@1.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2013 Nico Rehwaldt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF angular-data-depend@1.0.0 NOTICES AND INFORMATION
+
+
+
+angular-loader@1.7.9 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 Angular
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF angular-loader@1.7.9 NOTICES AND INFORMATION
+
+
+
+angular-mocks@1.7.9 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 Angular
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF angular-mocks@1.7.9 NOTICES AND INFORMATION
+
+
+
+angular-moment@1.3.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2013-2016 Uri Shaked and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF angular-moment@1.3.0 NOTICES AND INFORMATION
+
+
+
+angular-resource@1.7.9 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 Angular
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF angular-resource@1.7.9 NOTICES AND INFORMATION
+
+
+
+angular-route@1.7.9 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 Angular
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF angular-route@1.7.9 NOTICES AND INFORMATION
+
+
+
+angular-sanitize@1.7.9 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 Angular
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF angular-sanitize@1.7.9 NOTICES AND INFORMATION
+
+
+
+angular-scenario@1.7.9 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 Angular
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF angular-scenario@1.7.9 NOTICES AND INFORMATION
+
+
+
+angular-touch@1.7.9 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 Angular
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF angular-touch@1.7.9 NOTICES AND INFORMATION
+
+
+
+angular-translate@2.18.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2013-2017 The angular-translate team and Pascal Precht
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF angular-translate@2.18.1 NOTICES AND INFORMATION
+
+
+
+angular@1.7.9 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 Angular
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF angular@1.7.9 NOTICES AND INFORMATION
+
+
+
+ansi-escapes@1.4.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF ansi-escapes@1.4.0 NOTICES AND INFORMATION
+
+
+
+ansi-regex@2.1.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF ansi-regex@2.1.1 NOTICES AND INFORMATION
+
+
+
+ansi-regex@3.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF ansi-regex@3.0.0 NOTICES AND INFORMATION
+
+
+
+ansi-styles@2.2.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF ansi-styles@2.2.1 NOTICES AND INFORMATION
+
+
+
+asynckit@0.4.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 Alex Indigo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF asynckit@0.4.0 NOTICES AND INFORMATION
+
+
+
+babel-polyfill@6.23.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License ), Copyright: Sebastian McKenzie
+
+
+==========================================
+END OF babel-polyfill@6.23.0 NOTICES AND INFORMATION
+
+
+
+babel-runtime@6.26.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License ), Copyright: Sebastian McKenzie
+
+
+==========================================
+END OF babel-runtime@6.26.0 NOTICES AND INFORMATION
+
+
+
+bootstrap@3.4.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2011-2019 Twitter, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF bootstrap@3.4.1 NOTICES AND INFORMATION
+
+
+
+bpmn-font@0.8.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+Copyright (c) 2014, camunda Services GmbH
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+==========================================
+END OF bpmn-font@0.8.0 NOTICES AND INFORMATION
+
+
+
+bpmn-js@3.4.3 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The bpmn.io-License)
+
+Copyright (c) 2014-present Camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+The source code responsible for displaying the bpmn.io logo (two green cogwheels in
+a box) that links back to http://bpmn.io as part of rendered diagrams MUST NOT be
+removed or changed. When this software is being used in a website or application,
+the logo must stay fully visible and not visually overlapped by other elements.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+==========================================
+END OF bpmn-js@3.4.3 NOTICES AND INFORMATION
+
+
+
+bpmn-moddle@5.2.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014 camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF bpmn-moddle@5.2.0 NOTICES AND INFORMATION
+
+
+
+camunda-dmn-moddle@1.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014-2018 camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF camunda-dmn-moddle@1.0.0 NOTICES AND INFORMATION
+
+
+
+camunda-webapp-translations@7.13.0-SNAPSHOT NOTICES AND INFORMATION BEGIN HERE
+==========================================
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+==========================================
+END OF camunda-webapp-translations@7.13.0-SNAPSHOT NOTICES AND INFORMATION
+
+
+
+chalk@1.1.3 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF chalk@1.1.3 NOTICES AND INFORMATION
+
+
+
+chardet@0.4.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+Copyright (C) 2017 Dmitry Shirokov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF chardet@0.4.2 NOTICES AND INFORMATION
+
+
+
+cli-cursor@2.1.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF cli-cursor@2.1.0 NOTICES AND INFORMATION
+
+
+
+cli-width@2.2.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The ISC License ), Copyright: Ilya Radchenko
+
+==========================================
+END OF cli-width@2.2.0 NOTICES AND INFORMATION
+
+
+
+clipboard@2.0.4 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License ) Copyright: Zeno Rocha
+
+==========================================
+END OF clipboard@2.0.4 NOTICES AND INFORMATION
+
+
+
+closest@0.0.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License ), Copyright: Jonathan Ong
+
+==========================================
+END OF closest@0.0.1 NOTICES AND INFORMATION
+
+
+
+cmmn-font@0.5.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+Copyright (c) 2016, camunda Services GmbH
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+==========================================
+END OF cmmn-font@0.5.0 NOTICES AND INFORMATION
+
+
+
+cmmn-js@0.18.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The bpmn.io-License)
+
+Copyright (c) 2015-2018 camunda services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+The source code responsible for displaying the bpmn.io logo (two green cogwheels in
+a box) that links back to http://bpmn.io as part of rendered diagrams MUST NOT be
+removed or changed. When this software is being used in a website or application,
+the logo must stay fully visible and not visually overlapped by other elements.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+==========================================
+END OF cmmn-js@0.18.1 NOTICES AND INFORMATION
+
+
+
+cmmn-moddle@5.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014 camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF cmmn-moddle@5.0.0 NOTICES AND INFORMATION
+
+
+
+combined-stream@1.0.8 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) 2011 Debuggable Limited <felix@debuggable.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF combined-stream@1.0.8 NOTICES AND INFORMATION
+
+
+
+component-emitter@1.3.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) 2014 Component contributors <dev@component.io>
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF component-emitter@1.3.0 NOTICES AND INFORMATION
+
+
+
+component-event@0.1.4 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+==========================================
+END OF component-event@0.1.4 NOTICES AND INFORMATION
+
+
+
+component-props@1.1.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+==========================================
+END OF component-props@1.1.1 NOTICES AND INFORMATION
+
+
+
+component-xor@0.0.4 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+
+(The MIT License ), Copyright: Matthew Mueller
+
+==========================================
+END OF component-xor@0.0.4 NOTICES AND INFORMATION
+
+
+
+cookiejar@2.1.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+Copyright (c) 2013 Bradley Meck 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+==========================================
+END OF cookiejar@2.1.2 NOTICES AND INFORMATION
+
+
+
+core-js@2.6.11 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) 2014-2019 Denis Pushkarev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF core-js@2.6.11 NOTICES AND INFORMATION
+
+
+
+css.escape@1.5.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright Mathias Bynens <https://mathiasbynens.be/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF css.escape@1.5.1 NOTICES AND INFORMATION
+
+
+
+debug@4.1.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
+and associated documentation files (the 'Software'), to deal in the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial 
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+==========================================
+END OF debug@4.1.1 NOTICES AND INFORMATION
+
+
+
+delayed-stream@1.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) 2011 Debuggable Limited <felix@debuggable.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF delayed-stream@1.0.0 NOTICES AND INFORMATION
+
+
+
+delegate-events@1.1.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+==========================================
+END OF delegate-events@1.1.1 NOTICES AND INFORMATION
+
+
+
+delegate@3.2.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License) Copyright: Zeno Rocha
+
+==========================================
+END OF delegate@3.2.0 NOTICES AND INFORMATION
+
+
+
+diagram-js-direct-editing@1.6.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014-2017 camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF diagram-js-direct-editing@1.6.1 NOTICES AND INFORMATION
+
+
+
+diagram-js@3.3.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014-present Camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF diagram-js@3.3.1 NOTICES AND INFORMATION
+
+
+
+diagram-js@6.4.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014-present Camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF diagram-js@6.4.1 NOTICES AND INFORMATION
+
+
+
+didi@4.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License
+
+Copyright (C) 2013 Vojta JÃ­na.
+Copyright (C) 2015-present Nico Rehwaldt.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF didi@4.0.0 NOTICES AND INFORMATION
+
+
+
+dmn-js-decision-table@8.0.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The bpmn.io-License)
+
+Copyright (c) 2015-present Camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+The source code responsible for displaying the bpmn.io logo (two green cogwheels in
+a box) that links back to http://bpmn.io as part of rendered tables MUST NOT be
+removed or changed. When this software is being used in a website or application,
+the logo must stay fully visible and not visually overlapped by other elements.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF dmn-js-decision-table@8.0.2 NOTICES AND INFORMATION
+
+
+
+dmn-js-drd@8.0.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The bpmn.io-License)
+
+Copyright (c) 2015-present Camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+The source code responsible for displaying the bpmn.io logo (two green cogwheels in
+a box) that links back to http://bpmn.io as part of rendered tables MUST NOT be
+removed or changed. When this software is being used in a website or application,
+the logo must stay fully visible and not visually overlapped by other elements.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF dmn-js-drd@8.0.2 NOTICES AND INFORMATION
+
+
+
+dmn-js-literal-expression@8.0.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The bpmn.io-License)
+
+Copyright (c) 2015-present Camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+The source code responsible for displaying the bpmn.io logo (two green cogwheels in
+a box) that links back to http://bpmn.io as part of rendered tables MUST NOT be
+removed or changed. When this software is being used in a website or application,
+the logo must stay fully visible and not visually overlapped by other elements.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF dmn-js-literal-expression@8.0.2 NOTICES AND INFORMATION
+
+
+
+dmn-js-shared@8.0.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The bpmn.io-License)
+
+Copyright (c) 2015-present Camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+The source code responsible for displaying the bpmn.io logo (two green cogwheels in
+a box) that links back to http://bpmn.io as part of rendered tables MUST NOT be
+removed or changed. When this software is being used in a website or application,
+the logo must stay fully visible and not visually overlapped by other elements.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF dmn-js-shared@8.0.2 NOTICES AND INFORMATION
+
+
+
+dmn-js@8.0.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The bpmn.io-License)
+
+Copyright (c) 2015-present Camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+The source code responsible for displaying the bpmn.io logo (two green cogwheels in
+a box) that links back to http://bpmn.io as part of rendered tables MUST NOT be
+removed or changed. When this software is being used in a website or application,
+the logo must stay fully visible and not visually overlapped by other elements.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF dmn-js@8.0.2 NOTICES AND INFORMATION
+
+
+
+dmn-moddle@8.0.4 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2015-2017 camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF dmn-moddle@8.0.4 NOTICES AND INFORMATION
+
+
+
+dom-iterator@1.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License ), Copyright: Matthew Mueller
+
+==========================================
+END OF dom-iterator@1.0.0 NOTICES AND INFORMATION
+
+
+
+dom4@2.1.5 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (C) 2013-2015 by Andrea Giammarchi - @WebReflection
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF dom4@2.1.5 NOTICES AND INFORMATION
+
+
+
+domify@1.4.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+==========================================
+END OF domify@1.4.0 NOTICES AND INFORMATION
+
+
+
+encoding@0.1.12 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License) Copyright: Andris Reinman
+
+==========================================
+END OF encoding@0.1.12 NOTICES AND INFORMATION
+
+
+
+escape-html@1.0.3 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) 2012-2013 TJ Holowaychuk
+Copyright (c) 2015 Andreas Lubbe
+Copyright (c) 2015 Tiancheng "Timothy" Gu
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF escape-html@1.0.3 NOTICES AND INFORMATION
+
+
+
+escape-string-regexp@1.0.5 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF escape-string-regexp@1.0.5 NOTICES AND INFORMATION
+
+
+
+events@3.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT
+
+Copyright Joyent, Inc. and other Node contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF events@3.0.0 NOTICES AND INFORMATION
+
+
+
+external-editor@2.2.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 Kevin Gravier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF external-editor@2.2.0 NOTICES AND INFORMATION
+
+
+
+fast-xml-parser@3.16.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) 2017 Amit Kumar Gupta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+If you use this library in a public repository then you give us the right to mention your company name and logo in user's list without further permission required, but you can request them to be taken down within 30 days. 
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF fast-xml-parser@3.16.0 NOTICES AND INFORMATION
+
+
+
+figures@2.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF figures@2.0.0 NOTICES AND INFORMATION
+
+
+
+form-data@2.5.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) 2012 Felix GeisendÃ¶rfer (felix@debuggable.com) and contributors
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+==========================================
+END OF form-data@2.5.1 NOTICES AND INFORMATION
+
+
+
+formidable@1.2.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2011-present Felix GeisendÃ¶rfer, and contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+==========================================
+END OF formidable@1.2.2 NOTICES AND INFORMATION
+
+
+
+good-listener@1.2.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License): Copyright: Zeno Rocha
+
+==========================================
+END OF good-listener@1.2.2 NOTICES AND INFORMATION
+
+
+
+hammerjs@2.0.8 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (C) 2011-2014 by Jorik Tangelder (Eight Media)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF hammerjs@2.0.8 NOTICES AND INFORMATION
+
+
+
+has-ansi@2.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF has-ansi@2.0.0 NOTICES AND INFORMATION
+
+
+
+hat@0.0.3 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(MIT/X11) Copyright: James Halliday
+
+==========================================
+END OF hat@0.0.3 NOTICES AND INFORMATION
+
+
+
+iconv-lite@0.4.24 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) 2011 Alexander Shtuchkin
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+==========================================
+END OF iconv-lite@0.4.24 NOTICES AND INFORMATION
+
+
+
+ids@0.2.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014 camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF ids@0.2.2 NOTICES AND INFORMATION
+
+
+
+ids@1.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014 camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF ids@1.0.0 NOTICES AND INFORMATION
+
+
+
+indexof@0.0.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License ) Copyright: 2012 TJ Holowaychuk
+
+==========================================
+END OF indexof@0.0.1 NOTICES AND INFORMATION
+
+
+
+inferno-shared@5.0.6 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT
+==========================================
+END OF inferno-shared@5.0.6 NOTICES AND INFORMATION
+
+
+
+inferno-vnode-flags@5.0.6 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License ) Copyright: (c) 2015-2019 Dominic Gannaway
+
+==========================================
+END OF inferno-vnode-flags@5.0.6 NOTICES AND INFORMATION
+
+
+
+inferno@5.0.6 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License ) Copyright: (c) 2013-2019 Dominic Gannaway
+
+==========================================
+END OF inferno@5.0.6 NOTICES AND INFORMATION
+
+
+
+inherits@2.0.4 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+
+==========================================
+END OF inherits@2.0.4 NOTICES AND INFORMATION
+
+
+
+inquirer@3.0.6 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License ) Copyright (c) 2012 Simon Boudrias
+
+==========================================
+END OF inquirer@3.0.6 NOTICES AND INFORMATION
+
+
+
+is-fullwidth-code-point@2.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF is-fullwidth-code-point@2.0.0 NOTICES AND INFORMATION
+
+
+
+is-promise@2.1.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) 2014 Forbes Lindesay
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF is-promise@2.1.0 NOTICES AND INFORMATION
+
+
+
+is-stream@1.1.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF is-stream@1.1.0 NOTICES AND INFORMATION
+
+
+
+jquery-ui@1.12.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+Copyright jQuery Foundation and other contributors, https://jquery.org/
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/jquery/jquery-ui
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code contained within the demos directory.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+All files located in the node_modules and external directories are
+externally maintained libraries used by this software which have their
+own licenses; we recommend you read them, as their terms may differ from
+the terms above.
+
+==========================================
+END OF jquery-ui@1.12.1 NOTICES AND INFORMATION
+
+
+
+jquery@3.4.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright JS Foundation and other contributors, https://js.foundation/
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF jquery@3.4.1 NOTICES AND INFORMATION
+
+
+
+lodash@4.17.14 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.
+
+==========================================
+END OF lodash@4.17.14 NOTICES AND INFORMATION
+
+
+
+matches-selector@0.0.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License) Copyright: 2013 Forbes Lindesay
+
+==========================================
+END OF matches-selector@0.0.1 NOTICES AND INFORMATION
+
+
+
+matches-selector@1.2.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) 2013 Forbes Lindesay
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF matches-selector@1.2.0 NOTICES AND INFORMATION
+
+
+
+methods@1.1.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) 2013-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2015-2016 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+==========================================
+END OF methods@1.1.2 NOTICES AND INFORMATION
+
+
+
+mime-db@1.43.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Jonathan Ong me@jongleberry.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF mime-db@1.43.0 NOTICES AND INFORMATION
+
+
+
+mime-types@2.1.26 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF mime-types@2.1.26 NOTICES AND INFORMATION
+
+
+
+mime@2.4.4 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF mime@2.4.4 NOTICES AND INFORMATION
+
+
+
+mimic-fn@1.2.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF mimic-fn@1.2.0 NOTICES AND INFORMATION
+
+
+
+min-dash@3.5.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2017-present camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF min-dash@3.5.2 NOTICES AND INFORMATION
+
+
+
+min-dom@3.1.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014 Nico Rehwaldt
+Copyright (c) 2015-present camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF min-dom@3.1.2 NOTICES AND INFORMATION
+
+
+
+minimist@1.2.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+This software is released under the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF minimist@1.2.0 NOTICES AND INFORMATION
+
+
+
+moddle-xml@7.5.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014-present Camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF moddle-xml@7.5.0 NOTICES AND INFORMATION
+
+
+
+moddle-xml@8.0.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014-present Camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF moddle-xml@8.0.2 NOTICES AND INFORMATION
+
+
+
+moddle@4.1.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014 camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF moddle@4.1.0 NOTICES AND INFORMATION
+
+
+
+moddle@5.0.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014-present Camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF moddle@5.0.1 NOTICES AND INFORMATION
+
+
+
+moment@2.24.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) JS Foundation and other contributors
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF moment@2.24.0 NOTICES AND INFORMATION
+
+
+
+mousetrap@1.6.3 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+--- Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+==========================================
+END OF mousetrap@1.6.3 NOTICES AND INFORMATION
+
+
+
+ms@2.1.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 Zeit, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF ms@2.1.2 NOTICES AND INFORMATION
+
+
+
+mute-stream@0.0.7 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+==========================================
+END OF mute-stream@0.0.7 NOTICES AND INFORMATION
+
+
+
+node-fetch@1.6.3 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2016 David Frank
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+==========================================
+END OF node-fetch@1.6.3 NOTICES AND INFORMATION
+
+
+
+object-assign@4.1.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF object-assign@4.1.1 NOTICES AND INFORMATION
+
+
+
+object-refs@0.3.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014-present camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF object-refs@0.3.0 NOTICES AND INFORMATION
+
+
+
+onetime@2.0.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF onetime@2.0.1 NOTICES AND INFORMATION
+
+
+
+opencollective@1.0.3 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) 2017 Open Collective
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF opencollective@1.0.3 NOTICES AND INFORMATION
+
+
+
+opn@4.0.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF opn@4.0.2 NOTICES AND INFORMATION
+
+
+
+os-tmpdir@1.0.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF os-tmpdir@1.0.2 NOTICES AND INFORMATION
+
+
+
+path-intersection@1.1.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2017 camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF path-intersection@1.1.1 NOTICES AND INFORMATION
+
+
+
+path-intersection@2.2.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2017 camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF path-intersection@2.2.0 NOTICES AND INFORMATION
+
+
+
+pinkie-promise@2.0.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Vsevolod Strukchinsky <floatdrop@gmail.com> (github.com/floatdrop)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF pinkie-promise@2.0.1 NOTICES AND INFORMATION
+
+
+
+pinkie@2.0.4 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Vsevolod Strukchinsky <floatdrop@gmail.com> (github.com/floatdrop)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF pinkie@2.0.4 NOTICES AND INFORMATION
+
+
+
+q@1.5.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright 2009â€“2017 Kristopher Michael Kowal. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+
+==========================================
+END OF q@1.5.1 NOTICES AND INFORMATION
+
+
+
+qs@6.9.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+BSD 3-Clause License
+
+Copyright (c) 2014, Nathan LaFreniere and other [contributors](https://github.com/ljharb/qs/graphs/contributors)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+==========================================
+END OF qs@6.9.1 NOTICES AND INFORMATION
+
+
+
+readable-stream@3.6.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Node.js is licensed for use as follows:
+
+"""
+Copyright Node.js contributors. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+"""
+
+This license applies to parts of Node.js originating from the
+https://github.com/joyent/node repository:
+
+"""
+Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+"""
+
+==========================================
+END OF readable-stream@3.6.0 NOTICES AND INFORMATION
+
+
+
+regenerator-runtime@0.10.5 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License ) Copyright: (c) 2014-present, Facebook, Inc.
+
+==========================================
+END OF regenerator-runtime@0.10.5 NOTICES AND INFORMATION
+
+
+
+regenerator-runtime@0.11.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License ) Copyright: (c) 2014-present, Facebook, Inc.
+
+==========================================
+END OF regenerator-runtime@0.11.1 NOTICES AND INFORMATION
+
+
+
+requirejs-angular-define@1.1.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2013 Nico Rehwaldt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF requirejs-angular-define@1.1.0 NOTICES AND INFORMATION
+
+
+
+requirejs@2.1.22 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License) Copyright: jQuery Foundation and other contributors, https://jquery.org/ (James Burke)
+
+==========================================
+END OF requirejs@2.1.22 NOTICES AND INFORMATION
+
+
+
+requirejs@2.3.6 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License) Copyright: jQuery Foundation and other contributors, https://jquery.org/ (James Burke)
+
+==========================================
+END OF requirejs@2.3.6 NOTICES AND INFORMATION
+
+
+
+restore-cursor@2.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF restore-cursor@2.0.0 NOTICES AND INFORMATION
+
+
+
+run-async@2.4.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014 Simon Boudrias
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF run-async@2.4.0 NOTICES AND INFORMATION
+
+
+
+rx@4.1.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+Copyright (c) Microsoft.  All rights reserved.
+Microsoft Open Technologies would like to thank its contributors, a list
+of whom are at http://rx.codeplex.com/wikipage?title=Contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You may
+obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+==========================================
+END OF rx@4.1.0 NOTICES AND INFORMATION
+
+
+
+safe-buffer@5.2.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Feross Aboukhadijeh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF safe-buffer@5.2.0 NOTICES AND INFORMATION
+
+
+
+safer-buffer@2.1.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) 2018 Nikita Skovoroda <chalkerx@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF safer-buffer@2.1.2 NOTICES AND INFORMATION
+
+
+
+saxen@8.1.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+Copyright (c) 2012 Vopilovskii Konstantin   <flash.vkv@gmail.com>
+Copyright (c) 2017-present Nico Rehwaldt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF saxen@8.1.0 NOTICES AND INFORMATION
+
+
+
+select@1.1.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License) Copyright: Zeno Rocha
+
+==========================================
+END OF select@1.1.2 NOTICES AND INFORMATION
+
+
+
+selection-ranges@3.0.3 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) 2017-present Nico Rehwaldt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF selection-ranges@3.0.3 NOTICES AND INFORMATION
+
+
+
+selection-update@0.1.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2015 Nico Rehwaldt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF selection-update@0.1.2 NOTICES AND INFORMATION
+
+
+
+signal-exit@3.0.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The ISC License
+
+Copyright (c) 2015, Contributors
+
+Permission to use, copy, modify, and/or distribute this software
+for any purpose with or without fee is hereby granted, provided
+that the above copyright notice and this permission notice
+appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE
+LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+==========================================
+END OF signal-exit@3.0.2 NOTICES AND INFORMATION
+
+
+
+string-width@2.1.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF string-width@2.1.1 NOTICES AND INFORMATION
+
+
+
+string_decoder@1.3.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License ) Copyright: Node.js contributors. All rights reserved.
+
+==========================================
+END OF string_decoder@1.3.0 NOTICES AND INFORMATION
+
+
+
+strip-ansi@3.0.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF strip-ansi@3.0.1 NOTICES AND INFORMATION
+
+
+
+strip-ansi@4.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF strip-ansi@4.0.0 NOTICES AND INFORMATION
+
+
+
+superagent@4.1.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) 2014-2016 TJ Holowaychuk <tj@vision-media.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF superagent@4.1.0 NOTICES AND INFORMATION
+
+
+
+supports-color@2.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF supports-color@2.0.0 NOTICES AND INFORMATION
+
+
+
+table-js@6.0.3 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2017-present camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF table-js@6.0.3 NOTICES AND INFORMATION
+
+
+
+through@2.3.8 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+Apache License, Version 2.0
+
+Copyright (c) 2011 Dominic Tarr
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+==========================================
+END OF through@2.3.8 NOTICES AND INFORMATION
+
+
+
+tiny-emitter@2.1.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2017 Scott Corgan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+==========================================
+END OF tiny-emitter@2.1.0 NOTICES AND INFORMATION
+
+
+
+tiny-svg@2.2.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014 Nico Rehwaldt
+Copyright (c) 2015-present camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF tiny-svg@2.2.2 NOTICES AND INFORMATION
+
+
+
+tmp@0.0.33 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014 KARASZI IstvÃ¡n
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF tmp@0.0.33 NOTICES AND INFORMATION
+
+
+
+util-deprecate@1.0.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF util-deprecate@1.0.2 NOTICES AND INFORMATION
+
+
 
 


### PR DESCRIPTION
Why the big diff?

* Run introduced quite a number of new Java dependencies
* The frontend part is now fully generated
  * In many cases, it contains the text of the license for every dependency
  * It currently includes both production and dev dependencies

related to CAM-11764