### PR TITLE
CAM-12651: fix(engine): clarify lock external task api behavior

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/LockExternalTaskDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/LockExternalTaskDto.ftl
@@ -6,6 +6,8 @@
       format = "int64"
       nullable = false
       last = true
-      desc = "The duration to lock the external task for in milliseconds." />
+      desc = "The duration to lock the external task for in milliseconds.
+              **Note:** Attempting to lock an already locked external task with the same `workerId`
+              will succeed and a new lock duration will be set, starting from the current moment." />
 
 </@lib.dto>

--- a/engine/src/main/java/org/camunda/bpm/engine/ExternalTaskService.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/ExternalTaskService.java
@@ -95,7 +95,10 @@ public interface ExternalTaskService {
   public ExternalTaskQueryBuilder fetchAndLock(int maxTasks, String workerId, boolean usePriority);
 
   /**
-   * <p>Lock an external task on behalf of a worker.</p>
+   * <p>Lock an external task on behalf of a worker.
+   *    Note: Attempting to lock an already locked external task with the same <code>workerId</code>
+   *    will succeed and a new lock duration will be set, starting from the current moment.
+   * </p>
    *
    * @param externalTaskId the id of the external task to lock
    * @param workerId  the id of the worker to lock the task for


### PR DESCRIPTION
* An already locked task, can be locked again by the same worker. In
  this case, the Lock API behaves like the Extend Lock API.

Related to CAM-12651, CAM-7170