### PR TITLE
chore(engine): enable async execution listener

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/listener/ExternalTaskExecutionListener.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/listener/ExternalTaskExecutionListener.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.bpmn.listener;
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.ExecutionListener;
+import org.camunda.bpm.engine.impl.context.Context;
+import org.camunda.bpm.engine.impl.core.operation.CoreAtomicOperation;
+import org.camunda.bpm.engine.impl.core.variable.mapping.value.ParameterValueProvider;
+import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.ExternalTaskEntity;
+
+public class ExternalTaskExecutionListener implements ExecutionListener {
+
+  protected ParameterValueProvider topicNameValueProvider;
+  protected String operation;
+
+  public ExternalTaskExecutionListener(ParameterValueProvider topicName) {
+    this.topicNameValueProvider = topicName;
+  }
+
+  @Override
+  public void notify(DelegateExecution execution) throws Exception {
+    ExecutionEntity executionEntity;
+    if (execution instanceof ExecutionEntity) {
+      executionEntity = (ExecutionEntity) execution;
+    } else {
+      executionEntity = Context.getCommandContext().getExecutionManager().findExecutionById(execution.getId());
+    }
+    String topic = (String) topicNameValueProvider.getValue(executionEntity);
+    ExternalTaskEntity.createAndInsert(executionEntity, topic, 0L, operation);
+  }
+
+  public void setOperation(CoreAtomicOperation<?> operation) {
+    this.operation = operation.getCanonicalName();
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
@@ -29,6 +29,7 @@ import org.camunda.bpm.engine.impl.bpmn.helper.BpmnProperties;
 import org.camunda.bpm.engine.impl.bpmn.listener.ClassDelegateExecutionListener;
 import org.camunda.bpm.engine.impl.bpmn.listener.DelegateExpressionExecutionListener;
 import org.camunda.bpm.engine.impl.bpmn.listener.ExpressionExecutionListener;
+import org.camunda.bpm.engine.impl.bpmn.listener.ExternalTaskExecutionListener;
 import org.camunda.bpm.engine.impl.bpmn.listener.ScriptExecutionListener;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.core.model.*;
@@ -4242,6 +4243,7 @@ public class BpmnParse extends Parse {
     String className = executionListenerElement.attribute(PROPERTYNAME_CLASS);
     String expression = executionListenerElement.attribute(PROPERTYNAME_EXPRESSION);
     String delegateExpression = executionListenerElement.attribute(PROPERTYNAME_DELEGATE_EXPRESSION);
+    String topic = executionListenerElement.attribute(PROPERTYNAME_EXTERNAL_TASK_TOPIC);
     Element scriptElement = executionListenerElement.elementNS(CAMUNDA_BPMN_EXTENSIONS_NS, "script");
 
     if (className != null) {
@@ -4266,6 +4268,12 @@ public class BpmnParse extends Parse {
         }
       } catch (BpmnParseException e) {
         addError(e, ancestorElementId);
+      }
+    } else if (topic != null) {
+      if (topic.isEmpty()) {
+        addError("Attribute 'topic' cannot be empty", executionListenerElement, ancestorElementId);
+      } else {
+        executionListener = new ExternalTaskExecutionListener(createParameterValueProvider(topic, expressionManager));
       }
     } else {
       addError("Element 'class', 'expression', 'delegateExpression' or 'script' is mandatory on executionListener", executionListenerElement, ancestorElementId);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExecutionEntity.java
@@ -1441,6 +1441,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
     persistentState.put("suspensionState", this.suspensionState);
     persistentState.put("cachedEntityState", getCachedEntityState());
     persistentState.put("sequenceCounter", getSequenceCounter());
+    persistentState.put("listenerIndex", this.listenerIndex);
     return persistentState;
   }
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.h2.create.engine.sql
+++ b/engine/src/main/resources/org/camunda/bpm/engine/db/create/activiti.h2.create.engine.sql
@@ -101,6 +101,7 @@ create table ACT_RU_EXECUTION (
     CACHED_ENT_STATE_ integer,
     SEQUENCE_COUNTER_ integer,
     TENANT_ID_ varchar(64),
+    LISTENER_INDEX_ integer,
     primary key (ID_)
 );
 
@@ -315,6 +316,9 @@ create table ACT_RU_EXT_TASK (
   ACT_INST_ID_ varchar(64),
   TENANT_ID_ varchar(64),
   PRIORITY_ bigint NOT NULL DEFAULT 0,
+  OPERATION_ varchar(64),
+  TRANSITION_ID_ varchar(64),
+  TRANSITION_IDS_ varchar(4000),
   primary key (ID_)
 );
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Execution.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Execution.xml
@@ -45,6 +45,7 @@
       CACHED_ENT_STATE_,
       SEQUENCE_COUNTER_,
       TENANT_ID_,
+      LISTENER_INDEX_,
       REV_
     )
     values
@@ -68,6 +69,7 @@
       #{cachedEntityState, jdbcType=INTEGER},
       #{sequenceCounter, jdbcType=BIGINT},
       #{tenantId, jdbcType=VARCHAR},
+      #{listenerIndex, jdbcType=INTEGER},
       1
     )
   </insert>
