### PR TITLE
fix(rest-openapi): fix string arrays definitions in query parameters

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/deployment-query-params.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/deployment-query-params.ftl
@@ -34,8 +34,7 @@
 <@lib.parameter
     name = "tenantIdIn"
     location = "query"
-    type = "array"
-    itemType = "string"
+    type = "string"
     desc = "Filter by a comma-separated list of tenant ids. A deployment must have one of the given tenant ids."/>
 
 <@lib.parameter

--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/external-task-query-params.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/external-task-query-params.ftl
@@ -7,8 +7,7 @@
   <@lib.parameter
       name = "externalTaskIdIn"
       location = "query"
-      type = "array"
-      itemType = "string"
+      type = "string"
       desc = "Filter by the comma-separated list of external task ids." />
 
   <@lib.parameter
@@ -78,8 +77,7 @@
   <@lib.parameter
       name = "activityIdIn"
       location = "query"
-      type = "array"
-      itemType = "string"
+      type = "string"
       desc = "Filter by the comma-separated list of ids of the activities that an external task is created for." />
 
   <@lib.parameter
@@ -97,8 +95,7 @@
   <@lib.parameter
       name = "processInstanceIdIn"
       location = "query"
-      type = "array"
-      itemType = "string"
+      type = "string"
       desc = "Filter by a comma-separated list of process instance ids that an external task may belong to." />
 
   <@lib.parameter
@@ -110,8 +107,7 @@
   <@lib.parameter
       name = "tenantIdIn"
       location = "query"
-      type = "array"
-      itemType = "string"
+      type = "string"
       desc = "Filter by a comma-separated list of tenant ids.
               An external task must have one of the given tenant ids." />
 

--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/process-definition-query-params.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/process-definition-query-params.ftl
@@ -5,9 +5,8 @@
 
   <@lib.parameter name = "processDefinitionIdIn"
       location = "query"
-      type = "array"
-      itemType = "string"
-      desc = "Filter by process definition ids."/>
+      type = "string"
+      desc = "Filter by a comma-separated list of process definition ids."/>
 
   <@lib.parameter name = "name"
       location = "query"
@@ -51,9 +50,8 @@
 
   <@lib.parameter name = "keysIn"
       location = "query"
-      type = "array"
-      itemType = "string"
-      desc = "Filter by process definition keys."/>
+      type = "string"
+      desc = "Filter by a comma-separated list of process definition keys."/>
 
   <@lib.parameter name = "keyLike"
       location = "query"
@@ -133,8 +131,7 @@
 
   <@lib.parameter name = "tenantIdIn"
       location = "query"
-      type = "array"
-      itemType = "string"
+      type = "string"
       desc = "Filter by a comma-separated list of tenant ids.
               A process definition must have one of the given tenant ids."/>
 

--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/utils.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/utils.ftl
@@ -3,7 +3,6 @@
         enumValues=[]
         defaultValue="" <#-- it will work for boolean, integer, string -->
         format=""
-        itemType=""
         required=false
         last=false >
   {
@@ -22,12 +21,6 @@
       </#if>
 
       "type": "${type}"
-
-      <#if type == "array">,
-        "items": {
-          "type": "${itemType}"
-        }
-      </#if>
 
       <#if format?has_content>,
         "format": "${format}"

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/history/HistoricProcessInstanceQueryDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/history/HistoricProcessInstanceQueryDto.ftl
@@ -288,7 +288,7 @@
                 A process instance matches a nested query if it fulfills at least one of the query's predicates.
                 With multiple nested queries, a process instance must fulfill at least one predicate of each query (Conjunctive Normal Form).
                 All process instance query properties can be used except for: sorting
-                See the [User Guide](https://docs.camunda.org/manual/latest/user-guide/process-engine/process-engine-api/#or-queries) for more information about OR queries." />
+                See the [User Guide](${docsUrl}/user-guide/process-engine/process-engine-api/#or-queries) for more information about OR queries." />
 
     "sorting": {
       "type": "array",


### PR DESCRIPTION
* OpenAPI supports `array` type in query parameters and
resolves them to idIn=val1&idIn=val2
* the REST API expects a comma-separated lists idIn=val1,val2

Related to CAM-11934