### PR TITLE
DMNEngineRule tweak

### DIFF
--- a/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/test/ClassNameUtil.java
+++ b/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/test/ClassNameUtil.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.dmn.engine.test;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+
+/**
+ * @author Tom Baeyens
+ */
+public abstract class ClassNameUtil {
+
+  protected static final Map<Class<?>, String> cachedNames = new ConcurrentHashMap<Class<?>, String>();
+
+  public static String getClassNameWithoutPackage(Object object) {
+    return getClassNameWithoutPackage(object.getClass());
+  }
+
+  public static String getClassNameWithoutPackage(Class<?> clazz) {
+    String unqualifiedClassName = cachedNames.get(clazz);
+    if (unqualifiedClassName==null) {
+      String fullyQualifiedClassName = clazz.getName();
+      unqualifiedClassName = fullyQualifiedClassName.substring(fullyQualifiedClassName.lastIndexOf('.')+1);
+      cachedNames.put(clazz, unqualifiedClassName);
+    }
+    return unqualifiedClassName;
+  }
+}

--- a/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/test/DmnDecisionKey.java
+++ b/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/test/DmnDecisionKey.java
@@ -1,0 +1,19 @@
+package org.camunda.bpm.dmn.engine.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for {@link org.camunda.bpm.dmn.engine.DmnDecision} retrieval around a test method.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface DmnDecisionKey {
+
+  /**
+   * Specify dmn definition by key
+   */
+  String name() default "";
+}

--- a/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/test/DmnEngineExtensionRule.java
+++ b/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/test/DmnEngineExtensionRule.java
@@ -1,0 +1,170 @@
+package org.camunda.bpm.dmn.engine.test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.camunda.bpm.dmn.engine.DmnDecision;
+import org.camunda.bpm.dmn.engine.DmnDecisionResult;
+import org.camunda.bpm.dmn.engine.DmnEngineConfiguration;
+import org.junit.runner.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Specialisation of Camunda's {@link DmnEngineRule} allowing to deploy DMN definitions in a declarative way rather than programmatic way.
+ *
+ * @see {@link DmnEngineRule}
+ * @see {@link DmnResource}
+ */
+public class DmnEngineExtensionRule extends DmnEngineRule {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DmnEngineRule.class);
+  /* available decisions */
+  private List<DmnDecision> decisions = new ArrayList<>();
+  /* the current decision */
+  private DmnDecision decision;
+
+  public DmnEngineExtensionRule() {
+    this(null);
+  }
+
+  public DmnEngineExtensionRule(DmnEngineConfiguration dmnEngineConfiguration) {
+    super(dmnEngineConfiguration);
+  }
+
+  public DmnDecisionResult evaluateDecision(Map<String, Object> variables) {
+    return getDmnEngine().evaluateDecision(decision, variables);
+  }
+
+  public DmnDecisionResult evaluateDecision(String key, Map<String, Object> variables) {
+    Optional<DmnDecision> decisionOpt = decisions.stream().filter(p -> p.getKey().equalsIgnoreCase(key.trim())).findFirst();
+    if (!decisionOpt.isPresent()) {
+      throw new IllegalArgumentException("decision id '" + key + "' does not exist");
+    }
+    decision = decisionOpt.get();
+    return evaluateDecision(variables);
+  }
+
+  @Override
+  public void starting(Description description) {
+    super.starting(description);
+    annotationDeploymentSetUp(description.getTestClass(), description.getMethodName(), description.getAnnotation(DmnResource.class), description.getAnnotation(
+      DmnDecisionKey.class)
+    );
+  }
+
+  @Override
+  protected void finished(Description description) {
+    annotationDeploymentTearDown(description.getTestClass(), description.getMethodName(), description.getAnnotation(DmnResource.class), description.getAnnotation(
+      DmnDecisionKey.class)
+    );
+    super.finished(description);
+  }
+
+  private void annotationDeploymentTearDown(Class<?> testClass, String methodName, DmnResource deploymentAnnotation, DmnDecisionKey decisionAnnotation) {
+    decisions.clear();
+    decision = null;
+  }
+
+  private void annotationDeploymentSetUp(Class<?> testClass, String methodName, DmnResource deploymentAnnotation, DmnDecisionKey decisionAnnotation) {
+    dmnResources(testClass, methodName, deploymentAnnotation);
+    dmnDecision(testClass, methodName, decisionAnnotation);
+  }
+
+  private void dmnDecision(Class<?> testClass, String methodName, DmnDecisionKey decisionAnnotation) {
+    Method method = null;
+    boolean onMethod = true;
+
+    try {
+      method = getMethod(testClass, methodName);
+    } catch (Exception e) {
+      if (decisionAnnotation == null) {
+        // we have neither the annotation, nor can look it up from the method
+        return;
+      }
+    }
+
+    if (decisionAnnotation == null) {
+      decisionAnnotation = method.getAnnotation(DmnDecisionKey.class);
+    }
+    // if not found on method, try on class level
+    if (decisionAnnotation == null) {
+      onMethod = false;
+      Class<?> lookForAnnotationClass = testClass;
+      while (lookForAnnotationClass != Object.class) {
+        decisionAnnotation = lookForAnnotationClass.getAnnotation(DmnDecisionKey.class);
+        if (decisionAnnotation != null) {
+          testClass = lookForAnnotationClass;
+          break;
+        }
+        lookForAnnotationClass = lookForAnnotationClass.getSuperclass();
+      }
+    }
+
+    if (decisionAnnotation == null) {
+      LOG.debug("No annotation @Decision found");
+      return;
+    }
+
+    LOG.debug("annotation @Decision for {}.{}", ClassNameUtil.getClassNameWithoutPackage(testClass), methodName);
+    String key = decisionAnnotation.name();
+    if (key.trim().isEmpty()) {
+      throw new IllegalArgumentException("@Decision for key '" + key + "' invalid");
+    }
+    decision = decisions.stream().filter(p -> p.getKey().equalsIgnoreCase(key.trim())).findFirst().orElse(null);
+  }
+
+  private void dmnResources(Class<?> testClass, String methodName, DmnResource deploymentAnnotation) {
+    Method method = null;
+    boolean onMethod = true;
+
+    try {
+      method = getMethod(testClass, methodName);
+    } catch (Exception e) {
+      if (deploymentAnnotation == null) {
+        // we have neither the annotation, nor can look it up from the method
+        return;
+      }
+    }
+
+    if (deploymentAnnotation == null) {
+      deploymentAnnotation = method.getAnnotation(DmnResource.class);
+    }
+    // if not found on method, try on class level
+    if (deploymentAnnotation == null) {
+      onMethod = false;
+      Class<?> lookForAnnotationClass = testClass;
+      while (lookForAnnotationClass != Object.class) {
+        deploymentAnnotation = lookForAnnotationClass.getAnnotation(DmnResource.class);
+        if (deploymentAnnotation != null) {
+          testClass = lookForAnnotationClass;
+          break;
+        }
+        lookForAnnotationClass = lookForAnnotationClass.getSuperclass();
+      }
+    }
+
+    if (deploymentAnnotation == null) {
+      LOG.debug("No annotation @Deployment found");
+      return;
+    }
+
+    LOG.debug("annotation @Deployment creates deployment for {}.{}", ClassNameUtil.getClassNameWithoutPackage(testClass), methodName);
+    String[] resources = deploymentAnnotation.resources();
+    for (String resource : resources) {
+      try (InputStream is = getClass().getResourceAsStream(resource)) {
+        decisions.addAll(getDmnEngine().parseDecisions(is));
+      } catch (IOException e) {
+        throw new IllegalArgumentException("Loading DMN resource '" + resource + "' failed", e);
+      }
+    }
+  }
+
+  protected static Method getMethod(Class<?> clazz, String methodName) throws SecurityException, NoSuchMethodException {
+    return clazz.getMethod(methodName, (Class<?>[]) null);
+  }
+}

