### PR TITLE
CAM-12908: feat(ci): add wildfly subsystem unit test stage

### DIFF
--- a/.ci/daily/Jenkinsfile
+++ b/.ci/daily/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
         sh '.ci/scripts/check-sql-scripts.sh'
       }
     }
-    stage('H2 QA tests') {
+    stage('Standalone QA tests') {
       parallel {
         stage('sql-scripts-h2') {
           when {
@@ -77,6 +77,29 @@ pipeline {
           post {
             failure {
               cambpmAddFailedStageType(failedStageTypes, 'sql-scripts')
+            }
+          }
+        }
+        stage('wildfly-subsystem-UNIT-wildfly') {
+          when {
+            branch cambpmDefaultBranch();
+            beforeAgent true
+          }
+          agent {
+            node {
+              label 'h2'
+            }
+          }
+          steps {
+            catchError(stageResult: 'FAILURE') {
+              withMaven(jdk: 'jdk-8-latest', maven: 'maven-3.2-latest', mavenSettingsConfig: 'camunda-maven-settings', options: [artifactsPublisher(disabled: true), junitPublisher(disabled: true)]) {
+                cambpmRunMaven('distro/wildfly/subsystem', 'test', runtimeStash: true)
+              }
+            }
+          }
+          post {
+            always {
+              cambpmPublishTestResult();
             }
           }
         }
@@ -123,7 +146,7 @@ pipeline {
           steps {
             catchError(stageResult: 'FAILURE') {
               withMaven(jdk: 'jdk-8-latest', maven: 'maven-3.2-latest', mavenSettingsConfig: 'camunda-maven-settings', options: [artifactsPublisher(disabled: true), junitPublisher(disabled: true)]) {
-                cambpmRunMaven('instance-migration', 'h2')
+                cambpmRunMavenByStageType('instance-migration', 'h2')
               }
             }
           }
@@ -205,7 +228,7 @@ pipeline {
           steps {
             catchError(stageResult: 'FAILURE') {
               withMaven(jdk: 'jdk-8-latest', maven: 'maven-3.2-latest', mavenSettingsConfig: 'camunda-maven-settings', options: [artifactsPublisher(disabled: true), junitPublisher(disabled: true)]) {
-                cambpmRunMaven('large-data-tests', 'h2')
+                cambpmRunMavenByStageType('large-data-tests', 'h2')
               }
             }
           }


### PR DESCRIPTION
* Add wildfly subsystem unit test stage
* Fix runMaven method calls for instance migration and large data stages

Related to CAM-12778, CAM-12908