### PR TITLE
CAM-12187: add direct JAXB-API dependency

### DIFF
--- a/distro/run/core/pom.xml
+++ b/distro/run/core/pom.xml
@@ -48,6 +48,19 @@
       <groupId>org.camunda.bpm.springboot</groupId>
       <artifactId>camunda-bpm-spring-boot-starter-rest</artifactId>
     </dependency>
+    
+    <!-- jersey-server (transitive dependency of camunda-bpm-spring-boot-starter-rest)
+      requires JAXB API and Activation API
+      to be present; Its pom has an optional profile 
+      (activated by Java 11+) that adds these dependencies.
+      However, in order to be able to build Run with Java 8 and
+      operate it with Java 11+, we must have a 
+      direct dependency to JAXB, regardless which Java version we 
+      use for building -->
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
- with the update to Spring Boot 2.3.1, Spring Boot no longer always
  brings the JAXB API; only some profiles in the jersey dependencies
  that are activated with Java 11+ include those APIs. Since we build
  Run with Java 8 and intend to operate with any Java version, this
  will create issues when operating it with Java 11+
- the fix adds a direct JAXB dependency so that we always include
  it in the Run distro regardless which Java version is used to build it
- This commit uses the Jakarta artifact of the JAXB API. This is
  a different artifact than the one we e.g. use with Spin. I did this,
  because the Jakarta artifacts are newer and Spring Boot uses the Jakarta
  artifacts itself. E.g. the jaxb-api version is now managed via the
  Spring Boot BOM. This should avoid some cases in which the JAXB API
  would be twice on the classpath in artifacts with different Maven
  coordinates

related to CAM-12187