### PR TITLE
chore(dependencies): bump Tomcat to 9.0.40

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
 
     <!-- This version is mirrored in the external task client.
     If you change it here, also change it there -->
-    <version.tomcat>9.0.36</version.tomcat>
+    <version.tomcat>9.0.40</version.tomcat>
 
     <version.arquillian>1.1.10.Final</version.arquillian>
     <version.shrinkwrap.resolvers>2.2.2</version.shrinkwrap.resolvers>


### PR DESCRIPTION
* resolves several security issues with Tomcat version <9.0.38

related to CAM-12775