### PR TITLE
chore(engine): enable empty string variable value on Oracle

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/AbstractQueryVariableValueCondition.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/AbstractQueryVariableValueCondition.java
@@ -33,7 +33,7 @@ public abstract class AbstractQueryVariableValueCondition {
     this.wrappedQueryValue = variableValue;
   }
 
-  public abstract void initializeValue(VariableSerializers serializers);
+  public abstract void initializeValue(VariableSerializers serializers, String dbType);
 
   public abstract List<SingleQueryVariableValueCondition> getDisjunctiveConditions();
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/AbstractVariableQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/AbstractVariableQueryImpl.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.camunda.bpm.engine.exception.NotValidException;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
@@ -98,7 +99,7 @@ public abstract class AbstractVariableQueryImpl<T extends Query<?,?>, U> extends
     addVariable(name, value, QueryOperator.LIKE, true);
     return (T)this;
   }
-  
+
   @SuppressWarnings("unchecked")
   public T matchVariableNamesIgnoreCase() {
     this.variableNamesIgnoreCase = true;
@@ -149,11 +150,11 @@ public abstract class AbstractVariableQueryImpl<T extends Query<?,?>, U> extends
 
   protected void ensureVariablesInitialized() {
     if (!queryVariableValues.isEmpty()) {
-      VariableSerializers variableSerializers = Context
-              .getProcessEngineConfiguration()
-              .getVariableSerializers();
+      ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+      VariableSerializers variableSerializers = processEngineConfiguration.getVariableSerializers();
+      String dbType = processEngineConfiguration.getDatabaseType();
       for(QueryVariableValue queryVariableValue : queryVariableValues) {
-        queryVariableValue.initialize(variableSerializers);
+        queryVariableValue.initialize(variableSerializers, dbType);
       }
     }
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/CompositeQueryVariableValueCondition.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/CompositeQueryVariableValueCondition.java
@@ -32,13 +32,13 @@ import org.camunda.bpm.engine.variable.value.TypedValue;
  */
 public class CompositeQueryVariableValueCondition extends AbstractQueryVariableValueCondition {
 
-  protected List<SingleQueryVariableValueCondition> aggregatedValues = new ArrayList<SingleQueryVariableValueCondition>();
+  protected List<SingleQueryVariableValueCondition> aggregatedValues = new ArrayList<>();
 
   public CompositeQueryVariableValueCondition(QueryVariableValue variableValue) {
     super(variableValue);
   }
 
-  public void initializeValue(VariableSerializers serializers) {
+  public void initializeValue(VariableSerializers serializers, String dbType) {
     TypedValue typedValue = wrappedQueryValue.getTypedValue();
 
     ValueTypeResolver resolver = Context.getProcessEngineConfiguration().getValueTypeResolver();
@@ -48,7 +48,7 @@ public class CompositeQueryVariableValueCondition extends AbstractQueryVariableV
       if (type.canConvertFromTypedValue(typedValue)) {
         TypedValue convertedValue = type.convertFromTypedValue(typedValue);
         SingleQueryVariableValueCondition aggregatedValue = new SingleQueryVariableValueCondition(wrappedQueryValue);
-        aggregatedValue.initializeValue(serializers, convertedValue);
+        aggregatedValue.initializeValue(serializers, convertedValue, dbType);
         aggregatedValues.add(aggregatedValue);
       }
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -33,6 +33,7 @@ import org.camunda.bpm.engine.BadUserRequestException;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
 import org.camunda.bpm.engine.history.HistoricProcessInstanceQuery;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
@@ -399,12 +400,13 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
     super.ensureVariablesInitialized();
 
     if (!queries.isEmpty()) {
-      VariableSerializers variableSerializers = Context.getProcessEngineConfiguration()
-          .getVariableSerializers();
+      ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+      VariableSerializers variableSerializers = processEngineConfiguration.getVariableSerializers();
+      String dbType = processEngineConfiguration.getDatabaseType();
 
       for (HistoricProcessInstanceQueryImpl orQuery: queries) {
         for (QueryVariableValue var : orQuery.queryVariableValues) {
-          var.initialize(variableSerializers);
+          var.initialize(variableSerializers, dbType);
         }
       }
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -27,6 +27,7 @@ import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.exception.NotValidException;
 import org.camunda.bpm.engine.history.HistoricTaskInstance;
 import org.camunda.bpm.engine.history.HistoricTaskInstanceQuery;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
@@ -281,7 +282,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
     this.unfinished = true;
     return this;
   }
-  
+
   @Override
   public HistoricTaskInstanceQuery matchVariableNamesIgnoreCase() {
     this.variableNamesIgnoreCase = true;
@@ -409,15 +410,17 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
   }
 
   protected void ensureVariablesInitialized() {
-    VariableSerializers types = Context.getProcessEngineConfiguration().getVariableSerializers();
+    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    VariableSerializers variableSerializers = processEngineConfiguration.getVariableSerializers();
+    String dbType = processEngineConfiguration.getDatabaseType();
     for(QueryVariableValue var : variables) {
-      var.initialize(types);
+      var.initialize(variableSerializers, dbType);
     }
 
     if (!queries.isEmpty()) {
       for (HistoricTaskInstanceQueryImpl orQuery: queries) {
         for (QueryVariableValue var : orQuery.variables) {
-          var.initialize(types);
+          var.initialize(variableSerializers, dbType);
         }
       }
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricVariableInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricVariableInstanceQueryImpl.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.camunda.bpm.engine.history.HistoricVariableInstance;
 import org.camunda.bpm.engine.history.HistoricVariableInstanceQuery;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.cmd.CommandLogger;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
@@ -193,8 +194,10 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
 
   protected void ensureVariablesInitialized() {
     if (this.queryVariableValue != null) {
-      VariableSerializers variableSerializers = Context.getProcessEngineConfiguration().getVariableSerializers();
-      queryVariableValue.initialize(variableSerializers);
+      ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+      VariableSerializers variableSerializers = processEngineConfiguration.getVariableSerializers();
+      String dbType = processEngineConfiguration.getDatabaseType();
+      queryVariableValue.initialize(variableSerializers, dbType);
     }
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessInstanceQueryImpl.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
@@ -351,12 +352,13 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
     super.ensureVariablesInitialized();
 
     if (!queries.isEmpty()) {
-      VariableSerializers variableSerializers = Context.getProcessEngineConfiguration()
-          .getVariableSerializers();
+      ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+      VariableSerializers variableSerializers = processEngineConfiguration.getVariableSerializers();
+      String dbType = processEngineConfiguration.getDatabaseType();
 
       for (ProcessInstanceQueryImpl orQuery: queries) {
         for (QueryVariableValue var : orQuery.queryVariableValues) {
-          var.initialize(variableSerializers);
+          var.initialize(variableSerializers, dbType);
         }
       }
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/QueryVariableValue.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/QueryVariableValue.java
@@ -37,7 +37,7 @@ public class QueryVariableValue implements Serializable {
   protected boolean local;
 
   protected AbstractQueryVariableValueCondition valueCondition;
-  
+
   protected boolean variableNameIgnoreCase;
   protected boolean variableValueIgnoreCase;
 
@@ -54,14 +54,14 @@ public class QueryVariableValue implements Serializable {
     this.variableValueIgnoreCase = variableValueIgnoreCase;
   }
 
-  public void initialize(VariableSerializers serializers) {
+  public void initialize(VariableSerializers serializers, String dbType) {
     if (value.getType() != null && value.getType().isAbstract()) {
       valueCondition = new CompositeQueryVariableValueCondition(this);
     } else {
       valueCondition = new SingleQueryVariableValueCondition(this);
     }
 
-    valueCondition.initializeValue(serializers);
+    valueCondition.initializeValue(serializers, dbType);
   }
 
   public List<SingleQueryVariableValueCondition> getValueConditions() {
@@ -94,7 +94,7 @@ public class QueryVariableValue implements Serializable {
   public boolean isLocal() {
     return local;
   }
-  
+
 
   public boolean isVariableNameIgnoreCase() {
     return variableNameIgnoreCase;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
@@ -1135,15 +1135,17 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   }
 
   protected void ensureVariablesInitialized() {
-    VariableSerializers types = Context.getProcessEngineConfiguration().getVariableSerializers();
+    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    VariableSerializers variableSerializers = processEngineConfiguration.getVariableSerializers();
+    String dbType = processEngineConfiguration.getDatabaseType();
     for(QueryVariableValue var : variables) {
-      var.initialize(types);
+      var.initialize(variableSerializers, dbType);
     }
 
     if (!queries.isEmpty()) {
       for (TaskQueryImpl orQuery: queries) {
         for (QueryVariableValue var : orQuery.variables) {
-          var.initialize(types);
+          var.initialize(variableSerializers, dbType);
         }
       }
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/externaltask/TopicFetchInstruction.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/externaltask/TopicFetchInstruction.java
@@ -18,6 +18,7 @@ package org.camunda.bpm.engine.impl.externaltask;
 
 import org.camunda.bpm.engine.impl.QueryOperator;
 import org.camunda.bpm.engine.impl.QueryVariableValue;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.variable.serializer.VariableSerializers;
 
@@ -165,11 +166,11 @@ public class TopicFetchInstruction implements Serializable {
 
   public void ensureVariablesInitialized() {
     if (!filterVariables.isEmpty()) {
-      VariableSerializers variableSerializers = Context
-          .getProcessEngineConfiguration()
-          .getVariableSerializers();
+      ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+      VariableSerializers variableSerializers = processEngineConfiguration.getVariableSerializers();
+      String dbType = processEngineConfiguration.getDatabaseType();
       for(QueryVariableValue queryVariableValue : filterVariables) {
-        queryVariableValue.initialize(variableSerializers);
+        queryVariableValue.initialize(variableSerializers, dbType);
       }
     }
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/StringValueSerializer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/variable/serializer/StringValueSerializer.java
@@ -28,6 +28,8 @@ import org.camunda.bpm.engine.variable.value.StringValue;
  */
 public class StringValueSerializer extends PrimitiveValueSerializer<StringValue> {
 
+  public static final String EMPTY_STRING = "!emptyString!";
+
   public StringValueSerializer() {
     super(ValueType.STRING);
   }
@@ -37,11 +39,19 @@ public class StringValueSerializer extends PrimitiveValueSerializer<StringValue>
   }
 
   public StringValue readValue(ValueFields valueFields, boolean asTransientValue) {
-    return Variables.stringValue(valueFields.getTextValue(), asTransientValue);
+    String textValue = valueFields.getTextValue();
+    if (textValue == null && EMPTY_STRING.equals(valueFields.getTextValue2())) {
+      textValue = "";
+    }
+    return Variables.stringValue(textValue, asTransientValue);
   }
 
   public void writeValue(StringValue variableValue, ValueFields valueFields) {
-    valueFields.setTextValue(variableValue.getValue());
+    String value = variableValue.getValue();
+    valueFields.setTextValue(value);
+    if ("".equals(value)) {
+      valueFields.setTextValue2(EMPTY_STRING);
+    }
   }
 
 }

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Commons.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Commons.xml
@@ -31,28 +31,34 @@
     <foreach collection="queryVariableValue.valueConditions" item="valueCondition" separator="or">
       <trim prefix="(" prefixOverrides="and" suffix=")">
         <if test="!valueCondition.type.equals('null')">
-        <!-- When type of value is null, type doesn't matter! -->
-        and ${varPrefix}${varTypeField} is not null and ${varPrefix}${varTypeField} = #{valueCondition.type}
+          <!-- When type of value is null, type doesn't matter! -->
+          and ${varPrefix}${varTypeField} is not null and ${varPrefix}${varTypeField} = #{valueCondition.type}
         </if>
-         
         <if test="valueCondition.textValue != null &amp;&amp; valueCondition.longValue == null &amp;&amp; valueCondition.doubleValue == null">
-          and ${varPrefix}TEXT_ is not null and 
-		  <choose>
-		  	<when test="queryVariableValue.variableValueIgnoreCase">UPPER(${varPrefix}TEXT_)</when>
-		  	<otherwise>${varPrefix}TEXT_</otherwise>
-		  </choose>
-		  <choose>
-		    <when test="queryVariableValue.operatorName.contains('LIKE')">LIKE</when>
-		    <otherwise><include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.executionVariableOperator" /></otherwise>
-		  </choose>
-		  <choose>
-		  	<when test="queryVariableValue.variableValueIgnoreCase">UPPER(#{valueCondition.textValue})</when>
-		  	<otherwise>#{valueCondition.textValue}</otherwise>
-		  </choose>
-		  ${collationForCaseSensitivity}
-          <if test="queryVariableValue.operatorName.equals('LIKE')">ESCAPE ${escapeChar}</if>
+          <choose>
+            <when test="valueCondition.findNulledEmptyStrings">
+              and ${varPrefix}TEXT_ is null and ${varPrefix}TEXT2_ = '${@org.camunda.bpm.engine.impl.variable.serializer.StringValueSerializer@EMPTY_STRING}'
+            </when>
+            <otherwise>
+              and ${varPrefix}TEXT_ is not null and
+              <choose>
+                <when test="queryVariableValue.variableValueIgnoreCase">UPPER(${varPrefix}TEXT_)</when>
+                <otherwise>${varPrefix}TEXT_</otherwise>
+              </choose>
+              <choose>
+                <when test="queryVariableValue.operatorName.contains('LIKE')">LIKE</when>
+                <otherwise><include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.executionVariableOperator" /></otherwise>
+              </choose>
+              <choose>
+                <when test="queryVariableValue.variableValueIgnoreCase">UPPER(#{valueCondition.textValue})</when>
+                <otherwise>#{valueCondition.textValue}</otherwise>
+              </choose>
+              ${collationForCaseSensitivity}
+              <if test="queryVariableValue.operatorName.equals('LIKE')">ESCAPE ${escapeChar}</if>
+            </otherwise>
+          </choose>
         </if>
-        <if test="valueCondition.textValue2 != null">
+        <if test="valueCondition.textValue2 != null &amp;&amp; !valueCondition.type.equals('string')">
           and ${varPrefix}TEXT2_ is not null and ${varPrefix}TEXT2_
           <choose>
             <when test="queryVariableValue.operatorName.equals('LIKE')">LIKE</when>

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricVariableInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricVariableInstanceTest.java
@@ -298,7 +298,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
   })
   @Test
   public void testHistoricProcessVariableOnDeletion() {
-    HashMap<String, Object> variables = new HashMap<String,  Object>();
+    HashMap<String, Object> variables = new HashMap<>();
     variables.put("testVar", "Hallo Christian");
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
     runtimeService.deleteProcessInstance(processInstance.getId(), "deleted");
@@ -316,7 +316,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
       ProcessInstance pi = runtimeService.startProcessInstanceByKey("ProcessWithSubProcess");
 
       Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
-      Map<String, Object> variables = new HashMap<String, Object>();
+      Map<String, Object> variables = new HashMap<>();
       variables.put("test", "1");
       taskService.complete(task.getId(), variables);
 
@@ -333,7 +333,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
       List<HistoricDetail> updates = historyService.createHistoricDetailQuery().variableUpdates().list();
       assertEquals(2, updates.size());
 
-      Map<String, HistoricVariableUpdate> updatesMap = new HashMap<String, HistoricVariableUpdate>();
+      Map<String, HistoricVariableUpdate> updatesMap = new HashMap<>();
       HistoricVariableUpdate update = (HistoricVariableUpdate) updates.get(0);
       updatesMap.put((String) update.getValue(), update);
       update = (HistoricVariableUpdate) updates.get(1);
@@ -371,13 +371,13 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
   @Test
   public void testHistoricProcessInstanceDeleteCascadesCorrectly() {
 
-    Map<String, Object> variables = new HashMap<String, Object>();
+    Map<String, Object> variables = new HashMap<>();
     variables.put("var1", "value1");
     variables.put("var2", "value2");
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("myProcess", variables);
     assertNotNull(processInstance);
 
-    variables = new HashMap<String, Object>();
+    variables = new HashMap<>();
     variables.put("var3", "value3");
     variables.put("var4", "value4");
     ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("myProcess", variables);
@@ -431,7 +431,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
   @Test
   public void testHistoricVariableInstanceQueryByProcessIdIn() {
     // given
-    Map<String, Object> vars = new HashMap<String, Object>();
+    Map<String, Object> vars = new HashMap<>();
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("myProc",vars);
     ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("myProc",vars);
 
@@ -448,7 +448,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
   @Test
   public void testHistoricVariableInstanceQueryByInvalidProcessIdIn() {
     // given
-    Map<String, Object> vars = new HashMap<String, Object>();
+    Map<String, Object> vars = new HashMap<>();
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("myProc",vars);
 
     // check existing variables for task ID
@@ -467,7 +467,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
   @Test
   public void testHistoricVariableInstanceQueryByExecutionIds() {
     // given
-    Map<String, Object> variables1 = new HashMap<String, Object>();
+    Map<String, Object> variables1 = new HashMap<>();
     variables1.put("stringVar", "test");
     variables1.put("myVar", "test123");
     ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess", variables1);
@@ -480,7 +480,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
       assertEquals(processInstance1.getId(), variableInstance.getExecutionId());
     }
 
-    Map<String, Object> variables2 = new HashMap<String, Object>();
+    Map<String, Object> variables2 = new HashMap<>();
     variables2.put("myVar", "test123");
     ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess", variables2);
 
@@ -495,7 +495,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
     assertEquals(0, query.count());
 
     try {
-      historyService.createHistoricVariableInstanceQuery().executionIdIn(null);
+      historyService.createHistoricVariableInstanceQuery().executionIdIn((String[])null);
       fail("A ProcessEngineExcpetion was expected.");
     } catch (ProcessEngineException e) {}
 
@@ -511,7 +511,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
     assertEquals(0, query.count());
 
     try {
-      historyService.createHistoricVariableInstanceQuery().taskIdIn(null);
+      historyService.createHistoricVariableInstanceQuery().taskIdIn((String[])null);
       fail("A ProcessEngineExcpetion was expected.");
     } catch (ProcessEngineException e) {}
 
@@ -525,7 +525,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
   @Test
   public void testQueryByActivityInstanceIdIn() {
     // given
-    Map<String, Object> variables1 = new HashMap<String, Object>();
+    Map<String, Object> variables1 = new HashMap<>();
     variables1.put("stringVar", "test");
     variables1.put("myVar", "test123");
     ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess", variables1);
@@ -537,7 +537,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
     assertEquals(2, query.list().size());
     assertEquals(2, query.count());
 
-    Map<String, Object> variables2 = new HashMap<String, Object>();
+    Map<String, Object> variables2 = new HashMap<>();
     variables2.put("myVar", "test123");
     ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess", variables2);
 
@@ -555,7 +555,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
     assertEquals(0, query.count());
 
     try {
-      query.taskIdIn(null);
+      query.taskIdIn((String[])null);
       fail("A ProcessEngineExcpetion was expected.");
     } catch (ProcessEngineException e) {}
 
@@ -569,7 +569,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
   @Test
   public void testQueryByVariableTypeIn() {
     // given
-    Map<String, Object> variables1 = new HashMap<String, Object>();
+    Map<String, Object> variables1 = new HashMap<>();
     variables1.put("stringVar", "test");
     variables1.put("boolVar", true);
     runtimeService.startProcessInstanceByKey("oneTaskProcess", variables1);
@@ -587,7 +587,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
   @Test
   public void testQueryByVariableTypeInWithCapitalLetter() {
     // given
-    Map<String, Object> variables1 = new HashMap<String, Object>();
+    Map<String, Object> variables1 = new HashMap<>();
     variables1.put("stringVar", "test");
     variables1.put("boolVar", true);
     runtimeService.startProcessInstanceByKey("oneTaskProcess", variables1);
@@ -606,7 +606,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
   @Test
   public void testQueryByVariableTypeInWithSeveralTypes() {
     // given
-    Map<String, Object> variables1 = new HashMap<String, Object>();
+    Map<String, Object> variables1 = new HashMap<>();
     variables1.put("stringVar", "test");
     variables1.put("boolVar", true);
     variables1.put("intVar", 5);
@@ -636,7 +636,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
 
     try {
       // when
-      query.variableTypeIn(null);
+      query.variableTypeIn((String[])null);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
       // then fails
@@ -742,7 +742,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
     Task newTask = taskService.newTask();
     taskService.saveTask(newTask);
 
-    Map<String, Object> variables = new HashMap<String, Object>();
+    Map<String, Object> variables = new HashMap<>();
     variables.put("customSerializable", new CustomSerializable());
     variables.put("failingSerializable", new FailingSerializable());
     taskService.setVariables(newTask.getId(), variables);
@@ -781,7 +781,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
     Task newTask = taskService.newTask();
     taskService.saveTask(newTask);
 
-    Map<String, Object> variables = new HashMap<String, Object>();
+    Map<String, Object> variables = new HashMap<>();
     variables.put("customSerializable", new CustomSerializable());
     variables.put("failingSerializable", new FailingSerializable());
     taskService.setVariables(newTask.getId(), variables);
@@ -977,6 +977,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
         .activityId("task")
         .singleResult();
 
+    @SuppressWarnings("unchecked")
     List<String> list = (List<String>) runtimeService.getVariable(instance.getId(), "listVar");
     assertNotNull(list);
     assertEquals(1, list.size());
@@ -991,6 +992,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
     assertEquals(historicServiceTask.getId(), historicVariableInstance.getActivityInstanceId());
   }
 
+  @SuppressWarnings("unchecked")
   @Deployment(resources = "org/camunda/bpm/engine/test/history/HistoricVariableInstanceTest.testImplicitVariableUpdate.bpmn20.xml")
   @Ignore
   @Test
@@ -1063,6 +1065,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
     assertEquals("newValue", typedValue.getValue());
   }
 
+  @SuppressWarnings("serial")
   public static class CustomVar implements Serializable {
     private String value;
 
@@ -1079,6 +1082,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
     }
   }
 
+  @SuppressWarnings("unchecked")
   @Deployment
   @Test
   public void testNoImplicitUpdateOnHistoricValues() {
@@ -1150,6 +1154,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
 
       HistoricVariableUpdate update1 = (HistoricVariableUpdate) historicDetails.get(0);
 
+      @SuppressWarnings("unchecked")
       List<String> value1 = (List<String>) update1.getValue();
 
       assertNotNull(value1);
@@ -1196,6 +1201,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
 
     HistoricVariableUpdate update1 = (HistoricVariableUpdate) historicDetails.get(0);
 
+    @SuppressWarnings("unchecked")
     List<String> value1 = (List<String>) update1.getValue();
 
     assertNotNull(value1);
@@ -1907,7 +1913,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
     assertEquals(0, query.count());
 
     try {
-      query.caseActivityIdIn(null);
+      query.caseActivityIdIn((String[])null);
       fail("A ProcessEngineExcpetion was expected.");
     } catch (NullValueException e) {}
 
@@ -2018,7 +2024,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
   @Deployment(resources = "org/camunda/bpm/engine/test/bpmn/async/AsyncStartEventTest.testAsyncStartEvent.bpmn20.xml")
   @Test
   public void testAsyncStartEventVariableHistory() {
-    Map<String, Object> variables = new HashMap<String, Object>();
+    Map<String, Object> variables = new HashMap<>();
     variables.put("foo", "bar");
     String processInstanceId = runtimeService.startProcessInstanceByKey("asyncStartEvent", variables).getId();
 
@@ -2061,7 +2067,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
   @Deployment(resources = {"org/camunda/bpm/engine/test/bpmn/async/AsyncStartEventTest.testMultipleAsyncStartEvents.bpmn20.xml"})
   @Test
   public void testMultipleAsyncStartEventsVariableHistory() {
-    Map<String, Object> variables = new HashMap<String, Object>();
+    Map<String, Object> variables = new HashMap<>();
     variables.put("foo", "bar");
     runtimeService.correlateMessage("newInvoiceMessage", new HashMap<String, Object>(), variables);
 
@@ -2187,7 +2193,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
       .singleResult()
       .getId();
 
-    Map<String, Object> properties = new HashMap<String, Object>();
+    Map<String, Object> properties = new HashMap<>();
     properties.put("foo", "bar");
 
     formService.submitStartForm(processDefinitionId, properties);
@@ -2255,7 +2261,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
       .singleResult()
       .getId();
 
-    Map<String, Object> properties = new HashMap<String, Object>();
+    Map<String, Object> properties = new HashMap<>();
     properties.put("foo", "bar");
 
     formService.submitStartForm(processDefinitionId, properties);
@@ -2426,7 +2432,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
     SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss.SSS");
     Date fixedDate = sdf.parse("01/01/2001 01:01:01.000");
     ClockUtil.setCurrentTime(fixedDate);
-    Map<String, Object> variables = new HashMap<String, Object>();
+    Map<String, Object> variables = new HashMap<>();
     variables.put("stringVar", "test");
     // when
     runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
@@ -2443,7 +2449,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
   @Test
   public void testVariableNameEqualsIgnoreCase() {
     // given
-    Map<String, Object> variables = new HashMap<String, Object>();
+    Map<String, Object> variables = new HashMap<>();
     String variableName = "variableName";
     variables.put(variableName, "variableValue");
     runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
@@ -2464,7 +2470,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
   @Test
   public void testVariableValueEqualsIgnoreCase() {
     // given
-    Map<String, Object> variables = new HashMap<String, Object>();
+    Map<String, Object> variables = new HashMap<>();
     String variableName = "variableName";
     String variableValue = "variableValue";
     variables.put(variableName, variableValue);
@@ -2487,7 +2493,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
   @Test
   public void testVariableNameAndValueEqualsIgnoreCase() {
     // given
-    Map<String, Object> variables = new HashMap<String, Object>();
+    Map<String, Object> variables = new HashMap<>();
     String variableName = "variableName";
     String variableValue = "variableValue";
     variables.put(variableName, variableValue);
@@ -2515,14 +2521,32 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
 
   @Deployment(resources = { "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml" })
   @Test
+  public void testVariableNameAndValueEqualsEmptyString() {
+    // given
+    Map<String, Object> variables = new HashMap<>();
+    String variableName = "variableName";
+    String variableValue = "";
+    variables.put(variableName, variableValue);
+    runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
+
+    // when
+    HistoricVariableInstance instance = historyService.createHistoricVariableInstanceQuery().variableValueEquals(variableName, variableValue).singleResult();
+
+    // then
+    assertThat(instance).isNotNull();
+    assertThat(instance.getValue()).isEqualTo("");
+  }
+
+  @Deployment(resources = { "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml" })
+  @Test
   public void testVariableNameLikeIgnoreCase() {
     // given
-    Map<String, Object> variables = new HashMap<String, Object>();
+    Map<String, Object> variables = new HashMap<>();
     String variableName = "variableName";
     String variableValue = "variableValue";
     variables.put(variableName, variableValue);
     runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
-    
+
     // when
     HistoricVariableInstance instance = historyService.createHistoricVariableInstanceQuery().variableNameLike("variableN%").singleResult();
     HistoricVariableInstance instanceIgnoreCase = historyService.createHistoricVariableInstanceQuery().variableNameLike("variablen%").singleResult();

--- a/qa/test-db-instance-migration/test-fixture-714/src/main/java/org/camunda/bpm/qa/upgrade/TestFixture.java
+++ b/qa/test-db-instance-migration/test-fixture-714/src/main/java/org/camunda/bpm/qa/upgrade/TestFixture.java
@@ -19,6 +19,7 @@ package org.camunda.bpm.qa.upgrade;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.qa.upgrade.variable.EmptyStringVariableScenario;
 
 public class TestFixture {
 
@@ -36,7 +37,7 @@ public class TestFixture {
     ScenarioRunner runner = new ScenarioRunner(processEngine, ENGINE_VERSION);
 
     // example scenario setup
-    // runner.setupScenarios(ExampleScenario.class);
+   runner.setupScenarios(EmptyStringVariableScenario.class);
 
     processEngine.close();
   }

--- a/qa/test-db-instance-migration/test-fixture-714/src/main/java/org/camunda/bpm/qa/upgrade/variable/EmptyStringVariableScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-714/src/main/java/org/camunda/bpm/qa/upgrade/variable/EmptyStringVariableScenario.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.qa.upgrade.variable;
+
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.qa.upgrade.DescribesScenario;
+import org.camunda.bpm.qa.upgrade.ScenarioSetup;
+
+public class EmptyStringVariableScenario {
+
+  @Deployment
+  public static String deploy() {
+    return "org/camunda/bpm/qa/upgrade/variable/oneTaskProcess.bpmn20.xml";
+  }
+
+  @DescribesScenario("emptyStringVariableScenario")
+  public static ScenarioSetup createUserOperationLogEntries() {
+    return new ScenarioSetup() {
+      @Override
+      public void execute(ProcessEngine engine, String scenarioName) {
+        RuntimeService runtimeService = engine.getRuntimeService();
+        runtimeService.startProcessInstanceByKey("oneTaskProcess_714", scenarioName,
+            Variables.createVariables().putValue("myStringVar", ""));
+      }
+    };
+  }
+
+}

--- a/qa/test-db-instance-migration/test-fixture-714/src/main/resources/org/camunda/bpm/qa/upgrade/variable/oneTaskProcess.bpmn20.xml
+++ b/qa/test-db-instance-migration/test-fixture-714/src/main/resources/org/camunda/bpm/qa/upgrade/variable/oneTaskProcess.bpmn20.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  targetNamespace="Examples">
+
+  <process id="oneTaskProcess_714" name="The One Task Process" isExecutable="true" camunda:historyTimeToLive="5">
+    <documentation>This is a process for testing purposes</documentation>
+
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="firstTask" />
+    <userTask id="firstTask" name="First task" />
+    <sequenceFlow id="flow2" sourceRef="firstTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7150/variable/EmptyStringVariableTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7150/variable/EmptyStringVariableTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.qa.upgrade.scenarios7150.variable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.impl.db.sql.DbSqlSessionFactory;
+import org.camunda.bpm.engine.runtime.VariableInstance;
+import org.camunda.bpm.engine.runtime.VariableInstanceQuery;
+import org.camunda.bpm.qa.upgrade.Origin;
+import org.camunda.bpm.qa.upgrade.ScenarioUnderTest;
+import org.camunda.bpm.qa.upgrade.UpgradeTestRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+@ScenarioUnderTest("EmptyStringVariableScenario")
+@Origin("7.14.0")
+public class EmptyStringVariableTest {
+
+  @Rule
+  public UpgradeTestRule engineRule = new UpgradeTestRule();
+
+  RuntimeService runtimeService;
+
+  @Before
+  public void assignServices() {
+    runtimeService = engineRule.getRuntimeService();
+  }
+
+  @Test
+  @ScenarioUnderTest("emptyStringVariableScenario.1")
+  public void shouldFindEmptyStringVariable() {
+    // given
+    VariableInstanceQuery variableQuery = runtimeService.createVariableInstanceQuery().variableName("myStringVar");
+
+    // when
+    VariableInstance variable = variableQuery.singleResult();
+
+    // then
+    assertNotNull(variable);
+    if (DbSqlSessionFactory.ORACLE.equals(engineRule.getProcessEngineConfiguration().getDatabaseType())) {
+      assertNull(variable.getValue());
+    } else {
+      assertEquals("", variable.getValue());
+    }
+  }
+
+}

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/camunda/bpm/qa/rolling/update/TestFixture.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/camunda/bpm/qa/rolling/update/TestFixture.java
@@ -34,6 +34,7 @@ import org.camunda.bpm.qa.rolling.update.scenarios.task.ProcessWithUserTaskAndTi
 import org.camunda.bpm.qa.rolling.update.scenarios.task.ProcessWithUserTaskScenario;
 import org.camunda.bpm.qa.rolling.update.scenarios.timestamp.IncidentTimestampUpdateScenario;
 import org.camunda.bpm.qa.rolling.update.scenarios.timestamp.JobTimestampsUpdateScenario;
+import org.camunda.bpm.qa.rolling.update.scenarios.variable.EmptyStringVariableScenario;
 import org.camunda.bpm.qa.upgrade.ScenarioRunner;
 
 /**
@@ -80,6 +81,7 @@ public class TestFixture {
 
     if (RollingUpdateConstants.NEW_ENGINE_TAG.equals(currentFixtureTag)) { // create data with new engine
       runner.setupScenarios(HistoryCleanupScenario.class);
+      runner.setupScenarios(EmptyStringVariableScenario.class);
     }
 
     processEngine.close();

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/camunda/bpm/qa/rolling/update/scenarios/variable/EmptyStringVariableScenario.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/camunda/bpm/qa/rolling/update/scenarios/variable/EmptyStringVariableScenario.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.qa.rolling.update.scenarios.variable;
+
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.qa.upgrade.DescribesScenario;
+import org.camunda.bpm.qa.upgrade.ScenarioSetup;
+import org.camunda.bpm.qa.upgrade.Times;
+
+public class EmptyStringVariableScenario {
+
+  public static final String PROCESS_DEF_KEY = "oneTaskProcess";
+
+  @Deployment
+  public static String deploy() {
+    return "org/camunda/bpm/qa/rolling/update/oneTaskProcess.bpmn20.xml";
+  }
+
+  @DescribesScenario("init")
+  @Times(1)
+  public static ScenarioSetup startProcess() {
+    return new ScenarioSetup() {
+      public void execute(ProcessEngine engine, String scenarioName) {
+        engine.getRuntimeService().startProcessInstanceByKey(PROCESS_DEF_KEY, scenarioName,
+            Variables.createVariables().putValue("myStringVar", ""));
+      }
+    };
+  }
+
+}

--- a/qa/test-db-rolling-update/test-old-engine/src/test/java/org/camunda/bpm/qa/rolling/update/variable/EmptyStringVariableTest.java
+++ b/qa/test-db-rolling-update/test-old-engine/src/test/java/org/camunda/bpm/qa/rolling/update/variable/EmptyStringVariableTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.qa.rolling.update.variable;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.camunda.bpm.engine.impl.db.sql.DbSqlSessionFactory;
+import org.camunda.bpm.engine.runtime.VariableInstance;
+import org.camunda.bpm.engine.runtime.VariableInstanceQuery;
+import org.camunda.bpm.qa.rolling.update.AbstractRollingUpdateTestCase;
+import org.camunda.bpm.qa.upgrade.ScenarioUnderTest;
+import org.junit.Test;
+
+/**
+ * This test ensures that the old engine can read an empty String variable created by the new engine.
+ * Note: this test class needs to be adjusted after 7.15.0, since the behavior is fixed in 7.15.0
+ * and therefore will work in rolling updates from there on
+ *
+ */
+@ScenarioUnderTest("EmptyStringVariableScenario")
+public class EmptyStringVariableTest extends AbstractRollingUpdateTestCase {
+
+  @Test
+  @ScenarioUnderTest("init.1")
+  public void shouldFindEmptyStringVariableWithValue() {
+    //given
+    VariableInstance variableInstance = rule.getRuntimeService().createVariableInstanceQuery()
+        .variableName("myStringVar")
+        .singleResult();
+    String databaseType = rule.getProcessEngineConfiguration().getDatabaseType();
+
+    // then
+    if (DbSqlSessionFactory.ORACLE.equals(databaseType)) {
+      assertThat(variableInstance.getValue(), nullValue());
+    } else {
+      assertThat(variableInstance.getValue(), is(""));
+    }
+  }
+
+  @Test
+  @ScenarioUnderTest("init.1")
+  public void shouldQueryEmptyStringVariableWithValueEquals() {
+    //given
+    VariableInstanceQuery variableInstanceQuery = rule.getRuntimeService().createVariableInstanceQuery()
+        .variableValueEquals("myStringVar", "");
+    String databaseType = rule.getProcessEngineConfiguration().getDatabaseType();
+
+    // then
+    if (DbSqlSessionFactory.ORACLE.equals(databaseType)) {
+      assertThat(variableInstanceQuery.count(), is(0L));
+    } else {
+      assertThat(variableInstanceQuery.count(), is(1L));
+    }
+  }
+
+  @Test
+  @ScenarioUnderTest("init.1")
+  public void shouldQueryEmptyStringVariableWithValueNotEquals() {
+    //given
+    VariableInstanceQuery variableInstanceQuery = rule.getRuntimeService().createVariableInstanceQuery()
+        .variableValueNotEquals("myStringVar", "");
+    String databaseType = rule.getProcessEngineConfiguration().getDatabaseType();
+
+    // then
+    if (DbSqlSessionFactory.ORACLE.equals(databaseType)) {
+      assertThat(variableInstanceQuery.count(), is(1L));
+    } else {
+      assertThat(variableInstanceQuery.count(), is(0L));
+    }
+  }
+
+}

--- a/webapps/src/main/java/org/camunda/bpm/cockpit/impl/plugin/base/dto/query/AbstractProcessInstanceQueryDto.java
+++ b/webapps/src/main/java/org/camunda/bpm/cockpit/impl/plugin/base/dto/query/AbstractProcessInstanceQueryDto.java
@@ -100,8 +100,8 @@ public abstract class AbstractProcessInstanceQueryDto<T extends ProcessInstanceD
     return queryVariableValues;
   }
 
-  public void initQueryVariableValues(VariableSerializers variableTypes) {
-    queryVariableValues = createQueryVariableValues(variableTypes, variables);
+  public void initQueryVariableValues(VariableSerializers variableTypes, String dbType) {
+    queryVariableValues = createQueryVariableValues(variableTypes, variables, dbType);
   }
 
   public String getParentProcessInstanceId() {
@@ -181,7 +181,7 @@ public abstract class AbstractProcessInstanceQueryDto<T extends ProcessInstanceD
     }
   }
 
-  private List<QueryVariableValue> createQueryVariableValues(VariableSerializers variableTypes, List<VariableQueryParameterDto> variables) {
+  private List<QueryVariableValue> createQueryVariableValues(VariableSerializers variableTypes, List<VariableQueryParameterDto> variables, String dbType) {
 
     List<QueryVariableValue> values = new ArrayList<QueryVariableValue>();
 
@@ -196,7 +196,7 @@ public abstract class AbstractProcessInstanceQueryDto<T extends ProcessInstanceD
           ConditionQueryParameterDto.getQueryOperator(variable.getOperator()),
           false);
 
-      value.initialize(variableTypes);
+      value.initialize(variableTypes, dbType);
       values.add(value);
     }
 

--- a/webapps/src/main/java/org/camunda/bpm/cockpit/impl/plugin/base/dto/query/ProcessDefinitionQueryDto.java
+++ b/webapps/src/main/java/org/camunda/bpm/cockpit/impl/plugin/base/dto/query/ProcessDefinitionQueryDto.java
@@ -98,8 +98,8 @@ public class ProcessDefinitionQueryDto extends AbstractRestQueryParametersDto<Pr
     return queryVariableValues;
   }
 
-  public void initQueryVariableValues(VariableSerializers variableTypes) {
-    queryVariableValues = createQueryVariableValues(variableTypes, variables);
+  public void initQueryVariableValues(VariableSerializers variableTypes, String dbType) {
+    queryVariableValues = createQueryVariableValues(variableTypes, variables, dbType);
   }
 
   @Override
@@ -112,7 +112,7 @@ public class ProcessDefinitionQueryDto extends AbstractRestQueryParametersDto<Pr
     return false;
   }
 
-  private List<QueryVariableValue> createQueryVariableValues(VariableSerializers variableTypes, List<VariableQueryParameterDto> variables) {
+  private List<QueryVariableValue> createQueryVariableValues(VariableSerializers variableTypes, List<VariableQueryParameterDto> variables, String dbType) {
 
     List<QueryVariableValue> values = new ArrayList<QueryVariableValue>();
 
@@ -127,7 +127,7 @@ public class ProcessDefinitionQueryDto extends AbstractRestQueryParametersDto<Pr
           ConditionQueryParameterDto.getQueryOperator(variable.getOperator()),
           false);
 
-      value.initialize(variableTypes);
+      value.initialize(variableTypes, dbType);
       values.add(value);
     }
 

--- a/webapps/src/main/java/org/camunda/bpm/cockpit/impl/plugin/base/sub/resources/ProcessDefinitionResource.java
+++ b/webapps/src/main/java/org/camunda/bpm/cockpit/impl/plugin/base/sub/resources/ProcessDefinitionResource.java
@@ -81,7 +81,7 @@ public class ProcessDefinitionResource extends AbstractPluginResource {
       parameter.setHistoryEnabled(false);
     }
 
-    parameter.initQueryVariableValues(processEngineConfiguration.getVariableSerializers());
+    parameter.initQueryVariableValues(processEngineConfiguration.getVariableSerializers(), processEngineConfiguration.getDatabaseType());
   }
 
   protected void configureExecutionQuery(ProcessDefinitionQueryDto query) {

--- a/webapps/src/main/java/org/camunda/bpm/cockpit/impl/plugin/resources/ProcessInstanceRestService.java
+++ b/webapps/src/main/java/org/camunda/bpm/cockpit/impl/plugin/resources/ProcessInstanceRestService.java
@@ -132,7 +132,7 @@ public class ProcessInstanceRestService extends AbstractPluginResource {
       parameter.setHistoryEnabled(false);
     }
 
-    parameter.initQueryVariableValues(processEngineConfiguration.getVariableSerializers());
+    parameter.initQueryVariableValues(processEngineConfiguration.getVariableSerializers(), processEngineConfiguration.getDatabaseType());
   }
 
   protected void configureExecutionQuery(ProcessInstanceQueryDto query) {


### PR DESCRIPTION
* allows to differentiate empty string variable values
  from null values on Oracle DBs (empty strings are persisted
  as NULL there) by using the TEXT2_ column

related to CAM-12592