### PR TITLE
CAM-11872: use OpenJPA 2 in old-engine-tests

### DIFF
--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -139,7 +139,6 @@
         <dependency>
           <groupId>org.apache.openjpa</groupId>
           <artifactId>openjpa</artifactId>
-          <version>1.2.3</version>
           <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
- during 7.13 development, we switched to testing against OpenJPA 2 instead
  of OpenJPA 1. In the old-engine test suite, we had to keep the OpenJPA1
  dependency, because we run the tests of the old engine version there
  (and switching to OpenJPA 2 required some code changes). With 7.13.0
  released, we can switch to OpenJPA 2 in the test suite

related to CAM-11872