### PR TITLE
[CAM-12804] fix(engine): Make the default IdentityService more reusable for custom implementations

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/IdentityServiceImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/IdentityServiceImpl.java
@@ -68,7 +68,6 @@ import org.camunda.bpm.engine.impl.cmd.UnlockUserCmd;
 import org.camunda.bpm.engine.impl.identity.Account;
 import org.camunda.bpm.engine.impl.identity.Authentication;
 import org.camunda.bpm.engine.impl.identity.PasswordPolicyResultImpl;
-import org.camunda.bpm.engine.impl.persistence.entity.GroupEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.IdentityInfoEntity;
 import org.camunda.bpm.engine.impl.util.EnsureUtil;
 import org.camunda.bpm.engine.impl.util.ExceptionUtil;
@@ -101,7 +100,7 @@ public class IdentityServiceImpl extends ServiceImpl implements IdentityService 
   public void saveGroup(Group group) {
 
     try {
-      commandExecutor.execute(new SaveGroupCmd((GroupEntity) group));
+      commandExecutor.execute(new SaveGroupCmd(group));
     } catch (ProcessEngineException ex) {
       if (ExceptionUtil.checkConstraintViolationException(ex)) {
         throw new BadUserRequestException("The group already exists", ex);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SaveGroupCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SaveGroupCmd.java
@@ -21,10 +21,10 @@ import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureWhitelistedResou
 
 import java.io.Serializable;
 
+import org.camunda.bpm.engine.identity.Group;
 import org.camunda.bpm.engine.impl.identity.IdentityOperationResult;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
-import org.camunda.bpm.engine.impl.persistence.entity.GroupEntity;
 
 
 /**
@@ -33,9 +33,9 @@ import org.camunda.bpm.engine.impl.persistence.entity.GroupEntity;
 public class SaveGroupCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void>, Serializable {
   
   private static final long serialVersionUID = 1L;
-  protected GroupEntity group;
+  protected Group group;
   
-  public SaveGroupCmd(GroupEntity group) {
+  public SaveGroupCmd(Group group) {
     this.group = group;
   }
   

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SaveUserCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SaveUserCmd.java
@@ -67,6 +67,6 @@ public class SaveUserCmd extends AbstractWritableIdentityServiceCmd<Void> implem
 
   protected boolean shouldCheckPasswordPolicy(CommandContext commandContext) {
     return ((UserEntity) user).hasNewPassword() && !skipPasswordPolicy
-            && commandContext.getProcessEngineConfiguration().isEnablePasswordPolicy();
+        && commandContext.getProcessEngineConfiguration().isEnablePasswordPolicy();
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SaveUserCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SaveUserCmd.java
@@ -21,40 +21,32 @@ import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureWhitelistedResou
 
 import java.io.Serializable;
 
-import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.identity.User;
 import org.camunda.bpm.engine.impl.identity.IdentityOperationResult;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
-import org.camunda.bpm.engine.impl.persistence.entity.UserEntity;
 
 /**
  * @author Joram Barrez
  */
 public class SaveUserCmd extends AbstractWritableIdentityServiceCmd<Void> implements Command<Void>, Serializable {
-  
+
   private static final long serialVersionUID = 1L;
-  protected UserEntity user;
+  protected User user;
   protected boolean skipPasswordPolicy;
-  
+
   public SaveUserCmd(User user) {
     this(user, false);
   }
-  
+
   public SaveUserCmd(User user, boolean skipPasswordPolicy) {
-    this.user = (UserEntity) user;
+    this.user = user;
     this.skipPasswordPolicy = skipPasswordPolicy;
   }
-  
+
   protected Void executeCmd(CommandContext commandContext) {
     ensureNotNull("user", user);
     ensureWhitelistedResourceId(commandContext, "User", user.getId());
-
-    if(shouldCheckPasswordPolicy(commandContext)) {
-      if(!user.checkPasswordAgainstPolicy()) {
-        throw new ProcessEngineException("Password does not match policy");
-      }
-    }
 
     IdentityOperationResult operationResult = commandContext
       .getWritableIdentityProvider()
@@ -63,10 +55,5 @@ public class SaveUserCmd extends AbstractWritableIdentityServiceCmd<Void> implem
     commandContext.getOperationLogManager().logUserOperation(operationResult, user.getId());
 
     return null;
-  }
-
-  protected boolean shouldCheckPasswordPolicy(CommandContext commandContext) {
-    return user.hasNewPassword() && !skipPasswordPolicy
-        && commandContext.getProcessEngineConfiguration().isEnablePasswordPolicy();
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/identity/db/DbIdentityServiceProvider.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/identity/db/DbIdentityServiceProvider.java
@@ -64,12 +64,6 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
   public IdentityOperationResult saveUser(User user) {
     UserEntity userEntity = (UserEntity) user;
 
-    if(shouldCheckPasswordPolicy(userEntity)) {
-      if(!userEntity.checkPasswordAgainstPolicy()) {
-        throw new ProcessEngineException("Password does not match policy");
-      }
-    }
-
     // encrypt password
     userEntity.encryptPassword();
 
@@ -384,11 +378,6 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
       return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_DELETE);
     }
     return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_NONE);
-  }
-
-  protected boolean shouldCheckPasswordPolicy(UserEntity user) {
-    return user.hasNewPassword() && !skipPasswordPolicy
-            && Context.getCommandContext().getProcessEngineConfiguration().isEnablePasswordPolicy();
   }
 
   protected void deleteTenantMembershipsOfUser(String userId) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/identity/db/DbIdentityServiceProvider.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/identity/db/DbIdentityServiceProvider.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.authorization.Permissions;
 import org.camunda.bpm.engine.authorization.Resources;
 import org.camunda.bpm.engine.identity.Group;


### PR DESCRIPTION
This PR tries to fix [CAM-12804](https://jira.camunda.com/browse/CAM-12804)