### PR TITLE
CAM-12421: chore(engine): add telemetry request timeout configuration

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -941,6 +941,10 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   /** default: once every 24 hours */
   protected long telemetryReportingPeriod = 24 * 60 * 60;
   protected Data telemetryData;
+  /** the connection and socket timeout configuration of the telemetry request
+   * in milliseconds
+   *  default: 15 seconds */
+  protected int telemetryRequestTimeout = 15 * 1000;
 
 
   // buildProcessEngine ///////////////////////////////////////////////////////
@@ -2664,7 +2668,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
                                                   telemetryData,
                                                   telemetryHttpConnector,
                                                   telemetryRegistry,
-                                                  metricsRegistry);
+                                                  metricsRegistry,
+                                                  telemetryRequestTimeout);
       }
     }
   }
@@ -4860,6 +4865,15 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public ProcessEngineConfigurationImpl setTelemetryData(Data telemetryData) {
     this.telemetryData = telemetryData;
+    return this;
+  }
+
+  public int getTelemetryRequestTimeout() {
+    return telemetryRequestTimeout;
+  }
+
+  public ProcessEngineConfigurationImpl setTelemetryRequestTimeout(int telemetryRequestTimeout) {
+    this.telemetryRequestTimeout = telemetryRequestTimeout;
     return this;
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/reporter/TelemetryReporter.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/reporter/TelemetryReporter.java
@@ -49,6 +49,7 @@ public class TelemetryReporter {
   protected Connector<? extends ConnectorRequest<?>> httpConnector;
   protected TelemetryRegistry telemetryRegistry;
   protected MetricsRegistry metricsRegistry;
+  protected int telemetryRequestTimeout;
 
   public TelemetryReporter(CommandExecutor commandExecutor,
                            String telemetryEndpoint,
@@ -57,7 +58,8 @@ public class TelemetryReporter {
                            Data data,
                            Connector<? extends ConnectorRequest<?>> httpConnector,
                            TelemetryRegistry telemetryRegistry,
-                           MetricsRegistry metricsRegistry) {
+                           MetricsRegistry metricsRegistry,
+                           int telemetryRequestTimeout) {
     this.commandExecutor = commandExecutor;
     this.telemetryEndpoint = telemetryEndpoint;
     this.telemetryRequestRetries = telemetryRequestRetries;
@@ -66,6 +68,7 @@ public class TelemetryReporter {
     this.httpConnector = httpConnector;
     this.telemetryRegistry = telemetryRegistry;
     this.metricsRegistry = metricsRegistry;
+    this.telemetryRequestTimeout = telemetryRequestTimeout;
     initTelemetrySendingTask();
   }
 
@@ -76,7 +79,8 @@ public class TelemetryReporter {
                                                     data,
                                                     httpConnector,
                                                     telemetryRegistry,
-                                                    metricsRegistry);
+                                                    metricsRegistry,
+                                                    telemetryRequestTimeout);
   }
 
   public synchronized void start() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/ConnectUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/ConnectUtil.java
@@ -25,9 +25,14 @@ public class ConnectUtil {
   public static final String PARAM_NAME_REQUEST_URL = "url";
   public static final String PARAM_NAME_REQUEST_METHOD = "method";
   public static final String PARAM_NAME_REQUEST_PAYLOAD = "payload";
+  public static final String PARAM_NAME_REQUEST_CONFIG = "request-config";
 
   // request methods
   public static final String METHOD_NAME_POST = "POST";
+
+  // config options
+  public static final String CONFIG_NAME_CONNECTION_TIMEOUT = "connection-timeout";
+  public static final String CONFIG_NAME_SOCKET_TIMEOUT = "socket-timeout";
 
   // response
   public static final String PARAM_NAME_RESPONSE_STATUS_CODE = "statusCode";
@@ -54,4 +59,14 @@ public class ConnectUtil {
     return requestParams;
   }
 
+  public static Map<String, Object> addRequestTimeoutConfiguration(Map<String, Object> requestParams,
+                                                           int timeout) {
+    Map<String, Object> config = new HashMap<>();
+    config.put(CONFIG_NAME_CONNECTION_TIMEOUT, timeout);
+    config.put(CONFIG_NAME_SOCKET_TIMEOUT, timeout);
+
+    requestParams.put(PARAM_NAME_REQUEST_CONFIG, config);
+
+    return requestParams;
+  }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryConfigurationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryConfigurationTest.java
@@ -37,7 +37,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 public class TelemetryConfigurationTest {
 
-  protected static final String TELEMETRY_ENDPOINT = "http://localhost:8081/pings";
+  protected static final String TELEMETRY_ENDPOINT = "http://localhost:8085/pings";
 
   @Rule
   public ProcessEngineLoggingRule loggingRule = new ProcessEngineLoggingRule();
@@ -174,8 +174,6 @@ public class TelemetryConfigurationTest {
     assertThat(loggingRule.getFilteredLog("No telemetry property found in the database").size()).isOne();
     assertThat(loggingRule.getFilteredLog("Creating the telemetry property in database with the value: " + telemetryInitialized).size()).isOne();
   }
-  //WireMockServer wireMockServer = new WireMockServer(wireMockConfig().port(8089)); //No-args constructor will start on port 8080, no HTTPS
-//  wireMockServer.start();
 
   @Test
   @WatchLogger(loggerNames = {"org.camunda.bpm.engine.telemetry"}, level = "INFO")

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryConfigurationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryConfigurationTest.java
@@ -34,8 +34,6 @@ import org.junit.Test;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class TelemetryConfigurationTest {
 
@@ -180,8 +178,8 @@ public class TelemetryConfigurationTest {
 //  wireMockServer.start();
 
   @Test
-  @WatchLogger(loggerNames = {"org.camunda.bpm.engine.telemetry"}, level = "DEBUG")
-  public void shouldThrowAnTimeoutException() {
+  @WatchLogger(loggerNames = {"org.camunda.bpm.engine.telemetry"}, level = "INFO")
+  public void shouldThrowAnException() {
     // given
     wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().port(8085));
     wireMockServer.start();
@@ -205,13 +203,6 @@ public class TelemetryConfigurationTest {
             + "ConnectorRequestException with message 'HTCL-02007 Unable to execute HTTP request'")
         .size())
         .isOne();
-    ILoggingEvent debugLog = loggingRule
-        .getFilteredLog("ConnectorRequestException occurred while sending telemetry data.").get(0);
-    assertThat(debugLog.getLevel()).isEqualTo(Level.DEBUG);
-    // the root cause it timeout exception
-    assertThat(debugLog
-        .getThrowableProxy().getCause().getClassName())
-    .contains("TimeoutException");
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryReporterTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryReporterTest.java
@@ -190,7 +190,8 @@ public class TelemetryReporterTest {
                                                                 data,
                                                                 configuration.getTelemetryHttpConnector(),
                                                                 configuration.getTelemetryRegistry(),
-                                                                configuration.getMetricsRegistry());
+                                                                configuration.getMetricsRegistry(),
+                                                                configuration.getTelemetryRequestTimeout());
 
     // when
     telemetryReporter.reportNow();
@@ -648,7 +649,8 @@ public class TelemetryReporterTest {
                                                                 data,
                                                                 null,
                                                                 configuration.getTelemetryRegistry(),
-                                                                configuration.getMetricsRegistry());
+                                                                configuration.getMetricsRegistry(),
+                                                                configuration.getTelemetryRequestTimeout());
 
     // when
     telemetryReporter.reportNow();

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/telemetry/TelemetryTaskWorkerMetricsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/telemetry/TelemetryTaskWorkerMetricsTest.java
@@ -150,7 +150,8 @@ public class TelemetryTaskWorkerMetricsTest {
                           data,
                           configuration.getTelemetryHttpConnector(),
                           configuration.getTelemetryRegistry(),
-                          configuration.getMetricsRegistry()).reportNow();
+                          configuration.getMetricsRegistry(),
+                          configuration.getTelemetryRequestTimeout()).reportNow();
 
     // then
     verify(postRequestedFor(urlEqualTo(TELEMETRY_ENDPOINT_PATH))

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <version.joda-time>2.1</version.joda-time>
     <version.uuid-generator>3.2.0</version.uuid-generator>
     <version.camunda.commons>1.9.0</version.camunda.commons>
-    <version.camunda.connect>1.4.0</version.camunda.connect>
+    <version.camunda.connect>1.5.0-SNAPSHOT</version.camunda.connect>
     <version.camunda.spin>1.10.0</version.camunda.spin>
     <version.camunda.template-engines>2.0.0</version.camunda.template-engines>
     <version.camunda.ee.xslt-plugin>1.1.0</version.camunda.ee.xslt-plugin>

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/telemetry/TelemetryConnectPluginTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/telemetry/TelemetryConnectPluginTest.java
@@ -130,7 +130,8 @@ public class TelemetryConnectPluginTest extends AbstractFoxPlatformIntegrationTe
                                                                 data,
                                                                 configuration.getTelemetryHttpConnector(),
                                                                 configuration.getTelemetryRegistry(),
-                                                                configuration.getMetricsRegistry());
+                                                                configuration.getMetricsRegistry(),
+                                                                configuration.getTelemetryRequestTimeout());
 
     // when
     telemetryReporter.reportNow();


### PR DESCRIPTION
* introduce a process engine configuration property
* default value 15 seconds
* apply the configuration on the telemetry request

Related to CAM-12421