### PR TITLE
[CAM-12829] Add task object to business calendar interface

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/BusinessCalendar.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/BusinessCalendar.java
@@ -18,6 +18,8 @@ package org.camunda.bpm.engine.impl.calendar;
 
 import java.util.Date;
 
+import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
+
 
 /**
  * @author Tom Baeyens
@@ -28,4 +30,5 @@ public interface BusinessCalendar {
   
   Date resolveDuedate(String duedateDescription, Date startDate);
 
+  Date resolveDuedate(String dueDate, TaskEntity task);
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/CycleBusinessCalendar.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/CycleBusinessCalendar.java
@@ -19,6 +19,7 @@ package org.camunda.bpm.engine.impl.calendar;
 import java.util.Date;
 
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
+import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.camunda.bpm.engine.impl.util.EngineUtilLogger;
 
@@ -28,8 +29,12 @@ public class CycleBusinessCalendar implements BusinessCalendar {
 
   public static String NAME = "cycle";
 
+  public Date resolveDuedate(String dueDate, TaskEntity task) {
+	return resolveDuedate(dueDate);
+  }
+  
   public Date resolveDuedate(String duedateDescription) {
-    return resolveDuedate(duedateDescription, null);
+    return resolveDuedate(duedateDescription, (Date)null);
   }
 
   public Date resolveDuedate(String duedateDescription, Date startDate) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/DefaultBusinessCalendar.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/DefaultBusinessCalendar.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 
 
@@ -50,8 +51,12 @@ public class DefaultBusinessCalendar implements BusinessCalendar {
     units.put("years", Calendar.YEAR);
   }
   
+  public Date resolveDuedate(String dueDate, TaskEntity task) {
+	return resolveDuedate(dueDate);
+  }
+  
   public Date resolveDuedate(String duedate) {
-    return resolveDuedate(duedate, null);
+    return resolveDuedate(duedate, (Date)null);
   }
   
   public Date resolveDuedate(String duedate, Date startDate) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/DueDateBusinessCalendar.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/DueDateBusinessCalendar.java
@@ -19,6 +19,7 @@ package org.camunda.bpm.engine.impl.calendar;
 import java.util.Date;
 
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
+import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.camunda.bpm.engine.impl.util.EngineUtilLogger;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISOPeriodFormat;
@@ -30,8 +31,12 @@ public class DueDateBusinessCalendar implements BusinessCalendar {
 
   public static final String NAME = "dueDate";
 
+  public Date resolveDuedate(String dueDate, TaskEntity task) {
+	return resolveDuedate(dueDate);
+  }
+  
   public Date resolveDuedate(String duedate) {
-    return resolveDuedate(duedate, null);
+    return resolveDuedate(duedate, (Date)null);
   }
   
   public Date resolveDuedate(String duedate, Date startDate) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/DurationBusinessCalendar.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/DurationBusinessCalendar.java
@@ -19,6 +19,7 @@ package org.camunda.bpm.engine.impl.calendar;
 import java.util.Date;
 
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
+import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.camunda.bpm.engine.impl.util.EngineUtilLogger;
 
 
@@ -30,9 +31,14 @@ public class DurationBusinessCalendar implements BusinessCalendar {
   private final static EngineUtilLogger LOG = ProcessEngineLogger.UTIL_LOGGER;
 
   public static String NAME = "duration";
+  
+  
+  public Date resolveDuedate(String dueDate, TaskEntity task) {
+	return resolveDuedate(dueDate);
+  }
 
   public Date resolveDuedate(String duedate) {
-    return resolveDuedate(duedate, null);
+    return resolveDuedate(duedate, (Date)null);
   }
   
   public Date resolveDuedate(String duedate, Date startDate) {
@@ -44,4 +50,5 @@ public class DurationBusinessCalendar implements BusinessCalendar {
       throw LOG.exceptionWhileResolvingDuedate(duedate, e);
     }
   }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/task/TaskDecorator.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/task/TaskDecorator.java
@@ -89,8 +89,7 @@ public class TaskDecorator {
 
         } else if (dueDate instanceof String) {
           BusinessCalendar businessCalendar = getBusinessCalender();
-          task.setDueDate(businessCalendar.resolveDuedate((String) dueDate));
-
+          task.setDueDate(businessCalendar.resolveDuedate((String) dueDate, task));
         } else {
           throw new ProcessEngineException("Due date expression does not resolve to a Date or Date string: " +
               dueDateExpression.getExpressionText());
@@ -109,7 +108,7 @@ public class TaskDecorator {
 
         } else if (followUpDate instanceof String) {
           BusinessCalendar businessCalendar = getBusinessCalender();
-          task.setFollowUpDate(businessCalendar.resolveDuedate((String) followUpDate));
+          task.setFollowUpDate(businessCalendar.resolveDuedate((String) followUpDate, task));
 
         } else {
           throw new ProcessEngineException("Follow up date expression does not resolve to a Date or Date string: " +


### PR DESCRIPTION
Motivation: We need to resolve task dueDates using a custom calendar per task. This means, for example, task A would use Business Calendar X to resolve its due date, and task B would use Business Calendar Z to resolve its due date.

To implement this behaviour in Camunda, we extended the BusinessCalendar interface to be able to receive the task object. With this information, a custom calendar implementation would be able to calculate a task dueDate using values like taskId, processInstanceId, processDefinitionId, tenantId, etc. as input parameters.

We left there all the old methods, so this change is completely transparent, and can be leveraged by a BusinessCalendar implementation.

This is based on our previous question: https://forum.camunda.org/t/support-for-more-than-one-business-calendar/23911

related to CAM-12829