### PR TITLE
chore(engine): adjust initilizeTelemetry config to null by default

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/ManagementService.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/ManagementService.java
@@ -1356,7 +1356,7 @@ public interface ManagementService {
    * @return
    *   <ul>
    *     <li><code>null</code> if the configuration is not defined so far,
-   *     treated as <code>false</code> and no data is send,</li>
+   *     treated as <code>false</code> and no data is sent,</li>
    *     <li><code>true</code> if the telemetry sending is enabled, and</li>
    *     <li><code>false</code> if the telemetry is disabled explicitly.</li>
    *   </ul>

--- a/engine/src/main/java/org/camunda/bpm/engine/ManagementService.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/ManagementService.java
@@ -1352,7 +1352,15 @@ public interface ManagementService {
   void toggleTelemetry(boolean enabled);
 
   /**
-   * Checks if sending telemetry data to Camunda is enabled/disabled
+   * Checks how sending telemetry data to Camunda is configured
+   * @return
+   *   <ul>
+   *     <li><code>null</code> if the configuration is not defined so far,
+   *     treated as <code>false</code> and no data is send,</li>
+   *     <li><code>true</code> if the telemetry sending is enabled, and</li>
+   *     <li><code>false</code> if the telemetry is disabled explicitly.</li>
+   *   </ul>
    */
-  boolean isTelemetryEnabled();
+  Boolean isTelemetryEnabled();
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/BootstrapEngineCommand.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/BootstrapEngineCommand.java
@@ -132,8 +132,13 @@ public class BootstrapEngineCommand implements ProcessEngineBootstrapCommand {
   }
 
   protected void createTelemetryProperty(CommandContext commandContext) {
-    boolean telemetryEnabled = Context.getProcessEngineConfiguration().isInitializeTelemetry();
-    PropertyEntity property = new PropertyEntity(TELEMETRY_PROPERTY_NAME, Boolean.toString(telemetryEnabled));
+    Boolean telemetryEnabled = Context.getProcessEngineConfiguration().isInitializeTelemetry();
+    PropertyEntity property = null;
+    if (telemetryEnabled != null) {
+      property = new PropertyEntity(TELEMETRY_PROPERTY_NAME, Boolean.toString(telemetryEnabled));
+    } else {
+      property = new PropertyEntity(TELEMETRY_PROPERTY_NAME, "null");
+    }
     commandContext.getPropertyManager().insert(property);
     LOG.creatingTelemetryPropertyInDatabase(telemetryEnabled);
   }
@@ -194,7 +199,7 @@ public class BootstrapEngineCommand implements ProcessEngineBootstrapCommand {
   protected void startTelemetryReporter(CommandContext commandContext) {
     ProcessEngineConfigurationImpl processEngineConfiguration = commandContext.getProcessEngineConfiguration();
     // start telemetry reporter only if the telemetry is enabled
-    if (processEngineConfiguration.getManagementService().isTelemetryEnabled() &&
+    if (Boolean.TRUE.equals(processEngineConfiguration.getManagementService().isTelemetryEnabled()) &&
         processEngineConfiguration.getTelemetryReporter() != null &&
         processEngineConfiguration.getTelemetryReporter().getHttpConnector() != null) {
       processEngineConfiguration.getTelemetryReporter().start();

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ManagementServiceImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ManagementServiceImpl.java
@@ -508,7 +508,8 @@ public class ManagementServiceImpl extends ServiceImpl implements ManagementServ
     commandExecutor.execute(new TelemetryConfigureCmd(enabled));
   }
 
-  public boolean isTelemetryEnabled() {
+  public Boolean isTelemetryEnabled() {
     return commandExecutor.execute(new IsTelemetryEnabledCmd());
   }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -886,7 +886,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    * Subsequent changes can be done only via the
    * {@link ManagementService#toggleTelemetry(boolean) Telemetry} API in {@link ManagementService}
    */
-  protected boolean initializeTelemetry = false;
+  protected Boolean initializeTelemetry = null;
   /** The endpoint which telemetry is sent to */
   protected String telemetryEndpoint = "https://api.telemetry.camunda.cloud/pings";
   protected TelemetryReporter telemetryReporter;
@@ -4701,11 +4701,11 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return this;
   }
 
-  public boolean isInitializeTelemetry() {
+  public Boolean isInitializeTelemetry() {
     return initializeTelemetry;
   }
 
-  public ProcessEngineConfigurationImpl setInitializeTelemetry(boolean telemetryInitialized) {
+  public ProcessEngineConfigurationImpl setInitializeTelemetry(Boolean telemetryInitialized) {
     this.initializeTelemetry = telemetryInitialized;
     return this;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/IsTelemetryEnabledCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/IsTelemetryEnabledCmd.java
@@ -34,10 +34,14 @@ public class IsTelemetryEnabledCmd implements Command<Boolean> {
 
     PropertyEntity telemetryProperty = commandContext.getPropertyManager().findPropertyById("camunda.telemetry.enabled");
     if (telemetryProperty != null) {
-      return Boolean.parseBoolean(telemetryProperty.getValue());
+      if (telemetryProperty.getValue().toLowerCase().equals("null")) {
+        return null;
+      } else {
+        return Boolean.parseBoolean(telemetryProperty.getValue());
+      }
     } else {
       LOG.databaseTelemetryPropertyMissingInfo();
-      return false;
+      return null;
     }
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentTelemetryConfigurationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentTelemetryConfigurationTest.java
@@ -42,7 +42,7 @@ public class ConcurrentTelemetryConfigurationTest extends ConcurrencyTestCase {
 
   @Before
   public void setUp() {
-    TestHelper.deleteInstallationId(processEngineConfiguration);
+    TestHelper.deleteTelemetryProperty(processEngineConfiguration);
   }
 
   @Test

--- a/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentTelemetryConfigurationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentTelemetryConfigurationTest.java
@@ -72,7 +72,7 @@ public class ConcurrentTelemetryConfigurationTest extends ConcurrencyTestCase {
 
     assertNull(thread1.exception);
     assertNull(thread2.exception);
-    assertThat(managementService.isTelemetryEnabled()).isFalse();
+    assertThat(managementService.isTelemetryEnabled()).isNull();
   }
 
   protected static class ControllableUpdateTelemetrySetupCommand extends ControllableCommand<Void> {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/telemetry/TelemetryDefaultConfigTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/telemetry/TelemetryDefaultConfigTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.standalone.telemetry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.test.TestHelper;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineBootstrapRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class TelemetryDefaultConfigTest {
+
+  protected static final String TELEMETRY_ENDPOINT = "http://localhost:8082/pings";
+
+  @ClassRule
+  public static ProcessEngineBootstrapRule bootstrapRule =
+      new ProcessEngineBootstrapRule(configuration ->
+      configuration.setTelemetryEndpoint(TELEMETRY_ENDPOINT));
+
+  protected ProcessEngineRule engineRule = new ProvidedProcessEngineRule(bootstrapRule);
+
+  @Rule
+  public RuleChain ruleChain = RuleChain.outerRule(engineRule);
+
+  ProcessEngineConfigurationImpl configuration;
+
+  @Before
+  public void setup() {
+    configuration = engineRule.getProcessEngineConfiguration();
+    TestHelper.deleteTelemetryProperty(configuration);
+  }
+
+  @Test
+  public void shouldHaveEmptyInitilizeTelemetryByDefault() {
+    // given default configuration
+
+    // then
+    assertThat(configuration.isInitializeTelemetry()).isNull();
+    assertThat(configuration.getManagementService().isTelemetryEnabled()).isNull();
+  }
+
+}


### PR DESCRIPTION
* enabling to fetch null whether the telemetry is already configured or
not
* extend tests

Related to CAM-12377