### PR TITLE
test(spring/cdi): add dmn juel context tests

### DIFF
--- a/engine-cdi/pom.xml
+++ b/engine-cdi/pom.xml
@@ -74,6 +74,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>

--- a/engine-cdi/src/test/java/org/camunda/bpm/engine/cdi/test/dmn/DmnJuelTest.java
+++ b/engine-cdi/src/test/java/org/camunda/bpm/engine/cdi/test/dmn/DmnJuelTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.cdi.test.dmn;
+
+import org.camunda.bpm.dmn.engine.DmnDecisionResult;
+import org.camunda.bpm.engine.cdi.test.CdiProcessEngineTestCase;
+import org.camunda.bpm.engine.test.Deployment;
+import org.junit.Test;
+
+import javax.inject.Named;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DmnJuelTest extends CdiProcessEngineTestCase {
+
+  @Named
+  public static class BeanFoo {
+
+    protected String bar = "baz";
+
+    public String getBar() {
+      return bar;
+    }
+
+  }
+
+  @Test
+  @Deployment(resources = {"org/camunda/bpm/engine/cdi/test/dmn/JuelTest.dmn"})
+  public void shouldResolveBean() {
+    // given
+
+    // when
+    DmnDecisionResult result = decisionService.evaluateDecisionByKey("drg-with-bean-expression")
+        .evaluate();
+
+    // then
+    assertThat((String)result.getSingleEntry()).isEqualTo("bar");
+  }
+
+}

--- a/engine-cdi/src/test/resources/org/camunda/bpm/engine/cdi/test/dmn/JuelTest.dmn
+++ b/engine-cdi/src/test/resources/org/camunda/bpm/engine/cdi/test/dmn/JuelTest.dmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="Definitions_1ov1jf9" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.0.0-alpha.3">
+  <decision id="drg-with-bean-expression" name="Decision 1">
+    <decisionTable id="DecisionTable_1ju7hid">
+      <input id="Input_1">
+        <inputExpression expressionLanguage="juel" id="InputExpression_1" typeRef="string">
+          <text>${beanFoo.getBar()}</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" typeRef="string" />
+      <rule id="DecisionRule_0dorm6y">
+        <inputEntry id="UnaryTests_16ybhz3">
+          <text>"baz"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0r5kzib">
+          <text>"bar"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1s7tmvg">
+        <inputEntry id="UnaryTests_0gxmhtw">
+          <text>"bar"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1o9o0r1">
+          <text>"foo"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="Decision_00khy2n">
+        <dc:Bounds height="80" width="180" x="100" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/dmn/DmnJuelTest.java
+++ b/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/dmn/DmnJuelTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.spring.test.dmn;
+
+import org.camunda.bpm.dmn.engine.DmnDecisionResult;
+import org.camunda.bpm.engine.DecisionService;
+import org.camunda.bpm.engine.RepositoryService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+    "classpath:org/camunda/bpm/engine/spring/test/dmn/DmnJuelTest-applicationContext.xml" })
+public class DmnJuelTest {
+
+  @Autowired
+  protected RepositoryService repositoryService;
+
+  @Autowired
+  protected DecisionService decisionService;
+
+  protected String deploymentId;
+
+  @Before
+  public void deploy() {
+    deploymentId = repositoryService.createDeployment()
+        .addClasspathResource("org/camunda/bpm/engine/spring/test/dmn/JuelTest.dmn")
+        .deploy()
+        .getId();
+  }
+
+  @After
+  public void clean() {
+    repositoryService.deleteDeployment(deploymentId, true);
+  }
+
+  @Test
+  public void shouldResolveBean() {
+    // given
+
+    // when
+    DmnDecisionResult result = decisionService.evaluateDecisionByKey("drg-with-bean-expression")
+        .evaluate();
+
+    // then
+    assertThat((String)result.getSingleEntry()).isEqualTo("bar");
+  }
+
+}

--- a/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/dmn/Testbean.java
+++ b/engine-spring/core/src/test/java/org/camunda/bpm/engine/spring/test/dmn/Testbean.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.spring.test.dmn;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class Testbean {
+
+  protected String bar = "baz";
+
+  public String getBar() {
+    return bar;
+  }
+
+}

--- a/engine-spring/core/src/test/resources/org/camunda/bpm/engine/spring/test/dmn/DmnJuelTest-applicationContext.xml
+++ b/engine-spring/core/src/test/resources/org/camunda/bpm/engine/spring/test/dmn/DmnJuelTest-applicationContext.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans" 
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd
+                           http://www.springframework.org/schema/tx      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd">
+
+  <bean id="testbean" class="org.camunda.bpm.engine.spring.test.dmn.Testbean" />
+
+  <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
+    <property name="driverClass" value="org.h2.Driver" />
+    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
+    <property name="username" value="sa" />
+    <property name="password" value="" />
+  </bean>
+
+  <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <property name="dataSource" ref="dataSource" />
+  </bean>
+  
+  <bean id="processEngineConfiguration" class="org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration">
+    <property name="dataSource" ref="dataSource" />
+    <property name="transactionManager" ref="transactionManager" />
+    <property name="databaseSchemaUpdate" value="true" />
+    <property name="jobExecutorActivate" value="false" />
+    <!-- turn off metrics reporter -->
+    <property name="dbMetricsReporterActivate" value="false" />
+    <property name="telemetryReporterActivate" value="false" />
+  </bean>
+  
+  <bean id="processEngine" class="org.camunda.bpm.engine.spring.ProcessEngineFactoryBean">
+    <property name="processEngineConfiguration" ref="processEngineConfiguration" />
+  </bean>
+
+  <bean id="repositoryService" factory-bean="processEngine" factory-method="getRepositoryService" />
+  <bean id="decisionService" factory-bean="processEngine" factory-method="getDecisionService" />
+
+</beans>

--- a/engine-spring/core/src/test/resources/org/camunda/bpm/engine/spring/test/dmn/JuelTest.dmn
+++ b/engine-spring/core/src/test/resources/org/camunda/bpm/engine/spring/test/dmn/JuelTest.dmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="Definitions_1ov1jf9" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.0.0-alpha.3">
+  <decision id="drg-with-bean-expression" name="Decision 1">
+    <decisionTable id="DecisionTable_1ju7hid">
+      <input id="Input_1">
+        <inputExpression expressionLanguage="juel" id="InputExpression_1" typeRef="string">
+          <text>${testbean.getBar()}</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" typeRef="string" />
+      <rule id="DecisionRule_0dorm6y">
+        <inputEntry id="UnaryTests_16ybhz3">
+          <text>"baz"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0r5kzib">
+          <text>"bar"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1s7tmvg">
+        <inputEntry id="UnaryTests_0gxmhtw">
+          <text>"bar"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1o9o0r1">
+          <text>"foo"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="Decision_00khy2n">
+        <dc:Bounds height="80" width="180" x="100" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>


### PR DESCRIPTION
Test cases show that CDI & Spring beans can be resolved in the DMN Engine using JUEL.