@@ -90,7 +92,8 @@
       SUSPENSION_STATE_ = #{suspensionState, jdbcType=INTEGER},
       CACHED_ENT_STATE_ = #{cachedEntityState, jdbcType=INTEGER},
       SEQUENCE_COUNTER_ = #{sequenceCounter, jdbcType=BIGINT},
-      TENANT_ID_ = #{tenantId, jdbcType=BIGINT}
+      TENANT_ID_ = #{tenantId, jdbcType=BIGINT},
+      LISTENER_INDEX_ = #{listenerIndex, jdbcType=INTEGER}
     where ID_ = #{id, jdbcType=VARCHAR}
       and REV_ = #{revision, jdbcType=INTEGER}
   </update>
@@ -155,6 +158,7 @@
     <result property="cachedEntityState" column="CACHED_ENT_STATE_" jdbcType="INTEGER"/>
     <result property="sequenceCounter" column="SEQUENCE_COUNTER_" jdbcType="BIGINT"/>
     <result property="tenantId" column="TENANT_ID_" jdbcType="VARCHAR"/>
+    <result property="listenerIndex" column="LISTENER_INDEX_" jdbcType="INTEGER"/>
   </resultMap>
   
   <resultMap type="org.camunda.bpm.engine.impl.util.ImmutablePair" id="deploymentIdMapping">

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ExternalTask.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ExternalTask.xml
@@ -42,6 +42,9 @@
     <result property="tenantId" column="TENANT_ID_" jdbcType="VARCHAR" />
     <result property="priority" column="PRIORITY_" jdbcType="BIGINT" />
     <result property="businessKey" column="BUSINESS_KEY_" jdbcType="VARCHAR" />
+    <result property="operation" column="OPERATION_" jdbcType="VARCHAR" />
+    <result property="transitionId" column="TRANSITION_ID_" jdbcType="VARCHAR" />
+    <result property="transitionsToTakeIds" column="TRANSITION_IDS_" jdbcType="VARCHAR" />
     <!-- note: if you add mappings here, make sure to select the columns in 'columnSelection' -->
   </resultMap>
   
@@ -68,6 +71,9 @@
       ACT_INST_ID_,
       TENANT_ID_,
       PRIORITY_,
+      OPERATION_,
+      TRANSITION_ID_,
+      TRANSITION_IDS_,
       REV_
     ) values (
       #{id, jdbcType=VARCHAR},
@@ -86,6 +92,9 @@
       #{activityInstanceId, jdbcType=VARCHAR},
       #{tenantId, jdbcType=VARCHAR},
       #{priority, jdbcType=BIGINT},
+      #{operation, jdbcType=VARCHAR},
+      #{transitionId, jdbcType=VARCHAR},
+      #{transitionsToTakeIds, jdbcType=VARCHAR},
       1
     )
   </insert>
@@ -107,7 +116,10 @@
       ACT_ID_ = #{activityId, jdbcType=VARCHAR},
       ACT_INST_ID_ = #{activityInstanceId, jdbcType=VARCHAR},
       SUSPENSION_STATE_ = #{suspensionState, jdbcType=INTEGER},
-      PRIORITY_ = #{priority, jdbcType=BIGINT}
+      PRIORITY_ = #{priority, jdbcType=BIGINT},
+      OPERATION_ = #{operation, jdbcType=VARCHAR},
+      TRANSITION_ID_ = #{transitionId, jdbcType=VARCHAR},
+      TRANSITION_IDS_ = #{transitionsToTakeIds, jdbcType=VARCHAR}
     </set>
     where ID_= #{id, jdbcType=VARCHAR}
       and REV_ = #{revision, jdbcType=INTEGER}
@@ -450,6 +462,9 @@
     RES.SUSPENSION_STATE_,
     RES.TENANT_ID_,
     RES.PRIORITY_,
+    RES.OPERATION_,
+    RES.TRANSITION_ID_,
+    RES.TRANSITION_IDS_,
     RES.BUSINESS_KEY_,
     RES.VERSION_TAG_
   </sql>

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.java
@@ -40,7 +40,6 @@ import org.camunda.bpm.engine.delegate.BpmnError;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.ExecutionListener;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
-import org.camunda.bpm.engine.externaltask.LockedExternalTask;
 import org.camunda.bpm.engine.history.HistoricVariableInstance;
 import org.camunda.bpm.engine.history.HistoricVariableInstanceQuery;
 import org.camunda.bpm.engine.repository.DeploymentWithDefinitions;
