### PR TITLE
CAM-12432М chore(engine): collect dynamic data only when telemetry is enabled

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/BootstrapEngineCommand.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/BootstrapEngineCommand.java
@@ -116,6 +116,8 @@ public class BootstrapEngineCommand implements ProcessEngineBootstrapCommand {
         createTelemetryProperty(commandContext);
       }
 
+      // enable collecting dynamic data in case telemetry is initialized with true
+      // or already enabled
       if ((databaseTelemetryProperty == null && processEngineConfiguration.isInitializeTelemetry())
           || Boolean.valueOf(databaseTelemetryProperty.getValue())) {
         TelemetryUtil.updateCollectingTelemetryDataEnabled(processEngineConfiguration.getTelemetryRegistry(),

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/BootstrapEngineCommand.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/BootstrapEngineCommand.java
@@ -32,6 +32,7 @@ import org.camunda.bpm.engine.impl.telemetry.dto.Data;
 import org.camunda.bpm.engine.impl.telemetry.dto.LicenseKeyData;
 import org.camunda.bpm.engine.impl.telemetry.reporter.TelemetryReporter;
 import org.camunda.bpm.engine.impl.util.LicenseKeyUtil;
+import org.camunda.bpm.engine.impl.util.TelemetryUtil;
 
 /**
  * @author Nikola Koevski
@@ -109,9 +110,17 @@ public class BootstrapEngineCommand implements ProcessEngineBootstrapCommand {
       commandContext.getPropertyManager().acquireExclusiveLockForTelemetry();
       PropertyEntity databaseTelemetryProperty = databaseTelemetryConfiguration(commandContext);
 
+      ProcessEngineConfigurationImpl processEngineConfiguration = commandContext.getProcessEngineConfiguration();
       if (databaseTelemetryProperty == null) {
         LOG.noTelemetryPropertyFound();
         createTelemetryProperty(commandContext);
+      }
+
+      if ((databaseTelemetryProperty == null && processEngineConfiguration.isInitializeTelemetry())
+          || Boolean.valueOf(databaseTelemetryProperty.getValue())) {
+        TelemetryUtil.updateCollectingTelemetryDataEnabled(processEngineConfiguration.getTelemetryRegistry(),
+                                                           processEngineConfiguration.getMetricsRegistry(),
+                                                           true);
       }
 
     } catch (Exception e) {
@@ -136,7 +145,7 @@ public class BootstrapEngineCommand implements ProcessEngineBootstrapCommand {
   }
 
   protected void createTelemetryProperty(CommandContext commandContext) {
-    Boolean telemetryEnabled = Context.getProcessEngineConfiguration().isInitializeTelemetry();
+    Boolean telemetryEnabled = commandContext.getProcessEngineConfiguration().isInitializeTelemetry();
     PropertyEntity property = null;
     if (telemetryEnabled != null) {
       property = new PropertyEntity(TELEMETRY_PROPERTY_NAME, Boolean.toString(telemetryEnabled));
@@ -200,11 +209,12 @@ public class BootstrapEngineCommand implements ProcessEngineBootstrapCommand {
 
     // set installationId in the telemetry data
     telemetryData.setInstallation(installationId);
+
     // set the persisted license key in the telemetry data and registry
-    String licenseKey = commandContext.getProcessEngineConfiguration().getManagementService().getLicenseKey();
+    String licenseKey = processEngineConfiguration.getManagementService().getLicenseKey();
     if (licenseKey != null) {
       LicenseKeyData licenseKeyData = LicenseKeyUtil.getLicenseKeyData(licenseKey);
-      commandContext.getProcessEngineConfiguration().getTelemetryRegistry().setLicenseKey(licenseKeyData);
+      processEngineConfiguration.getTelemetryRegistry().setLicenseKey(licenseKeyData);
       telemetryData.getProduct().getInternals().setLicenseKey(licenseKeyData);
     }
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/TelemetryConfigureCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/TelemetryConfigureCmd.java
@@ -23,7 +23,7 @@ import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.persistence.entity.AuthorizationManager;
 import org.camunda.bpm.engine.impl.telemetry.TelemetryLogger;
 import org.camunda.bpm.engine.impl.telemetry.reporter.TelemetryReporter;
-import org.camunda.bpm.engine.impl.util.ClockUtil;
+import org.camunda.bpm.engine.impl.util.TelemetryUtil;
 
 public class TelemetryConfigureCmd implements Command<Void> {
 
@@ -66,6 +66,11 @@ public class TelemetryConfigureCmd implements Command<Void> {
     if (isReportedActivated && currentValue != null && !currentValue.booleanValue() && telemetryEnabled) {
       telemetryReporter.reschedule();
     }
+
+    // update registry flags
+    TelemetryUtil.updateCollectingTelemetryDataEnabled(
+        processEngineConfiguration.getTelemetryRegistry(),
+        processEngineConfiguration.getMetricsRegistry(), telemetryEnabled);
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandCounterInterceptor.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandCounterInterceptor.java
@@ -35,7 +35,7 @@ public class CommandCounterInterceptor extends CommandInterceptor {
       return next.execute(command);
     } finally {
       TelemetryRegistry telemetryRegistry = processEngineConfiguration.getTelemetryRegistry();
-      if (telemetryRegistry != null) {
+      if (telemetryRegistry != null && telemetryRegistry.isCollectingTelemetryDataEnabled()) {
         telemetryRegistry.markOccurrence(ClassNameUtil.getClassNameWithoutPackage(command));
       }
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/metrics/MetricsRegistry.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/metrics/MetricsRegistry.java
@@ -28,6 +28,8 @@ public class MetricsRegistry {
   protected Map<String, Meter> dbMeters = new HashMap<String, Meter>();
   protected Map<String, Meter> telemetryMeters = new HashMap<String, Meter>();
 
+  protected boolean isCollectingTelemetryMetrics = false;
+
   public Meter getDbMeterByName(String name) {
     return dbMeters.get(name);
   }
@@ -40,13 +42,23 @@ public class MetricsRegistry {
     return telemetryMeters;
   }
 
+  public boolean isCollectingTelemetryMetrics() {
+    return isCollectingTelemetryMetrics;
+  }
+
+  public void setCollectingTelemetryMetrics(boolean isCollectingTelemetryMetrics) {
+    this.isCollectingTelemetryMetrics = isCollectingTelemetryMetrics;
+  }
+
   public void markOccurrence(String name) {
     markOccurrence(name, 1);
   }
 
   public void markOccurrence(String name, long times) {
     markOccurrence(dbMeters, name, times);
-    markOccurrence(telemetryMeters, name, times);
+    if (isCollectingTelemetryMetrics) {
+      markOccurrence(telemetryMeters, name, times);
+    }
   }
 
   public void markTelemetryOccurrence(String name, long times) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryRegistry.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryRegistry.java
@@ -30,6 +30,7 @@ public class TelemetryRegistry {
   protected ApplicationServer applicationServer;
   protected LicenseKeyData licenseKey;
   protected String camundaIntegration;
+  protected boolean isCollectingTelemetryDataEnabled = false;
 
   public synchronized ApplicationServer getApplicationServer() {
     return applicationServer;
@@ -61,6 +62,14 @@ public class TelemetryRegistry {
 
   public void setLicenseKey(LicenseKeyData licenseKey) {
     this.licenseKey = licenseKey;
+  }
+
+  public boolean isCollectingTelemetryDataEnabled() {
+    return isCollectingTelemetryDataEnabled;
+  }
+
+  public void setCollectingTelemetryDataEnabled(boolean isTelemetryEnabled) {
+    this.isCollectingTelemetryDataEnabled = isTelemetryEnabled;
   }
 
   public void markOccurrence(String name) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/TelemetryUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/TelemetryUtil.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.util;
+
+import org.camunda.bpm.engine.impl.metrics.MetricsRegistry;
+import org.camunda.bpm.engine.impl.telemetry.TelemetryRegistry;
+
+public class TelemetryUtil {
+
+  public static void updateCollectingTelemetryDataEnabled(TelemetryRegistry telemetryRegistry, MetricsRegistry metricsRegistry, boolean enabled) {
+    if (telemetryRegistry != null) {
+      telemetryRegistry.setCollectingTelemetryDataEnabled(enabled);
+    }
+    if (metricsRegistry != null) {
+      metricsRegistry.setCollectingTelemetryMetrics(enabled);
+    }
+  }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryConfigurationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryConfigurationTest.java
@@ -37,7 +37,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 public class TelemetryConfigurationTest {
 
-  protected static final String TELEMETRY_ENDPOINT = "http://localhost:8085/pings";
+  protected static final String TELEMETRY_ENDPOINT = "http://localhost:8086/pings";
 
   @Rule
   public ProcessEngineLoggingRule loggingRule = new ProcessEngineLoggingRule();
@@ -61,7 +61,7 @@ public class TelemetryConfigurationTest {
   }
 
   @Test
-  public void shouldStartEngineTelemetryDisabled() {
+  public void shouldStartEngineWithTelemetryDisabled() {
     // given
     inMemoryConfiguration = new StandaloneInMemProcessEngineConfiguration();
     inMemoryConfiguration
@@ -74,6 +74,7 @@ public class TelemetryConfigurationTest {
     // then
     assertThat(inMemoryConfiguration.isInitializeTelemetry()).isFalse();
     assertThat(inMemoryConfiguration.getManagementService().isTelemetryEnabled()).isFalse();
+    assertThat(inMemoryConfiguration.getTelemetryRegistry().isCollectingTelemetryDataEnabled()).isFalse();
 
     // the telemetry reporter is always scheduled
     assertThat(inMemoryConfiguration.isTelemetryReporterActivate()).isTrue();
@@ -95,6 +96,7 @@ public class TelemetryConfigurationTest {
     // then
     assertThat(inMemoryConfiguration.isInitializeTelemetry()).isTrue();
     assertThat(inMemoryConfiguration.getManagementService().isTelemetryEnabled()).isTrue();
+    assertThat(inMemoryConfiguration.getTelemetryRegistry().isCollectingTelemetryDataEnabled()).isTrue();
   }
 
   @Test

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryConfigurationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryConfigurationTest.java
@@ -75,6 +75,7 @@ public class TelemetryConfigurationTest {
     assertThat(inMemoryConfiguration.isInitializeTelemetry()).isFalse();
     assertThat(inMemoryConfiguration.getManagementService().isTelemetryEnabled()).isFalse();
     assertThat(inMemoryConfiguration.getTelemetryRegistry().isCollectingTelemetryDataEnabled()).isFalse();
+    assertThat(inMemoryConfiguration.getMetricsRegistry().isCollectingTelemetryMetrics()).isFalse();
 
     // the telemetry reporter is always scheduled
     assertThat(inMemoryConfiguration.isTelemetryReporterActivate()).isTrue();
@@ -97,6 +98,7 @@ public class TelemetryConfigurationTest {
     assertThat(inMemoryConfiguration.isInitializeTelemetry()).isTrue();
     assertThat(inMemoryConfiguration.getManagementService().isTelemetryEnabled()).isTrue();
     assertThat(inMemoryConfiguration.getTelemetryRegistry().isCollectingTelemetryDataEnabled()).isTrue();
+    assertThat(inMemoryConfiguration.getMetricsRegistry().isCollectingTelemetryMetrics()).isTrue();
   }
 
   @Test

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryMultipleEnginesTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryMultipleEnginesTest.java
@@ -106,7 +106,6 @@ public class TelemetryMultipleEnginesTest {
     // the second engine reports its metrics
     verify(postRequestedFor(urlEqualTo(TELEMETRY_ENDPOINT_PATH))
         .withHeader("Content-Type",  equalTo("application/json")));
-
   }
 
   @Test
@@ -143,6 +142,25 @@ public class TelemetryMultipleEnginesTest {
     LoggedRequest secondRequest = requests.get(1);
     Data secondRequestBody = gson.fromJson(secondRequest.getBodyAsString(), Data.class);
     assertReportedMetrics(secondRequestBody, 1, 0, 0, 0);
+  }
+
+  @Test
+  public void shouldUpdateTelemetryFlagDuringReporting() {
+    // given
+    defaultEngine.getManagementService().toggleTelemetry(true);
+
+    // when
+    secondTelemetryReporter.reportNow();
+
+    // then
+    assertThat(defaultEngine.getProcessEngineConfiguration().getTelemetryRegistry().isCollectingTelemetryDataEnabled())
+        .isTrue();
+    assertThat(secondEngine.getProcessEngineConfiguration().getTelemetryRegistry().isCollectingTelemetryDataEnabled())
+        .isTrue();
+    assertThat(((ProcessEngineConfigurationImpl) defaultEngine.getProcessEngineConfiguration()).getMetricsRegistry()
+        .isCollectingTelemetryMetrics()).isTrue();
+    assertThat(((ProcessEngineConfigurationImpl) secondEngine.getProcessEngineConfiguration()).getMetricsRegistry()
+        .isCollectingTelemetryMetrics()).isTrue();
   }
 
   private TelemetryReporter getTelemetryReporter(ProcessEngine engine) {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryStaticDataTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryStaticDataTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.camunda.bpm.engine.impl.telemetry.dto.ApplicationServer;
 import org.junit.Test;
 
-public class TelemetryDataTest {
+public class TelemetryStaticDataTest {
 
   @Test
   public void shouldValidateWildFlyVendor() {


### PR DESCRIPTION
* introduce collecting telemetry data flag in telemetry and metrics
registry for (commands and metrics data)
* update flags on start up, telemetry toggle and report
* add null check for metrics registry in telemetry

Related to CAM-12432