### PR TITLE
refactor(Font): rename method in camelCase style

### DIFF
--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/impl/instance/dc/FontImpl.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/impl/instance/dc/FontImpl.java
@@ -110,7 +110,7 @@ public class FontImpl extends BpmnModelElementInstanceImpl implements Font {
     return isUnderlineAttribute.getValue(this);
   }
 
-  public void SetUnderline(boolean isUnderline) {
+  public void setUnderline(boolean isUnderline) {
     isUnderlineAttribute.setValue(this, isUnderline);
   }
 

--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/instance/dc/Font.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/instance/dc/Font.java
@@ -43,7 +43,7 @@ public interface Font extends BpmnModelElementInstance {
 
   Boolean isUnderline();
 
-  void SetUnderline(boolean isUnderline);
+  void setUnderline(boolean isUnderline);
 
   Boolean isStrikeThrough();
 


### PR DESCRIPTION
In this commit we change method name from `SetUnderline` to `setUnderline` in both interface and implementation