### PR TITLE
CAM-10520: do not persist transient local variables

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/DecisionEvaluationUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/DecisionEvaluationUtil.java
@@ -31,7 +31,9 @@ import org.camunda.bpm.engine.impl.dmn.result.SingleEntryDecisionResultMapper;
 import org.camunda.bpm.engine.impl.dmn.result.SingleResultDecisionResultMapper;
 import org.camunda.bpm.engine.repository.DecisionDefinition;
 import org.camunda.bpm.engine.variable.VariableMap;
+import org.camunda.bpm.engine.variable.Variables;
 import org.camunda.bpm.engine.variable.context.VariableContext;
+import org.camunda.bpm.engine.variable.value.TypedValue;
 
 /**
  * @author Roman Smirnov
@@ -73,7 +75,8 @@ public class DecisionEvaluationUtil {
 
     DmnDecisionResult result = invocation.getInvocationResult();
     if (result != null) {
-      execution.setVariableLocalTransient(DECISION_RESULT_VARIABLE, result);
+      TypedValue typedValue = Variables.untypedValue(result, true);
+      execution.setVariableLocal(DECISION_RESULT_VARIABLE, typedValue);
 
       if (resultVariable != null && decisionResultMapper != null) {
         Object mappedDecisionResult = decisionResultMapper.mapDecisionResult(result);


### PR DESCRIPTION
- on any API that accepts local variables (e.g. message correlation,
  DelegateExecution)
- removes redundant code in abstract variable scope; the distinction between
  transient and non-transient can be made in a single place
  (#setVariableLocal) to which all variable-setting APIs delegate

related to CAM-10520