### PR TITLE
chore(engine+rest): add license key to telemetry

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/util/WebApplicationUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/util/WebApplicationUtil.java
@@ -18,9 +18,6 @@ package org.camunda.bpm.engine.rest.util;
 
 import static org.camunda.bpm.engine.rest.util.EngineUtil.getProcessEngineProvider;
 
-import java.util.function.Consumer;
-import java.util.function.Function;
-
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.impl.telemetry.TelemetryRegistry;
@@ -31,22 +28,24 @@ public class WebApplicationUtil {
 
   public static void setApplicationServer(String serverInfo) {
     if (serverInfo != null && !serverInfo.isEmpty() ) {
-      addToTelemetryRegistry(t -> t.setApplicationServer(serverInfo), t -> t.getApplicationServer() == null);
+      ProcessEngineProvider processEngineProvider = getProcessEngineProvider();
+      for (String engineName : processEngineProvider.getProcessEngineNames()) {
+        TelemetryRegistry telemetryRegistry = getTelemetryRegistry(processEngineProvider, engineName);
+        if (telemetryRegistry != null && telemetryRegistry.getApplicationServer() == null) {
+            telemetryRegistry.setApplicationServer(serverInfo);
+        }
+      }
     }
   }
 
   public static void setLicenseKey(LicenseKeyData licenseKeyData) {
     if (licenseKeyData != null) {
-      addToTelemetryRegistry(t -> t.setLicenseKey(licenseKeyData), t -> true);
-    }
-  }
-
-  protected static void addToTelemetryRegistry(Consumer<TelemetryRegistry> addTelemetryData, Function<TelemetryRegistry, Boolean> addTelemetryDataFilter) {
-    ProcessEngineProvider processEngineProvider = getProcessEngineProvider();
-    for (String engineName : processEngineProvider.getProcessEngineNames()) {
-      TelemetryRegistry telemetryRegistry = getTelemetryRegistry(processEngineProvider, engineName);
-      if (telemetryRegistry != null && addTelemetryDataFilter.apply(telemetryRegistry)) {
-          addTelemetryData.accept(telemetryRegistry);
+      ProcessEngineProvider processEngineProvider = getProcessEngineProvider();
+      for (String engineName : processEngineProvider.getProcessEngineNames()) {
+        TelemetryRegistry telemetryRegistry = getTelemetryRegistry(processEngineProvider, engineName);
+        if (telemetryRegistry != null) {
+            telemetryRegistry.setLicenseKey(licenseKeyData);;
+        }
       }
     }
   }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/util/WebApplicationUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/util/WebApplicationUtil.java
@@ -18,28 +18,42 @@ package org.camunda.bpm.engine.rest.util;
 
 import static org.camunda.bpm.engine.rest.util.EngineUtil.getProcessEngineProvider;
 
-import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.impl.telemetry.TelemetryRegistry;
+import org.camunda.bpm.engine.impl.telemetry.dto.LicenseKeyData;
 import org.camunda.bpm.engine.rest.spi.ProcessEngineProvider;
 
 public class WebApplicationUtil {
 
   public static void setApplicationServer(String serverInfo) {
     if (serverInfo != null && !serverInfo.isEmpty() ) {
-      ProcessEngineProvider processEngineProvider = getProcessEngineProvider();
-      Set<String> processEngineNames = processEngineProvider.getProcessEngineNames();
+      addToTelemetryRegistry(t -> t.setApplicationServer(serverInfo), t -> t.getApplicationServer() == null);
+    }
+  }
 
-      for (String engineName : processEngineNames) {
-        ProcessEngine processEngine = processEngineProvider.getProcessEngine(engineName);
-        ProcessEngineConfiguration configuration = processEngine.getProcessEngineConfiguration();
-        TelemetryRegistry telemetryRegistry = configuration.getTelemetryRegistry();
-        if (telemetryRegistry != null && telemetryRegistry.getApplicationServer() == null) {
-            telemetryRegistry.setApplicationServer(serverInfo);
-        }
+  public static void setLicenseKey(LicenseKeyData licenseKeyData) {
+    if (licenseKeyData != null) {
+      addToTelemetryRegistry(t -> t.setLicenseKey(licenseKeyData), t -> true);
+    }
+  }
+
+  protected static void addToTelemetryRegistry(Consumer<TelemetryRegistry> addTelemetryData, Function<TelemetryRegistry, Boolean> addTelemetryDataFilter) {
+    ProcessEngineProvider processEngineProvider = getProcessEngineProvider();
+    for (String engineName : processEngineProvider.getProcessEngineNames()) {
+      TelemetryRegistry telemetryRegistry = getTelemetryRegistry(processEngineProvider, engineName);
+      if (telemetryRegistry != null && addTelemetryDataFilter.apply(telemetryRegistry)) {
+          addTelemetryData.accept(telemetryRegistry);
       }
     }
+  }
+
+  protected static TelemetryRegistry getTelemetryRegistry(ProcessEngineProvider processEngineProvider, String engineName) {
+    ProcessEngine processEngine = processEngineProvider.getProcessEngine(engineName);
+    ProcessEngineConfiguration configuration = processEngine.getProcessEngineConfiguration();
+    return configuration.getTelemetryRegistry();
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -2665,7 +2665,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     Jdk jdk = ParseUtil.parseJdkDetails();
 
-    Internals internals = new Internals(database, telemetryRegistry.getApplicationServer(), jdk);
+    Internals internals = new Internals(database, telemetryRegistry.getApplicationServer(), telemetryRegistry.getLicenseKey(), jdk);
 
     String camundaIntegration = telemetryRegistry.getCamundaIntegration();
     if (camundaIntegration != null && !camundaIntegration.isEmpty()) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteLicenseKeyCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteLicenseKeyCmd.java
@@ -27,11 +27,17 @@ import org.camunda.bpm.engine.impl.persistence.entity.ResourceManager;
 public class DeleteLicenseKeyCmd extends LicenseCmd implements Command<Object> {
 
   boolean deleteProperty;
-  
+  boolean updateTelemetry;
+
   public DeleteLicenseKeyCmd(boolean deleteProperty) {
-    this.deleteProperty = deleteProperty;
+    this(deleteProperty, true);
   }
-  
+
+  public DeleteLicenseKeyCmd(boolean deleteProperty, boolean updateTelemetry) {
+    this.deleteProperty = deleteProperty;
+    this.updateTelemetry = updateTelemetry;
+  }
+
   @Override
   public Object execute(CommandContext commandContext) {
     AuthorizationManager authorizationManager = commandContext.getAuthorizationManager();
@@ -39,7 +45,7 @@ public class DeleteLicenseKeyCmd extends LicenseCmd implements Command<Object> {
 
     final ResourceManager resourceManager = commandContext.getResourceManager();
     final PropertyManager propertyManager = commandContext.getPropertyManager();
-    
+
     // lock the property
     @SuppressWarnings("unused")
     PropertyEntity licenseProperty = propertyManager.findPropertyById(LICENSE_KEY_BYTE_ARRAY_ID);
@@ -56,6 +62,10 @@ public class DeleteLicenseKeyCmd extends LicenseCmd implements Command<Object> {
     if(deleteProperty) {
       // delete license key byte array id
       new DeletePropertyCmd(LICENSE_KEY_BYTE_ARRAY_ID).execute(commandContext);
+    }
+
+    if (updateTelemetry) {
+      commandContext.getProcessEngineConfiguration().getTelemetryRegistry().setLicenseKey(null);
     }
 
     return null;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SetLicenseKeyCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SetLicenseKeyCmd.java
@@ -16,14 +16,14 @@
  */
 package org.camunda.bpm.engine.impl.cmd;
 
+import static org.camunda.bpm.engine.impl.util.LicenseKeyUtil.addToTelemetry;
+
 import java.nio.charset.StandardCharsets;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.persistence.entity.AuthorizationManager;
 import org.camunda.bpm.engine.impl.persistence.entity.ResourceEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.ResourceManager;
-import org.camunda.bpm.engine.impl.telemetry.TelemetryRegistry;
-import org.camunda.bpm.engine.impl.telemetry.dto.LicenseKeyData;
 import org.camunda.bpm.engine.impl.util.EnsureUtil;
 
 public class SetLicenseKeyCmd extends LicenseCmd implements Command<Object> {
@@ -59,18 +59,8 @@ public class SetLicenseKeyCmd extends LicenseCmd implements Command<Object> {
     new DeletePropertyCmd(LICENSE_KEY_PROPERTY_NAME).execute(commandContext);
 
     // add raw license to telemetry data if not there already
-    addToTelemetry(licenseKey, commandContext);
+    addToTelemetry(licenseKey, commandContext.getProcessEngineConfiguration().getTelemetryRegistry());
 
     return null;
-  }
-
-  protected void addToTelemetry(String licenseKey, CommandContext context) {
-    TelemetryRegistry telemetryRegistry = context.getProcessEngineConfiguration().getTelemetryRegistry();
-    LicenseKeyData currentLicenseData = telemetryRegistry.getLicenseKey();
-    // only report license body without signature, if present
-    String newLicenseData = licenseKey.contains(";") ? licenseKey.split(";", 2)[1] : licenseKey;
-    if (currentLicenseData == null || !newLicenseData.equals(currentLicenseData.getRaw())) {
-      telemetryRegistry.setLicenseKey(new LicenseKeyData(null, null, null, null, null, newLicenseData));
-    }
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryRegistry.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryRegistry.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.camunda.bpm.engine.impl.telemetry.dto.ApplicationServer;
+import org.camunda.bpm.engine.impl.telemetry.dto.LicenseKeyData;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 
 public class TelemetryRegistry {
@@ -30,6 +31,7 @@ public class TelemetryRegistry {
   protected Map<String, CommandCounter> commands = new HashMap<>();
   protected ApplicationServer applicationServer;
   protected Date startReportTime = ClockUtil.getCurrentTime();
+  protected LicenseKeyData licenseKey;
   protected String camundaIntegration;
 
   public synchronized ApplicationServer getApplicationServer() {
@@ -64,6 +66,14 @@ public class TelemetryRegistry {
     this.camundaIntegration = camundaIntegration;
   }
 
+  public LicenseKeyData getLicenseKey() {
+    return licenseKey;
+  }
+
+  public void setLicenseKey(LicenseKeyData licenseKey) {
+    this.licenseKey = licenseKey;
+  }
+
   public void markOccurrence(String name) {
     markOccurrence(name, 1);
   }
@@ -84,6 +94,8 @@ public class TelemetryRegistry {
 
   public void clear() {
     commands.clear();
+    licenseKey = null;
+    applicationServer = null;
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/dto/Internals.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/dto/Internals.java
@@ -27,10 +27,12 @@ public class Internals {
 
   public static final String SERIALIZED_APPLICATION_SERVER = "application-server";
   public static final String SERIALIZED_CAMUNDA_INTEGRATION = "camunda-integration";
+  public static final String SERIALIZED_LICENSE_KEY = "license-key";
 
   protected Database database;
   @SerializedName(value = SERIALIZED_APPLICATION_SERVER)
   protected ApplicationServer applicationServer;
+  @SerializedName(value = SERIALIZED_LICENSE_KEY)
   protected LicenseKeyData licenseKey;
   protected Map<String, Command> commands;
   @SerializedName(value = SERIALIZED_CAMUNDA_INTEGRATION)

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/dto/Internals.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/dto/Internals.java
@@ -31,6 +31,7 @@ public class Internals {
   protected Database database;
   @SerializedName(value = SERIALIZED_APPLICATION_SERVER)
   protected ApplicationServer applicationServer;
+  protected LicenseKeyData licenseKey;
   protected Map<String, Command> commands;
   @SerializedName(value = SERIALIZED_CAMUNDA_INTEGRATION)
   protected Set<String> camundaIntegration;
@@ -40,21 +41,22 @@ public class Internals {
   protected Jdk jdk;
 
   public Internals() {
-    this(null, null, null);
+    this(null, null, null, null);
   }
 
-  public Internals(Database database, ApplicationServer server, Jdk jdk) {
+  public Internals(Database database, ApplicationServer server, LicenseKeyData licenseKey, Jdk jdk) {
     this.database = database;
     this.applicationServer = server;
+    this.licenseKey = licenseKey;
     this.commands = new HashMap<>();
     this.jdk = jdk;
     this.camundaIntegration = new HashSet<>();
   }
 
   public Internals(Internals internals) {
-    this(internals.database, internals.applicationServer, internals.jdk);
-    this.commands = internals.getCommands();
-    this.metrics = internals.getMetrics();
+    this(internals.database, internals.applicationServer, internals.licenseKey, internals.jdk);
+    this.commands = new HashMap<>(internals.getCommands());
+    this.metrics = internals.metrics == null ? null : new HashMap<>(internals.getMetrics());
   }
 
   public Database getDatabase() {
@@ -108,6 +110,14 @@ public class Internals {
 
   public void setCamundaIntegration(Set<String> camundaIntegration) {
     this.camundaIntegration = camundaIntegration;
+  }
+
+  public LicenseKeyData getLicenseKey() {
+    return licenseKey;
+  }
+
+  public void setLicenseKey(LicenseKeyData licenseKey) {
+    this.licenseKey = licenseKey;
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/dto/LicenseKeyData.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/dto/LicenseKeyData.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.telemetry.dto;
+
+import java.util.Map;
+
+public class LicenseKeyData {
+
+  protected String customer;
+  protected String type;
+  protected String validUntil;
+  protected Boolean isUnlimited;
+  protected Map<String, String> features;
+  protected String raw;
+
+  public LicenseKeyData(String customer, String type, String validUntil, Boolean isUnlimited, Map<String, String> features, String raw) {
+    this.customer = customer;
+    this.type = type;
+    this.validUntil = validUntil;
+    this.isUnlimited = isUnlimited;
+    this.features = features;
+    this.raw = raw;
+  }
+
+  public String getCustomer() {
+    return customer;
+  }
+
+  public void setCustomer(String customer) {
+    this.customer = customer;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public String getValidUntil() {
+    return validUntil;
+  }
+
+  public void setValidUntil(String validUntil) {
+    this.validUntil = validUntil;
+  }
+
+  public Boolean isUnlimited() {
+    return isUnlimited;
+  }
+
+  public void setUnlimited(Boolean isUnlimited) {
+    this.isUnlimited = isUnlimited;
+  }
+
+  public Map<String, String> getFeatures() {
+    return features;
+  }
+
+  public void setFeatures(Map<String, String> features) {
+    this.features = features;
+  }
+
+  public String getRaw() {
+    return raw;
+  }
+
+  public void setRaw(String raw) {
+    this.raw = raw;
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/dto/LicenseKeyData.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/dto/LicenseKeyData.java
@@ -18,11 +18,18 @@ package org.camunda.bpm.engine.impl.telemetry.dto;
 
 import java.util.Map;
 
+import com.google.gson.annotations.SerializedName;
+
 public class LicenseKeyData {
+
+  public static final String SERIALIZED_VALID_UNTIL = "valid-until";
+  public static final String SERIALIZED_IS_UNLIMITED = "unlimited";
 
   protected String customer;
   protected String type;
+  @SerializedName(value = SERIALIZED_VALID_UNTIL)
   protected String validUntil;
+  @SerializedName(value = SERIALIZED_IS_UNLIMITED)
   protected Boolean isUnlimited;
   protected Map<String, String> features;
   protected String raw;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/reporter/TelemetrySendingTask.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/reporter/TelemetrySendingTask.java
@@ -123,6 +123,10 @@ public class TelemetrySendingTask extends TimerTask {
       ApplicationServer applicationServer = telemetryRegistry.getApplicationServer();
       internals.setApplicationServer(applicationServer);
     }
+
+    // license key data is fed from the outside to the registry but needs to be constantly updated
+    internals.setLicenseKey(telemetryRegistry.getLicenseKey());
+
   }
 
   protected boolean isTelemetryEnabled() {
@@ -175,6 +179,7 @@ public class TelemetrySendingTask extends TimerTask {
     internals.setApplicationServer(null);
     internals.setCommands(null);
     internals.setMetrics(null);
+    internals.setLicenseKey(null);
   }
 
   protected void restoreDynamicData(Internals internals) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/LicenseKeyUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/LicenseKeyUtil.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.util;
+
+import org.camunda.bpm.engine.impl.telemetry.TelemetryRegistry;
+import org.camunda.bpm.engine.impl.telemetry.dto.LicenseKeyData;
+
+public class LicenseKeyUtil {
+
+  public static void addToTelemetry(String licenseKey, TelemetryRegistry telemetryRegistry) {
+    LicenseKeyData currentLicenseData = telemetryRegistry.getLicenseKey();
+    // only report license body without signature, if present
+    LicenseKeyData newLicenseData = getLicenseKeyData(licenseKey);
+    if (currentLicenseData == null || !newLicenseData.getRaw().equals(currentLicenseData.getRaw())) {
+      telemetryRegistry.setLicenseKey(newLicenseData);
+    }
+  }
+
+  public static LicenseKeyData getLicenseKeyData(String licenseKey) {
+    String newLicenseData = licenseKey.contains(";") ? licenseKey.split(";", 2)[1] : licenseKey;
+    return new LicenseKeyData(null, null, null, null, null, newLicenseData);
+  }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/license/LicenseKeyTelemetryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/license/LicenseKeyTelemetryTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.api.mgmt.license;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.engine.ManagementService;
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.telemetry.TelemetryRegistry;
+import org.camunda.bpm.engine.impl.telemetry.dto.LicenseKeyData;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
+
+public class LicenseKeyTelemetryTest {
+
+  public ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule();
+  public ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
+  public ExpectedException exceptionRule = ExpectedException.none();
+
+  @Rule
+  public RuleChain ruleChain = RuleChain.outerRule(testRule).around(engineRule).around(exceptionRule);
+
+  ProcessEngine processEngine;
+  ProcessEngineConfigurationImpl processEngineConfiguration;
+  ManagementService managementService;
+  TelemetryRegistry telemetryRegistry;
+
+  @Before
+  public void init() {
+    processEngine = engineRule.getProcessEngine();
+    processEngineConfiguration = (ProcessEngineConfigurationImpl) processEngine.getProcessEngineConfiguration();
+    managementService = processEngine.getManagementService();
+    telemetryRegistry = processEngineConfiguration.getTelemetryRegistry();
+  }
+
+  @After
+  public void tearDown() {
+    managementService.deleteLicenseKey();
+    telemetryRegistry.clear();
+  }
+
+  @Test
+  public void shouldSetLicenseKeyInTelemetryRegistry() {
+    // given
+    String licenseKey = "testLicenseKey";
+
+    // when
+    managementService.setLicenseKey(licenseKey);
+
+    // then
+    assertThat(telemetryRegistry.getLicenseKey().getRaw()).isEqualTo(licenseKey);
+  }
+
+  @Test
+  public void shouldNotOverrideSameLicenseKeyInTelemetryRegistry() {
+    // given
+    String licenseKey = "testLicenseKey";
+    LicenseKeyData licenseKeyData = new LicenseKeyData("customer", null, null, null, null, licenseKey);
+    telemetryRegistry.setLicenseKey(licenseKeyData);
+
+    // when
+    managementService.setLicenseKey(licenseKey);
+
+    // then
+    assertThat(telemetryRegistry.getLicenseKey()).isEqualTo(licenseKeyData);
+  }
+
+  @Test
+  public void shouldNotOverrideSameMultipartLicenseKeyInTelemetryRegistry() {
+    // given
+    String licenseKey = "signature;testLicenseKey;more;data";
+    LicenseKeyData licenseKeyData = new LicenseKeyData("customer", null, null, null, null, "testLicenseKey;more;data");
+    telemetryRegistry.setLicenseKey(licenseKeyData);
+
+    // when
+    managementService.setLicenseKey(licenseKey);
+
+    // then
+    assertThat(telemetryRegistry.getLicenseKey()).isEqualTo(licenseKeyData);
+  }
+
+  @Test
+  public void shouldRemoveLicenseKeyFromTelemetryRegistry() {
+    // given
+    LicenseKeyData licenseKeyData = new LicenseKeyData("customer", null, null, null, null, "testLicenseKey");
+    telemetryRegistry.setLicenseKey(licenseKeyData);
+
+    // when
+    managementService.deleteLicenseKey();
+
+    // then
+    assertThat(telemetryRegistry.getLicenseKey()).isNull();
+  }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/ProcessEngineDetailsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/ProcessEngineDetailsTest.java
@@ -21,35 +21,10 @@ import static org.camunda.bpm.engine.impl.util.ParseUtil.parseProcessEngineVersi
 import static org.camunda.bpm.engine.impl.util.ProcessEngineDetails.EDITION_COMMUNITY;
 import static org.camunda.bpm.engine.impl.util.ProcessEngineDetails.EDITION_ENTERPRISE;
 
-import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.util.ProcessEngineDetails;
-import org.camunda.bpm.engine.test.ProcessEngineRule;
-import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
-import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 public class ProcessEngineDetailsTest {
-
-  protected ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
-  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
-
-  ProcessEngineConfigurationImpl configuration;
-
-  @Before
-  public void init() {
-    configuration = engineRule.getProcessEngineConfiguration();
-  }
-
-  @After
-  public void tearDown() {
-  }
 
   // process engine version and edition ////////////////////////////////////////////////////////////
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryRegistryCounterTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryRegistryCounterTest.java
@@ -78,13 +78,14 @@ public class TelemetryRegistryCounterTest {
     // then
     TelemetryRegistry telemetryRegistry = processEngineInMem.getProcessEngineConfiguration().getTelemetryRegistry();
     Map<String, CommandCounter> entries = telemetryRegistry.getCommands();
-    assertThat(entries.size()).isEqualTo(5);
+    assertThat(entries.size()).isEqualTo(6);
     assertThat(entries.keySet()).containsExactlyInAnyOrder(
         "SchemaOperationsProcessEngineBuild",
         "HistoryLevelSetupCommand",
         "GetTableMetaDataCmd",
         "HistoryCleanupCmd",
-        "BootstrapEngineCommand");
+        "BootstrapEngineCommand",
+        "GetLicenseKeyCmd");
     for (String commandName : entries.keySet()) {
       assertThat(entries.get(commandName).get()).isEqualTo(1);
     }


### PR DESCRIPTION
* adds utility function in REST API to add license key data to telemetry
* adds license key data object in telemetry
* handles setting and deleting license keys via ManagementService with
  regards to telemetry data

related to CAM-12379