### PR TITLE
fix(telemetry): reliably fetch app server info

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/util/WebApplicationUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/util/WebApplicationUtil.java
@@ -19,6 +19,7 @@ package org.camunda.bpm.engine.rest.util;
 import static org.camunda.bpm.engine.rest.util.EngineUtil.getProcessEngineProvider;
 
 import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.impl.telemetry.PlatformTelemetryRegistry;
 import org.camunda.bpm.engine.impl.telemetry.TelemetryRegistry;
 import org.camunda.bpm.engine.impl.telemetry.dto.LicenseKeyData;
 import org.camunda.bpm.engine.rest.spi.ProcessEngineProvider;
@@ -27,12 +28,9 @@ public class WebApplicationUtil {
 
   public static void setApplicationServer(String serverInfo) {
     if (serverInfo != null && !serverInfo.isEmpty() ) {
-      ProcessEngineProvider processEngineProvider = getProcessEngineProvider();
-      for (String engineName : processEngineProvider.getProcessEngineNames()) {
-        TelemetryRegistry telemetryRegistry = getTelemetryRegistry(processEngineProvider, engineName);
-        if (telemetryRegistry != null && telemetryRegistry.getApplicationServer() == null) {
-          telemetryRegistry.setApplicationServer(serverInfo);
-        }
+      // set the application server info globally for all engines in the container
+      if (PlatformTelemetryRegistry.getApplicationServer() == null) {
+        PlatformTelemetryRegistry.setApplicationServer(serverInfo);
       }
     }
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/PlatformTelemetryRegistry.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/PlatformTelemetryRegistry.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.telemetry;
+
+import org.camunda.bpm.engine.impl.telemetry.dto.ApplicationServer;
+
+public class PlatformTelemetryRegistry {
+
+  protected static ApplicationServer applicationServer;
+
+  public static synchronized ApplicationServer getApplicationServer() {
+    return applicationServer;
+  }
+
+  public static synchronized void setApplicationServer(String applicationServerVersion) {
+    if (applicationServer == null) {
+      applicationServer = new ApplicationServer(applicationServerVersion);
+    }
+  }
+
+  public static synchronized void clear() {
+    applicationServer = null;
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryRegistry.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryRegistry.java
@@ -36,6 +36,9 @@ public class TelemetryRegistry {
   protected boolean isCollectingTelemetryDataEnabled = false;
 
   public synchronized ApplicationServer getApplicationServer() {
+    if (applicationServer == null) {
+      applicationServer = PlatformTelemetryRegistry.getApplicationServer();
+    }
     return applicationServer;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/test/ProcessEngineRule.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/test/ProcessEngineRule.java
@@ -37,6 +37,7 @@ import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.impl.ProcessEngineImpl;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.telemetry.PlatformTelemetryRegistry;
 import org.camunda.bpm.engine.impl.test.TestHelper;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.junit.Assume;
@@ -237,6 +238,8 @@ public class ProcessEngineRule extends TestWatcher implements ProcessEngineServi
 
 
     clearServiceReferences();
+
+    PlatformTelemetryRegistry.clear();
   }
 
   public void setCurrentTime(Date currentTime) {


### PR DESCRIPTION
* pushes the app server info from servlet contexts to a
  container-wide telemetry registry
* fetches the app server info from the container-wide registry
  until it is provided (if ever)

related to CAM-12499