### PR TITLE
[CAM-12581] Use try with resources instead of try-catch-finally block

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -344,7 +344,6 @@ import org.camunda.bpm.engine.impl.telemetry.dto.Internals;
 import org.camunda.bpm.engine.impl.telemetry.dto.Jdk;
 import org.camunda.bpm.engine.impl.telemetry.dto.Product;
 import org.camunda.bpm.engine.impl.telemetry.reporter.TelemetryReporter;
-import org.camunda.bpm.engine.impl.util.IoUtil;
 import org.camunda.bpm.engine.impl.util.ParseUtil;
 import org.camunda.bpm.engine.impl.util.ProcessEngineDetails;
 import org.camunda.bpm.engine.impl.util.ReflectUtil;
@@ -1612,8 +1611,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   }
 
   protected String checkForCrdb(Connection connection) {
-    try {
-      ResultSet result = connection.prepareStatement("select version() as version;").executeQuery();
+    try (ResultSet result = connection.prepareStatement("select version() as version;").executeQuery()) {
       if (result.next()) {
         String versionData = result.getString(1);
         if (versionData != null && versionData.toLowerCase().contains("cockroachdb")) {
@@ -1653,9 +1651,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       }
 
       if (sqlSessionFactory == null) {
-        InputStream inputStream = null;
-        try {
-          inputStream = getMyBatisXmlConfigurationSteam();
+        try (InputStream inputStream = getMyBatisXmlConfigurationSteam()) {
 
           // update the jdbc parameters to the configured ones...
           Environment environment = new Environment("default", transactionFactory, dataSource);
@@ -1691,8 +1687,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
         } catch (Exception e) {
           throw new ProcessEngineException("Error while building ibatis SqlSessionFactory: " + e.getMessage(), e);
-        } finally {
-          IoUtil.closeSilently(inputStream);
         }
       }
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSession.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSession.java
@@ -54,7 +54,10 @@ import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbEntityOperation;
 import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
 import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation.State;
 import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperationType;
-import org.camunda.bpm.engine.impl.util.*;
+import org.camunda.bpm.engine.impl.util.DatabaseUtil;
+import org.camunda.bpm.engine.impl.util.ExceptionUtil;
+import org.camunda.bpm.engine.impl.util.IoUtil;
+import org.camunda.bpm.engine.impl.util.ReflectUtil;
 
 /**
 *

--- a/model-api/cmmn-model/src/main/java/org/camunda/bpm/model/cmmn/Cmmn.java
+++ b/model-api/cmmn-model/src/main/java/org/camunda/bpm/model/cmmn/Cmmn.java
@@ -239,7 +239,7 @@ public class Cmmn {
     } catch (FileNotFoundException e) {
       throw new CmmnModelException("Cannot read model from file "+file+": file does not exist.");
     } catch (IOException e) {
-      throw new CmmnModelException(String.format("Cannot read model from file %s exception %s", file, e.getMessage()));
+      throw new CmmnModelException("Cannot read model from file " + file, e);
     }
   }
 
@@ -253,7 +253,7 @@ public class Cmmn {
     } catch (FileNotFoundException e) {
       throw new CmmnModelException("Cannot write model to file "+file+": file does not exist.");
     } catch (IOException e) {
-      throw new CmmnModelException(String.format("Cannot write model to file %s exception %s", file, e.getMessage()));
+      throw new CmmnModelException("Cannot write model to file " + file, e);
     }
   }
 

--- a/model-api/cmmn-model/src/main/java/org/camunda/bpm/model/cmmn/Cmmn.java
+++ b/model-api/cmmn-model/src/main/java/org/camunda/bpm/model/cmmn/Cmmn.java
@@ -19,12 +19,7 @@ package org.camunda.bpm.model.cmmn;
 import static org.camunda.bpm.model.cmmn.impl.CmmnModelConstants.CMMN10_NS;
 import static org.camunda.bpm.model.cmmn.impl.CmmnModelConstants.CMMN11_NS;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 
 import org.camunda.bpm.model.cmmn.impl.CmmnParser;
 import org.camunda.bpm.model.cmmn.impl.instance.ApplicabilityRuleImpl;
@@ -239,17 +234,12 @@ public class Cmmn {
   }
 
   protected CmmnModelInstance doReadModelFromFile(File file) {
-    InputStream is = null;
-    try {
-      is = new FileInputStream(file);
+    try (InputStream is = new FileInputStream(file)) {
       return doReadModelFromInputStream(is);
-
     } catch (FileNotFoundException e) {
       throw new CmmnModelException("Cannot read model from file "+file+": file does not exist.");
-
-    } finally {
-      IoUtil.closeSilently(is);
-
+    } catch (IOException e) {
+      throw new CmmnModelException(String.format("Cannot read model from file %s exception %s", file, e.getMessage()));
     }
   }
 
@@ -258,15 +248,12 @@ public class Cmmn {
   }
 
   protected void doWriteModelToFile(File file, CmmnModelInstance modelInstance) {
-    OutputStream os = null;
-    try {
-      os = new FileOutputStream(file);
+    try (OutputStream os = new FileOutputStream(file)) {
       doWriteModelToOutputStream(os, modelInstance);
-    }
-    catch (FileNotFoundException e) {
+    } catch (FileNotFoundException e) {
       throw new CmmnModelException("Cannot write model to file "+file+": file does not exist.");
-    } finally {
-      IoUtil.closeSilently(os);
+    } catch (IOException e) {
+      throw new CmmnModelException(String.format("Cannot write model to file %s exception %s", file, e.getMessage()));
     }
   }
 


### PR DESCRIPTION
- Fixes sonar issue "Try-with-resources should be used"
- Some of the resources like `ResultSet` and `PreparedStatement` were not closed at all, now they are inside try-with-resources block and will be closed.

related to CAM-12581