### PR TITLE
CAM-12524: fix(engine): detect crdb errors on tx commit

### DIFF
--- a/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringTransactionInterceptor.java
+++ b/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringTransactionInterceptor.java
@@ -16,10 +16,13 @@
  */
 package org.camunda.bpm.engine.spring;
 
+import org.camunda.bpm.engine.impl.ProcessEngineLogger;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.db.sql.DbSqlSession;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandInterceptor;
 import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.TransactionSystemException;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -31,21 +34,36 @@ public class SpringTransactionInterceptor extends CommandInterceptor {
   
   protected PlatformTransactionManager transactionManager;
   protected int transactionPropagation;
+  protected ProcessEngineConfigurationImpl processEngineConfiguration;
   
   public SpringTransactionInterceptor(PlatformTransactionManager transactionManager, int transactionPropagation) {
+    this(transactionManager, transactionPropagation, null);
+  }
+
+  public SpringTransactionInterceptor(PlatformTransactionManager transactionManager,
+                                      int transactionPropagation,
+                                      ProcessEngineConfigurationImpl processEngineConfiguration) {
     this.transactionManager = transactionManager;
     this.transactionPropagation = transactionPropagation;
+    this.processEngineConfiguration = processEngineConfiguration;
   }
-  
+
   @SuppressWarnings("unchecked")
   public <T> T execute(final Command<T> command) {
     TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
     transactionTemplate.setPropagationBehavior(transactionPropagation);
-    T result = (T) transactionTemplate.execute(new TransactionCallback() {
-      public Object doInTransaction(TransactionStatus status) {
-        return next.execute(command);
+    try {
+      T result = (T) transactionTemplate.execute((TransactionCallback) status -> next.execute(command));
+      return result;
+    } catch (TransactionSystemException ex) {
+      // When CockroachDB is used, a CRDB concurrency error may occur on transaction commit.
+      // To ensure that these errors are still detected as OLEs, we must catch them and wrap
+      // them in a CrdbTransactionRetryException
+      if (DbSqlSession.isCrdbConcurrencyConflictOnCommit(ex, processEngineConfiguration)) {
+        throw ProcessEngineLogger.PERSISTENCE_LOGGER.crdbTransactionRetryExceptionOnCommit(ex);
+      } else {
+        throw ex;
       }
-    });
-    return result;
+    }
   }
 }

--- a/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringTransactionsProcessEngineConfiguration.java
+++ b/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringTransactionsProcessEngineConfiguration.java
@@ -83,7 +83,7 @@ public class SpringTransactionsProcessEngineConfiguration extends ProcessEngineC
     defaultCommandInterceptorsTxRequired.add(new LogInterceptor());
     defaultCommandInterceptorsTxRequired.add(new CommandCounterInterceptor(this));
     defaultCommandInterceptorsTxRequired.add(new ProcessApplicationContextInterceptor(this));
-    defaultCommandInterceptorsTxRequired.add(new SpringTransactionInterceptor(transactionManager, TransactionTemplate.PROPAGATION_REQUIRED));
+    defaultCommandInterceptorsTxRequired.add(new SpringTransactionInterceptor(transactionManager, TransactionTemplate.PROPAGATION_REQUIRED, this));
     CommandContextInterceptor commandContextInterceptor = new CommandContextInterceptor(commandContextFactory, this);
     defaultCommandInterceptorsTxRequired.add(commandContextInterceptor);
     return defaultCommandInterceptorsTxRequired;
@@ -99,7 +99,7 @@ public class SpringTransactionsProcessEngineConfiguration extends ProcessEngineC
     defaultCommandInterceptorsTxRequiresNew.add(new LogInterceptor());
     defaultCommandInterceptorsTxRequiresNew.add(new CommandCounterInterceptor(this));
     defaultCommandInterceptorsTxRequiresNew.add(new ProcessApplicationContextInterceptor(this));
-    defaultCommandInterceptorsTxRequiresNew.add(new SpringTransactionInterceptor(transactionManager, TransactionTemplate.PROPAGATION_REQUIRES_NEW));
+    defaultCommandInterceptorsTxRequiresNew.add(new SpringTransactionInterceptor(transactionManager, TransactionTemplate.PROPAGATION_REQUIRES_NEW, this));
     CommandContextInterceptor commandContextInterceptor = new CommandContextInterceptor(commandContextFactory, this, true);
     defaultCommandInterceptorsTxRequiresNew.add(commandContextInterceptor);
     return defaultCommandInterceptorsTxRequiresNew;

--- a/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/transaction/crdb/CrdbTxRetryOnCommitDelegate.java
+++ b/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/transaction/crdb/CrdbTxRetryOnCommitDelegate.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.spring.test.transaction.crdb;
+
+import java.sql.SQLException;
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.TransactionSystemException;
+
+@Service("simulateCommitFailureDelegate")
+public class CrdbTxRetryOnCommitDelegate implements JavaDelegate {
+
+  protected static boolean throwException = true;
+
+  @Override
+  public void execute(DelegateExecution execution) throws Exception {
+
+      if (throwException) {
+          throwException = false;
+          // simulate a CRDB TX Error on TX Commit
+          throw new TransactionSystemException("CRDB Error:",
+              new SQLException("ERROR: restart transaction: TransactionRetryWithProtoRefreshError: " +
+                  "TransactionRetryError: retry txn (RETRY_SERIALIZABLE)"));
+      }
+  }
+
+}

--- a/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/transaction/crdb/CrdbTxRetryOnCommitTest.java
+++ b/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/transaction/crdb/CrdbTxRetryOnCommitTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.spring.test.transaction.crdb;
+
+import org.camunda.bpm.engine.CrdbTransactionRetryException;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * This tests simulates a CockroachDB concurrency error on TX commit.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"classpath:org/camunda/bpm/engine/spring/test/transaction/" +
+    "CrdbTransactionIntegrationTest-applicationContext.xml"})
+public class CrdbTxRetryOnCommitTest {
+
+  @Rule
+  @Autowired
+  public ProcessEngineRule rule;
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Autowired
+  public ProcessEngineConfigurationImpl processEngineConfiguration;
+
+  /**
+   * Scenario can't be successfully run without modifying runtime code
+   * since we only use H2 in the Spring integration tests, and this test
+   * requires the hard-coded CRDB check to work.
+   */
+  @Test
+  @Ignore
+  @Deployment(resources = {"org/camunda/bpm/engine/spring/test/transaction/" +
+      "CrdbTransactionIntegrationTest.crdbFailureProcess.bpmn20.xml" })
+  public void shouldReportCrdbException() {
+    // given a command that fails with a CRDB concurrency error on commit
+
+    // then
+    // the StartProcessInstanceCmd is not retryable, and an exception is thrown
+    thrown.expect(CrdbTransactionRetryException.class);
+
+    // when
+    // the command is executed
+    processEngineConfiguration.getRuntimeService()
+        .startProcessInstanceByKey("crdbFailureProcess");
+  }
+}

