### PR TITLE
fix(engine): prevent caching of procDefs on app resume

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/repository/DefaultDeploymentHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/repository/DefaultDeploymentHandler.java
@@ -58,8 +58,8 @@ public class DefaultDeploymentHandler implements DeploymentHandler {
       String[] processDefinitionKeys) {
 
     Set<String> deploymentIds = new HashSet<>();
-    List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery()
-        .processDefinitionKeysIn(processDefinitionKeys).list();
+    List<ProcessDefinition> processDefinitions = Context.getCommandContext().getProcessDefinitionManager()
+        .findProcessDefinitionsByKeyIn(processDefinitionKeys);
     for (ProcessDefinition processDefinition : processDefinitions) {
       deploymentIds.add(processDefinition.getDeploymentId());
     }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/ProcessApplicationDeploymentTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/ProcessApplicationDeploymentTest.java
@@ -743,6 +743,28 @@ public class ProcessApplicationDeploymentTest {
   }
 
   @Test
+  public void testProcessApplicationDeploymentResumptionDoesNotCachePreviousBpmnModelInstance() {
+    // given an initial deployment
+    testRule.deploy(repositoryService
+        .createDeployment(processApplication.getReference())
+        .name("deployment")
+        .addClasspathResource("org/camunda/bpm/engine/test/api/repository/version1.bpmn20.xml"));
+
+    deploymentCache.discardProcessDefinitionCache();
+
+    // when an update with changes is deployed
+    testRule.deploy(repositoryService
+        .createDeployment(processApplication.getReference())
+        .name("deployment")
+        .enableDuplicateFiltering(false)
+        .resumePreviousVersions()
+        .addClasspathResource("org/camunda/bpm/engine/test/api/repository/version2.bpmn20.xml"));
+
+    // then the cache is still empty
+    assertTrue(deploymentCache.getBpmnModelInstanceCache().isEmpty());
+  }
+
+  @Test
   public void testDeploymentSourceShouldBeNull() {
     // given
     String key = "process";


### PR DESCRIPTION
* using the `ProcessDefinitionQuery` to fetch definitions results in
  parsing the model and caching the result in the `DeploymentCache`;
  thus we should avoid using it on engine/application startup to
  prevent previous versions of models being parsed and in the cache

related to CAM-11956