### PR TITLE
[CAM-12098] fix(openapi-template): corrected VariableQueryParameterDto property for the name of the variable

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/VariableQueryParameterDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/VariableQueryParameterDto.ftl
@@ -1,7 +1,7 @@
 <@lib.dto>
 
     <@lib.property
-        name = "value"
+        name = "name"
         type = "string"
         desc = "Variable name"/>
 


### PR DESCRIPTION
The property designated for the name of the variable had the wrong (duplicate) property name, causing the generated class to miss the property for the name of the variable.

related to CAM-12098