### PR TITLE
CAM-12164: bump MySQL driver version

### DIFF
--- a/database/pom.xml
+++ b/database/pom.xml
@@ -25,7 +25,7 @@
     <version.oracle>${version.oracle-11}</version.oracle>
     <version.mariadb>1.1.8</version.mariadb>
     <version.mariadb.galera>1.6.3</version.mariadb.galera>
-    <version.mysql>5.1.21</version.mysql>
+    <version.mysql>8.0.21</version.mysql>
     <version.sqlserver>4.2</version.sqlserver>
     <version.db2-11.1>11.1.1.1</version.db2-11.1>
     <version.db2-10.5>10.5.0.5</version.db2-10.5>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -25,7 +25,7 @@
     <version.oracle>${version.oracle-11}</version.oracle>
     <version.mariadb>1.1.8</version.mariadb>
     <version.mariadb.galera>1.6.3</version.mariadb.galera>
-    <version.mysql>8.0.21</version.mysql>
+    <version.mysql>5.1.49</version.mysql>
     <version.sqlserver>4.2</version.sqlserver>
     <version.db2-11.1>11.1.1.1</version.db2-11.1>
     <version.db2-10.5>10.5.0.5</version.db2-10.5>


### PR DESCRIPTION
- moves to latest patch level of driver 8 which is documented to be
  compatible with our supported MySQL versions

related to CAM-12164