### PR TITLE
CAM-11925 added support for file variables with spaces in their name

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/impl/history/HistoricProcessInstanceRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/impl/history/HistoricProcessInstanceRestServiceImpl.java
@@ -144,7 +144,7 @@ import java.util.List;
         String csv = getReportResultAsCsv(uriInfo);
         return Response
             .ok(csv, mediaType)
-            .header("Content-Disposition", "attachment; filename=process-instance-report.csv")
+            .header("Content-Disposition", "attachment; filename=\"process-instance-report.csv\"")
             .build();
       }
     }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/impl/VariableResponseProvider.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/impl/VariableResponseProvider.java
@@ -51,7 +51,7 @@ public class VariableResponseProvider {
       type += "; charset=" + fileValue.getEncoding();
     }
     Object value = fileValue.getValue() == null ? "" : fileValue.getValue();
-    return Response.ok(value, type).header("Content-Disposition", "attachment; filename=" + fileValue.getFilename()).build();
+    return Response.ok(value, type).header("Content-Disposition", "attachment; filename=\"" + fileValue.getFilename() + "\"").build();
   }
 
   /**

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/repository/impl/CaseDefinitionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/repository/impl/CaseDefinitionResourceImpl.java
@@ -173,7 +173,7 @@ public class CaseDefinitionResourceImpl implements CaseDefinitionResource {
       return Response.noContent().build();
     } else {
       String fileName = definition.getDiagramResourceName();
-      return Response.ok(caseDiagram).header("Content-Disposition", "attachment; filename=" + fileName)
+      return Response.ok(caseDiagram).header("Content-Disposition", "attachment; filename=\"" + fileName + "\"")
           .type(ProcessDefinitionResourceImpl.getMediaTypeForFileSuffix(fileName)).build();
     }
   }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/repository/impl/DecisionDefinitionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/repository/impl/DecisionDefinitionResourceImpl.java
@@ -123,7 +123,7 @@ public class DecisionDefinitionResourceImpl implements DecisionDefinitionResourc
       return Response.noContent().build();
     } else {
       String fileName = definition.getDiagramResourceName();
-      return Response.ok(decisionDiagram).header("Content-Disposition", "attachment; filename=" + fileName)
+      return Response.ok(decisionDiagram).header("Content-Disposition", "attachment; filename=\"" + fileName + "\"")
           .type(ProcessDefinitionResourceImpl.getMediaTypeForFileSuffix(fileName)).build();
     }
   }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/repository/impl/DecisionRequirementsDefinitionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/repository/impl/DecisionRequirementsDefinitionResourceImpl.java
@@ -107,7 +107,7 @@ public class DecisionRequirementsDefinitionResourceImpl implements DecisionRequi
       return Response.noContent().build();
     } else {
       String fileName = definition.getDiagramResourceName();
-      return Response.ok(decisionRequirementsDiagram).header("Content-Disposition", "attachment; filename=" + fileName)
+      return Response.ok(decisionRequirementsDiagram).header("Content-Disposition", "attachment; filename=\"" + fileName + "\"")
           .type(ProcessDefinitionResourceImpl.getMediaTypeForFileSuffix(fileName)).build();
     }
   }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/repository/impl/DeploymentResourcesResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/repository/impl/DeploymentResourcesResourceImpl.java
@@ -145,7 +145,7 @@ public class DeploymentResourcesResourceImpl implements DeploymentResourcesResou
 
       return Response
           .ok(resourceAsStream, mediaType)
-          .header("Content-Disposition", "attachment; filename=" + filename)
+          .header("Content-Disposition", "attachment; filename=\"" + filename + "\"")
           .build();
     }
     else {

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/repository/impl/ProcessDefinitionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/repository/impl/ProcessDefinitionResourceImpl.java
@@ -276,7 +276,7 @@ public class ProcessDefinitionResourceImpl implements ProcessDefinitionResource 
     } else {
       String fileName = definition.getDiagramResourceName();
       return Response.ok(processDiagram)
-          .header("Content-Disposition", "attachment; filename=" + fileName)
+          .header("Content-Disposition", "attachment; filename=\"" + fileName + "\"")
           .type(getMediaTypeForFileSuffix(fileName)).build();
     }
   }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/task/impl/TaskReportResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/task/impl/TaskReportResourceImpl.java
@@ -56,7 +56,7 @@ public class TaskReportResourceImpl implements TaskReportResource {
         String csv = getReportResultAsCsv();
         return Response
           .ok(csv, mediaType)
-          .header("Content-Disposition", "attachment; filename=task-count-by-candidate-group.csv")
+          .header("Content-Disposition", "attachment; filename=\"task-count-by-candidate-group.csv\"")
           .build();
       }
     }

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/CaseDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/CaseDefinitionRestServiceInteractionTest.java
@@ -564,8 +564,8 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("image/png")
-          .header("Content-Disposition", "attachment; filename=" +
-              MockProvider.EXAMPLE_CASE_DEFINITION_DIAGRAM_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" +
+              MockProvider.EXAMPLE_CASE_DEFINITION_DIAGRAM_RESOURCE_NAME + "\"")
         .when().get(DIAGRAM_DEFINITION_URL).getBody().asByteArray();
 
     // verify service interaction

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/CaseDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/CaseDefinitionRestServiceInteractionTest.java
@@ -591,7 +591,7 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
       .expect()
       .statusCode(Status.OK.getStatusCode())
       .contentType("application/octet-stream")
-      .header("Content-Disposition", "attachment; filename=" + null)
+      .header("Content-Disposition", "attachment; filename=\"" + null + "\"")
       .when().get(DIAGRAM_DEFINITION_URL).getBody().asByteArray();
 
     // verify service interaction

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/DecisionDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/DecisionDefinitionRestServiceInteractionTest.java
@@ -328,8 +328,8 @@ public class DecisionDefinitionRestServiceInteractionTest extends AbstractRestSe
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("image/png")
-          .header("Content-Disposition", "attachment; filename=" +
-              MockProvider.EXAMPLE_DECISION_DEFINITION_DIAGRAM_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" +
+              MockProvider.EXAMPLE_DECISION_DEFINITION_DIAGRAM_RESOURCE_NAME + "\"")
         .when().get(DIAGRAM_DEFINITION_URL).getBody().asByteArray();
 
     // verify service interaction

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/DecisionDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/DecisionDefinitionRestServiceInteractionTest.java
@@ -355,7 +355,7 @@ public class DecisionDefinitionRestServiceInteractionTest extends AbstractRestSe
       .expect()
       .statusCode(Status.OK.getStatusCode())
       .contentType("application/octet-stream")
-      .header("Content-Disposition", "attachment; filename=" + null)
+      .header("Content-Disposition", "attachment; filename=\"" + null + "\"")
       .when().get(DIAGRAM_DEFINITION_URL).getBody().asByteArray();
 
     // verify service interaction

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/DecisionRequirementsDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/DecisionRequirementsDefinitionRestServiceInteractionTest.java
@@ -236,8 +236,8 @@ public class DecisionRequirementsDefinitionRestServiceInteractionTest extends Ab
       .expect()
         .statusCode(Status.OK.getStatusCode())
         .contentType("image/png")
-        .header("Content-Disposition", "attachment; filename=" +
-            MockProvider.EXAMPLE_DECISION_DEFINITION_DIAGRAM_RESOURCE_NAME)
+        .header("Content-Disposition", "attachment; filename=\"" +
+            MockProvider.EXAMPLE_DECISION_DEFINITION_DIAGRAM_RESOURCE_NAME + "\"")
       .when().get(DIAGRAM_DEFINITION_URL).getBody().asByteArray();
 
     verify(repositoryServiceMock).getDecisionRequirementsDefinition(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID);

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/DeploymentRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/DeploymentRestServiceInteractionTest.java
@@ -273,7 +273,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("application/octet-stream")
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -298,7 +298,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("image/svg+xml")
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_SVG_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_SVG_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -324,7 +324,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("image/png")
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_PNG_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_PNG_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -350,7 +350,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("image/gif")
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_GIF_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_GIF_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -376,7 +376,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("image/jpeg")
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_JPG_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_JPG_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -402,7 +402,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("image/jpeg")
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_JPEG_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_JPEG_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -428,7 +428,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("image/jpeg")
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_JPE_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_JPE_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -454,7 +454,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("image/tiff")
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_TIF_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_TIF_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -480,7 +480,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("image/tiff")
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_TIFF_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_TIFF_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -504,7 +504,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.XML)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_BPMN_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_BPMN_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -528,7 +528,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.XML)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_BPMN_XML_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_BPMN_XML_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -554,7 +554,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.XML)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_CMMN_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_CMMN_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -580,7 +580,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.XML)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_CMMN_XML_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_CMMN_XML_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -606,7 +606,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.XML)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_DMN_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_DMN_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -632,7 +632,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.XML)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_DMN_XML_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_DMN_XML_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -658,7 +658,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.XML)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_XML_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_XML_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -684,7 +684,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.JSON)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_JSON_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_JSON_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -710,7 +710,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.TEXT)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_GROOVY_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_GROOVY_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -736,7 +736,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.TEXT)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_JAVA_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_JAVA_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -762,7 +762,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.TEXT)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_JS_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_JS_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -788,7 +788,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.TEXT)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_PYTHON_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_PYTHON_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -814,7 +814,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.TEXT)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_RUBY_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_RUBY_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -840,7 +840,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.TEXT)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_PHP_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_PHP_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -866,7 +866,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.HTML)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_HTML_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_HTML_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -892,7 +892,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.TEXT)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_TXT_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_TXT_RESOURCE_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -918,7 +918,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.XML)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_RESOURCE_FILENAME_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_RESOURCE_FILENAME_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
@@ -944,7 +944,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType(ContentType.XML)
-          .header("Content-Disposition", "attachment; filename=" + MockProvider.EXAMPLE_DEPLOYMENT_RESOURCE_FILENAME_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" + MockProvider.EXAMPLE_DEPLOYMENT_RESOURCE_FILENAME_NAME + "\"")
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
@@ -282,7 +282,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
       .expect()
       .statusCode(Status.OK.getStatusCode())
       .contentType("application/octet-stream")
-      .header("Content-Disposition", "attachment; filename=" + null)
+      .header("Content-Disposition", "attachment; filename=\"" + null + "\"")
       .when().get(DIAGRAM_DEFINITION_URL).getBody().asByteArray();
 
     // verify service interaction

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
@@ -255,8 +255,8 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("image/png")
-          .header("Content-Disposition", "attachment; filename=" +
-              MockProvider.EXAMPLE_PROCESS_DEFINITION_DIAGRAM_RESOURCE_NAME)
+          .header("Content-Disposition", "attachment; filename=\"" +
+              MockProvider.EXAMPLE_PROCESS_DEFINITION_DIAGRAM_RESOURCE_NAME + "\"")
         .when().get(DIAGRAM_DEFINITION_URL).getBody().asByteArray();
 
     // verify service interaction

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ProcessEngineRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ProcessEngineRestServiceTest.java
@@ -673,7 +673,7 @@ public class ProcessEngineRestServiceTest extends
       .statusCode(Status.OK.getStatusCode())
       . body(is(equalTo(new String(byteContent))))
       .and()
-        .header("Content-Disposition", "attachment; filename="+filename)
+        .header("Content-Disposition", "attachment; filename=\"" + filename + "\"")
         .contentType(CoreMatchers.<String>either(equalTo(ContentType.TEXT.toString() + ";charset=UTF-8")).or(equalTo(ContentType.TEXT.toString() + " ;charset=UTF-8")))
       .when()
         .get(HISTORY_BINARY_VARIABLE_INSTANCE_URL);
@@ -744,7 +744,7 @@ public class ProcessEngineRestServiceTest extends
       .statusCode(Status.OK.getStatusCode())
       . body(is(equalTo(new String(byteContent))))
       .and()
-        .header("Content-Disposition", "attachment; filename="+filename)
+        .header("Content-Disposition", "attachment; filename=\"" + filename + "\"")
         .contentType(CoreMatchers.<String>either(equalTo(ContentType.TEXT.toString() + ";charset=UTF-8")).or(equalTo(ContentType.TEXT.toString() + " ;charset=UTF-8")))
       .when()
         .get(HISTORY_BINARY_DETAIL_URL);

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/TaskReportRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/TaskReportRestServiceTest.java
@@ -149,7 +149,7 @@ public class TaskReportRestServiceTest extends AbstractRestServiceTest {
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("text/csv")
-          .header("Content-Disposition", "attachment; filename=task-count-by-candidate-group.csv")
+          .header("Content-Disposition", "attachment; filename=\"task-count-by-candidate-group.csv\"")
       .when()
         .get(CANDIDATE_GROUP_REPORT_URL);
 
@@ -167,7 +167,7 @@ public class TaskReportRestServiceTest extends AbstractRestServiceTest {
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("application/csv")
-          .header("Content-Disposition", "attachment; filename=task-count-by-candidate-group.csv")
+          .header("Content-Disposition", "attachment; filename=\"task-count-by-candidate-group.csv\"")
         .when()
           .get(CANDIDATE_GROUP_REPORT_URL);
 

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/VariableInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/VariableInstanceRestServiceInteractionTest.java
@@ -313,7 +313,7 @@ public class VariableInstanceRestServiceInteractionTest extends AbstractRestServ
     Response response = given().pathParam("id", MockProvider.EXAMPLE_VARIABLE_INSTANCE_ID)
     .then().expect().statusCode(Status.OK.getStatusCode())
     .and()
-      .header("Content-Disposition", "attachment; filename="+filename)
+      .header("Content-Disposition", "attachment; filename=\"" + filename + "\"")
     .and()
       .body(is(equalTo(new String(byteContent))))
     .when().get(VARIABLE_INSTANCE_BINARY_DATA_URL);

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricDetailRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricDetailRestServiceInteractionTest.java
@@ -315,7 +315,7 @@ public class HistoricDetailRestServiceInteractionTest extends AbstractRestServic
       .statusCode(Status.OK.getStatusCode())
       . body(is(equalTo(new String(byteContent))))
       .and()
-        .header("Content-Disposition", "attachment; filename="+filename)
+        .header("Content-Disposition", "attachment; filename=\"" + filename + "\"")
     .when().get(VARIABLE_INSTANCE_BINARY_DATA_URL);
     //due to some problems with wildfly we gotta check this separately
     String contentType = response.getContentType();

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricProcessInstanceRestServiceReportTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricProcessInstanceRestServiceReportTest.java
@@ -314,7 +314,7 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
       .expect()
         .statusCode(Status.OK.getStatusCode())
         .contentType("text/csv")
-        .header("Content-Disposition", "attachment; filename=process-instance-report.csv")
+        .header("Content-Disposition", "attachment; filename=\"process-instance-report.csv\"")
       .when()
         .get(HISTORIC_PROCESS_INSTANCE_REPORT_URL);
 
@@ -332,7 +332,7 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
       .expect()
         .statusCode(Status.OK.getStatusCode())
         .contentType("text/csv")
-        .header("Content-Disposition", "attachment; filename=process-instance-report.csv")
+        .header("Content-Disposition", "attachment; filename=\"process-instance-report.csv\"")
       .when()
         .get(HISTORIC_PROCESS_INSTANCE_REPORT_URL);
 
@@ -419,7 +419,7 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("text/csv")
-          .header("Content-Disposition", "attachment; filename=process-instance-report.csv")
+          .header("Content-Disposition", "attachment; filename=\"process-instance-report.csv\"")
       .when().get(HISTORIC_PROCESS_INSTANCE_REPORT_URL);
 
     String responseContent = response.asString();
@@ -440,7 +440,7 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("text/csv")
-          .header("Content-Disposition", "attachment; filename=process-instance-report.csv")
+          .header("Content-Disposition", "attachment; filename=\"process-instance-report.csv\"")
       .when().get(HISTORIC_PROCESS_INSTANCE_REPORT_URL);
 
     String responseContent = response.asString();
@@ -461,7 +461,7 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("application/csv")
-          .header("Content-Disposition", "attachment; filename=process-instance-report.csv")
+          .header("Content-Disposition", "attachment; filename=\"process-instance-report.csv\"")
       .when().get(HISTORIC_PROCESS_INSTANCE_REPORT_URL);
 
     String responseContent = response.asString();
@@ -482,7 +482,7 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
         .expect()
           .statusCode(Status.OK.getStatusCode())
           .contentType("application/csv")
-          .header("Content-Disposition", "attachment; filename=process-instance-report.csv")
+          .header("Content-Disposition", "attachment; filename=\"process-instance-report.csv\"")
       .when().get(HISTORIC_PROCESS_INSTANCE_REPORT_URL);
 
     String responseContent = response.asString();
@@ -511,7 +511,7 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
       .expect()
         .statusCode(Status.OK.getStatusCode())
         .contentType("text/csv")
-        .header("Content-Disposition", "attachment; filename=process-instance-report.csv")
+        .header("Content-Disposition", "attachment; filename=\"process-instance-report.csv\"")
       .when()
         .get(HISTORIC_PROCESS_INSTANCE_REPORT_URL);
 
@@ -532,7 +532,7 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
       .expect()
         .statusCode(Status.OK.getStatusCode())
         .contentType("text/csv")
-        .header("Content-Disposition", "attachment; filename=process-instance-report.csv")
+        .header("Content-Disposition", "attachment; filename=\"process-instance-report.csv\"")
     .when()
       .get(HISTORIC_PROCESS_INSTANCE_REPORT_URL);
 

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricVariableInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricVariableInstanceRestServiceInteractionTest.java
@@ -293,7 +293,7 @@ public class HistoricVariableInstanceRestServiceInteractionTest extends Abstract
       .statusCode(Status.OK.getStatusCode())
     .and()
       .body(is(equalTo(new String(byteContent))))
-      .header("Content-Disposition", "attachment; filename="+filename)
+      .header("Content-Disposition", "attachment; filename=\"" + filename + "\"")
     .when().get(VARIABLE_INSTANCE_BINARY_DATA_URL);
     //due to some problems with wildfly we gotta check this separately
     String contentType = response.getContentType();


### PR DESCRIPTION
Please review the code changes I made to fix the issue related to truncated filenames when downloading file variables which filenames contain spaces. filename attribute of content-disposition should enclose the file name in quotes in order for browsers to properly get the name.