### PR TITLE
fix(engine): change property setter to primitive

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -4736,7 +4736,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return initializeTelemetry;
   }
 
-  public ProcessEngineConfigurationImpl setInitializeTelemetry(Boolean telemetryInitialized) {
+  public ProcessEngineConfigurationImpl setInitializeTelemetry(boolean telemetryInitialized) {
     this.initializeTelemetry = telemetryInitialized;
     return this;
   }


### PR DESCRIPTION
as wrapper Boolean is not supported when parsing xml process engine
configuration

Related to CAM-12406