--- a/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/test/DmnResource.java
+++ b/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/test/DmnResource.java
@@ -1,0 +1,14 @@
+package org.camunda.bpm.dmn.engine.test;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotation for a test method or class to create and delete a deployment around a test method.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DmnResource {
+
+  /** Specify classpath resources that make up the dmn definition. */
+  String[] resources() default {};
+}


### PR DESCRIPTION
Hello community,

I would like to contribute some code to the DmnEngineRule and I would like to know if there is interest of doing so. Following features:

- declarative approach for loading dmn resources
- declarative approach for “deploying”/“activating” specific dmn rule
- convenience methods for “evaluateDecision” and “evaluateDecisionTable”

Example unit test:
```
@DmnResource(resources = "/rule.dmn")
public class RptNttMatchClassicTest {

  @Rule
  public DmnEngineRule dmnEngineRule = new DmnEngineRule();

  @Test
  @DmnDecisionKey(name = "rule-id")
  public void rptTTMatchClassicNormaliseProductsTest() {
    // given
    Map<String, Object> variables = new HashMap<String, Object>();
    ...
    // when
    DmnDecisionResult dmnDecisionResult = dmnEngineRule.evaluateDecision(variables);
    // then
    ...
  }
}
```

I had a basic discussion at the Camunda forum https://forum.camunda.org/t/features-for-dmnenginerule/23253 about my idea.

After digging into the "camunda-engine-dmn" code, I realized that there is already similar functionality for internal use only: DmnEngineTestRule.

I am wondering how to proceed ? Should the already existing DmnEngineTestRule made public?
Anyway, I attached some code snippet as a starting point for discussions.