### PR TITLE
CAM-11950: separate Spring boot build into assembly and distro

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,9 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <modules>
+        <!-- This profile is run in the CI as the first step (platform-ASSEMBLY); It must not activate
+          any modules that have a dependency to the webapps. See also the referenced POMs, 
+          they usually define which modules are covered by the distro profile -->
         <module>spring-boot-starter</module>
 
         <module>qa</module>
@@ -102,6 +105,10 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <modules>
+        <!-- This profile is run in the CI after the webapps were built (platform-DISTRO); 
+          It should activate any module that has a dependency to the webapps -->
+        <module>spring-boot-starter</module>
+        
         <module>distro/license-book</module>
         <module>distro/jbossas7</module>
         <module>distro/tomcat</module>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -19,14 +19,6 @@
 
   <packaging>pom</packaging>
 
-  <modules>
-    <module>starter</module>
-    <module>starter-rest</module>
-    <module>starter-webapp-core</module>
-    <module>starter-webapp</module>
-    <module>starter-test</module>
-  </modules>
-
   <properties>
     <!-- disable javadoc linter for JDK8 to not fail on incomplete javadoc -->
     <additionalparam>-Xdoclint:none</additionalparam>
@@ -88,6 +80,20 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <modules>
+        <module>starter</module>
+        <module>starter-rest</module>
+        <module>starter-test</module>
+        <module>starter-qa</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>distro-ce</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>starter-webapp-core</module>
+        <module>starter-webapp</module>
         <module>starter-qa</module>
       </modules>
     </profile>

--- a/spring-boot-starter/starter-qa/pom.xml
+++ b/spring-boot-starter/starter-qa/pom.xml
@@ -14,18 +14,38 @@
   <artifactId>camunda-bpm-spring-boot-starter-qa</artifactId>
   <name>camunda BPM - Spring Boot Starter - QA - Root Pom</name>
 
-  <modules>
-    <module>integration-test-simple</module>
-    <module>integration-test-webapp</module>
-    <module>integration-test-plugins</module>
-  </modules>
-
   <profiles>  
     <profile>
       <id>distro</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
+      <modules>
+        <module>integration-test-simple</module>
+        <module>integration-test-plugins</module>
+      </modules>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <skipTests>true</skipTests>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>distro-ce</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>integration-test-webapp</module>
+      </modules>
       <build>
         <pluginManagement>
           <plugins>


### PR DESCRIPTION
- modules with webapp dependencies should not be built as part of the
  distro profile, because that profile is run in the platform-ASSEMBLY
  build, at which point the webapps have not been built yet
- See the Run and Tomcat distro builds for the same pattern, e.g.
  distro/tomcat/pom.xml builds the Tomcat webapp only in the distro-ce
  profile

related to CAM-11950