### PR TITLE
CAM-12182: bump release parent 2.2.1

### DIFF
--- a/engine-dmn/feel-juel/pom.xml
+++ b/engine-dmn/feel-juel/pom.xml
@@ -66,7 +66,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -516,7 +516,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.3</version>
           <configuration>
             <createSourcesJar>true</createSourcesJar>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-bpm-release-parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.1</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath />
   </parent>

--- a/qa/performance-tests-engine/pom.xml
+++ b/qa/performance-tests-engine/pom.xml
@@ -77,7 +77,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>2.4.3</version>
             <executions>
               <execution>
                 <phase>package</phase>


### PR DESCRIPTION
- fixes that maven-shade-plugin is not executed for every module

related to CAM-12182