### PR TITLE
CAM-12652: feat(rest): lock external task without fetch

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/CompleteExternalTaskDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/CompleteExternalTaskDto.ftl
@@ -1,9 +1,4 @@
-<@lib.dto>
-
-  <@lib.property
-      name = "workerId"
-      type = "string"
-      desc = "The id of the worker that completes the task. Must match the id of the worker who has most recently locked the task." />
+<@lib.dto extends = "HandleExternalTaskDto" >
 
   <@lib.property
       name = "variables"

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/ExtendLockOnExternalTaskDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/ExtendLockOnExternalTaskDto.ftl
@@ -1,15 +1,11 @@
-<@lib.dto>
-
-  <@lib.property
-      name = "workerId"
-      type = "string"
-      desc = "The ID of a worker who is locking the external task." />
+<@lib.dto extends = "HandleExternalTaskDto" >
 
   <@lib.property
       name = "newDuration"
       type = "integer"
       format = "int64"
       last = true
-      desc = "An amount of time (in milliseconds). This is the new lock duration starting from the current moment." />
+      desc = "An amount of time (in milliseconds). This is the new lock duration starting from the
+              current moment." />
 
 </@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/ExternalTaskFailureDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/ExternalTaskFailureDto.ftl
@@ -1,10 +1,4 @@
-<@lib.dto>
-
-  <@lib.property
-    name = "workerId"
-    type = "string"
-    desc = "The id of the worker that reports the failure. Must match the id of the worker who has most recently
-            locked the task." />
+<@lib.dto extends = "HandleExternalTaskDto" >
 
   <@lib.property
       name = "errorMessage"

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/HandleExternalTaskDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/HandleExternalTaskDto.ftl
@@ -1,0 +1,12 @@
+<@lib.dto>
+
+    <@lib.property
+    name = "workerId"
+    type = "string"
+    nullable = false
+    last = true
+    desc = "**Mandatory.** The ID of the worker who is performing the operation on the external task.
+            If the task is already locked, must match the id of the worker who has most recently
+            locked the task." />
+
+</@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/LockExternalTaskDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/LockExternalTaskDto.ftl
@@ -1,0 +1,11 @@
+<@lib.dto extends = "HandleExternalTaskDto" >
+
+  <@lib.property
+      name = "lockDuration"
+      type = "integer"
+      format = "int64"
+      nullable = false
+      last = true
+      desc = "The duration to lock the external task for in milliseconds." />
+
+</@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/lock/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/lock/post.ftl
@@ -1,0 +1,55 @@
+{
+
+  <@lib.endpointInfo
+      id = "lock"
+      tag = "External Task"
+      desc = "Lock an external task by a given id for a specified worker and amount of time." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the external task."/>
+
+  ],
+
+  <@lib.requestBody
+      mediaType = "application/json"
+      dto = "LockExternalTaskDto"
+      examples = ['"example-1": {
+                     "summary": "POST /external-task/anId/lock",
+                     "value": {
+                       "workerId": "anId",
+                       "lockDuration": 100000
+                     }
+                   }'] />
+
+  "responses" : {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful." />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "In case the lock duration is negative or the external task is already locked by
+                a different worker, an exception of type `InvalidRequestException` is returned. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        last = true
+        desc = "Returned if the task does not exist. This could indicate a wrong task id as well as a cancelled task,
+                e.g., due to a caught BPMN boundary event. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format." />
+
+  }
+}

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/externaltask/CompleteExternalTaskDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/externaltask/CompleteExternalTaskDto.java
@@ -24,19 +24,10 @@ import org.camunda.bpm.engine.rest.dto.VariableValueDto;
  * @author Thorben Lindhauer
  *
  */
