### PR TITLE
CAM-11950: fix(jboss): revert distro and distro-ce profile merge

### DIFF
--- a/distro/jbossas7/pom.xml
+++ b/distro/jbossas7/pom.xml
@@ -23,10 +23,17 @@
       <modules>
         <module>modules</module>
         <module>subsystem</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>distro-ce</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
         <module>webapp</module>
         <module>webapp-standalone</module>
       </modules>
     </profile>
   </profiles>
-
 </project>


### PR DESCRIPTION
* Revert the merging of the JBoss distro module 'distro' and 'distro-ce' profiles since it
  creates a cycle in the Maven modules build hierarchy by requiring the
Webapps during the ASSEMBLY phase (uses the 'distro' profile), which breaks the build.

Related to CAM-11950