### PR TITLE
CAM-12106: make el resolver volatile

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/el/ExpressionManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/el/ExpressionManager.java
@@ -61,7 +61,7 @@ public class ExpressionManager {
   // Default implementation (does nothing)
   protected ELContext parsingElContext = new ProcessEngineElContext(functionMappers);
   protected Map<Object, Object> beans;
-  protected ELResolver elResolver;
+  protected volatile ELResolver elResolver; // why volatile? => https://jira.camunda.com/browse/CAM-12106
 
   public ExpressionManager() {
     this(null);


### PR DESCRIPTION
- fixes concurrency issues with lazy initialization in #getCachedElResolver,
  due to which it was possible that the resolver object could
  be created but not yet initialized when being accessed by another thread
- see https://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html

related to CAM-12106