### PR TITLE
CAM-12769: populate incident message when job has 0 retries

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DefaultJobRetryCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DefaultJobRetryCmd.java
@@ -99,7 +99,11 @@ public class DefaultJobRetryCmd extends JobRetryCmd {
 
     } else {
 
-      if (isFirstJobExecution(job)) {
+      boolean isFirstExecution = isFirstJobExecution(job);
+
+      logException(job);
+
+      if (isFirstExecution) {
         // then change default retries to the ones configured
         initializeRetries(job, retryConfiguration.getRetries());
 
@@ -115,7 +119,6 @@ public class DefaultJobRetryCmd extends JobRetryCmd {
       job.setDuedate(durationHelper.getDateAfter());
       job.unlock();
 
-      logException(job);
       decrementRetries(job);
       notifyAcquisition(commandContext);
     }


### PR DESCRIPTION
- when retry configuration is R0/..., the incident message was not
  populated because the incident was already created before the
  exception message was set in the job entity

related to CAM-12769