### PR TITLE
chore(telemetry): send initial message to ET

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/TelemetryConfigureCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/TelemetryConfigureCmd.java
@@ -63,8 +63,12 @@ public class TelemetryConfigureCmd implements Command<Void> {
     boolean isReportedActivated = processEngineConfiguration.isTelemetryReporterActivate();
     TelemetryReporter telemetryReporter = processEngineConfiguration.getTelemetryReporter();
 
-    if (isReportedActivated && currentValue != null && !currentValue.booleanValue() && telemetryEnabled) {
-      telemetryReporter.reschedule();
+    if (isReportedActivated) {
+      // telemetry enabled or set for the first time
+      if (currentValue == null || (!currentValue.booleanValue() && telemetryEnabled)) {
+        telemetryReporter.reschedule(currentValue == null);
+      }
+
     }
 
     // update registry flags

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/EnginePersistenceLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/EnginePersistenceLogger.java
@@ -789,11 +789,11 @@ public class EnginePersistenceLogger extends ProcessEngineLogger {
         preconditionMessage,
         failedOperation.toString());
   }
-  
+
   public void logTaskWithoutExecution(String taskId) {
 	  logDebug("091",
 			  "Execution of external task {} is null. This indicates that the task was concurrently completed or deleted. "
-			  + "It is not returned by the current fetch and lock command.", 
+			  + "It is not returned by the current fetch and lock command.",
 			  taskId);
   }
 
@@ -837,4 +837,11 @@ public class EnginePersistenceLogger extends ProcessEngineLogger {
       "106", "No exclusive lock is acquired on CockroachDB or H2, " +
             "as pessimistic locks are disabled on these databases.");
   }
+
+  public void errorFetchingTelemetryInitialMessagePropertyInDatabase(Exception exception) {
+    logDebug(
+        "107",
+        "Error while fetching the telemetry initial message status property from the database: {}", exception.getMessage());
+  }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryLogger.java
@@ -26,9 +26,10 @@ public class TelemetryLogger extends ProcessEngineLogger {
         "001", "Start telemetry sending task.");
   }
 
