### PR TITLE
CAM-12115: refactor telemetry reporting

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/BootstrapEngineCommand.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/BootstrapEngineCommand.java
@@ -64,12 +64,12 @@ public class BootstrapEngineCommand implements ProcessEngineBootstrapCommand {
     if (Context.getProcessEngineConfiguration().getManagementService().getTableMetaData("ACT_RU_JOB") != null) {
       // CAM-9671: avoid transaction rollback due to the OLE being caught in CommandContext#close
       commandContext.getDbEntityManager().registerOptimisticLockingListener(new OptimisticLockingListener() {
-        
+
         @Override
         public Class<? extends DbEntity> getEntityType() {
           return EverLivingJobEntity.class;
         }
-        
+
         @Override
         public void failedOperation(DbOperation operation) {
           // nothing do to, reconfiguration will be handled later on
@@ -203,9 +203,14 @@ public class BootstrapEngineCommand implements ProcessEngineBootstrapCommand {
     if (Boolean.TRUE.equals(processEngineConfiguration.getManagementService().isTelemetryEnabled()) &&
         processEngineConfiguration.getTelemetryReporter() != null &&
         processEngineConfiguration.getTelemetryReporter().getHttpConnector() != null) {
-      processEngineConfiguration.getTelemetryReporter().start();
-      // set start report time
-      processEngineConfiguration.getTelemetryRegistry().setStartReportTime(ClockUtil.getCurrentTime());
+
+      try {
+        processEngineConfiguration.getTelemetryReporter().start();
+        // set start report time
+        processEngineConfiguration.getTelemetryRegistry().setStartReportTime(ClockUtil.getCurrentTime());
+      } catch (Exception e) {
+        ProcessEngineLogger.TELEMETRY_LOGGER.schedulingTaskFailsOnEngineStart(e);
+      }
     }
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -902,6 +902,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected TelemetryReporter telemetryReporter;
   /** http client used for sending telemetry */
   protected Connector<? extends ConnectorRequest<?>> telemetryHttpConnector;
+  /** default: once every 24 hours */
+  protected long telemetryReportingPeriod = 24 * 60 * 60;
   protected Data telemetryData;
 
 
@@ -2622,6 +2624,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         telemetryReporter = new TelemetryReporter(commandExecutorTxRequired,
                                                   telemetryEndpoint,
                                                   telemetryRequestRetries,
+                                                  telemetryReportingPeriod,
                                                   telemetryData,
                                                   telemetryHttpConnector,
                                                   telemetryRegistry);
@@ -4760,6 +4763,15 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public ProcessEngineConfigurationImpl setTelemetryRequestRetries(int telemetryRequestRetries) {
     this.telemetryRequestRetries = telemetryRequestRetries;
+    return this;
+  }
+
+  public long getTelemetryReportingPeriod() {
+    return telemetryReportingPeriod;
+  }
+
+  public ProcessEngineConfigurationImpl setTelemetryReportingPeriod(long telemetryReportingPeriod) {
+    this.telemetryReportingPeriod = telemetryReportingPeriod;
     return this;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -897,6 +897,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected Boolean initializeTelemetry = null;
   /** The endpoint which telemetry is sent to */
   protected String telemetryEndpoint = "https://api.telemetry.camunda.cloud/pings";
+  /** The number of times the telemetry request is retried in case it fails **/
+  protected int telemetryRequestRetries = 2;
   protected TelemetryReporter telemetryReporter;
   /** http client used for sending telemetry */
   protected Connector<? extends ConnectorRequest<?>> telemetryHttpConnector;
@@ -2619,8 +2621,10 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       if (telemetryReporter == null) {
         telemetryReporter = new TelemetryReporter(commandExecutorTxRequired,
                                                   telemetryEndpoint,
+                                                  telemetryRequestRetries,
                                                   telemetryData,
-                                                  telemetryHttpConnector);
+                                                  telemetryHttpConnector,
+                                                  telemetryRegistry);
       }
     }
   }
@@ -4747,6 +4751,15 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public ProcessEngineConfigurationImpl setTelemetryEndpoint(String telemetryEndpoint) {
     this.telemetryEndpoint = telemetryEndpoint;
+    return this;
+  }
+
+  public int getTelemetryRequestRetries() {
+    return telemetryRequestRetries;
+  }
+
+  public ProcessEngineConfigurationImpl setTelemetryRequestRetries(int telemetryRequestRetries) {
+    this.telemetryRequestRetries = telemetryRequestRetries;
     return this;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/CommandCounter.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/CommandCounter.java
@@ -40,6 +40,13 @@ public class CommandCounter {
     count.incrementAndGet();
   }
 
+  public void mark(long times) {
+    count.addAndGet(times);
+  }
+
+  public long getAndClear() {
+    return count.getAndSet(0);
+  }
 
   public long get() {
     return count.get();

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryLogger.java
@@ -70,9 +70,20 @@ public class TelemetryLogger extends ProcessEngineLogger {
         "009", "Sending telemetry is disabled.");
   }
 
-  public void schedulingTaskFails(String message) {
+  public ProcessEngineException schedulingTaskFails(Exception e) {
+    return new ProcessEngineException(
+        exceptionMessage("010", "Cannot schedule the telemetry task."), e);
+  }
+
+  public void schedulingTaskFailsOnEngineStart(Exception e) {
+    logWarn("013",
+        "Could not start telemetry task. Reason: {} with message '{}'. Set this logger to DEBUG/FINE for the full stacktrace.",
+        e.getClass().getSimpleName(),
+        e.getMessage());
     logDebug(
-        "010", "An exception occured during scheduling telemetry task: {}", message);
+        "014", "{} occurred while starting the telemetry task.",
+        e.getClass().getCanonicalName(),
+        e);
   }
 
   public void unableToConfigureHttpConnectorWarning() {
@@ -86,7 +97,6 @@ public class TelemetryLogger extends ProcessEngineLogger {
         e.getClass().getCanonicalName(),
         e.getMessage());
   }
-
 
   public void unexpectedResponseSuccessCode(int statusCode) {
     logDebug(

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryLogger.java
@@ -39,7 +39,7 @@ public class TelemetryLogger extends ProcessEngineLogger {
 
   public ProcessEngineException unexpectedResponseWhileSendingTelemetryData(int responseCode) {
     return new ProcessEngineException(
-      exceptionMessage("013", "Unexpected response code {} when sending telemetry data", responseCode));
+      exceptionMessage("004", "Unexpected response code {} when sending telemetry data", responseCode));
   }
 
   public void unexpectedResponseWhileSendingTelemetryData() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryLogger.java
@@ -16,6 +16,7 @@
  */
 package org.camunda.bpm.engine.impl.telemetry;
 
+import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 
 public class TelemetryLogger extends ProcessEngineLogger {
@@ -26,59 +27,75 @@ public class TelemetryLogger extends ProcessEngineLogger {
   }
 
   public void exceptionWhileSendingTelemetryData(Exception e) {
-    logDebug(
-        "002", "'{}' exception occurred while sending telemetry data with message: {}", 
-        e.getClass().getCanonicalName(),
+    logWarn("002",
+        "Could not send telemetry data. Reason: {} with message '{}'. Set this logger to DEBUG/FINE for the full stacktrace.",
+        e.getClass().getSimpleName(),
         e.getMessage());
+    logDebug(
+        "003", "{} occurred while sending telemetry data.",
+        e.getClass().getCanonicalName(),
+        e);
   }
 
-  public void unexpectedResponseWhileSendingTelemetryData(int responseCode) {
-    logDebug(
-        "003", "Unexpected response while sending telemetry data. Status code: {}", responseCode);
+  public ProcessEngineException unexpectedResponseWhileSendingTelemetryData(int responseCode) {
+    return new ProcessEngineException(
+      exceptionMessage("013", "Unexpected response code {} when sending telemetry data", responseCode));
   }
 
   public void unexpectedResponseWhileSendingTelemetryData() {
     logDebug(
-        "004", "Unexpected 'null' response while sending telemetry data.");
+        "005", "Unexpected 'null' response while sending telemetry data.");
   }
 
-  public void telemetryDataSent(String data) {
+  public void sendingTelemetryData(String data) {
     logDebug(
-        "005", "Telemetry data sent: {}", data);
+        "006", "Sending telemetry data: {}", data);
   }
 
   public void databaseTelemetryPropertyMissingInfo(boolean telemetryEnabled) {
     logInfo(
-        "006",
+        "007",
         "`camunda.telemetry.enabled` property is missing in the database, creating the property with value: {}",
         Boolean.toString(telemetryEnabled));
   }
 
   public void databaseTelemetryPropertyMissingInfo() {
     logInfo(
-        "007",
+        "008",
         "`camunda.telemetry.enabled` property is missing in the database");
   }
 
   public void telemetryDisabled() {
     logDebug(
-        "008", "Sending telemetry is disabled.");
+        "009", "Sending telemetry is disabled.");
   }
 
   public void schedulingTaskFails(String message) {
     logDebug(
-        "009", "An exception occured during scheduling telemetry task: {}", message);
+        "010", "An exception occured during scheduling telemetry task: {}", message);
   }
 
   public void unableToConfigureHttpConnectorWarning() {
     logWarn(
-        "010","The http connector used to send telemetry is `null`, telemetry data will not be sent.");
+        "011","The http connector used to send telemetry is `null`, telemetry data will not be sent.");
   }
 
   public void unexpectedExceptionDuringHttpConnectorConfiguration(Exception e) {
     logDebug(
-        "011", "'{}' exception occurred while configuring http connector with message: {}", 
+        "012", "'{}' exception occurred while configuring http connector with message: {}",
         e.getClass().getCanonicalName(),
         e.getMessage());
+  }
+
+
+  public void unexpectedResponseSuccessCode(int statusCode) {
+    logDebug(
+        "015", "Telemetry request was sent, but received an unexpected response success code: {}", statusCode);
+  }
+
+
+  public void telemetrySentSuccessfully() {
+    logDebug(
+        "016", "Telemetry request was successful.");
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryRegistry.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryRegistry.java
@@ -58,6 +58,10 @@ public class TelemetryRegistry {
   }
 
   public void markOccurrence(String name) {
+    markOccurrence(name, 1);
+  }
+
+  public void markOccurrence(String name, long times) {
     CommandCounter counter = commands.get(name);
     if (counter == null) {
       synchronized (commands) {
@@ -68,7 +72,11 @@ public class TelemetryRegistry {
       }
     }
 
-    counter.mark();
+    counter.mark(times);
+  }
+
+  public void clear() {
+    commands.clear();
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/dto/Data.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/dto/Data.java
@@ -24,9 +24,12 @@ public class Data {
   protected Product product;
 
   public Data(String installation, Product product) {
-    super();
     this.installation = installation;
     this.product = product;
+  }
+
+  public Data(Data other) {
+    this(other.installation, new Product(other.product));
   }
 
   public String getInstallation() {
@@ -43,6 +46,10 @@ public class Data {
 
   public void setProduct(Product product) {
     this.product = product;
+  }
+
+  public void mergeInternals(Internals other) {
+    product.getInternals().mergeDynamicData(other);
   }
 
   @Override

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/dto/Internals.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/dto/Internals.java
@@ -32,11 +32,20 @@ public class Internals {
 
   protected Map<String, Metric> metrics;
 
+  public Internals() {
+    this(null, null);
+  }
+
   public Internals(Database database, ApplicationServer server) {
-    super();
     this.database = database;
     this.applicationServer = server;
     this.commands = new HashMap<>();
+  }
+
+  public Internals(Internals internals) {
+    this(internals.database, internals.applicationServer);
+    this.commands = internals.getCommands();
+    this.metrics = internals.getMetrics();
   }
 
   public Database getDatabase() {
@@ -69,6 +78,11 @@ public class Internals {
 
   public void setMetrics(Map<String, Metric> metrics) {
     this.metrics = metrics;
+  }
+
+  public void mergeDynamicData(Internals other) {
+    this.commands = other.commands;
+    this.metrics = other.metrics;
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/dto/Product.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/dto/Product.java
@@ -31,6 +31,10 @@ public class Product {
     this.internals = internals;
   }
 
+  public Product(Product other) {
+    this(other.name, other.version, other.edition, new Internals(other.internals));
+  }
+
   public String getName() {
     return name;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/reporter/TelemetryReporter.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/reporter/TelemetryReporter.java
@@ -30,8 +30,7 @@ public class TelemetryReporter {
 
   protected static final TelemetryLogger LOG = ProcessEngineLogger.TELEMETRY_LOGGER;
 
-  // send report every 24 hours
-  protected long reportingIntervalInSeconds = 24 * 60 * 60;
+  protected long reportingIntervalInSeconds;
   /**
    * Report after 5 minutes the first time so that we get an initial ping
    * quickly. 5 minutes delay so that other modules (e.g. those collecting the app
@@ -54,12 +53,14 @@ public class TelemetryReporter {
   public TelemetryReporter(CommandExecutor commandExecutor,
                            String telemetryEndpoint,
                            int telemetryRequestRetries,
+                           long telemetryReportingPeriod,
                            Data data,
                            Connector<? extends ConnectorRequest<?>> httpConnector,
                            TelemetryRegistry telemetryRegistry) {
     this.commandExecutor = commandExecutor;
     this.telemetryEndpoint = telemetryEndpoint;
     this.telemetryRequestRetries = telemetryRequestRetries;
+    this.reportingIntervalInSeconds = telemetryReportingPeriod;
     this.data = data;
     this.httpConnector = httpConnector;
     this.telemetryRegistry = telemetryRegistry;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/reporter/TelemetryReporter.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/reporter/TelemetryReporter.java
@@ -21,6 +21,7 @@ import java.util.Timer;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 import org.camunda.bpm.engine.impl.telemetry.TelemetryLogger;
+import org.camunda.bpm.engine.impl.telemetry.TelemetryRegistry;
 import org.camunda.bpm.engine.impl.telemetry.dto.Data;
 import org.camunda.connect.spi.Connector;
 import org.camunda.connect.spi.ConnectorRequest;
@@ -37,27 +38,35 @@ public class TelemetryReporter {
 
   protected CommandExecutor commandExecutor;
   protected String telemetryEndpoint;
+  protected int telemetryRequestRetries;
   protected Data data;
   protected Connector<? extends ConnectorRequest<?>> httpConnector;
+  protected TelemetryRegistry telemetryRegistry;
 
   protected boolean stopped;
 
   public TelemetryReporter(CommandExecutor commandExecutor,
                            String telemetryEndpoint,
+                           int telemetryRequestRetries,
                            Data data,
-                           Connector<? extends ConnectorRequest<?>> httpConnector) {
+                           Connector<? extends ConnectorRequest<?>> httpConnector,
+                           TelemetryRegistry telemetryRegistry) {
     this.commandExecutor = commandExecutor;
     this.telemetryEndpoint = telemetryEndpoint;
+    this.telemetryRequestRetries = telemetryRequestRetries;
     this.data = data;
     this.httpConnector = httpConnector;
+    this.telemetryRegistry = telemetryRegistry;
     initTelemetrySendingTask();
   }
 
   protected void initTelemetrySendingTask() {
     telemetrySendingTask = new TelemetrySendingTask(commandExecutor,
                                                     telemetryEndpoint,
+                                                    telemetryRequestRetries,
                                                     data,
-                                                    httpConnector);
+                                                    httpConnector,
+                                                    telemetryRegistry);
   }
 
   public synchronized void start() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/reporter/TelemetryReporter.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/reporter/TelemetryReporter.java
@@ -32,6 +32,12 @@ public class TelemetryReporter {
 
   // send report every 24 hours
   protected long reportingIntervalInSeconds = 24 * 60 * 60;
+  /**
+   * Report after 5 minutes the first time so that we get an initial ping
+   * quickly. 5 minutes delay so that other modules (e.g. those collecting the app
+   * server name) can contribute their data.
+   */
+  protected long initialReportingDelayInSeconds = 5 * 60;
 
   protected TelemetrySendingTask telemetrySendingTask;
   protected Timer timer;
@@ -77,11 +83,12 @@ public class TelemetryReporter {
     if (timer == null) { // initialize timer if only the the timer is not scheduled yet
       timer = new Timer("Camunda BPM Runtime Telemetry Reporter", true);
       long reportingIntervalInMillis =  reportingIntervalInSeconds * 1000;
+      long initialReportingDelay = initialReportingDelayInSeconds * 1000;
 
       try {
-        timer.scheduleAtFixedRate(telemetrySendingTask, reportingIntervalInMillis, reportingIntervalInMillis);
+        timer.scheduleAtFixedRate(telemetrySendingTask, initialReportingDelay, reportingIntervalInMillis);
       } catch (Exception e) {
-        LOG.schedulingTaskFails(e.getMessage());
+        throw LOG.schedulingTaskFails(e);
       }
     }
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryReporterTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryReporterTest.java
@@ -173,6 +173,7 @@ public class TelemetryReporterTest {
     TelemetryReporter telemetryReporter = new TelemetryReporter(configuration.getCommandExecutorTxRequired(),
                                                                 TELEMETRY_ENDPOINT,
                                                                 0,
+                                                                1000,
                                                                 data,
                                                                 configuration.getTelemetryHttpConnector(),
                                                                 configuration.getTelemetryRegistry());
@@ -514,6 +515,7 @@ public class TelemetryReporterTest {
     TelemetryReporter telemetryReporter = new TelemetryReporter(configuration.getCommandExecutorTxRequired(),
                                                                 TELEMETRY_ENDPOINT,
                                                                 0,
+                                                                1000,
                                                                 data,
                                                                 null,
                                                                 configuration.getTelemetryRegistry());

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/telemetry/TelemetryTaskWorkerMetricsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/telemetry/TelemetryTaskWorkerMetricsTest.java
@@ -60,6 +60,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.gson.Gson;
@@ -143,13 +144,14 @@ public class TelemetryTaskWorkerMetricsTest {
     new TelemetryReporter(configuration.getCommandExecutorSchemaOperations(),
                           TELEMETRY_ENDPOINT,
                           0,
+                          1000,
                           data,
                           configuration.getTelemetryHttpConnector(),
                           configuration.getTelemetryRegistry()).reportNow();
 
     // then
     verify(postRequestedFor(urlEqualTo(TELEMETRY_ENDPOINT_PATH))
-        .withRequestBody(equalToJson(requestBody))
+        .withRequestBody(equalToJson(requestBody, JSONCompareMode.LENIENT))
         .withHeader("Content-Type",  equalTo("application/json")));
     Map<String, Metric> metrics = configuration.getTelemetryData().getProduct().getInternals().getMetrics();
     assertThat(metrics.get(UNIQUE_TASK_WORKERS).getCount()).isEqualTo(0);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/telemetry/TelemetryTaskWorkerMetricsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/telemetry/TelemetryTaskWorkerMetricsTest.java
@@ -142,8 +142,10 @@ public class TelemetryTaskWorkerMetricsTest {
     // when
     new TelemetryReporter(configuration.getCommandExecutorSchemaOperations(),
                           TELEMETRY_ENDPOINT,
+                          0,
                           data,
-                          configuration.getTelemetryHttpConnector()).reportNow();
+                          configuration.getTelemetryHttpConnector(),
+                          configuration.getTelemetryRegistry()).reportNow();
 
     // then
     verify(postRequestedFor(urlEqualTo(TELEMETRY_ENDPOINT_PATH))


### PR DESCRIPTION
- implements retries for sending the telemetry
- retries are configurable in the engine configuration
- lets the toggling of the telemetry fail if the timer for reporting cannot be scheduled
- makes the reporting period configurable via engine configuration and makes the first telemetry request after five minutes

related to CAM-12115