### PR TITLE
chore(spring-boot-starter): bump to Spring Boot 2.4

### DIFF
--- a/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/util/SpringBootManagedContainer.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/camunda/bpm/run/qa/util/SpringBootManagedContainer.java
@@ -180,21 +180,30 @@ public class SpringBootManagedContainer {
 
   protected boolean isRunning() {
     try {
-      URLConnection conn = new URL(this.baseUrl).openConnection();
-      HttpURLConnection hconn = (HttpURLConnection) conn;
-      hconn.setAllowUserInteraction(false);
-      hconn.setDoInput(true);
-      hconn.setUseCaches(false);
-      hconn.setDoOutput(false);
-      hconn.setRequestMethod("OPTIONS");
-      hconn.setRequestProperty("User-Agent", "Camunda-Managed-SpringBoot-Container/1.0");
-      hconn.setRequestProperty("Accept", "text/plain");
-      hconn.connect();
-      processResponse(hconn);
+      processOptionsRequests(this.baseUrl);
+      return true;
     } catch (Exception e) {
-      return false;
+      try {
+        processOptionsRequests(this.baseUrl + "/engine-rest/engine");
+      } catch (Exception ex) {
+        return false;
+      }
     }
     return true;
+  }
+
+  protected void processOptionsRequests(String urlToCall) throws IOException {
+    URLConnection conn = new URL(urlToCall).openConnection();
+    HttpURLConnection hconn = (HttpURLConnection) conn;
+    hconn.setAllowUserInteraction(false);
+    hconn.setDoInput(true);
+    hconn.setUseCaches(false);
+    hconn.setDoOutput(false);
+    hconn.setRequestMethod("OPTIONS");
+    hconn.setRequestProperty("User-Agent", "Camunda-Managed-SpringBoot-Container/1.0");
+    hconn.setRequestProperty("Accept", "text/plain");
+    hconn.connect();
+    processResponse(hconn);
   }
 
   protected void processResponse(HttpURLConnection hconn) throws IOException {
@@ -216,8 +225,8 @@ public class SpringBootManagedContainer {
     try {
       Process p = null;
       Integer pid = null;
-      
-      // must kill a hierachy of processes: the script process (which corresponds to the pid value) 
+
+      // must kill a hierachy of processes: the script process (which corresponds to the pid value)
       // and the Java process it has spawned
       if (isUnixLike()) {
         pid = unixLikeProcessId(process);

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -19,7 +19,7 @@
 
   <properties>
     <version.spring.framework>5.2.8.RELEASE</version.spring.framework>
-    <version.spring-boot>2.3.1.RELEASE</version.spring-boot>
+    <version.spring-boot>2.4.0</version.spring-boot>
     <version.cxf>3.0.3</version.cxf>
     <version.resteasy>2.3.5.Final</version.resteasy>
     <version.resteasy3>3.10.0.Final</version.resteasy3>

--- a/spring-boot-starter/starter-test/pom.xml
+++ b/spring-boot-starter/starter-test/pom.xml
@@ -25,6 +25,19 @@
       <scope>compile</scope>
     </dependency>
 
+    <!-- needed for JUnit4 execution -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <dependency>
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine</artifactId>

--- a/spring-boot-starter/starter/pom.xml
+++ b/spring-boot-starter/starter/pom.xml
@@ -93,12 +93,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-security</artifactId>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>


### PR DESCRIPTION
* keeps JUnit 4 legacy support in `starter-test`
* removes optional Spring Security dependency from `starter`
  to not enable auto-configuration of web security for web-based
  integration tests (newly enabled by Spring Boot 2.4's
  `ManagementWebSecurityAutoConfiguration`)
* makes Run ITs more robust in case of REST-only startup since
  no default `DispatcherServlet` is registered anymore listening
  for requests on "/" in this scenario

related to CAM-12148