-  public void exceptionWhileSendingTelemetryData(Exception e) {
+  public void exceptionWhileSendingTelemetryData(Exception e, boolean isInitialMessage) {
     logWarn("002",
-        "Could not send telemetry data. Reason: {} with message '{}'. Set this logger to DEBUG/FINE for the full stacktrace.",
+        "Could not send {}telemetry data. Reason: {} with message '{}'. Set this logger to DEBUG/FINE for the full stacktrace.",
+        getInitialMessageText(isInitialMessage),
         e.getClass().getSimpleName(),
         e.getMessage());
     logDebug(
@@ -37,19 +38,19 @@ public class TelemetryLogger extends ProcessEngineLogger {
         e);
   }
 
-  public ProcessEngineException unexpectedResponseWhileSendingTelemetryData(int responseCode) {
+  public ProcessEngineException unexpectedResponseWhileSendingTelemetryData(int responseCode, boolean isInitialMessage) {
     return new ProcessEngineException(
-      exceptionMessage("004", "Unexpected response code {} when sending telemetry data", responseCode));
+      exceptionMessage("004", "Unexpected response code {} when sending {}telemetry data", responseCode, getInitialMessageText(isInitialMessage)));
   }
 
-  public void unexpectedResponseWhileSendingTelemetryData() {
+  public void unexpectedResponseWhileSendingTelemetryData(boolean isInitialMessage) {
     logDebug(
-        "005", "Unexpected 'null' response while sending telemetry data.");
+        "005", "Unexpected 'null' response while sending {}telemetry data.", getInitialMessageText(isInitialMessage));
   }
 
-  public void sendingTelemetryData(String data) {
+  public void sendingTelemetryData(String data, boolean isInitialMessage) {
     logDebug(
-        "006", "Sending telemetry data: {}", data);
+        "006", "Sending {}telemetry data: {}", getInitialMessageText(isInitialMessage), data);
   }
 
   public void databaseTelemetryPropertyMissingInfo(boolean telemetryEnabled) {
@@ -98,14 +99,22 @@ public class TelemetryLogger extends ProcessEngineLogger {
         e.getMessage());
   }
 
-  public void unexpectedResponseSuccessCode(int statusCode) {
+  public void unexpectedResponseSuccessCode(int statusCode, boolean isInitialMessage) {
     logDebug(
-        "015", "Telemetry request was sent, but received an unexpected response success code: {}", statusCode);
+        "015", "{} request was sent, but received an unexpected response success code: {}", getInitialMessageTextCapitalized(isInitialMessage), statusCode);
   }
 
 
-  public void telemetrySentSuccessfully() {
+  public void telemetrySentSuccessfully(boolean isInitialMessage) {
     logDebug(
-        "016", "Telemetry request was successful.");
+        "016", "{} request was successful.", getInitialMessageTextCapitalized(isInitialMessage));
+  }
+
+  protected String getInitialMessageText(boolean isInitialMessage) {
+    return isInitialMessage ? "initial " : "";
+  }
+
+  protected String getInitialMessageTextCapitalized(boolean isInitialMessage) {
+    return isInitialMessage ? "Initial telemetry" : "Telemetry";
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/dto/Internals.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/dto/Internals.java
@@ -28,6 +28,7 @@ public class Internals {
   public static final String SERIALIZED_APPLICATION_SERVER = "application-server";
   public static final String SERIALIZED_CAMUNDA_INTEGRATION = "camunda-integration";
   public static final String SERIALIZED_LICENSE_KEY = "license-key";
+  public static final String SERIALIZED_TELEMETRY_ENABLED = "telemetry-enabled";
 
   protected Database database;
   @SerializedName(value = SERIALIZED_APPLICATION_SERVER)
@@ -41,6 +42,9 @@ public class Internals {
   protected Map<String, Metric> metrics;
 
   protected Jdk jdk;
+
+  @SerializedName(value = SERIALIZED_TELEMETRY_ENABLED)
+  protected Boolean telemetryEnabled;
 
   public Internals() {
     this(null, null, null, null);
@@ -60,6 +64,7 @@ public class Internals {
     this.camundaIntegration = internals.camundaIntegration == null ? null : new HashSet<>(internals.getCamundaIntegration());
     this.commands = new HashMap<>(internals.getCommands());
     this.metrics = internals.metrics == null ? null : new HashMap<>(internals.getMetrics());
+    this.telemetryEnabled = internals.telemetryEnabled;
   }
 
   public Database getDatabase() {
@@ -121,6 +126,14 @@ public class Internals {
 
   public void setLicenseKey(LicenseKeyData licenseKey) {
     this.licenseKey = licenseKey;
+  }
+
+  public Boolean getTelemetryEnabled() {
+    return telemetryEnabled;
+  }
+
+  public void setTelemetryEnabled(Boolean telemetryEnabled) {
+    this.telemetryEnabled = telemetryEnabled;
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryDynamicDataTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryDynamicDataTest.java
@@ -26,13 +26,13 @@ import org.camunda.bpm.engine.ProcessEngines;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.camunda.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
 import org.camunda.bpm.engine.impl.metrics.Meter;
 import org.camunda.bpm.engine.impl.telemetry.CommandCounter;
 import org.camunda.bpm.engine.impl.telemetry.TelemetryRegistry;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.util.NoInitMessageInMemProcessEngineConfiguration;
 import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.junit.After;
 import org.junit.Before;
@@ -94,7 +94,7 @@ public class TelemetryDynamicDataTest {
   @Test
   public void shouldCountCommandsFromEngineStart() {
     // when
-    processEngineInMem =  new StandaloneInMemProcessEngineConfiguration()
+    processEngineInMem =  new NoInitMessageInMemProcessEngineConfiguration()
         .setJdbcUrl("jdbc:h2:mem:camunda" + getClass().getSimpleName())
         .setInitializeTelemetry(true)
         .buildProcessEngine();
@@ -102,9 +102,10 @@ public class TelemetryDynamicDataTest {
     // then
     TelemetryRegistry telemetryRegistry = processEngineInMem.getProcessEngineConfiguration().getTelemetryRegistry();
     Map<String, CommandCounter> entries = telemetryRegistry.getCommands();
-    assertThat(entries.size()).isEqualTo(2);
+    assertThat(entries.size()).isEqualTo(3);
     assertThat(entries.keySet()).containsExactlyInAnyOrder(
-        "BootstrapEngineCommand",
+        "IsTelemetryEnabledCmd",
+        "NoInitMessageBootstrapEngineCommand",
         "GetLicenseKeyCmd");
     for (String commandName : entries.keySet()) {
       assertThat(entries.get(commandName).get()).isEqualTo(1);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/util/NoInitMessageBootstrapEngineCommand.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/util/NoInitMessageBootstrapEngineCommand.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.util;
+
+import org.camunda.bpm.engine.impl.BootstrapEngineCommand;
+
+public class NoInitMessageBootstrapEngineCommand extends BootstrapEngineCommand {
+
+  @Override
+  protected void initializeInitialTelemetryMessage() {
+    // do not send initial message
+    sendInitialTelemetryMessage = false;
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/util/NoInitMessageInMemProcessEngineConfiguration.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/util/NoInitMessageInMemProcessEngineConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.util;
+
+import org.camunda.bpm.engine.ProcessEngineBootstrapCommand;
+import org.camunda.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
+
+public class NoInitMessageInMemProcessEngineConfiguration extends StandaloneInMemProcessEngineConfiguration {
+
+  @Override
+  public ProcessEngineBootstrapCommand getProcessEngineBootstrapCommand() {
+    return new NoInitMessageBootstrapEngineCommand();
+  }
+}

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/telemetry/TelemetryConnectPluginTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/telemetry/TelemetryConnectPluginTest.java
@@ -77,7 +77,7 @@ public class TelemetryConnectPluginTest extends AbstractFoxPlatformIntegrationTe
 
     // clean up the recorded commands
     configuration.getTelemetryRegistry().clear();
-    
+
   }
 
   @After
@@ -158,6 +158,7 @@ public class TelemetryConnectPluginTest extends AbstractFoxPlatformIntegrationTe
 
     Map<String, Metric> metrics = getDefaultMetrics();
     internals.setMetrics(metrics);
+    internals.setTelemetryEnabled(true);
 
     Product product = new Product("Runtime", "7.14.0", "special", internals);
     Data data = new Data("f5b19e2e-b49a-11ea-b3de-0242ac130004", product);


### PR DESCRIPTION
* schedules an initial message to ET containing the status of
  telemetry (enabled, disabled, undefined) if the reporter
  is active and the message has not been sent yet once
* chooses an initial message delay based on the flag being `null` (3 hours)
  or set (5 minutes) to get feedback soon when changed from `null` to
  anything else and to make test data more unlikely (3 hours)
* reschedules the reporter task either when flag was null or changes
  from `false` to `true`

related to CAM-12459