### PR TITLE
CAM-12557: fix(telemetry): skip sending initial report during engine close

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/reporter/TelemetryReporter.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/reporter/TelemetryReporter.java
@@ -123,6 +123,8 @@ public class TelemetryReporter {
       timer.cancel();
       timer = null;
 
+      // sending initial message only upon start
+      telemetrySendingTask.sendInitialMessage = false;
       if (report) {
         // collect and send manually for the last time
         reportNow();

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryReporterTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryReporterTest.java
@@ -358,7 +358,7 @@ public class TelemetryReporterTest {
   }
 
   @Test
-  public void shouldReportInitialDataOnceInitTelemetryUndefined() {
+  public void shouldReportInitialDataOnlyOnceInitTelemetryUndefinedReportPlusClose() {
     // given
     ProcessEngineConfigurationImpl processEngineConfiguration = createEngineWithInitMessage(null);
     stubFor(post(urlEqualTo(TELEMETRY_ENDPOINT_PATH))
@@ -368,8 +368,9 @@ public class TelemetryReporterTest {
     Data expectedData = createInitialDataToSend(processEngineConfiguration.getTelemetryData(), null);
     String requestBody = new Gson().toJson(expectedData);
 
-    // when
     processEngineConfiguration.getTelemetryReporter().reportNow();
+
+    // when
     standaloneProcessEngine.close();
     standaloneProcessEngine = null;
 
@@ -381,7 +382,7 @@ public class TelemetryReporterTest {
 
 
   @Test
-  public void shouldReportInitialDataOnceInitTelemetryDisabled() {
+  public void shouldReportInitialDataOnlyOnceInitTelemetryDisabledReportPlusClose() {
     // given
     ProcessEngineConfigurationImpl processEngineConfiguration = createEngineWithInitMessage(false);
     stubFor(post(urlEqualTo(TELEMETRY_ENDPOINT_PATH))
@@ -391,8 +392,9 @@ public class TelemetryReporterTest {
     Data expectedData = createInitialDataToSend(processEngineConfiguration.getTelemetryData(), false);
     String requestBody = new Gson().toJson(expectedData);
 
-    // when
     processEngineConfiguration.getTelemetryReporter().reportNow();
+
+    // when
     standaloneProcessEngine.close();
     standaloneProcessEngine = null;
 
@@ -404,7 +406,7 @@ public class TelemetryReporterTest {
 
   @Test
   @WatchLogger(loggerNames = {"org.camunda.bpm.engine.telemetry"}, level = "DEBUG")
-  public void shouldReportInitialDataOnceInitTelemetryEnabled() {
+  public void shouldReportInitialDataOnlyOnceInitTelemetryEnabledReportPlusClose() {
     // given
     ProcessEngineConfigurationImpl processEngineConfiguration = createEngineWithInitMessage(true);
     stubFor(post(urlEqualTo(TELEMETRY_ENDPOINT_PATH))
@@ -414,8 +416,9 @@ public class TelemetryReporterTest {
     Data expectedData = createInitialDataToSend(processEngineConfiguration.getTelemetryData(), true);
     String requestBody = new Gson().toJson(expectedData);
 
-    // when
     processEngineConfiguration.getTelemetryReporter().reportNow();
+
+    // when
     standaloneProcessEngine.close();
     standaloneProcessEngine = null;
 
@@ -428,7 +431,7 @@ public class TelemetryReporterTest {
   }
 
   @Test
-  public void shouldReportInitialDataOnlyOnce() {
+  public void shouldReportInitialDataOnlyOnceWhenReportingTwice() {
     // given
     ProcessEngineConfigurationImpl processEngineConfiguration = createEngineWithInitMessage(false);
     stubFor(post(urlEqualTo(TELEMETRY_ENDPOINT_PATH))

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryReporterTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryReporterTest.java
@@ -45,7 +45,6 @@ import org.camunda.bpm.engine.IdentityService;
 import org.camunda.bpm.engine.ManagementService;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
-import org.camunda.bpm.engine.ProcessEngines;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.history.UserOperationLogEntry;
@@ -182,7 +181,6 @@ public class TelemetryReporterTest {
         standaloneProcessEngine.getManagementService().toggleTelemetry(false);
       }
       standaloneProcessEngine.close();
-      ProcessEngines.unregister(standaloneProcessEngine);
     }
 
     DefaultDmnEngineConfiguration dmnEngineConfiguration = configuration
@@ -256,6 +254,49 @@ public class TelemetryReporterTest {
   }
 
   @Test
+  public void shouldNotReportInitialDataWhenReporterActivatedAndInitTelemetryUndefinedDuringProcessEngineClose() {
+    // given
+    createEngineWithInitMessage(null);
+
+    // when
+    standaloneProcessEngine.close();
+    standaloneProcessEngine = null;
+
+    // then
+    verify(0, postRequestedFor(urlEqualTo(TELEMETRY_ENDPOINT_PATH)));
+  }
+
+  @Test
+  public void shouldNotReportInitialDataWhenReporterActivatedAndInitTelemetryDisabledDuringProcessEngineClose() {
+    // given
+    createEngineWithInitMessage(false);
+
+    // when
+    standaloneProcessEngine.close();
+    standaloneProcessEngine = null;
+
+    // then
+    verify(0, postRequestedFor(urlEqualTo(TELEMETRY_ENDPOINT_PATH)));
+  }
+
+  @Test
+  public void shouldNotReportInitialDataWhenReporterActivatedAndInitTelemetryEnabledDuringProcessEngineClose() {
+    // given
+    createEngineWithInitMessage(true);
+
+    stubFor(post(urlEqualTo(TELEMETRY_ENDPOINT_PATH))
+        .willReturn(aResponse()
+            .withStatus(HttpURLConnection.HTTP_ACCEPTED)));
+
+    // when
+    standaloneProcessEngine.close();
+    standaloneProcessEngine = null;
+
+    // then
+    verify(1, postRequestedFor(urlEqualTo(TELEMETRY_ENDPOINT_PATH))
+        .withHeader("Content-Type",  equalTo("application/json")));  }
+
+  @Test
   public void shouldReportInitialDataWhenReporterActivatedAndInitTelemetryUndefined() {
     // given
     ProcessEngineConfigurationImpl processEngineConfiguration = createEngineWithInitMessage(null);
@@ -274,6 +315,7 @@ public class TelemetryReporterTest {
               .withRequestBody(equalToJson(requestBody, JSONCompareMode.LENIENT))
               .withHeader("Content-Type",  equalTo("application/json")));
   }
+
 
   @Test
   public void shouldReportInitialDataWhenReporterActivatedAndInitTelemetryDisabled() {
@@ -313,6 +355,76 @@ public class TelemetryReporterTest {
     verify(postRequestedFor(urlEqualTo(TELEMETRY_ENDPOINT_PATH))
               .withRequestBody(equalToJson(requestBody, JSONCompareMode.LENIENT))
               .withHeader("Content-Type",  equalTo("application/json")));
+  }
+
+  @Test
+  public void shouldReportInitialDataOnceInitTelemetryUndefined() {
+    // given
+    ProcessEngineConfigurationImpl processEngineConfiguration = createEngineWithInitMessage(null);
+    stubFor(post(urlEqualTo(TELEMETRY_ENDPOINT_PATH))
+            .willReturn(aResponse()
+                        .withStatus(HttpURLConnection.HTTP_ACCEPTED)));
+
+    Data expectedData = createInitialDataToSend(processEngineConfiguration.getTelemetryData(), null);
+    String requestBody = new Gson().toJson(expectedData);
+
+    // when
+    processEngineConfiguration.getTelemetryReporter().reportNow();
+    standaloneProcessEngine.close();
+    standaloneProcessEngine = null;
+
+    // then
+    verify(1, postRequestedFor(urlEqualTo(TELEMETRY_ENDPOINT_PATH))
+              .withRequestBody(equalToJson(requestBody, JSONCompareMode.LENIENT))
+              .withHeader("Content-Type",  equalTo("application/json")));
+  }
+
+
+  @Test
+  public void shouldReportInitialDataOnceInitTelemetryDisabled() {
+    // given
+    ProcessEngineConfigurationImpl processEngineConfiguration = createEngineWithInitMessage(false);
+    stubFor(post(urlEqualTo(TELEMETRY_ENDPOINT_PATH))
+            .willReturn(aResponse()
+                        .withStatus(HttpURLConnection.HTTP_ACCEPTED)));
+
+    Data expectedData = createInitialDataToSend(processEngineConfiguration.getTelemetryData(), false);
+    String requestBody = new Gson().toJson(expectedData);
+
+    // when
+    processEngineConfiguration.getTelemetryReporter().reportNow();
+    standaloneProcessEngine.close();
+    standaloneProcessEngine = null;
+
+    // then
+    verify(1, postRequestedFor(urlEqualTo(TELEMETRY_ENDPOINT_PATH))
+              .withRequestBody(equalToJson(requestBody, JSONCompareMode.LENIENT))
+              .withHeader("Content-Type",  equalTo("application/json")));
+  }
+
+  @Test
+  @WatchLogger(loggerNames = {"org.camunda.bpm.engine.telemetry"}, level = "DEBUG")
+  public void shouldReportInitialDataOnceInitTelemetryEnabled() {
+    // given
+    ProcessEngineConfigurationImpl processEngineConfiguration = createEngineWithInitMessage(true);
+    stubFor(post(urlEqualTo(TELEMETRY_ENDPOINT_PATH))
+            .willReturn(aResponse()
+                        .withStatus(HttpURLConnection.HTTP_ACCEPTED)));
+
+    Data expectedData = createInitialDataToSend(processEngineConfiguration.getTelemetryData(), true);
+    String requestBody = new Gson().toJson(expectedData);
+
+    // when
+    processEngineConfiguration.getTelemetryReporter().reportNow();
+    standaloneProcessEngine.close();
+    standaloneProcessEngine = null;
+
+    // then
+    verify(3, postRequestedFor(urlEqualTo(TELEMETRY_ENDPOINT_PATH))
+              .withRequestBody(equalToJson(requestBody, JSONCompareMode.LENIENT))
+              .withHeader("Content-Type",  equalTo("application/json")));
+    assertThat(loggingRule.getFilteredLog("Sending initial telemetry data").size()).isOne();
+    assertThat(loggingRule.getFilteredLog("Initial telemetry request was successful.").size()).isOne();
   }
 
   @Test


### PR DESCRIPTION
Related to CAM-12557