--- a/engine-spring/core/src/test/resources/org/camunda/bpm/engine/spring/test/transaction/CrdbTransactionIntegrationTest.crdbFailureProcess.bpmn20.xml
+++ b/engine-spring/core/src/test/resources/org/camunda/bpm/engine/spring/test/transaction/CrdbTransactionIntegrationTest.crdbFailureProcess.bpmn20.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1ys0ol0" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+  <bpmn:process id="crdbFailureProcess" name="CRDB Failure Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start Event">
+      <bpmn:outgoing>Flow_12kxm3l</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_115acy2" name="End Event">
+      <bpmn:incoming>Flow_11saddo</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_12kxm3l" sourceRef="StartEvent_1" targetRef="Activity_1302wjt" />
+    <bpmn:sequenceFlow id="Flow_11saddo" sourceRef="Activity_1302wjt" targetRef="EndEvent_115acy2" />
+    <bpmn:serviceTask id="Activity_1302wjt" name="Failing Service Task" camunda:delegateExpression="${simulateCommitFailureDelegate}">
+      <bpmn:incoming>Flow_12kxm3l</bpmn:incoming>
+      <bpmn:outgoing>Flow_11saddo</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="simpleProcess">
+      <bpmndi:BPMNEdge id="Flow_12kxm3l_di" bpmnElement="Flow_12kxm3l">
+        <di:waypoint x="215" y="121" />
+        <di:waypoint x="310" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11saddo_di" bpmnElement="Flow_11saddo">
+        <di:waypoint x="410" y="121" />
+        <di:waypoint x="542" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="170" y="146" width="55" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_115acy2_di" bpmnElement="EndEvent_115acy2">
+        <dc:Bounds x="542" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="536" y="146" width="51" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_13xrbkg_di" bpmnElement="Activity_1302wjt">
+        <dc:Bounds x="310" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/JtaProcessEngineConfiguration.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/JtaProcessEngineConfiguration.java
@@ -73,7 +73,7 @@ public class JtaProcessEngineConfiguration extends ProcessEngineConfigurationImp
     defaultCommandInterceptorsTxRequired.add(new LogInterceptor());
     defaultCommandInterceptorsTxRequired.add(new CommandCounterInterceptor(this));
     defaultCommandInterceptorsTxRequired.add(new ProcessApplicationContextInterceptor(this));