@@ -322,41 +321,33 @@ public class ExecutionListenerTest {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
 
     // complete the "start" listener on process start
-    List<LockedExternalTask> listenerTasks = externalTaskService.fetchAndLock(1, "worker").topic("listen", 30000L).execute();
-    assertTrue(listenerTasks.size() == 1);
-    externalTaskService.complete(listenerTasks.get(0).getId(), "worker");
+    finishListener();
 
     // complete the "start" listener on start event
-    listenerTasks = externalTaskService.fetchAndLock(1, "worker").topic("listen", 30000L).execute();
-    assertTrue(listenerTasks.size() == 1);
-    externalTaskService.complete(listenerTasks.get(0).getId(), "worker");
+    finishListener();
 
     // complete the "end" listener on start event
-    listenerTasks = externalTaskService.fetchAndLock(1, "worker").topic("listen", 30000L).execute();
-    assertTrue(listenerTasks.size() == 1);
-    externalTaskService.complete(listenerTasks.get(0).getId(), "worker");
+    finishListener();
 
     // complete the "take" listener on flow
-    listenerTasks = externalTaskService.fetchAndLock(1, "worker").topic("listen", 30000L).execute();
-    assertTrue(listenerTasks.size() == 1);
-    externalTaskService.complete(listenerTasks.get(0).getId(), "worker");
+    finishListener();
 
     // complete the "start" listener on end event
-    listenerTasks = externalTaskService.fetchAndLock(1, "worker").topic("listen", 30000L).execute();
-    assertTrue(listenerTasks.size() == 1);
-    externalTaskService.complete(listenerTasks.get(0).getId(), "worker");
+    finishListener();
 
     // complete the "end" listener on end event
-    listenerTasks = externalTaskService.fetchAndLock(1, "worker").topic("listen", 30000L).execute();
-    assertTrue(listenerTasks.size() == 1);
-    externalTaskService.complete(listenerTasks.get(0).getId(), "worker");
+    finishListener();
 
     // complete the "end" listener on process
-    listenerTasks = externalTaskService.fetchAndLock(1, "worker").topic("listen", 30000L).execute();
-    assertTrue(listenerTasks.size() == 1);
-    externalTaskService.complete(listenerTasks.get(0).getId(), "worker");
+    finishListener();
 
     assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult());
