### PR TITLE
[CAM-12269] fix(openapi) correct format of IncidentDto.rootCauseIncidentId 

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/IncidentDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/IncidentDto.ftl
@@ -51,7 +51,6 @@
     <@lib.property
         name = "rootCauseIncidentId"
         type = "string"
-        format = "date-time"
         desc = "The id of the associated root cause incident which has been triggered." />
 
     <@lib.property


### PR DESCRIPTION
Fix error on java client IncidentDtodesirialization:
```
Cannot deserialize value of type `java.time.OffsetDateTime` from String "262e7d86-d650-11ea-bae9-0242ac170007": Failed to deserialize java.time.OffsetDateTime:
through reference chain: java.util.ArrayList[0]->com.example.model.IncidentDto["rootCauseIncidentId"]
```