-    defaultCommandInterceptorsTxRequired.add(new JtaTransactionInterceptor(transactionManager, false));
+    defaultCommandInterceptorsTxRequired.add(new JtaTransactionInterceptor(transactionManager, false, this));
     defaultCommandInterceptorsTxRequired.add(new CommandContextInterceptor(commandContextFactory, this));
     return defaultCommandInterceptorsTxRequired;
   }
@@ -89,7 +89,7 @@ public class JtaProcessEngineConfiguration extends ProcessEngineConfigurationImp
     defaultCommandInterceptorsTxRequiresNew.add(new LogInterceptor());
     defaultCommandInterceptorsTxRequiresNew.add(new CommandCounterInterceptor(this));
     defaultCommandInterceptorsTxRequiresNew.add(new ProcessApplicationContextInterceptor(this));
-    defaultCommandInterceptorsTxRequiresNew.add(new JtaTransactionInterceptor(transactionManager, true));
+    defaultCommandInterceptorsTxRequiresNew.add(new JtaTransactionInterceptor(transactionManager, true, this));
     defaultCommandInterceptorsTxRequiresNew.add(new CommandContextInterceptor(commandContextFactory, this, true));
     return defaultCommandInterceptorsTxRequiresNew;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSession.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSession.java
@@ -322,7 +322,9 @@ public abstract class DbSqlSession extends AbstractPersistenceSession {
   public static boolean isCrdbConcurrencyConflictOnCommit(Throwable cause, ProcessEngineConfigurationImpl configuration) {
     // only check when CRDB is used
     if (DatabaseUtil.checkDatabaseType(configuration, DbSqlSessionFactory.CRDB)) {
-      // with externally managed transactions, the real cause is sometimes suppressed
+      // with Java EE (JTA) transactions, the real cause is suppressed,
+      // and replaced with a RollbackException. We need to look into the
+      // suppressed exceptions to find the CRDB TransactionRetryError.
       List<Throwable> causes = new ArrayList<>(Arrays.asList(cause.getSuppressed()));
       causes.add(cause);
       for (Throwable throwable : causes) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSession.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSession.java
@@ -32,6 +32,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -43,6 +44,7 @@ import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.db.AbstractPersistenceSession;
 import org.camunda.bpm.engine.impl.db.DbEntity;
@@ -304,7 +306,34 @@ public abstract class DbSqlSession extends AbstractPersistenceSession {
     return false;
   }
 
+  /**
+   * In cases where CockroachDB is used, and a failed operation is detected,
+   * the method checks if the exception was caused by a CockroachDB
+   * <code>TransactionRetryException</code>. This method may be used when a
+   * CRDB Error occurs on commit, and a Command Context is not available, as
+   * it has already been closed. This is the case with Spring/JTA transaction
+   * interceptors.
+   *
+   * @param cause for which an operation failed
+   * @param configuration of the Process Engine
+   * @return true if the failure was due to a CRDB <code>TransactionRetryException</code>.
+   *          Otherwise, it's false.
+   */
+  public static boolean isCrdbConcurrencyConflictOnCommit(Throwable cause, ProcessEngineConfigurationImpl configuration) {
+    // only check when CRDB is used
+    if (DatabaseUtil.checkDatabaseType(configuration, DbSqlSessionFactory.CRDB)) {
+      // with externally managed transactions, the real cause is sometimes suppressed
+      List<Throwable> causes = new ArrayList<>(Arrays.asList(cause.getSuppressed()));
+      causes.add(cause);
+      for (Throwable throwable : causes) {
+        if (ExceptionUtil.checkCrdbTransactionRetryException(throwable)) {
+          return true;
+        }
+      }
+    }
 
+    return false;
+  }
 
   // insert //////////////////////////////////////////
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/JtaTransactionInterceptor.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/JtaTransactionInterceptor.java
@@ -28,21 +28,31 @@ import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.cmd.CommandLogger;
+import org.camunda.bpm.engine.impl.db.sql.DbSqlSession;
 
 /**
  * @author Guillaume Nodet
  */
 public class JtaTransactionInterceptor extends CommandInterceptor {
 
-  private final static CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
+  protected final static CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
 
-  private final TransactionManager transactionManager;
-  private final boolean requiresNew;
+  protected final TransactionManager transactionManager;
+  protected final boolean requiresNew;
+  protected ProcessEngineConfigurationImpl processEngineConfiguration;
 
   public JtaTransactionInterceptor(TransactionManager transactionManager, boolean requiresNew) {
+    this(transactionManager, requiresNew, null);
+  }
+
+  public JtaTransactionInterceptor(TransactionManager transactionManager,
+                                   boolean requiresNew,
+                                   ProcessEngineConfigurationImpl processEngineConfiguration) {
     this.transactionManager = transactionManager;
     this.requiresNew = requiresNew;
+    this.processEngineConfiguration = processEngineConfiguration;
   }
 
   public <T> T execute(Command<T> command) {
@@ -124,7 +134,14 @@ public class JtaTransactionInterceptor extends CommandInterceptor {
     } catch (HeuristicRollbackException e) {
       throw new TransactionException("Unable to commit transaction", e);
     } catch (RollbackException e) {
-      throw new TransactionException("Unable to commit transaction", e);
+      // When CockroachDB is used, a CRDB concurrency error may occur on transaction commit.
+      // To ensure that these errors are still detected as OLEs, we must catch them and wrap
+      // them in a CrdbTransactionRetryException
+      if (DbSqlSession.isCrdbConcurrencyConflictOnCommit(e, processEngineConfiguration)) {
+        throw ProcessEngineLogger.PERSISTENCE_LOGGER.crdbTransactionRetryExceptionOnCommit(e);
+      } else {
+        throw new TransactionException("Unable to commit transaction", e);
+      }
     } catch (SystemException e) {
       throw new TransactionException("Unable to commit transaction", e);
     } catch (RuntimeException e) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/JtaTransactionInterceptor.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/JtaTransactionInterceptor.java
@@ -43,10 +43,6 @@ public class JtaTransactionInterceptor extends CommandInterceptor {
   protected final boolean requiresNew;
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
 
-  public JtaTransactionInterceptor(TransactionManager transactionManager, boolean requiresNew) {
-    this(transactionManager, requiresNew, null);
-  }
-
   public JtaTransactionInterceptor(TransactionManager transactionManager,
                                    boolean requiresNew,
                                    ProcessEngineConfigurationImpl processEngineConfiguration) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/JtaTransactionInterceptor.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/JtaTransactionInterceptor.java
@@ -161,7 +161,7 @@ public class JtaTransactionInterceptor extends CommandInterceptor {
     }
   }
 
-  private static class TransactionException extends RuntimeException {
+  public static class TransactionException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     private TransactionException() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/DatabaseUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/DatabaseUtil.java
@@ -18,6 +18,7 @@ package org.camunda.bpm.engine.impl.util;
 
 import java.util.Arrays;
 
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.context.Context;
 
 public class DatabaseUtil {
@@ -29,7 +30,18 @@ public class DatabaseUtil {
    * @return true if any of the provided types match the used one. Otherwise false.
    */
   public static boolean checkDatabaseType(String... databaseTypes) {
-      String dbType = Context.getCommandContext().getProcessEngineConfiguration().getDatabaseType();
-      return Arrays.stream(databaseTypes).anyMatch(dbType::equals);
+    return checkDatabaseType(Context.getCommandContext().getProcessEngineConfiguration(), databaseTypes);
+  }
+
+  /**
+   * Checks if the currently used database is of a given database type.
+   *
+   * @param configuration for the Process Engine, when a Context is not available
+   * @param databaseTypes to check for
+   * @return true if any of the provided types match the used one. Otherwise false.
+   */
+  public static boolean checkDatabaseType(ProcessEngineConfigurationImpl configuration, String... databaseTypes) {
+    String dbType = configuration.getDatabaseType();
+    return Arrays.stream(databaseTypes).anyMatch(dbType::equals);
   }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/impl/cfg/JtaTransactionInterceptorTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/impl/cfg/JtaTransactionInterceptorTest.java
@@ -1,0 +1,114 @@
+package org.camunda.bpm.engine.impl.cfg;
+
+import java.sql.SQLException;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import javax.transaction.RollbackException;
+import javax.transaction.TransactionManager;
+
+import org.camunda.bpm.engine.CrdbTransactionRetryException;
+import org.camunda.bpm.engine.impl.db.sql.DbSqlSessionFactory;
+import org.camunda.bpm.engine.impl.interceptor.CommandInterceptor;
+import org.camunda.bpm.engine.impl.interceptor.JtaTransactionInterceptor;
+import org.camunda.bpm.engine.impl.interceptor.JtaTransactionInterceptor.TransactionException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * This test covers the exception handling of the JTA transaction interceptor, especially
+ * when used with CockroachDB. To avoid a complex setup (CRDB + engine with JTA configuration),
+ * it mocks the involved resources. This is not great, but better than no test.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class JtaTransactionInterceptorTest {
+
+
+  @Mock
+  public TransactionManager txManager;
+
+  @Mock
+  public ProcessEngineConfigurationImpl engineConfiguration;
+
+  @Mock
+  public CommandInterceptor nextInterceptor;
+
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
+
+  @Before
+  public void mockEngineConfiguration() {
+    when(engineConfiguration.getDatabaseType()).thenReturn(DbSqlSessionFactory.CRDB);
+  }
+
+  @Test
+  public void shouldConvertSqlExceptionToCrdbError() throws Exception {
+
+    // given
+    JtaTransactionInterceptor interceptor = new JtaTransactionInterceptor(
+        txManager, true, engineConfiguration);
+    interceptor.setNext(nextInterceptor);
+
+    RollbackException exception = new RollbackException();
+    exception.addSuppressed(buildCrdbCommitException());
+
+    doThrow(exception).when(txManager).commit();
+
+    // then the exception is converted to a CRDB exception that can be retried
+    exceptionRule.expect(CrdbTransactionRetryException.class);
+
+    // when
+    interceptor.execute(c -> null);
+  }
+
+  @Test
+  public void shoulNotConvertUnrelatedSqlExceptionToCrdbError() throws Exception {
+
+    // given
+    JtaTransactionInterceptor interceptor = new JtaTransactionInterceptor(
+        txManager, true, engineConfiguration);
+    interceptor.setNext(nextInterceptor);
+
+    RollbackException exception = new RollbackException();
+    exception.addSuppressed(new SQLException("unrelated error"));
+
+    doThrow(exception).when(txManager).commit();
+
+    // then the exception is converted to a CRDB exception that can be retried
+    exceptionRule.expect(TransactionException.class);
+    exceptionRule.expectMessage("Unable to commit transaction");
+
+    // when
+    interceptor.execute(c -> null);
+  }
+
+
+  @Test
+  public void shoulNotConvertGenericRuntimeExceptionToCrdbError() throws Exception {
+
+    // given
+    JtaTransactionInterceptor interceptor = new JtaTransactionInterceptor(
+        txManager, true, engineConfiguration);
+    interceptor.setNext(nextInterceptor);
+
+    doThrow(new RuntimeException()).when(txManager).commit();
+
+    // then the exception is converted to a CRDB exception that can be retried
+    exceptionRule.expect(RuntimeException.class);
+
+    // when
+    interceptor.execute(c -> null);
+  }
+
+  private Exception buildCrdbCommitException() {
+    return new SQLException("ERROR: restart transaction: TransactionRetryWithProtoRefreshError: " +
+        "TransactionRetryError: retry txn (RETRY_SERIALIZABLE)");
+  }
+
+}


### PR DESCRIPTION
* When CockroachDB is used, a CRDB concurrency error may occur on transaction commit.
  To ensure that these errors are still detected as OLEs, we must catch them and wrap
  them in a CrdbTransactionRetryException

Related to CAM-12524