### PR TITLE
CAM-12955: refactor(bpmn-model): add abstract key word to abstract classes

### DIFF
--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractCallActivityBuilder.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractCallActivityBuilder.java
@@ -24,7 +24,7 @@ import org.camunda.bpm.model.bpmn.instance.camunda.CamundaOut;
 /**
  * @author Sebastian Menski
  */
-public class AbstractCallActivityBuilder<B extends AbstractCallActivityBuilder<B>> extends AbstractActivityBuilder<B, CallActivity> {
+public abstract class AbstractCallActivityBuilder<B extends AbstractCallActivityBuilder<B>> extends AbstractActivityBuilder<B, CallActivity> {
 
   protected AbstractCallActivityBuilder(BpmnModelInstance modelInstance, CallActivity element, Class<?> selfType) {
     super(modelInstance, element, selfType);

--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractCamundaFormFieldBuilder.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractCamundaFormFieldBuilder.java
@@ -24,7 +24,7 @@ import org.camunda.bpm.model.bpmn.instance.camunda.CamundaFormField;
  * @author Kristin Polenz
  *
  */
-public class AbstractCamundaFormFieldBuilder<P, B extends AbstractCamundaFormFieldBuilder<P, B>> 
+public abstract class AbstractCamundaFormFieldBuilder<P, B extends AbstractCamundaFormFieldBuilder<P, B>> 
   extends AbstractBpmnModelElementBuilder<B, CamundaFormField> {
 
   protected BaseElement parent;

--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractComplexGatewayBuilder.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractComplexGatewayBuilder.java
@@ -24,7 +24,7 @@ import org.camunda.bpm.model.bpmn.instance.SequenceFlow;
 /**
  * @author Sebastian Menski
  */
-public class AbstractComplexGatewayBuilder<B extends AbstractComplexGatewayBuilder<B>> extends AbstractGatewayBuilder<B, ComplexGateway> {
+public abstract class AbstractComplexGatewayBuilder<B extends AbstractComplexGatewayBuilder<B>> extends AbstractGatewayBuilder<B, ComplexGateway> {
 
   protected AbstractComplexGatewayBuilder(BpmnModelInstance modelInstance, ComplexGateway element, Class<?> selfType) {
     super(modelInstance, element, selfType);

--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractConditionalEventDefinitionBuilder.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractConditionalEventDefinitionBuilder.java
@@ -28,7 +28,7 @@ import org.camunda.bpm.model.bpmn.instance.Event;
  * @author Christopher Zell <christopher.zell@camunda.com>
  * @param <B>
  */
-public class AbstractConditionalEventDefinitionBuilder<B extends AbstractConditionalEventDefinitionBuilder<B>> extends AbstractRootElementBuilder<B, ConditionalEventDefinition>{
+public abstract class AbstractConditionalEventDefinitionBuilder<B extends AbstractConditionalEventDefinitionBuilder<B>> extends AbstractRootElementBuilder<B, ConditionalEventDefinition>{
 
   public AbstractConditionalEventDefinitionBuilder(BpmnModelInstance modelInstance, ConditionalEventDefinition element, Class<?> selfType) {
     super(modelInstance, element, selfType);

--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractEmbeddedSubProcessBuilder.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractEmbeddedSubProcessBuilder.java
@@ -20,7 +20,7 @@ package org.camunda.bpm.model.bpmn.builder;
  * @author Sebastian Menski
  */
 @SuppressWarnings("rawtypes")
-public class AbstractEmbeddedSubProcessBuilder<B extends AbstractEmbeddedSubProcessBuilder<B, E>, E extends AbstractSubProcessBuilder> {
+public abstract class AbstractEmbeddedSubProcessBuilder<B extends AbstractEmbeddedSubProcessBuilder<B, E>, E extends AbstractSubProcessBuilder> {
 
   protected final E subProcessBuilder;
   protected final B myself;

--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractEventBasedGatewayBuilder.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractEventBasedGatewayBuilder.java
@@ -23,7 +23,7 @@ import org.camunda.bpm.model.bpmn.instance.EventBasedGateway;
 /**
  * @author Sebastian Menski
  */
-public class AbstractEventBasedGatewayBuilder<B extends AbstractEventBasedGatewayBuilder<B>> extends AbstractGatewayBuilder<B, EventBasedGateway> {
+public abstract class AbstractEventBasedGatewayBuilder<B extends AbstractEventBasedGatewayBuilder<B>> extends AbstractGatewayBuilder<B, EventBasedGateway> {
 
   protected AbstractEventBasedGatewayBuilder(BpmnModelInstance modelInstance, EventBasedGateway element, Class<?> selfType) {
     super(modelInstance, element, selfType);

--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractEventSubProcessBuilder.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractEventSubProcessBuilder.java
@@ -24,7 +24,7 @@ import org.camunda.bpm.model.bpmn.instance.SubProcess;
 import org.camunda.bpm.model.bpmn.instance.bpmndi.BpmnShape;
 import org.camunda.bpm.model.bpmn.instance.dc.Bounds;
 
-public class AbstractEventSubProcessBuilder <B extends AbstractEventSubProcessBuilder<B>> extends  AbstractFlowElementBuilder<B, SubProcess> {
+public abstract class AbstractEventSubProcessBuilder <B extends AbstractEventSubProcessBuilder<B>> extends  AbstractFlowElementBuilder<B, SubProcess> {
 
   protected AbstractEventSubProcessBuilder(BpmnModelInstance modelInstance, SubProcess element, Class<?> selfType) {
     super(modelInstance, element, selfType);

--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractMultiInstanceLoopCharacteristicsBuilder.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractMultiInstanceLoopCharacteristicsBuilder.java
@@ -26,7 +26,7 @@ import org.camunda.bpm.model.bpmn.instance.MultiInstanceLoopCharacteristics;
  * @author Thorben Lindhauer
  *
  */
-public class AbstractMultiInstanceLoopCharacteristicsBuilder<B extends AbstractMultiInstanceLoopCharacteristicsBuilder<B>>
+public abstract class AbstractMultiInstanceLoopCharacteristicsBuilder<B extends AbstractMultiInstanceLoopCharacteristicsBuilder<B>>
   extends AbstractBaseElementBuilder<B, MultiInstanceLoopCharacteristics>{
 
   protected AbstractMultiInstanceLoopCharacteristicsBuilder(BpmnModelInstance modelInstance, MultiInstanceLoopCharacteristics element, Class<?> selfType) {

--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractParallelGatewayBuilder.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractParallelGatewayBuilder.java
@@ -22,7 +22,7 @@ import org.camunda.bpm.model.bpmn.instance.ParallelGateway;
 /**
  * @author Sebastian Menski
  */
-public class AbstractParallelGatewayBuilder<B extends AbstractParallelGatewayBuilder<B>> extends AbstractGatewayBuilder<B, ParallelGateway> {
+public abstract class AbstractParallelGatewayBuilder<B extends AbstractParallelGatewayBuilder<B>> extends AbstractGatewayBuilder<B, ParallelGateway> {
 
   protected AbstractParallelGatewayBuilder(BpmnModelInstance modelInstance, ParallelGateway element, Class<?> selfType) {
     super(modelInstance, element, selfType);

--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractSubProcessBuilder.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractSubProcessBuilder.java
@@ -22,7 +22,7 @@ import org.camunda.bpm.model.bpmn.instance.SubProcess;
 /**
  * @author Sebastian Menski
  */
-public class AbstractSubProcessBuilder<B extends AbstractSubProcessBuilder<B>> extends  AbstractActivityBuilder<B, SubProcess> {
+public abstract class AbstractSubProcessBuilder<B extends AbstractSubProcessBuilder<B>> extends  AbstractActivityBuilder<B, SubProcess> {
 
   protected AbstractSubProcessBuilder(BpmnModelInstance modelInstance, SubProcess element, Class<?> selfType) {
     super(modelInstance, element, selfType);

--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractTransactionBuilder.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/builder/AbstractTransactionBuilder.java
@@ -24,7 +24,7 @@ import org.camunda.bpm.model.bpmn.instance.Transaction;
  * @author Thorben Lindhauer
  *
  */
-public class AbstractTransactionBuilder<B extends AbstractTransactionBuilder<B>> extends  AbstractSubProcessBuilder<B> {
+public abstract class AbstractTransactionBuilder<B extends AbstractTransactionBuilder<B>> extends  AbstractSubProcessBuilder<B> {
 
   protected AbstractTransactionBuilder(BpmnModelInstance modelInstance, Transaction element, Class<?> selfType) {
     super(modelInstance, element, selfType);


### PR DESCRIPTION
In this commit we add missing `abstract` key word to abstract classes