+  }
+
+  protected void finishListener() {
+    externalTaskService.complete(
+        externalTaskService.fetchAndLock(1, "worker").topic("listen", 30000L).execute().get(0).getId(),
+        "worker");
   }
 
   @Test

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.java
@@ -565,6 +565,42 @@ public class ExecutionListenerTest {
 
   @Test
   @Deployment
+  public void testAsyncListenerWithInterruptingMessageBoundaryEventOnEmbeddedSubprocess() {
+    // given
+    runtimeService.startProcessInstanceByKey("process");
+
+    // when
+    runtimeService.correlateMessage("abort_A");
+
+    /*
+     * then no "end" listener External Task will be created
+     * although they are invoked on deletion of the child activities
+     * since the child node deletion algorithm retries to delete the child
+     * when the operation simply "return"ed without deleting the child effectively
+     */
+    assertEquals(0L, externalTaskService.createExternalTaskQuery().count());
+  }
+
+  @Test
+  @Deployment(resources = "org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListenerWithInterruptingMessageBoundaryEventOnEmbeddedSubprocess.bpmn20.xml")
+  public void testInstanceDeletionAsyncListenerWithInterruptingMessageBoundaryEventOnEmbeddedSubprocess() {
+    // given
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
+
+    // when
+    runtimeService.deleteProcessInstance(processInstance.getId(), "foo");
+
+    /*
+     * then no "end" listener External Task will be created
+     * although they are invoked on deletion of the child activities
+     * since the child node deletion algorithm retries to delete the child
+     * when the operation simply "return"ed without deleting the child effectively
+     */
+    assertEquals(0L, externalTaskService.createExternalTaskQuery().count());
+  }
+
+  @Test
+  @Deployment
   public void testAsyncListenerOnMultiInstance() {
     // given
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListener.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListener.bpmn20.xml
@@ -1,0 +1,31 @@
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  targetNamespace="Examples">
+
+  <process id="process" isExecutable="true">
+    <extensionElements>
+      <camunda:executionListener event="start" topic="listen" />
+      <camunda:executionListener event="end" topic="listen" />
+    </extensionElements>
+
+    <startEvent id="start">
+      <extensionElements>
+        <camunda:executionListener event="start" topic="listen" />
+        <camunda:executionListener event="end" topic="listen" />
+      </extensionElements>
+    </startEvent>
+    <sequenceFlow id="flow" sourceRef="start" targetRef="end">
+      <extensionElements>
+        <camunda:executionListener topic="listen" />
+      </extensionElements>
+    </sequenceFlow>
+    <endEvent id="end">
+      <extensionElements>
+        <camunda:executionListener event="start" topic="listen" />
+        <camunda:executionListener event="end" topic="listen" />
+      </extensionElements>
+    </endEvent>
+  </process>
+</definitions>
+

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListenerOnMultiInstance.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListenerOnMultiInstance.bpmn20.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_02meulb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.3.0">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>start2service</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="start2service" sourceRef="start" targetRef="service" />
+    <bpmn:endEvent id="end_happy">
+      <bpmn:incoming>service2end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="service2end" sourceRef="service" targetRef="end_happy" />
+    <bpmn:serviceTask id="service" camunda:type="external" camunda:topic="service">
+      <bpmn:extensionElements>
+        <camunda:executionListener event="end" topic="listen" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>start2service</bpmn:incoming>
+      <bpmn:outgoing>service2end</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:loopCardinality xsi:type="bpmn:tFormalExpression">5</bpmn:loopCardinality>
+        <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">${nrOfCompletedInstances == 3}</bpmn:completionCondition>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="end_error">
+      <bpmn:incoming>error2end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="error2end" sourceRef="error_A" targetRef="end_error" />
+    <bpmn:boundaryEvent id="error_A" attachedToRef="service">
+      <bpmn:extensionElements>
+        <camunda:executionListener event="end" topic="listen-boundary" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>error2end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0unn9sq" messageRef="Message_0bb6ux3" />
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_0bb6ux3" name="message_A" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
+      <bpmndi:BPMNEdge id="Flow_1e5hics_di" bpmnElement="error2end">
+        <di:waypoint x="350" y="175" />
+        <di:waypoint x="350" y="240" />
+        <di:waypoint x="432" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0f8lipe_di" bpmnElement="service2end">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jbey9f_di" bpmnElement="start2service">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1f57sa9_di" bpmnElement="end_happy">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ck7mho_di" bpmnElement="service">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1cgd6sl_di" bpmnElement="end_error">
+        <dc:Bounds x="432" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01krrg5_di" bpmnElement="error_A">
+        <dc:Bounds x="332" y="139" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListenerWithErrorBoundaryEvent.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListenerWithErrorBoundaryEvent.bpmn20.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_02meulb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.3.0">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>start2service</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="start2service" sourceRef="start" targetRef="service" />
+    <bpmn:endEvent id="end_happy">
+      <bpmn:incoming>service2end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="service2end" sourceRef="service" targetRef="end_happy" />
+    <bpmn:serviceTask id="service" camunda:type="external" camunda:topic="service">
+      <bpmn:extensionElements>
+        <camunda:executionListener event="start" topic="listen" />
+        <camunda:executionListener event="end" topic="listen" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>start2service</bpmn:incoming>
+      <bpmn:outgoing>service2end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="error_A" attachedToRef="service">
+      <bpmn:outgoing>error2end</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_01cf319" errorRef="Error_1xc14wo" />
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="end_error">
+      <bpmn:incoming>error2end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="error2end" sourceRef="error_A" targetRef="end_error" />
+  </bpmn:process>
+  <bpmn:error id="Error_1xc14wo" name="A" errorCode="A" camunda:errorMessage="an error" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
+      <bpmndi:BPMNEdge id="Flow_1jbey9f_di" bpmnElement="start2service">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0f8lipe_di" bpmnElement="service2end">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1e5hics_di" bpmnElement="error2end">
+        <di:waypoint x="350" y="175" />
+        <di:waypoint x="350" y="240" />
+        <di:waypoint x="432" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1f57sa9_di" bpmnElement="end_happy">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ck7mho_di" bpmnElement="service">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1cgd6sl_di" bpmnElement="end_error">
+        <dc:Bounds x="432" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_081bmib_di" bpmnElement="error_A">
+        <dc:Bounds x="332" y="139" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListenerWithInterruptingMessageBoundaryEvent.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListenerWithInterruptingMessageBoundaryEvent.bpmn20.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_02meulb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.3.0">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>start2service</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="start2service" sourceRef="start" targetRef="service" />
+    <bpmn:endEvent id="end_happy">
+      <bpmn:incoming>service2end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="service2end" sourceRef="service" targetRef="end_happy" />
+    <bpmn:serviceTask id="service" camunda:type="external" camunda:topic="service">
+      <bpmn:extensionElements>
+        <camunda:executionListener topic="listen" event="end" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>start2service</bpmn:incoming>
+      <bpmn:outgoing>service2end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="end_error">
+      <bpmn:incoming>error2end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="error2end" sourceRef="error_A" targetRef="end_error" />
+    <bpmn:boundaryEvent id="error_A" attachedToRef="service">
+      <bpmn:extensionElements>
+        <camunda:executionListener topic="listen-boundary" event="end" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>error2end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0unn9sq" messageRef="Message_0bb6ux3" />
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_0bb6ux3" name="message_A" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
+      <bpmndi:BPMNEdge id="Flow_1e5hics_di" bpmnElement="error2end">
+        <di:waypoint x="350" y="175" />
+        <di:waypoint x="350" y="240" />
+        <di:waypoint x="432" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0f8lipe_di" bpmnElement="service2end">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jbey9f_di" bpmnElement="start2service">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1f57sa9_di" bpmnElement="end_happy">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ck7mho_di" bpmnElement="service">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1cgd6sl_di" bpmnElement="end_error">
+        <dc:Bounds x="432" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01krrg5_di" bpmnElement="error_A">
+        <dc:Bounds x="332" y="139" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListenerWithInterruptingMessageBoundaryEventOnEmbeddedSubprocess.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListenerWithInterruptingMessageBoundaryEventOnEmbeddedSubprocess.bpmn20.xml
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0nmdacg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.3.0">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1d8iv4x</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1d8iv4x" sourceRef="StartEvent_1" targetRef="Gateway_0smflu6" />
+    <bpmn:subProcess id="Sub_1" name="Sub 1">
+      <bpmn:incoming>Flow_1rcx6bj</bpmn:incoming>
+      <bpmn:outgoing>Flow_0u34kyx</bpmn:outgoing>
+      <bpmn:startEvent id="Event_0nhnjq9">
+        <bpmn:outgoing>Flow_1bsxqon</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_1bsxqon" sourceRef="Event_0nhnjq9" targetRef="Gateway_1kviz2c" />
+      <bpmn:subProcess id="Sub_2" name="Sub 2">
+        <bpmn:incoming>Flow_04x8tjs</bpmn:incoming>
+        <bpmn:outgoing>Flow_00710eq</bpmn:outgoing>
+        <bpmn:startEvent id="Event_0167dcm">
+          <bpmn:outgoing>Flow_1shie01</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:sequenceFlow id="Flow_1shie01" sourceRef="Event_0167dcm" targetRef="A" />
+        <bpmn:endEvent id="Event_1ys6qvr">
+          <bpmn:incoming>Flow_179wjcs</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_179wjcs" sourceRef="A" targetRef="Event_1ys6qvr" />
+        <bpmn:userTask id="A" name="A">
+          <bpmn:extensionElements>
+            <camunda:executionListener event="end" topic="listen-A" />
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_1shie01</bpmn:incoming>
+          <bpmn:outgoing>Flow_179wjcs</bpmn:outgoing>
+          <bpmn:multiInstanceLoopCharacteristics>
+            <bpmn:loopCardinality xsi:type="bpmn:tFormalExpression">5</bpmn:loopCardinality>
+          </bpmn:multiInstanceLoopCharacteristics>
+        </bpmn:userTask>
+      </bpmn:subProcess>
+      <bpmn:endEvent id="Event_1trosqs">
+        <bpmn:incoming>Flow_10iuayj</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_04x8tjs" sourceRef="Gateway_1kviz2c" targetRef="Sub_2" />
+      <bpmn:parallelGateway id="Gateway_1kviz2c">
+        <bpmn:incoming>Flow_1bsxqon</bpmn:incoming>
+        <bpmn:outgoing>Flow_04x8tjs</bpmn:outgoing>
+        <bpmn:outgoing>Flow_07vr0b7</bpmn:outgoing>
+      </bpmn:parallelGateway>
+      <bpmn:sequenceFlow id="Flow_07vr0b7" sourceRef="Gateway_1kviz2c" targetRef="B" />
+      <bpmn:userTask id="B" name="B">
+        <bpmn:extensionElements>
+          <camunda:executionListener event="end" topic="listen-B" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_07vr0b7</bpmn:incoming>
+        <bpmn:outgoing>Flow_0olmmvv</bpmn:outgoing>
+        <bpmn:multiInstanceLoopCharacteristics>
+          <bpmn:loopCardinality xsi:type="bpmn:tFormalExpression">10</bpmn:loopCardinality>
+        </bpmn:multiInstanceLoopCharacteristics>
+      </bpmn:userTask>
+      <bpmn:sequenceFlow id="Flow_0olmmvv" sourceRef="B" targetRef="Gateway_12mvgc3" />
+      <bpmn:sequenceFlow id="Flow_10iuayj" sourceRef="Gateway_12mvgc3" targetRef="Event_1trosqs" />
+      <bpmn:parallelGateway id="Gateway_12mvgc3">
+        <bpmn:incoming>Flow_0olmmvv</bpmn:incoming>
+        <bpmn:incoming>Flow_00710eq</bpmn:incoming>
+        <bpmn:outgoing>Flow_10iuayj</bpmn:outgoing>
+      </bpmn:parallelGateway>
+      <bpmn:sequenceFlow id="Flow_00710eq" sourceRef="Sub_2" targetRef="Gateway_12mvgc3" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_1rcx6bj" sourceRef="Gateway_0smflu6" targetRef="Sub_1" />
+    <bpmn:parallelGateway id="Gateway_0smflu6">
+      <bpmn:incoming>Flow_1d8iv4x</bpmn:incoming>
+      <bpmn:outgoing>Flow_1rcx6bj</bpmn:outgoing>
+      <bpmn:outgoing>Flow_03whtvz</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_03whtvz" sourceRef="Gateway_0smflu6" targetRef="C" />
+    <bpmn:userTask id="C" name="C">
+      <bpmn:extensionElements>
+        <camunda:executionListener event="end" topic="listen-C" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_03whtvz</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xb7ltz</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:loopCardinality xsi:type="bpmn:tFormalExpression">15</bpmn:loopCardinality>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1xb7ltz" sourceRef="C" targetRef="Gateway_0nmdu2x" />
+    <bpmn:parallelGateway id="Gateway_0nmdu2x">
+      <bpmn:incoming>Flow_1xb7ltz</bpmn:incoming>
+      <bpmn:incoming>Flow_0u34kyx</bpmn:incoming>
+      <bpmn:outgoing>Flow_0efduwp</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:endEvent id="Event_00d6vr7" name="happy end">
+      <bpmn:incoming>Flow_0efduwp</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0efduwp" sourceRef="Gateway_0nmdu2x" targetRef="Event_00d6vr7" />
+    <bpmn:sequenceFlow id="Flow_0u34kyx" sourceRef="Sub_1" targetRef="Gateway_0nmdu2x" />
+    <bpmn:endEvent id="Event_0c2k8nq" name="aborted">
+      <bpmn:incoming>Flow_0qcyujy</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0qcyujy" sourceRef="Event_07fyort" targetRef="Event_0c2k8nq" />
+    <bpmn:boundaryEvent id="Event_07fyort" name="abort" attachedToRef="Sub_1">
+      <bpmn:outgoing>Flow_0qcyujy</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_15u733q" messageRef="Message_1tyu3wk" />
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_1tyu3wk" name="abort_A" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
+      <bpmndi:BPMNEdge id="Flow_0qcyujy_di" bpmnElement="Flow_0qcyujy">
+        <di:waypoint x="978" y="130" />
+        <di:waypoint x="1112" y="130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0u34kyx_di" bpmnElement="Flow_0u34kyx">
+        <di:waypoint x="960" y="256" />
+        <di:waypoint x="1010" y="256" />
+        <di:waypoint x="1010" y="385" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0efduwp_di" bpmnElement="Flow_0efduwp">
+        <di:waypoint x="1035" y="410" />
+        <di:waypoint x="1112" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xb7ltz_di" bpmnElement="Flow_1xb7ltz">
+        <di:waypoint x="700" y="505" />
+        <di:waypoint x="1010" y="505" />
+        <di:waypoint x="1010" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03whtvz_di" bpmnElement="Flow_03whtvz">
+        <di:waypoint x="224" y="435" />
+        <di:waypoint x="224" y="505" />
+        <di:waypoint x="600" y="505" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rcx6bj_di" bpmnElement="Flow_1rcx6bj">
+        <di:waypoint x="224" y="385" />
+        <di:waypoint x="224" y="270" />
+        <di:waypoint x="280" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1d8iv4x_di" bpmnElement="Flow_1d8iv4x">
+        <di:waypoint x="168" y="410" />
+        <di:waypoint x="199" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="132" y="392" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18m1p0v_di" bpmnElement="Sub_1" isExpanded="true">
+        <dc:Bounds x="280" y="106" width="680" height="300" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_00710eq_di" bpmnElement="Flow_00710eq">
+        <di:waypoint x="810" y="196" />
+        <di:waypoint x="854" y="196" />
+        <di:waypoint x="854" y="241" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10iuayj_di" bpmnElement="Flow_10iuayj">
+        <di:waypoint x="879" y="266" />
+        <di:waypoint x="902" y="266" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0olmmvv_di" bpmnElement="Flow_0olmmvv">
+        <di:waypoint x="700" y="341" />
+        <di:waypoint x="854" y="341" />
+        <di:waypoint x="854" y="291" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07vr0b7_di" bpmnElement="Flow_07vr0b7">
+        <di:waypoint x="420" y="291" />
+        <di:waypoint x="420" y="341" />
+        <di:waypoint x="600" y="341" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04x8tjs_di" bpmnElement="Flow_04x8tjs">
+        <di:waypoint x="420" y="241" />
+        <di:waypoint x="420" y="193" />
+        <di:waypoint x="490" y="193" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bsxqon_di" bpmnElement="Flow_1bsxqon">
+        <di:waypoint x="338" y="266" />
+        <di:waypoint x="395" y="266" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0nhnjq9_di" bpmnElement="Event_0nhnjq9">
+        <dc:Bounds x="302" y="248" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_16cy27g_di" bpmnElement="Sub_2" isExpanded="true">
+        <dc:Bounds x="490" y="135" width="320" height="121" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_179wjcs_di" bpmnElement="Flow_179wjcs">
+        <di:waypoint x="700" y="196" />
+        <di:waypoint x="752" y="196" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1shie01_di" bpmnElement="Flow_1shie01">
+        <di:waypoint x="548" y="196" />
+        <di:waypoint x="600" y="196" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0167dcm_di" bpmnElement="Event_0167dcm">
+        <dc:Bounds x="512" y="178" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ys6qvr_di" bpmnElement="Event_1ys6qvr">
+        <dc:Bounds x="752" y="178" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0umbu4b_di" bpmnElement="A">
+        <dc:Bounds x="600" y="156" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1trosqs_di" bpmnElement="Event_1trosqs">
+        <dc:Bounds x="902" y="248" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_08lfh43_di" bpmnElement="Gateway_1kviz2c">
+        <dc:Bounds x="395" y="241" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sy3l3p_di" bpmnElement="B">
+        <dc:Bounds x="600" y="301" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_031sbld_di" bpmnElement="Gateway_12mvgc3">
+        <dc:Bounds x="829" y="241" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0s215ck_di" bpmnElement="Gateway_0smflu6">
+        <dc:Bounds x="199" y="385" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c1a9m8_di" bpmnElement="C">
+        <dc:Bounds x="600" y="465" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1fa8r2p_di" bpmnElement="Gateway_0nmdu2x">
+        <dc:Bounds x="985" y="385" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00d6vr7_di" bpmnElement="Event_00d6vr7">
+        <dc:Bounds x="1112" y="392" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1104" y="435" width="52" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0c2k8nq_di" bpmnElement="Event_0c2k8nq">
+        <dc:Bounds x="1112" y="112" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1111" y="155" width="38" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ux7hsa_di" bpmnElement="Event_07fyort">
+        <dc:Bounds x="942" y="112" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="966" y="153" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListenerWithInterruptingMessageEventSubprocess.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListenerWithInterruptingMessageEventSubprocess.bpmn20.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_02meulb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.3.0">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>start2service</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="start2service" sourceRef="start" targetRef="service" />
+    <bpmn:endEvent id="end_happy">
+      <bpmn:incoming>service2end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="service2end" sourceRef="service" targetRef="end_happy" />
+    <bpmn:serviceTask id="service" camunda:type="external" camunda:topic="service">
+      <bpmn:extensionElements>
+        <camunda:executionListener event="end" topic="listen" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>start2service</bpmn:incoming>
+      <bpmn:outgoing>service2end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:subProcess id="error_A" triggeredByEvent="true">
+      <bpmn:endEvent id="Event_0hbax2r">
+        <bpmn:incoming>Flow_0nhmce3</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_0nhmce3" sourceRef="Event_0mip387" targetRef="Event_0hbax2r" />
+      <bpmn:startEvent id="Event_0mip387">
+        <bpmn:extensionElements>
+          <camunda:executionListener topic="listen-subprocess" event="end" />
+        </bpmn:extensionElements>
+        <bpmn:outgoing>Flow_0nhmce3</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_1uljey2" messageRef="Message_0bb6ux3" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmn:message id="Message_0bb6ux3" name="message_A" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
+      <bpmndi:BPMNEdge id="Flow_0f8lipe_di" bpmnElement="service2end">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jbey9f_di" bpmnElement="start2service">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1f57sa9_di" bpmnElement="end_happy">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ck7mho_di" bpmnElement="service">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_04ufcxf_di" bpmnElement="error_A" isExpanded="true">
+        <dc:Bounds x="230" y="190" width="165" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0nhmce3_di" bpmnElement="Flow_0nhmce3">
+        <di:waypoint x="286" y="250" />
+        <di:waypoint x="337" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0hbax2r_di" bpmnElement="Event_0hbax2r">
+        <dc:Bounds x="337" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1eciww3_di" bpmnElement="Event_0mip387">
+        <dc:Bounds x="250" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListenerWithNonInterruptingMessageBoundaryEvent.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListenerWithNonInterruptingMessageBoundaryEvent.bpmn20.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_02meulb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.3.0">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>start2service</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="start2service" sourceRef="start" targetRef="service" />
+    <bpmn:endEvent id="end_happy">
+      <bpmn:incoming>service2end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="service2end" sourceRef="service" targetRef="end_happy" />
+    <bpmn:serviceTask id="service" camunda:type="external" camunda:topic="service">
+      <bpmn:extensionElements>
+        <camunda:executionListener topic="listen" event="end" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>start2service</bpmn:incoming>
+      <bpmn:outgoing>service2end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="end_error">
+      <bpmn:incoming>error2end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="error2end" sourceRef="error_A" targetRef="end_error" />
+    <bpmn:boundaryEvent id="error_A" cancelActivity="false" attachedToRef="service">
+      <bpmn:extensionElements>
+        <camunda:executionListener topic="listen-boundary" event="end" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>error2end</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0unn9sq" messageRef="Message_0bb6ux3" />
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_0bb6ux3" name="message_A" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
+      <bpmndi:BPMNEdge id="Flow_1e5hics_di" bpmnElement="error2end">
+        <di:waypoint x="350" y="175" />
+        <di:waypoint x="350" y="240" />
+        <di:waypoint x="432" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0f8lipe_di" bpmnElement="service2end">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jbey9f_di" bpmnElement="start2service">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1f57sa9_di" bpmnElement="end_happy">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ck7mho_di" bpmnElement="service">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1cgd6sl_di" bpmnElement="end_error">
+        <dc:Bounds x="432" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01krrg5_di" bpmnElement="error_A">
+        <dc:Bounds x="332" y="139" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListenerWithNonInterruptingMessageEventSubprocess.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/executionlistener/ExecutionListenerTest.testAsyncListenerWithNonInterruptingMessageEventSubprocess.bpmn20.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_02meulb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.3.0">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>start2service</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="start2service" sourceRef="start" targetRef="service" />
+    <bpmn:endEvent id="end_happy">
+      <bpmn:incoming>service2end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="service2end" sourceRef="service" targetRef="end_happy" />
+    <bpmn:serviceTask id="service" camunda:type="external" camunda:topic="service">
+      <bpmn:extensionElements>
+        <camunda:executionListener event="end" topic="listen" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>start2service</bpmn:incoming>
+      <bpmn:outgoing>service2end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:subProcess id="error_A" triggeredByEvent="true">
+      <bpmn:endEvent id="Event_0hbax2r">
+        <bpmn:incoming>Flow_0nhmce3</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_0nhmce3" sourceRef="Event_0mip387" targetRef="Event_0hbax2r" />
+      <bpmn:startEvent id="Event_0mip387" isInterrupting="false">
+        <bpmn:extensionElements>
+          <camunda:executionListener topic="listen-subprocess" event="end" />
+        </bpmn:extensionElements>
+        <bpmn:outgoing>Flow_0nhmce3</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_1uljey2" messageRef="Message_0bb6ux3" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmn:message id="Message_0bb6ux3" name="message_A" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
+      <bpmndi:BPMNEdge id="Flow_0f8lipe_di" bpmnElement="service2end">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jbey9f_di" bpmnElement="start2service">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1f57sa9_di" bpmnElement="end_happy">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ck7mho_di" bpmnElement="service">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_04ufcxf_di" bpmnElement="error_A" isExpanded="true">
+        <dc:Bounds x="230" y="190" width="165" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0nhmce3_di" bpmnElement="Flow_0nhmce3">
+        <di:waypoint x="286" y="250" />
+        <di:waypoint x="337" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0hbax2r_di" bpmnElement="Event_0hbax2r">
+        <dc:Bounds x="337" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1eciww3_di" bpmnElement="Event_0mip387">
+        <dc:Bounds x="250" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
* adds ExternalTaskExecutionListener (async execution listener) that creates
  an external task for the execution listener
* allows to perform an atomic operation when completing an external task
* suspends atomic operation execution chain for async execution listeners
  (they are resumed from the completion of the external task)
* invokes one listener after the other (async listeners are synchronized in
  their order just as sync listeners are)
* expands ExternalTask and Execution tables with new attributes for operation,
  transitionId, transitionsToTakeIds, listenerIndex to allow resuming execution
  after the newly introduced wait states within the execution of an activity or
  transition