### PR TITLE
chore(engine): adjust telemetry configuration property

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/BootstrapEngineCommand.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/BootstrapEngineCommand.java
@@ -124,7 +124,7 @@ public class BootstrapEngineCommand implements ProcessEngineBootstrapCommand {
   }
 
   protected void createTelemetryProperty(CommandContext commandContext) {
-    boolean telemetryEnabled = Context.getProcessEngineConfiguration().isTelemetryInitialized();
+    boolean telemetryEnabled = Context.getProcessEngineConfiguration().isInitializeTelemetry();
     PropertyEntity property = new PropertyEntity(TELEMETRY_PROPERTY_NAME, Boolean.toString(telemetryEnabled));
     commandContext.getPropertyManager().insert(property);
     LOG.creatingTelemetryPropertyInDatabase(telemetryEnabled);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/BootstrapEngineCommand.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/BootstrapEngineCommand.java
@@ -46,7 +46,7 @@ public class BootstrapEngineCommand implements ProcessEngineBootstrapCommand {
       createHistoryCleanupJob(commandContext);
     }
 
-    configureTelemetryProperty(commandContext);
+    initializeTelemetryProperty(commandContext);
 
     return null;
   }
@@ -89,7 +89,7 @@ public class BootstrapEngineCommand implements ProcessEngineBootstrapCommand {
         .isHistoryCleanupEnabled();
   }
 
