### PR TITLE
CAM-12120: replace log4j with logback

### DIFF
--- a/engine-dmn/feel-scala/pom.xml
+++ b/engine-dmn/feel-scala/pom.xml
@@ -35,20 +35,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/engine-dmn/feel-scala/src/test/resources/logback-test.xml
+++ b/engine-dmn/feel-scala/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.camunda.feel.FeelEngine" level="debug" />
+
+  <root level="debug">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>

--- a/engine-dmn/pom.xml
+++ b/engine-dmn/pom.xml
@@ -16,7 +16,6 @@
 
   <properties>
     <version.juel>2.2.7</version.juel>
-    <version.log4j>2.9.0</version.log4j>
   </properties>
 
   <dependencyManagement>
@@ -45,25 +44,6 @@
         <artifactId>feel-engine</artifactId>
         <version>${version.feel-scala}</version>
       </dependency>
-
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
-        <version>${version.log4j}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <version>${version.log4j}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
-        <version>${version.log4j}</version>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
- we already use logback as our slf4j implementation in other modules
  (e.g. engine)
- that way, we only maintain a single logging dependency

related to CAM-12120