-public class CompleteExternalTaskDto {
+public class CompleteExternalTaskDto extends HandleExternalTaskDto {
 
-  protected String workerId;
   protected Map<String, VariableValueDto> variables;
   protected Map<String, VariableValueDto> localVariables;
-
-  public String getWorkerId() {
-    return workerId;
-  }
-
-  public void setWorkerId(String workerId) {
-    this.workerId = workerId;
-  }
 
   public Map<String, VariableValueDto> getVariables() {
     return variables;

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/externaltask/ExternalTaskFailureDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/externaltask/ExternalTaskFailureDto.java
@@ -20,9 +20,8 @@ package org.camunda.bpm.engine.rest.dto.externaltask;
  * @author Thorben Lindhauer
  * @author Askar Akhmerov
  */
-public class ExternalTaskFailureDto {
+public class ExternalTaskFailureDto extends HandleExternalTaskDto {
 
-  protected String workerId;
   //short error description
   protected String errorMessage;
   //full stack trace or error information
@@ -30,27 +29,26 @@ public class ExternalTaskFailureDto {
   protected long retryTimeout;
   protected int retries;
 
-  public String getWorkerId() {
-    return workerId;
-  }
-  public void setWorkerId(String workerId) {
-    this.workerId = workerId;
-  }
   public String getErrorMessage() {
     return errorMessage;
   }
+
   public void setErrorMessage(String errorMessage) {
     this.errorMessage = errorMessage;
   }
+
   public long getRetryTimeout() {
     return retryTimeout;
   }
+
   public void setRetryTimeout(long retryTimeout) {
     this.retryTimeout = retryTimeout;
   }
+
   public int getRetries() {
     return retries;
   }
+
   public void setRetries(int retries) {
     this.retries = retries;
   }
@@ -62,4 +60,5 @@ public class ExternalTaskFailureDto {
   public void setErrorDetails(String errorDetails) {
     this.errorDetails = errorDetails;
   }
+
 }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/externaltask/HandleExternalTaskDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/externaltask/HandleExternalTaskDto.java
@@ -16,16 +16,31 @@
  */
 package org.camunda.bpm.engine.rest.dto.externaltask;
 
-public class ExtendLockOnExternalTaskDto extends HandleExternalTaskDto {
+/**
+ * Base DTO class for Worker-related External Task operations.
+ * Contains the <code>workerId</code> property.
+ *
+ * Used in:
+ * <ul>
+ *   <li>{@link LockExternalTaskDto}</li>
+ *   <li>{@link ExtendLockOnExternalTaskDto}</li>
+ *   <li>{@link ExternalTaskFailureDto}</li>
+ *   <li>{@link CompleteExternalTaskDto}</li>
+ * </ul>
+ *
+ * Note: the {@link ExternalTaskBpmnError} class doesn't extend this class. Any adjustments made here
+ * should be mirrored in that class as well.
+ */
+public class HandleExternalTaskDto {
 
-  protected long newDuration;
+  protected String workerId;
 
-  public long getNewDuration() {
-    return newDuration;
+  public String getWorkerId() {
+    return workerId;
   }
 
-  public void setNewDuration(long newDuration) {
-    this.newDuration = newDuration;
+  public void setWorkerId(String workerId) {
+    this.workerId = workerId;
   }
 
 }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/externaltask/LockExternalTaskDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/externaltask/LockExternalTaskDto.java
@@ -16,16 +16,16 @@
  */
 package org.camunda.bpm.engine.rest.dto.externaltask;
 
-public class ExtendLockOnExternalTaskDto extends HandleExternalTaskDto {
+public class LockExternalTaskDto extends HandleExternalTaskDto {
 
-  protected long newDuration;
+  protected long lockDuration;
 
-  public long getNewDuration() {
-    return newDuration;
+  public long getLockDuration() {
+    return lockDuration;
   }
 
-  public void setNewDuration(long newDuration) {
-    this.newDuration = newDuration;
+  public void setLockDuration(long lockDuration) {
+    this.lockDuration = lockDuration;
   }
 
 }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/externaltask/ExternalTaskResource.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/externaltask/ExternalTaskResource.java
@@ -29,6 +29,7 @@ import org.camunda.bpm.engine.rest.dto.externaltask.ExtendLockOnExternalTaskDto;
 import org.camunda.bpm.engine.rest.dto.externaltask.ExternalTaskBpmnError;
 import org.camunda.bpm.engine.rest.dto.externaltask.ExternalTaskDto;
 import org.camunda.bpm.engine.rest.dto.externaltask.ExternalTaskFailureDto;
+import org.camunda.bpm.engine.rest.dto.externaltask.LockExternalTaskDto;
 import org.camunda.bpm.engine.rest.dto.runtime.PriorityDto;
 import org.camunda.bpm.engine.rest.dto.runtime.RetriesDto;
 
@@ -74,11 +75,16 @@ public interface ExternalTaskResource {
   void handleBpmnError(ExternalTaskBpmnError dto);
 
   @POST
-  @Path("/unlock")
-  void unlock();
+  @Path("/lock")
+  @Consumes(MediaType.APPLICATION_JSON)
+  void lock(LockExternalTaskDto lockExternalTaskDto);
 
   @POST
   @Path("/extendLock")
   @Consumes(MediaType.APPLICATION_JSON)
   void extendLock(ExtendLockOnExternalTaskDto extendLockDto);
+
+  @POST
+  @Path("/unlock")
+  void unlock();
 }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/externaltask/impl/ExternalTaskResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/externaltask/impl/ExternalTaskResourceImpl.java
@@ -29,6 +29,7 @@ import org.camunda.bpm.engine.rest.dto.externaltask.ExtendLockOnExternalTaskDto;
 import org.camunda.bpm.engine.rest.dto.externaltask.ExternalTaskBpmnError;
 import org.camunda.bpm.engine.rest.dto.externaltask.ExternalTaskDto;
 import org.camunda.bpm.engine.rest.dto.externaltask.ExternalTaskFailureDto;
+import org.camunda.bpm.engine.rest.dto.externaltask.LockExternalTaskDto;
 import org.camunda.bpm.engine.rest.dto.runtime.PriorityDto;
 import org.camunda.bpm.engine.rest.dto.runtime.RetriesDto;
 import org.camunda.bpm.engine.rest.exception.InvalidRequestException;
@@ -156,13 +157,16 @@ public class ExternalTaskResourceImpl implements ExternalTaskResource {
   }
 
   @Override
-  public void unlock() {
+  public void lock(LockExternalTaskDto lockExternalTaskDto) {
     ExternalTaskService externalTaskService = engine.getExternalTaskService();
 
     try {
-      externalTaskService.unlock(externalTaskId);
+      externalTaskService
+          .lock(externalTaskId, lockExternalTaskDto.getWorkerId(), lockExternalTaskDto.getLockDuration());
     } catch (NotFoundException e) {
       throw new RestException(Status.NOT_FOUND, e, "External task with id " + externalTaskId + " does not exist");
+    } catch (BadUserRequestException e) {
+      throw new RestException(Status.BAD_REQUEST, e, e.getMessage());
     }
   }
 
@@ -176,6 +180,17 @@ public class ExternalTaskResourceImpl implements ExternalTaskResource {
       throw new RestException(Status.NOT_FOUND, e, "External task with id " + externalTaskId + " does not exist");
     } catch (BadUserRequestException e) {
       throw new RestException(Status.BAD_REQUEST, e, e.getMessage());
+    }
+  }
+
+  @Override
+  public void unlock() {
+    ExternalTaskService externalTaskService = engine.getExternalTaskService();
+
+    try {
+      externalTaskService.unlock(externalTaskId);
+    } catch (NotFoundException e) {
+      throw new RestException(Status.NOT_FOUND, e, "External task with id " + externalTaskId + " does not exist");
     }
   }
 }

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ExternalTaskRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ExternalTaskRestServiceInteractionTest.java
@@ -103,6 +103,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   protected static final String RETRIES_EXTERNAL_TASK_SYNC_URL = EXTERNAL_TASK_URL + "/retries";
   protected static final String RETRIES_EXTERNAL_TASKS_ASYNC_URL = EXTERNAL_TASK_URL + "/retries-async";
   protected static final String PRIORITY_EXTERNAL_TASK_URL = SINGLE_EXTERNAL_TASK_URL + "/priority";
+  protected static final String LOCK_EXTERNAL_TASK = SINGLE_EXTERNAL_TASK_URL + "/lock";
   protected static final String EXTEND_LOCK_ON_EXTERNAL_TASK = SINGLE_EXTERNAL_TASK_URL + "/extendLock";
 
 
@@ -180,12 +181,12 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
 
     // when
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("maxTasks", 5);
     parameters.put("workerId", "aWorkerId");
     parameters.put("usePriority", true);
 
-    Map<String, Object> topicParameter = new HashMap<String, Object>();
+    Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("lockDuration", 12354L);
     topicParameter.put("variables", Arrays.asList(MockProvider.EXAMPLE_VARIABLE_INSTANCE_NAME));
@@ -207,12 +208,12 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
 
     // when
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("maxTasks", 5);
     parameters.put("workerId", "aWorkerId");
     parameters.put("usePriority", true);
 
-    Map<String, Object> topicParameter = new HashMap<String, Object>();
+    Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("businessKey", EXAMPLE_BUSINESS_KEY);
     topicParameter.put("lockDuration", 12354L);
@@ -236,12 +237,12 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
 
     // when
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("maxTasks", 5);
     parameters.put("workerId", "aWorkerId");
     parameters.put("usePriority", true);
 
-    Map<String, Object> topicParameter = new HashMap<String, Object>();
+    Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("processDefinitionId", EXAMPLE_PROCESS_DEFINITION_ID);
     topicParameter.put("processDefinitionIdIn", Arrays.asList(EXAMPLE_PROCESS_DEFINITION_ID));
@@ -269,18 +270,18 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
 
     // when
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("maxTasks", 5);
     parameters.put("workerId", "aWorkerId");
     parameters.put("usePriority", true);
 
-    Map<String, Object> topicParameter = new HashMap<String, Object>();
+    Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("businessKey", EXAMPLE_BUSINESS_KEY);
     topicParameter.put("lockDuration", 12354L);
     topicParameter.put("variables", Arrays.asList(MockProvider.EXAMPLE_VARIABLE_INSTANCE_NAME));
 
-    Map<String, Object> variableValueParameter = new HashMap<String, Object>();
+    Map<String, Object> variableValueParameter = new HashMap<>();
     variableValueParameter.put(MockProvider.EXAMPLE_VARIABLE_INSTANCE_NAME, MockProvider.EXAMPLE_PRIMITIVE_VARIABLE_VALUE.getValue());
     topicParameter.put("processVariables", variableValueParameter);
 
@@ -304,11 +305,11 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
 
     // when
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("maxTasks", 5);
     parameters.put("workerId", "aWorkerId");
 
-    Map<String, Object> topicParameter = new HashMap<String, Object>();
+    Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("lockDuration", 12354L);
     parameters.put("topics", Arrays.asList(topicParameter));
@@ -337,12 +338,12 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
 
     // when
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("maxTasks", 5);
     parameters.put("workerId", "aWorkerId");
     parameters.put("usePriority", true);
 
-    Map<String, Object> topicParameter = new HashMap<String, Object>();
+    Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("withoutTenantId", true);
     topicParameter.put("tenantId", "tenant1");
@@ -367,11 +368,11 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
     
     // when
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("maxTasks", 5);
     parameters.put("workerId", "aWorkerId");
     
-    Map<String, Object> topicParameter = new HashMap<String, Object>();
+    Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("lockDuration", 12354L);
     topicParameter.put("processDefinitionVersionTag", "versionTag");
@@ -393,11 +394,11 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
 
     // when
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("maxTasks", 5);
     parameters.put("workerId", "aWorkerId");
 
-    Map<String, Object> topicParameter = new HashMap<String, Object>();
+    Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("lockDuration", 12354L);
     topicParameter.put("includeExtensionProperties", true);
@@ -420,11 +421,11 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
 
     // when
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("maxTasks", 5);
     parameters.put("workerId", "aWorkerId");
 
-    Map<String, Object> topicParameter = new HashMap<String, Object>();
+    Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("lockDuration", 12354L);
     topicParameter.put("variables", Arrays.asList(MockProvider.EXAMPLE_VARIABLE_INSTANCE_NAME));
@@ -456,11 +457,11 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     when(fetchTopicBuilder.execute()).thenReturn(Arrays.asList(lockedExternalTaskMock));
 
     // when
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("maxTasks", 5);
     parameters.put("workerId", "aWorkerId");
 
-    Map<String, Object> topicParameter = new HashMap<String, Object>();
+    Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");
     topicParameter.put("lockDuration", 12354L);
     topicParameter.put("variables", Arrays.asList(MockProvider.EXAMPLE_VARIABLE_INSTANCE_NAME));
@@ -489,7 +490,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
   @Test
   public void testComplete() {
-    Map<String, String> parameters = new HashMap<String, String>();
+    Map<String, String> parameters = new HashMap<>();
     parameters.put("workerId", "aWorkerId");
 
     given()
@@ -508,7 +509,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
   @Test
   public void testCompleteWithVariables() {
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("workerId", "aWorkerId");
 
     Map<String, Object> variables = VariablesBuilder
@@ -548,7 +549,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
   @Test
   public void testCompleteWithLocalVariables() {
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("workerId", "aWorkerId");
 
     Map<String, Object> variables = VariablesBuilder
@@ -592,7 +593,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
       .when(externalTaskService)
       .complete(any(String.class), any(String.class), anyMapOf(String.class, Object.class), anyMapOf(String.class, Object.class));
 
-    Map<String, String> parameters = new HashMap<String, String>();
+    Map<String, String> parameters = new HashMap<>();
     parameters.put("workerId", "aWorkerId");
 
     given()
@@ -614,7 +615,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
       .when(externalTaskService)
       .complete(any(String.class), any(String.class), anyMapOf(String.class, Object.class), anyMapOf(String.class, Object.class));
 
-    Map<String, String> parameters = new HashMap<String, String>();
+    Map<String, String> parameters = new HashMap<>();
     parameters.put("workerId", "aWorkerId");
 
     given()
@@ -636,7 +637,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
       .when(externalTaskService)
       .complete(any(String.class), any(String.class), anyMapOf(String.class, Object.class), anyMapOf(String.class, Object.class));
 
-    Map<String, String> parameters = new HashMap<String, String>();
+    Map<String, String> parameters = new HashMap<>();
     parameters.put("workerId", "aWorkerId");
 
     given()
@@ -754,7 +755,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
   @Test
   public void testHandleFailure() {
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("workerId", "aWorkerId");
     parameters.put("errorMessage", "anErrorMessage");
     parameters.put("retries", 5);
@@ -776,7 +777,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
   @Test
   public void testHandleFailureWithStackTrace() {
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("workerId", "aWorkerId");
     parameters.put("errorMessage", "anErrorMessage");
     parameters.put("errorDetails", "aStackTrace");
@@ -803,7 +804,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
       .when(externalTaskService)
       .handleFailure(any(String.class), any(String.class), any(String.class),any(String.class), anyInt(), anyLong());
 
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("workerId", "aWorkerId");
     parameters.put("errorMessage", "anErrorMessage");
     parameters.put("retries", 5);
@@ -828,7 +829,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
       .when(externalTaskService)
       .handleFailure(any(String.class), any(String.class), any(String.class),any(String.class), anyInt(), anyLong());
 
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("workerId", "aWorkerId");
     parameters.put("errorMessage", "anErrorMessage");
     parameters.put("retries", 5);
@@ -853,7 +854,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
       .when(externalTaskService)
       .handleFailure(any(String.class), any(String.class), any(String.class),any(String.class), anyInt(), anyLong());
 
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("workerId", "aWorkerId");
     parameters.put("errorMessage", "anErrorMessage");
     parameters.put("retries", 5);
@@ -876,7 +877,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
   @Test
   public void testHandleBpmnError() {
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("workerId", "aWorkerId");
     parameters.put("errorCode", "anErrorCode");
 
@@ -896,7 +897,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
   @Test
   public void testHandleBpmnErrorWithVariables() {
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("workerId", "aWorkerId");
     parameters.put("errorCode", "anErrorCode");
     parameters.put("errorMessage", "anErrorMessage");
@@ -941,7 +942,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
       .when(externalTaskService)
       .handleBpmnError(any(String.class), any(String.class), any(String.class), any(String.class), anyMapOf(String.class, Object.class));
 
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("workerId", "aWorkerId");
     parameters.put("errorCode", "errorCode");
 
@@ -964,7 +965,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
       .when(externalTaskService)
       .handleBpmnError(any(String.class), any(String.class), any(String.class), any(String.class), anyMapOf(String.class, Object.class));
 
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("workerId", "aWorkerId");
     parameters.put("errorCode", "errorCode");
 
@@ -987,7 +988,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
       .when(externalTaskService)
       .handleBpmnError(any(String.class), any(String.class), any(String.class), any(String.class), anyMapOf(String.class, Object.class));
 
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("workerId", "aWorkerId");
     parameters.put("errorCode", "errorCode");
 
@@ -1007,7 +1008,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
   @Test
   public void testSetRetries() {
-    Map<String, String> parameters = new HashMap<String, String>();
+    Map<String, String> parameters = new HashMap<>();
     parameters.put("retries", "5");
 
     given()
@@ -1028,7 +1029,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   public void testSetRetriesNonExistingTask() {
     doThrow(new NotFoundException()).when(externalTaskService).setRetries(any(String.class), anyInt());
 
-    Map<String, String> parameters = new HashMap<String, String>();
+    Map<String, String> parameters = new HashMap<>();
     parameters.put("retries", "5");
 
     given()
@@ -1048,7 +1049,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   public void testSetRetriesThrowsAuthorizationException() {
     doThrow(new AuthorizationException("aMessage")).when(externalTaskService).setRetries(any(String.class), anyInt());
 
-    Map<String, String> parameters = new HashMap<String, String>();
+    Map<String, String> parameters = new HashMap<>();
     parameters.put("retries", "5");
 
     given()
@@ -1068,7 +1069,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
 
   @Test
   public void testSetPriority() {
-    Map<String, String> parameters = new HashMap<String, String>();
+    Map<String, String> parameters = new HashMap<>();
     parameters.put("priority", "5");
 
     given()
@@ -1089,7 +1090,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   public void testSetPriorityNonExistingTask() {
     doThrow(new NotFoundException()).when(externalTaskService).setPriority(any(String.class), anyInt());
 
-    Map<String, String> parameters = new HashMap<String, String>();
+    Map<String, String> parameters = new HashMap<>();
     parameters.put("priority", "5");
 
     given()
@@ -1109,7 +1110,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   public void testSetPriorityThrowsAuthorizationException() {
     doThrow(new AuthorizationException("aMessage")).when(externalTaskService).setPriority(any(String.class), anyInt());
 
-    Map<String, String> parameters = new HashMap<String, String>();
+    Map<String, String> parameters = new HashMap<>();
     parameters.put("priority", "5");
 
     given()
@@ -1172,7 +1173,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   public void testSetRetriesForExternalTasksAsync() {
     List<String> externalTaskIds = Arrays.asList("externalTaskId1", "externalTaskId2");
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", "5");
     parameters.put("externalTaskIds", externalTaskIds);
 
@@ -1200,7 +1201,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   public void testSetRetriesForExternalTasksSync() {
     List<String> externalTaskIds = Arrays.asList("externalTaskId1", "externalTaskId2");
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", "5");
     parameters.put("externalTaskIds", externalTaskIds);
 
@@ -1228,7 +1229,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   public void testSetRetriesForExternalTasksAsyncByProcessInstanceIds() {
     List<String> processInstanceIds = Arrays.asList("123", "456");
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", "5");
     parameters.put("processInstanceIds", processInstanceIds);
 
@@ -1256,7 +1257,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   public void testSetRetriesForExternalTasksSyncByProcessInstanceIds() {
     List<String> processInstanceIds = Arrays.asList("123", "456");
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", "5");
     parameters.put("processInstanceIds", processInstanceIds);
 
@@ -1286,7 +1287,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     doThrow(BadUserRequestException.class).when(updateRetriesBuilder).setAsync(anyInt());
 
     List<String> externalTaskIds = null;
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", "5");
     parameters.put("externalTaskIds", externalTaskIds);
 
@@ -1316,7 +1317,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     doThrow(BadUserRequestException.class).when(updateRetriesBuilder).setAsync(anyInt());
 
     List<String> externalTaskIds = null;
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", "-5");
     parameters.put("externalTaskIds", externalTaskIds);
 
@@ -1344,7 +1345,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   @Test
   public void testSetNullRetriesForExternalTasks() {
     List<String> externalTaskIds = null;
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", null);
     parameters.put("externalTaskIds", externalTaskIds);
     
@@ -1393,7 +1394,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     ProcessInstanceQueryDto processInstanceQuery = new ProcessInstanceQueryDto();
     processInstanceQuery.setProcessDefinitionId(EXAMPLE_PROCESS_DEFINITION_ID);
 
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", "5");
     parameters.put("processInstanceQuery", processInstanceQuery);
 
@@ -1431,7 +1432,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     HistoricProcessInstanceQueryDto query = new HistoricProcessInstanceQueryDto();
     query.setProcessDefinitionId(EXAMPLE_PROCESS_DEFINITION_ID);
 
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", "5");
     parameters.put("historicProcessInstanceQuery", query);
 
@@ -1469,7 +1470,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     ProcessInstanceQueryDto processInstanceQuery = new ProcessInstanceQueryDto();
     processInstanceQuery.setProcessDefinitionId(EXAMPLE_PROCESS_DEFINITION_ID);
 
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", "5");
     parameters.put("processInstanceQuery", processInstanceQuery);
 
@@ -1507,7 +1508,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     HistoricProcessInstanceQueryDto query = new HistoricProcessInstanceQueryDto();
     query.setProcessDefinitionId(EXAMPLE_PROCESS_DEFINITION_ID);
 
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", "5");
     parameters.put("historicProcessInstanceQuery", query);
 
@@ -1545,7 +1546,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     ExternalTaskQueryDto query = new ExternalTaskQueryDto();
     query.setProcessDefinitionId(EXAMPLE_PROCESS_DEFINITION_ID);
 
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", "5");
     parameters.put("externalTaskQuery", query);
 
@@ -1584,7 +1585,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     ExternalTaskQueryDto query = new ExternalTaskQueryDto();
     query.setProcessDefinitionId(EXAMPLE_PROCESS_DEFINITION_ID);
 
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("retries", "5");
     parameters.put("externalTaskQuery", query);
 
@@ -1617,61 +1618,107 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
   }
 
   @Test
-  public void testExtendLockOnExternalTask() {
+  public void shouldLockExternalTask() {
 
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("workerId", "workerId");
+    parameters.put("lockDuration", "1000");
+
+    given()
+        .pathParam("id", MockProvider.EXTERNAL_TASK_ID)
+        .contentType(ContentType.JSON)
+        .body(parameters)
+    .then()
+        .expect()
+        .statusCode(Status.NO_CONTENT.getStatusCode())
+    .when()
+        .post(LOCK_EXTERNAL_TASK);
+
+    verify(externalTaskService).lock(MockProvider.EXTERNAL_TASK_ID, "workerId", 1000);
+    verifyNoMoreInteractions(externalTaskService);
+  }
+
+  @Test
+  public void shouldFailOnLockExternalTaskWithNegativeLockDuration() {
+
+    doThrow(BadUserRequestException.class).when(externalTaskService).lock(anyString(), anyString(), anyLong());
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("workerId", "workerId");
+    parameters.put("lockDuration", -1);
+
+    given()
+        .pathParam("id", MockProvider.EXTERNAL_TASK_ID)
+        .contentType(ContentType.JSON)
+        .body(parameters)
+    .then()
+        .expect()
+        .statusCode(Status.BAD_REQUEST.getStatusCode())
+    .when()
+        .post(LOCK_EXTERNAL_TASK);
+
+  }
+
+  @Test
+  public void shouldFailToLockNonexistentExternalTask() {
+    doThrow(NotFoundException.class).when(externalTaskService).lock(anyString(), anyString(), anyLong());
+
+    Map<String, Object> json = new HashMap<>();
+    json.put("workerId", "workerId");
+    json.put("lockDuration", 1000);
+
+    given()
+        .pathParam("id", MockProvider.EXTERNAL_TASK_ID)
+        .contentType(ContentType.JSON)
+        .body(json)
+    .then()
+        .expect()
+        .statusCode(Status.NOT_FOUND.getStatusCode())
+    .when()
+        .post(LOCK_EXTERNAL_TASK);
+  }
+
+  @Test
+  public void shouldExtendLockOnExternalTask() {
+
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("workerId", "workerId");
     parameters.put("newDuration", "1000");
 
-    given()
-      .pathParam("id", MockProvider.EXTERNAL_TASK_ID)
-      .contentType(ContentType.JSON)
-      .body(parameters)
-    .then()
-      .expect()
-      .statusCode(Status.NO_CONTENT.getStatusCode())
-    .when()
-      .post(EXTEND_LOCK_ON_EXTERNAL_TASK);
-
+    validateExtendLockRequest(parameters, Status.NO_CONTENT.getStatusCode());
     verify(externalTaskService).extendLock(MockProvider.EXTERNAL_TASK_ID, "workerId", 1000);
     verifyNoMoreInteractions(externalTaskService);
   }
 
   @Test
-  public void testExtendLockOnExternalTaskFailed() {
+  public void shouldFailOnExtendLockOnExternalTaskWithNegativeNewDuration() {
 
     doThrow(BadUserRequestException.class).when(externalTaskService).extendLock(anyString(), anyString(), anyLong());
-    Map<String, Object> parameters = new HashMap<String, Object>();
+    Map<String, Object> parameters = new HashMap<>();
     parameters.put("workerId", "workerId");
     parameters.put("newDuration", -1);
 
-    given()
-      .pathParam("id", MockProvider.EXTERNAL_TASK_ID)
-      .contentType(ContentType.JSON)
-      .body(parameters)
-    .then()
-      .expect()
-      .statusCode(Status.BAD_REQUEST.getStatusCode())
-    .when()
-      .post(EXTEND_LOCK_ON_EXTERNAL_TASK);
-
+    validateExtendLockRequest(parameters, Status.BAD_REQUEST.getStatusCode());
   }
 
   @Test
-  public void testExtendLockOnUnexistingExternalTask() {
+  public void shouldFailToExtendLockOnNonexistentExternalTask() {
     doThrow(NotFoundException.class).when(externalTaskService).extendLock(anyString(), anyString(), anyLong());
 
-    Map<String, Object> json = new HashMap<String, Object>();
+    Map<String, Object> json = new HashMap<>();
     json.put("workerId", "workerId");
     json.put("newDuration", 1000);
 
+    validateExtendLockRequest(json, Status.NOT_FOUND.getStatusCode());
+  }
+
+  protected void validateExtendLockRequest(Map json, int statusCode) {
     given()
       .pathParam("id", MockProvider.EXTERNAL_TASK_ID)
       .contentType(ContentType.JSON)
       .body(json)
     .then()
       .expect()
-      .statusCode(Status.NOT_FOUND.getStatusCode())
+      .statusCode(statusCode)
     .when()
       .post(EXTEND_LOCK_ON_EXTERNAL_TASK);
   }


### PR DESCRIPTION
* Allow for an External Task to be locked without a fetch operation through the Rest API.
* Document the new External Task Lock Rest API endpoint in the OpenAPI documentation.
* Deprecate the `ExtendLockOnExternalTaskDto` methods `#getNewDuration()` and `#setNewDuration(long)` in favor of the new `lockDuration` property.

Related to CAM-12652, CAM-7170

:information_source: Note: this PR is currently based on #1089 since it relies on the code contributed by that PR.