-  public void configureTelemetryProperty(CommandContext commandContext) {
+  public void initializeTelemetryProperty(CommandContext commandContext) {
     try {
 
       checkTelemetryLockExists(commandContext);
@@ -100,12 +100,6 @@ public class BootstrapEngineCommand implements ProcessEngineBootstrapCommand {
       if (databaseTelemetryProperty == null) {
         LOG.noTelemetryPropertyFound();
         createTelemetryProperty(commandContext);
-      } else {
-        boolean oldValue = Boolean.parseBoolean(databaseTelemetryProperty.getValue());
-        boolean currentValue = Context.getProcessEngineConfiguration().isTelemetryEnabled();
-        if(currentValue != oldValue) {
-          databaseTelemetryProperty.setValue(Boolean.toString(currentValue));
-        }
       }
 
     } catch (Exception e) {
@@ -130,7 +124,7 @@ public class BootstrapEngineCommand implements ProcessEngineBootstrapCommand {
   }
 
   protected void createTelemetryProperty(CommandContext commandContext) {
-    boolean telemetryEnabled = Context.getProcessEngineConfiguration().isTelemetryEnabled();
+    boolean telemetryEnabled = Context.getProcessEngineConfiguration().isTelemetryInitialized();
     PropertyEntity property = new PropertyEntity(TELEMETRY_PROPERTY_NAME, Boolean.toString(telemetryEnabled));
     commandContext.getPropertyManager().insert(property);
     LOG.creatingTelemetryPropertyInDatabase(telemetryEnabled);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -865,7 +865,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
 
   // telemetry ///////////////////////////////////////////////////////
-  protected boolean telemetryEnabled = false;
+  /** if set to true the telemetry will be enabled from the first engine start*/
+  protected boolean telemetryInitialized = false;
   /** The endpoint which telemetry is sent to */
   protected String telemetryEndpoint = "https://api.telemetry.camunda.cloud/pings";
 
@@ -2187,7 +2188,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   }
 
   protected void initTelemetry() {
-    if (telemetryEnabled) {
+    if (telemetryInitialized) {
       // initialize telemetry reporter
     }
   }
@@ -4622,12 +4623,12 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return this;
   }
 
-  public boolean isTelemetryEnabled() {
-    return telemetryEnabled;
+  public boolean isTelemetryInitialized() {
+    return telemetryInitialized;
   }
 
-  public ProcessEngineConfigurationImpl setTelemetryEnabled(boolean telemetryEnabled) {
-    this.telemetryEnabled = telemetryEnabled;
+  public ProcessEngineConfigurationImpl setTelemetryInitialized(boolean telemetryInitialized) {
+    this.telemetryInitialized = telemetryInitialized;
     return this;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -865,8 +865,13 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
 
   // telemetry ///////////////////////////////////////////////////////
-  /** if set to true the telemetry will be enabled from the first engine start*/
-  protected boolean telemetryInitialized = false;
+  /**
+   * Sets the initial property value of telemetry configuration only once
+   * when it has never been enabled/disabled before.
+   * Subsequent changes can be done only via the
+   * {@link ManagementService#enableTelemetry(boolean) Telemetry} API in {@link ManagementService}
+   */
+  protected boolean initializeTelemetry = false;
   /** The endpoint which telemetry is sent to */
   protected String telemetryEndpoint = "https://api.telemetry.camunda.cloud/pings";
 
@@ -2188,7 +2193,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   }
 
   protected void initTelemetry() {
-    if (telemetryInitialized) {
+    if (initializeTelemetry) {
       // initialize telemetry reporter
     }
   }
@@ -4623,12 +4628,12 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return this;
   }
 
-  public boolean isTelemetryInitialized() {
-    return telemetryInitialized;
+  public boolean isInitializeTelemetry() {
+    return initializeTelemetry;
   }
 
-  public ProcessEngineConfigurationImpl setTelemetryInitialized(boolean telemetryInitialized) {
-    this.telemetryInitialized = telemetryInitialized;
+  public ProcessEngineConfigurationImpl setInitializeTelemetry(boolean telemetryInitialized) {
+    this.initializeTelemetry = telemetryInitialized;
     return this;
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/ManagementAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/ManagementAuthorizationTest.java
@@ -252,14 +252,17 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
 
   public void testTelemetryEnabledAsCamundaAdmin() {
     // given
+    disableAuthorization();
+    managementService.enableTelemetry(true);
+    enableAuthorization();
     identityService.setAuthentication(userId, Collections.singletonList(Groups.CAMUNDA_ADMIN));
 
     // when
-    managementService.enableTelemetry(true);
+    managementService.enableTelemetry(false);
 
     // then
     String telemetryPropertyValue = TelemetryHelper.fetchConfigurationProperty(processEngineConfiguration).getValue();
-    assertThat(Boolean.parseBoolean(telemetryPropertyValue)).isTrue();
+    assertThat(Boolean.parseBoolean(telemetryPropertyValue)).isFalse();
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryConfigurationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryConfigurationTest.java
@@ -53,7 +53,7 @@ public class TelemetryConfigurationTest {
     processEngineConfiguration.buildProcessEngine();
 
     // then
-    assertThat(processEngineConfiguration.isTelemetryInitialized()).isFalse();
+    assertThat(processEngineConfiguration.isInitializeTelemetry()).isFalse();
     assertThat(Boolean.parseBoolean(fetchConfigurationProperty(processEngineConfiguration).getValue())).isFalse();
   }
 
@@ -62,14 +62,14 @@ public class TelemetryConfigurationTest {
     // given
     processEngineConfiguration = new StandaloneInMemProcessEngineConfiguration();
     processEngineConfiguration
-                              .setTelemetryInitialized(true)
+                              .setInitializeTelemetry(true)
                               .setJdbcUrl("jdbc:h2:mem:camunda" + getClass().getSimpleName());
 
     // when
     processEngineConfiguration.buildProcessEngine();
 
     // then
-    assertThat(processEngineConfiguration.isTelemetryInitialized()).isTrue();
+    assertThat(processEngineConfiguration.isInitializeTelemetry()).isTrue();
     assertThat(Boolean.parseBoolean(fetchConfigurationProperty(processEngineConfiguration).getValue())).isTrue();
   }
 
@@ -80,7 +80,7 @@ public class TelemetryConfigurationTest {
     boolean telemetryInitialized = true;
     processEngineConfiguration = new StandaloneInMemProcessEngineConfiguration();
     processEngineConfiguration
-                              .setTelemetryInitialized(telemetryInitialized)
+                              .setInitializeTelemetry(telemetryInitialized)
                               .setJdbcUrl("jdbc:h2:mem:camunda" + getClass().getSimpleName());
  
     // when

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryConfigurationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryConfigurationTest.java
@@ -53,7 +53,7 @@ public class TelemetryConfigurationTest {
     processEngineConfiguration.buildProcessEngine();
 
     // then
-    assertThat(processEngineConfiguration.isTelemetryEnabled()).isFalse();
+    assertThat(processEngineConfiguration.isTelemetryInitialized()).isFalse();
     assertThat(Boolean.parseBoolean(fetchConfigurationProperty(processEngineConfiguration).getValue())).isFalse();
   }
 
@@ -62,14 +62,14 @@ public class TelemetryConfigurationTest {
     // given
     processEngineConfiguration = new StandaloneInMemProcessEngineConfiguration();
     processEngineConfiguration
-                              .setTelemetryEnabled(true)
+                              .setTelemetryInitialized(true)
                               .setJdbcUrl("jdbc:h2:mem:camunda" + getClass().getSimpleName());
 
     // when
     processEngineConfiguration.buildProcessEngine();
 
     // then
-    assertThat(processEngineConfiguration.isTelemetryEnabled()).isTrue();
+    assertThat(processEngineConfiguration.isTelemetryInitialized()).isTrue();
     assertThat(Boolean.parseBoolean(fetchConfigurationProperty(processEngineConfiguration).getValue())).isTrue();
   }
 
@@ -77,10 +77,10 @@ public class TelemetryConfigurationTest {
   @WatchLogger(loggerNames = {"org.camunda.bpm.engine.persistence"}, level = "DEBUG")
   public void shouldLogTelemetryPersistenceLog() {
     // given
-    boolean telemetryEnabled = true;
+    boolean telemetryInitialized = true;
     processEngineConfiguration = new StandaloneInMemProcessEngineConfiguration();
     processEngineConfiguration
-                              .setTelemetryEnabled(telemetryEnabled)
+                              .setTelemetryInitialized(telemetryInitialized)
                               .setJdbcUrl("jdbc:h2:mem:camunda" + getClass().getSimpleName());
  
     // when
@@ -88,7 +88,7 @@ public class TelemetryConfigurationTest {
 
     // then
     assertThat(loggingRule.getFilteredLog("No telemetry property found in the database").size()).isOne();
-    assertThat(loggingRule.getFilteredLog("Creating the telemetry property in database with the value: " + telemetryEnabled).size()).isOne();
+    assertThat(loggingRule.getFilteredLog("Creating the telemetry property in database with the value: " + telemetryInitialized).size()).isOne();
   }
 
   @Test

--- a/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentTelemetryConfigurationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentTelemetryConfigurationTest.java
@@ -94,7 +94,7 @@ public class ConcurrentTelemetryConfigurationTest extends ConcurrencyTestCase {
 
       monitor.sync(); // thread will block here until makeContinue() is called form main thread
 
-      new BootstrapEngineCommand().configureTelemetryProperty(commandContext);
+      new BootstrapEngineCommand().initializeTelemetryProperty(commandContext);
 
       monitor.sync(); // thread will block here until waitUntilDone() is called form main thread
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentTelemetryConfigurationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentTelemetryConfigurationTest.java
@@ -38,12 +38,6 @@ import org.camunda.bpm.engine.test.util.DatabaseHelper;
 public class ConcurrentTelemetryConfigurationTest extends ConcurrencyTestCase {
 
   @Override
-  protected void setUp() throws Exception {
-    super.setUp();
-    TestHelper.deleteTelemetryProperty(processEngineConfiguration);
-  }
-
-  @Override
   protected void runTest() throws Throwable {
     final Integer transactionIsolationLevel = DatabaseHelper.getTransactionIsolationLevel(processEngineConfiguration);
     String databaseType = DatabaseHelper.getDatabaseType(processEngineConfiguration);
@@ -52,6 +46,8 @@ public class ConcurrentTelemetryConfigurationTest extends ConcurrencyTestCase {
         || (transactionIsolationLevel != null && !transactionIsolationLevel.equals(Connection.TRANSACTION_READ_COMMITTED))) {
       // skip test method - if database is H2
     } else {
+      // clean up the db property
+      TestHelper.deleteTelemetryProperty(processEngineConfiguration);
       // invoke the test method
       super.runTest();
     }


### PR DESCRIPTION
* renamed to `telemetryInitialized`
* considered only for the initial value of the telemetryEnabled db property

Related to CAM-12023