### PR TITLE
chore(engine-rest): add annotation methods to incident

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/AnnotationDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/AnnotationDto.ftl
@@ -1,0 +1,9 @@
+<@lib.dto>
+
+  <@lib.property
+      name = "annotation"
+      type = "string"
+      desc = "The annotation value to put."
+      last=true />
+
+</@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/IncidentDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/IncidentDto.ftl
@@ -71,6 +71,11 @@
     <@lib.property
         name = "jobDefinitionId"
         type = "string"
-        last = true
         desc = "The job definition id the incident is associated with." />
+        
+    <@lib.property
+        name = "annotation"
+        type = "string"
+        last = true
+        desc = "The annotation set to the incident." />
 </@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/incident/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/incident/get.ftl
@@ -41,7 +41,8 @@
                              "configuration": "aConfiguration",
                              "tenantId": null,
                              "incidentMessage": "anIncidentMessage",
-                             "jobDefinitionId": "aJobDefinitionId"
+                             "jobDefinitionId": "aJobDefinitionId",
+                             "annotation": "an annotation"
                            },
                            {
                              "id": "anIncidentId",
@@ -57,7 +58,8 @@
                              "configuration": "anotherConfiguration",
                              "tenantId": null,
                              "incidentMessage": "anotherIncidentMessage",
-                             "jobDefinitionId": null
+                             "jobDefinitionId": null,
+                             "annotation": "another annotation"
                            }
                          ]
                      }'] />

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/incident/{id}/annotation/delete.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/incident/{id}/annotation/delete.ftl
@@ -1,0 +1,30 @@
+{
+
+  <@lib.endpointInfo
+      id = "clearIncidentAnnotation"
+      tag = "Incident"
+      summary = "Clear Incident Annotation"
+      desc = "Clears the annotation of an incident with given id." />
+
+  "parameters": [
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the incident to clear the annotation at." />
+  ],
+  "responses" : {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful." />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        last = true
+        desc = "Returned if no incident can be found for the given id." />
+    }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/incident/{id}/annotation/put.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/incident/{id}/annotation/put.ftl
@@ -1,0 +1,41 @@
+{
+
+  <@lib.endpointInfo
+      id = "setIncidentAnnotation"
+      tag = "Incident"
+      summary = "Set Incident Annotation"
+      desc = "Sets the annotation of an incident with given id." />
+
+  "parameters": [
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the incident to clear the annotation at." />
+  ],
+  <@lib.requestBody
+      mediaType = "application/json"
+      dto = "AnnotationDto"
+      examples = [
+                  '"example-1": {
+                     "summary": "PUT `/incident/7c80cc8f-ef95-11e6-b6e6-34f39ab71d4b/annotation`",
+                     "value": {
+                                "annotation": "my annotation"
+                              }
+                   }'
+                ] />
+  "responses" : {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful." />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        last = true
+        desc = "Returned if no incident can be found for the given id." />
+    }
+}

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/incident/{id}/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/incident/{id}/get.ftl
@@ -37,7 +37,8 @@
                            "configuration": "aConfiguration",
                            "tenantId": null,
                            "incidentMessage": "anIncidentMessage",
-                           "jobDefinitionId": "aJobDefinitionId"
+                           "jobDefinitionId": "aJobDefinitionId",
+                            "annotation": "an annotation"
                          }
                      }'] />
 

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricIncidentDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricIncidentDto.java
@@ -48,6 +48,7 @@ public class HistoricIncidentDto {
   protected Boolean open;
   protected Boolean deleted;
   protected Boolean resolved;
+  protected String annotation;
 
   public String getId() {
     return id;
@@ -137,6 +138,10 @@ public class HistoricIncidentDto {
     return resolved;
   }
 
+  public String getAnnotation() {
+    return annotation;
+  }
+
   public static HistoricIncidentDto fromHistoricIncident(HistoricIncident historicIncident) {
     HistoricIncidentDto dto = new HistoricIncidentDto();
 
@@ -162,6 +167,7 @@ public class HistoricIncidentDto {
     dto.jobDefinitionId = historicIncident.getJobDefinitionId();
     dto.removalTime = historicIncident.getRemovalTime();
     dto.rootProcessInstanceId = historicIncident.getRootProcessInstanceId();
+    dto.annotation = historicIncident.getAnnotation();
 
     return dto;
   }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/runtime/IncidentDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/runtime/IncidentDto.java
@@ -41,6 +41,7 @@ public class IncidentDto {
   protected String incidentMessage;
   protected String tenantId;
   protected String jobDefinitionId;
+  protected String annotation;
 
   public String getId() {
     return id;
@@ -98,6 +99,10 @@ public class IncidentDto {
     return jobDefinitionId;
   }
 
+  public String getAnnotation() {
+    return annotation;
+  }
+
   public static IncidentDto fromIncident(Incident incident) {
     IncidentDto dto = new IncidentDto();
 
@@ -115,6 +120,7 @@ public class IncidentDto {
     dto.incidentMessage = incident.getIncidentMessage();
     dto.tenantId = incident.getTenantId();
     dto.jobDefinitionId = incident.getJobDefinitionId();
+    dto.annotation = incident.getAnnotation();
 
     return dto;
   }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/repository/impl/IncidentResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/repository/impl/IncidentResourceImpl.java
@@ -16,11 +16,13 @@
  */
 package org.camunda.bpm.engine.rest.sub.repository.impl;
 
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import org.camunda.bpm.engine.BadUserRequestException;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.exception.NotFoundException;
+import org.camunda.bpm.engine.rest.dto.AnnotationDto;
 import org.camunda.bpm.engine.rest.dto.runtime.IncidentDto;
 import org.camunda.bpm.engine.rest.exception.InvalidRequestException;
 import org.camunda.bpm.engine.rest.sub.runtime.IncidentResource;
@@ -56,5 +58,17 @@ public class IncidentResourceImpl implements IncidentResource {
     } catch (BadUserRequestException e) {
       throw new InvalidRequestException(Status.BAD_REQUEST, e.getMessage());
     }
+  }
+
+  @Override
+  public Response setAnnotation(AnnotationDto annotationDto) {
+    engine.getRuntimeService().setAnnotationForIncidentById(incidentId, annotationDto.getAnnotation());
+    return Response.noContent().build();
+  }
+
+  @Override
+  public Response clearAnnotation() {
+    engine.getRuntimeService().clearAnnotationForIncidentById(incidentId);
+    return Response.noContent().build();
   }
 }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/runtime/IncidentResource.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/runtime/IncidentResource.java
@@ -16,12 +16,16 @@
  */
 package org.camunda.bpm.engine.rest.sub.runtime;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.camunda.bpm.engine.rest.dto.AnnotationDto;
 import org.camunda.bpm.engine.rest.dto.runtime.IncidentDto;
 
 public interface IncidentResource {
@@ -32,4 +36,15 @@ public interface IncidentResource {
 
   @DELETE
   void resolveIncident();
+
+  @PUT
+  @Path("/annotation")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.APPLICATION_JSON)
+  Response setAnnotation(AnnotationDto annotationDto);
+
+  @DELETE
+  @Path("/annotation")
+  @Produces(MediaType.APPLICATION_JSON)
+  Response clearAnnotation();
 }

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/IncidentRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/IncidentRestServiceQueryTest.java
@@ -354,6 +354,7 @@ public class IncidentRestServiceQueryTest extends AbstractRestServiceTest {
     String returnedIncidentMessage = from(content).getString("[0].incidentMessage");
     String returnedTenantId = from(content).getString("[0].tenantId");
     String returnedJobDefinitionId = from(content).getString("[0].jobDefinitionId");
+    String returnedAnnotation = from(content).getString("[0].annotation");
 
     Assert.assertEquals(MockProvider.EXAMPLE_INCIDENT_ID, returnedId);
     Assert.assertEquals(MockProvider.EXAMPLE_INCIDENT_PROC_INST_ID, returnedProcessInstanceId);
@@ -369,6 +370,7 @@ public class IncidentRestServiceQueryTest extends AbstractRestServiceTest {
     Assert.assertEquals(MockProvider.EXAMPLE_INCIDENT_MESSAGE, returnedIncidentMessage);
     Assert.assertEquals(MockProvider.EXAMPLE_TENANT_ID, returnedTenantId);
     Assert.assertEquals(MockProvider.EXAMPLE_JOB_DEFINITION_ID, returnedJobDefinitionId);
+    Assert.assertEquals(MockProvider.EXAMPLE_USER_OPERATION_ANNOTATION, returnedAnnotation);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
@@ -975,7 +975,7 @@ public abstract class MockProvider {
   }
 
   public static List<Task> createMockTasks() {
-    List<Task> mocks = new ArrayList<Task>();
+    List<Task> mocks = new ArrayList<>();
     mocks.add(createMockTask());
     return mocks;
   }
@@ -997,7 +997,7 @@ public abstract class MockProvider {
     when(mockFormData.getFormKey()).thenReturn(EXAMPLE_FORM_KEY);
     when(mockFormData.getDeploymentId()).thenReturn(EXAMPLE_DEPLOYMENT_ID);
 
-    List<FormProperty> mockFormProperties = new ArrayList<FormProperty>();
+    List<FormProperty> mockFormProperties = new ArrayList<>();
     mockFormProperties.add(mockFormProperty);
     when(mockFormData.getFormProperties()).thenReturn(mockFormProperties);
     return mockFormData;
@@ -1016,7 +1016,7 @@ public abstract class MockProvider {
     TaskFormData mockFormData = mock(TaskFormData.class);
     when(mockFormData.getDeploymentId()).thenReturn(EXAMPLE_DEPLOYMENT_ID);
 
-    List<FormField> mockFormFields = new ArrayList<FormField>();
+    List<FormField> mockFormFields = new ArrayList<>();
     mockFormFields.add(mockFormField);
     when(mockFormData.getFormFields()).thenReturn(mockFormFields);
     return mockFormData;
@@ -1036,7 +1036,7 @@ public abstract class MockProvider {
   }
 
   public static List<Comment> createMockTaskComments() {
-    List<Comment> mocks = new ArrayList<Comment>();
+    List<Comment> mocks = new ArrayList<>();
     mocks.add(createMockTaskComment());
     return mocks;
   }
@@ -1059,7 +1059,7 @@ public abstract class MockProvider {
   }
 
   public static List<Attachment> createMockTaskAttachments() {
-    List<Attachment> mocks = new ArrayList<Attachment>();
+    List<Attachment> mocks = new ArrayList<>();
     mocks.add(createMockTaskAttachment());
     return mocks;
   }
@@ -1069,7 +1069,7 @@ public abstract class MockProvider {
     when(mock.getGroupName()).thenReturn(EXAMPLE_GROUP_ID);
     when(mock.getTaskCount()).thenReturn(EXAMPLE_TASK_COUNT_BY_CANDIDATE_GROUP);
 
-    List<TaskCountByCandidateGroupResult> mockList = new ArrayList<TaskCountByCandidateGroupResult>();
+    List<TaskCountByCandidateGroupResult> mockList = new ArrayList<>();
     mockList.add(mock);
     return mockList;
   }
@@ -1106,7 +1106,7 @@ public abstract class MockProvider {
     when(mock.getPeriod()).thenReturn(EXAMPLE_HISTORIC_TASK_INST_DURATION_REPORT_PERIOD);
     when(mock.getPeriodUnit()).thenReturn(periodUnit);
 
-    List<DurationReportResult> mockList = new ArrayList<DurationReportResult>();
+    List<DurationReportResult> mockList = new ArrayList<>();
     mockList.add(mock);
     return mockList;
   }
@@ -1131,7 +1131,7 @@ public abstract class MockProvider {
     when(mockFormData.getDeploymentId()).thenReturn(EXAMPLE_DEPLOYMENT_ID);
     when(mockFormData.getProcessDefinition()).thenReturn(definition);
 
-    List<FormProperty> mockFormProperties = new ArrayList<FormProperty>();
+    List<FormProperty> mockFormProperties = new ArrayList<>();
     mockFormProperties.add(mockFormProperty);
     when(mockFormData.getFormProperties()).thenReturn(mockFormProperties);
     return mockFormData;
@@ -1151,7 +1151,7 @@ public abstract class MockProvider {
     when(mockFormData.getDeploymentId()).thenReturn(EXAMPLE_DEPLOYMENT_ID);
     when(mockFormData.getProcessDefinition()).thenReturn(definition);
 
-    List<FormField> mockFormFields = new ArrayList<FormField>();
+    List<FormField> mockFormFields = new ArrayList<>();
     mockFormFields.add(mockFormField);
     when(mockFormData.getFormFields()).thenReturn(mockFormFields);
 
@@ -1291,7 +1291,7 @@ public abstract class MockProvider {
     when(incidentStaticits.getIncidentType()).thenReturn(EXAMPLE_INCIDENT_TYPE);
     when(incidentStaticits.getIncidentCount()).thenReturn(EXAMPLE_INCIDENT_COUNT);
 
-    List<IncidentStatistics> exampleIncidentList = new ArrayList<IncidentStatistics>();
+    List<IncidentStatistics> exampleIncidentList = new ArrayList<>();
     exampleIncidentList.add(incidentStaticits);
     when(statistics.getIncidentStatistics()).thenReturn(exampleIncidentList);
 
@@ -1308,11 +1308,11 @@ public abstract class MockProvider {
     when(anotherIncidentStaticits.getIncidentType()).thenReturn(ANOTHER_EXAMPLE_INCIDENT_TYPE);
     when(anotherIncidentStaticits.getIncidentCount()).thenReturn(ANOTHER_EXAMPLE_INCIDENT_COUNT);
 
-    List<IncidentStatistics> anotherExampleIncidentList = new ArrayList<IncidentStatistics>();
+    List<IncidentStatistics> anotherExampleIncidentList = new ArrayList<>();
     anotherExampleIncidentList.add(anotherIncidentStaticits);
     when(anotherStatistics.getIncidentStatistics()).thenReturn(anotherExampleIncidentList);
 
-    List<ProcessDefinitionStatistics> processDefinitionResults = new ArrayList<ProcessDefinitionStatistics>();
+    List<ProcessDefinitionStatistics> processDefinitionResults = new ArrayList<>();
     processDefinitionResults.add(statistics);
     processDefinitionResults.add(anotherStatistics);
 
@@ -1329,7 +1329,7 @@ public abstract class MockProvider {
     when(incidentStaticits.getIncidentType()).thenReturn(EXAMPLE_INCIDENT_TYPE);
     when(incidentStaticits.getIncidentCount()).thenReturn(EXAMPLE_INCIDENT_COUNT);
 
-    List<IncidentStatistics> exampleIncidentList = new ArrayList<IncidentStatistics>();
+    List<IncidentStatistics> exampleIncidentList = new ArrayList<>();
     exampleIncidentList.add(incidentStaticits);
     when(statistics.getIncidentStatistics()).thenReturn(exampleIncidentList);
 
@@ -1342,11 +1342,11 @@ public abstract class MockProvider {
     when(anotherIncidentStaticits.getIncidentType()).thenReturn(ANOTHER_EXAMPLE_INCIDENT_TYPE);
     when(anotherIncidentStaticits.getIncidentCount()).thenReturn(ANOTHER_EXAMPLE_INCIDENT_COUNT);
 
-    List<IncidentStatistics> anotherExampleIncidentList = new ArrayList<IncidentStatistics>();
+    List<IncidentStatistics> anotherExampleIncidentList = new ArrayList<>();
     anotherExampleIncidentList.add(anotherIncidentStaticits);
     when(anotherStatistics.getIncidentStatistics()).thenReturn(anotherExampleIncidentList);
 
-    List<ActivityStatistics> activityResults = new ArrayList<ActivityStatistics>();
+    List<ActivityStatistics> activityResults = new ArrayList<>();
     activityResults.add(statistics);
     activityResults.add(anotherStatistics);
 
@@ -1355,13 +1355,13 @@ public abstract class MockProvider {
 
   // process definition
   public static List<ProcessDefinition> createMockDefinitions() {
-    List<ProcessDefinition> mocks = new ArrayList<ProcessDefinition>();
+    List<ProcessDefinition> mocks = new ArrayList<>();
     mocks.add(createMockDefinition());
     return mocks;
   }
 
   public static List<ProcessDefinition> createMockTwoDefinitions() {
-    List<ProcessDefinition> mocks = new ArrayList<ProcessDefinition>();
+    List<ProcessDefinition> mocks = new ArrayList<>();
     mocks.add(createMockDefinition());
     mocks.add(createMockAnotherDefinition());
     return mocks;
@@ -1384,7 +1384,7 @@ public abstract class MockProvider {
 
   // deployments
   public static List<Deployment> createMockDeployments() {
-    List<Deployment> mocks = new ArrayList<Deployment>();
+    List<Deployment> mocks = new ArrayList<>();
     mocks.add(createMockDeployment());
     return mocks;
   }
@@ -1441,7 +1441,7 @@ public abstract class MockProvider {
 
   // deployment resources
   public static List<Resource> createMockDeploymentResources() {
-    List<Resource> mocks = new ArrayList<Resource>();
+    List<Resource> mocks = new ArrayList<>();
     mocks.add(createMockDeploymentResource());
     return mocks;
   }
@@ -1685,7 +1685,7 @@ public abstract class MockProvider {
   }
 
   public static List<Group> createMockGroups() {
-    List<Group> mockGroups = new ArrayList<Group>();
+    List<Group> mockGroups = new ArrayList<>();
     mockGroups.add(createMockGroup());
     return mockGroups;
   }
@@ -1741,13 +1741,13 @@ public abstract class MockProvider {
   }
 
   public static List<Job> createMockJobs() {
-    List<Job> mockList = new ArrayList<Job>();
+    List<Job> mockList = new ArrayList<>();
     mockList.add(createMockJob());
     return mockList;
   }
 
   public static List<Job> createMockEmptyJobList() {
-    return new ArrayList<Job>();
+    return new ArrayList<>();
   }
 
   public static User createMockUserUpdate() {
@@ -1761,7 +1761,7 @@ public abstract class MockProvider {
   }
 
   public static List<User> createMockUsers() {
-    ArrayList<User> list = new ArrayList<User>();
+    ArrayList<User> list = new ArrayList<>();
     list.add(createMockUser());
     return list;
   }
@@ -1836,7 +1836,7 @@ public abstract class MockProvider {
 
   public static ProcessApplicationInfo createMockProcessApplicationInfo() {
     ProcessApplicationInfo appInfo = mock(ProcessApplicationInfo.class);
-    Map<String, String> mockAppProperties = new HashMap<String, String>();
+    Map<String, String> mockAppProperties = new HashMap<>();
     String mockServletContextPath = MockProvider.EXAMPLE_PROCESS_APPLICATION_CONTEXT_PATH;
     mockAppProperties.put(ProcessApplicationInfo.PROP_SERVLET_CONTEXT_PATH, mockServletContextPath);
     when(appInfo.getProperties()).thenReturn(mockAppProperties);
@@ -1845,7 +1845,7 @@ public abstract class MockProvider {
 
   // History
   public static List<HistoricActivityInstance> createMockHistoricActivityInstances() {
-    List<HistoricActivityInstance> mockList = new ArrayList<HistoricActivityInstance>();
+    List<HistoricActivityInstance> mockList = new ArrayList<>();
     mockList.add(createMockHistoricActivityInstance());
     return mockList;
   }
@@ -1883,7 +1883,7 @@ public abstract class MockProvider {
   }
 
   public static List<HistoricActivityInstance> createMockRunningHistoricActivityInstances() {
-    List<HistoricActivityInstance> mockList = new ArrayList<HistoricActivityInstance>();
+    List<HistoricActivityInstance> mockList = new ArrayList<>();
     mockList.add(createMockRunningHistoricActivityInstance());
     return mockList;
   }
@@ -1911,7 +1911,7 @@ public abstract class MockProvider {
   }
 
   public static List<HistoricCaseActivityInstance> createMockHistoricCaseActivityInstances() {
-    ArrayList<HistoricCaseActivityInstance> mockList = new ArrayList<HistoricCaseActivityInstance>();
+    ArrayList<HistoricCaseActivityInstance> mockList = new ArrayList<>();
     mockList.add(createMockHistoricCaseActivityInstance());
     return mockList;
   }
@@ -1950,7 +1950,7 @@ public abstract class MockProvider {
   }
 
   public static List<HistoricCaseActivityInstance> createMockRunningHistoricCaseActivityInstances() {
-    List<HistoricCaseActivityInstance> mockList = new ArrayList<HistoricCaseActivityInstance>();
+    List<HistoricCaseActivityInstance> mockList = new ArrayList<>();
     mockList.add(createMockRunningHistoricCaseActivityInstance());
     return mockList;
   }
@@ -1993,7 +1993,7 @@ public abstract class MockProvider {
     when(anotherStatistics.getResolvedIncidents()).thenReturn(ANOTHER_EXAMPLE_RESOLVED_INCIDENTS_LONG);
     when(anotherStatistics.getDeletedIncidents()).thenReturn(ANOTHER_EXAMPLE_DELETED_INCIDENTS_LONG);
 
-    List<HistoricActivityStatistics> activityResults = new ArrayList<HistoricActivityStatistics>();
+    List<HistoricActivityStatistics> activityResults = new ArrayList<>();
     activityResults.add(statistics);
     activityResults.add(anotherStatistics);
 
@@ -2021,7 +2021,7 @@ public abstract class MockProvider {
     when(anotherStatistics.getEnabled()).thenReturn(ANOTHER_EXAMPLE_ENABLED_LONG);
     when(anotherStatistics.getTerminated()).thenReturn(ANOTHER_EXAMPLE_TERMINATED_LONG);
 
-    List<HistoricCaseActivityStatistics> activityResults = new ArrayList<HistoricCaseActivityStatistics>();
+    List<HistoricCaseActivityStatistics> activityResults = new ArrayList<>();
     activityResults.add(statistics);
     activityResults.add(anotherStatistics);
 
@@ -2029,7 +2029,7 @@ public abstract class MockProvider {
   }
 
   public static List<HistoricProcessInstance> createMockHistoricProcessInstances() {
-    List<HistoricProcessInstance> mockList = new ArrayList<HistoricProcessInstance>();
+    List<HistoricProcessInstance> mockList = new ArrayList<>();
     mockList.add(createMockHistoricProcessInstance());
     return mockList;
   }
@@ -2065,7 +2065,7 @@ public abstract class MockProvider {
   }
 
   public static List<HistoricProcessInstance> createMockRunningHistoricProcessInstances() {
-    List<HistoricProcessInstance> mockList = new ArrayList<HistoricProcessInstance>();
+    List<HistoricProcessInstance> mockList = new ArrayList<>();
     mockList.add(createMockHistoricProcessInstanceUnfinished());
     return mockList;
   }
@@ -2090,7 +2090,7 @@ public abstract class MockProvider {
     when(mock.getPeriod()).thenReturn(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_PERIOD);
     when(mock.getPeriodUnit()).thenReturn(PeriodUnit.MONTH);
 
-    List<DurationReportResult> mockList = new ArrayList<DurationReportResult>();
+    List<DurationReportResult> mockList = new ArrayList<>();
     mockList.add(mock);
     return mockList;
   }
@@ -2103,13 +2103,13 @@ public abstract class MockProvider {
     when(mock.getPeriod()).thenReturn(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_PERIOD);
     when(mock.getPeriodUnit()).thenReturn(PeriodUnit.QUARTER);
 
-    List<DurationReportResult> mockList = new ArrayList<DurationReportResult>();
+    List<DurationReportResult> mockList = new ArrayList<>();
     mockList.add(mock);
     return mockList;
   }
 
   public static List<HistoricCaseInstance> createMockHistoricCaseInstances() {
-    List<HistoricCaseInstance> mockList = new ArrayList<HistoricCaseInstance>();
+    List<HistoricCaseInstance> mockList = new ArrayList<>();
     mockList.add(createMockHistoricCaseInstance());
     return mockList;
   }
@@ -2142,7 +2142,7 @@ public abstract class MockProvider {
   }
 
   public static List<HistoricCaseInstance> createMockRunningHistoricCaseInstances() {
-    List<HistoricCaseInstance> mockList = new ArrayList<HistoricCaseInstance>();
+    List<HistoricCaseInstance> mockList = new ArrayList<>();
     mockList.add(createMockHistoricCaseInstanceNotClosed());
     return mockList;
   }
@@ -2191,7 +2191,7 @@ public abstract class MockProvider {
   }
 
   public static List<ProcessInstance> createAnotherMockProcessInstanceList() {
-    List<ProcessInstance> mockProcessInstanceList = new ArrayList<ProcessInstance>();
+    List<ProcessInstance> mockProcessInstanceList = new ArrayList<>();
     mockProcessInstanceList.add(createMockInstance());
     mockProcessInstanceList.add(createAnotherMockInstance());
     return mockProcessInstanceList;
@@ -2211,7 +2211,7 @@ public abstract class MockProvider {
   }
 
   public static Set<String> createMockSetFromList(String list){
-    return new HashSet<String>(Arrays.asList(list.split(",")));
+    return new HashSet<>(Arrays.asList(list.split(",")));
   }
 
   public static IdentityLink createMockUserAssigneeIdentityLink() {
@@ -2276,14 +2276,14 @@ public abstract class MockProvider {
   }
 
   public static List<HistoricIdentityLinkLog> createMockHistoricIdentityLinks() {
-    List<HistoricIdentityLinkLog> entries = new ArrayList<HistoricIdentityLinkLog>();
+    List<HistoricIdentityLinkLog> entries = new ArrayList<>();
     entries.add(createMockHistoricIdentityLink());
     return entries;
   }
 
   // job definition
   public static List<JobDefinition> createMockJobDefinitions() {
-    List<JobDefinition> mocks = new ArrayList<JobDefinition>();
+    List<JobDefinition> mocks = new ArrayList<>();
     mocks.add(createMockJobDefinition());
     return mocks;
   }
@@ -2306,7 +2306,7 @@ public abstract class MockProvider {
   }
 
   public static List<UserOperationLogEntry> createUserOperationLogEntries() {
-    List<UserOperationLogEntry> entries = new ArrayList<UserOperationLogEntry>();
+    List<UserOperationLogEntry> entries = new ArrayList<>();
     entries.add(createUserOperationLogEntry());
     return entries;
   }
@@ -2400,7 +2400,7 @@ public abstract class MockProvider {
   }
 
   public static List<HistoricFormField> createMockHistoricFormFields() {
-    List<HistoricFormField> entries = new ArrayList<HistoricFormField>();
+    List<HistoricFormField> entries = new ArrayList<>();
     entries.add(createMockHistoricFormField());
     return entries;
   }
@@ -2410,7 +2410,7 @@ public abstract class MockProvider {
   }
 
   public static List<HistoricDetail> createMockHistoricDetails(String tenantId) {
-    List<HistoricDetail> entries = new ArrayList<HistoricDetail>();
+    List<HistoricDetail> entries = new ArrayList<>();
     entries.add(mockHistoricVariableUpdate(tenantId).build());
     entries.add(createMockHistoricFormField(tenantId));
     return entries;
@@ -2454,7 +2454,7 @@ public abstract class MockProvider {
   }
 
   public static List<HistoricTaskInstance> createMockHistoricTaskInstances() {
-    List<HistoricTaskInstance> entries = new ArrayList<HistoricTaskInstance>();
+    List<HistoricTaskInstance> entries = new ArrayList<>();
     entries.add(createMockHistoricTaskInstance());
     return entries;
   }
@@ -2482,12 +2482,13 @@ public abstract class MockProvider {
     when(incident.getIncidentMessage()).thenReturn(EXAMPLE_INCIDENT_MESSAGE);
     when(incident.getTenantId()).thenReturn(tenantId);
     when(incident.getJobDefinitionId()).thenReturn(EXAMPLE_JOB_DEFINITION_ID);
+    when(incident.getAnnotation()).thenReturn(EXAMPLE_USER_OPERATION_ANNOTATION);
 
     return incident;
   }
 
   public static List<Incident> createMockIncidents() {
-    List<Incident> entries = new ArrayList<Incident>();
+    List<Incident> entries = new ArrayList<>();
     entries.add(createMockIncident());
     return entries;
   }
@@ -2521,25 +2522,26 @@ public abstract class MockProvider {
     when(incident.getJobDefinitionId()).thenReturn(EXAMPLE_JOB_DEFINITION_ID);
     when(incident.getRemovalTime()).thenReturn(DateTimeUtil.parseDate(EXAMPLE_HIST_INCIDENT_REMOVAL_TIME));
     when(incident.getRootProcessInstanceId()).thenReturn(EXAMPLE_HIST_INCIDENT_ROOT_PROC_INST_ID);
+    when(incident.getAnnotation()).thenReturn(EXAMPLE_USER_OPERATION_ANNOTATION);
 
     return incident;
   }
 
   public static List<HistoricIncident> createMockHistoricIncidents() {
-    List<HistoricIncident> entries = new ArrayList<HistoricIncident>();
+    List<HistoricIncident> entries = new ArrayList<>();
     entries.add(createMockHistoricIncident());
     return entries;
   }
 
   // case definition
   public static List<CaseDefinition> createMockCaseDefinitions() {
-    List<CaseDefinition> mocks = new ArrayList<CaseDefinition>();
+    List<CaseDefinition> mocks = new ArrayList<>();
     mocks.add(createMockCaseDefinition());
     return mocks;
   }
 
   public static List<CaseDefinition> createMockTwoCaseDefinitions() {
-    List<CaseDefinition> mocks = new ArrayList<CaseDefinition>();
+    List<CaseDefinition> mocks = new ArrayList<>();
     mocks.add(createMockCaseDefinition());
     mocks.add(createAnotherMockCaseDefinition());
     return mocks;
@@ -2570,7 +2572,7 @@ public abstract class MockProvider {
 
   // case instance
   public static List<CaseInstance> createMockCaseInstances() {
-    List<CaseInstance> mocks = new ArrayList<CaseInstance>();
+    List<CaseInstance> mocks = new ArrayList<>();
     mocks.add(createMockCaseInstance());
     return mocks;
   }
@@ -2595,7 +2597,7 @@ public abstract class MockProvider {
 
   // case execution
   public static List<CaseExecution> createMockCaseExecutions() {
-    List<CaseExecution> mocks = new ArrayList<CaseExecution>();
+    List<CaseExecution> mocks = new ArrayList<>();
     mocks.add(createMockCaseExecution());
     return mocks;
   }
@@ -2631,7 +2633,7 @@ public abstract class MockProvider {
   }
 
   public static List<Filter> createMockFilters() {
-    List<Filter> mocks = new ArrayList<Filter>();
+    List<Filter> mocks = new ArrayList<>();
     mocks.add(createMockFilter(EXAMPLE_FILTER_ID));
     mocks.add(createMockFilter(ANOTHER_EXAMPLE_FILTER_ID));
     return mocks;
@@ -2709,7 +2711,7 @@ public abstract class MockProvider {
   }
 
   public static List<MetricIntervalValue> createMockMetricIntervalResult() {
-    List<MetricIntervalValue> metrics = new ArrayList<MetricIntervalValue>();
+    List<MetricIntervalValue> metrics = new ArrayList<>();
 
     MetricIntervalEntity entity1 = new MetricIntervalEntity(new Date(15 * 60 * 1000 * 1), EXAMPLE_METRICS_NAME, EXAMPLE_METRICS_REPORTER);
     entity1.setValue(21);
@@ -2729,13 +2731,13 @@ public abstract class MockProvider {
 
   // decision definition
   public static List<DecisionDefinition> createMockDecisionDefinitions() {
-    List<DecisionDefinition> mocks = new ArrayList<DecisionDefinition>();
+    List<DecisionDefinition> mocks = new ArrayList<>();
     mocks.add(createMockDecisionDefinition());
     return mocks;
   }
 
   public static List<DecisionDefinition> createMockTwoDecisionDefinitions() {
-    List<DecisionDefinition> mocks = new ArrayList<DecisionDefinition>();
+    List<DecisionDefinition> mocks = new ArrayList<>();
     mocks.add(createMockDecisionDefinition());
     mocks.add(createAnotherMockDecisionDefinition());
     return mocks;
@@ -2795,13 +2797,13 @@ public abstract class MockProvider {
   }
 
   public static List<DecisionRequirementsDefinition> createMockDecisionRequirementsDefinitions() {
-    List<DecisionRequirementsDefinition> mocks = new ArrayList<DecisionRequirementsDefinition>();
+    List<DecisionRequirementsDefinition> mocks = new ArrayList<>();
     mocks.add(createMockDecisionRequirementsDefinition());
     return mocks;
   }
 
   public static List<DecisionRequirementsDefinition> createMockTwoDecisionRequirementsDefinitions() {
-    List<DecisionRequirementsDefinition> mocks = new ArrayList<DecisionRequirementsDefinition>();
+    List<DecisionRequirementsDefinition> mocks = new ArrayList<>();
     mocks.add(createMockDecisionRequirementsDefinition());
     mocks.add(createAnotherMockDecisionRequirementsDefinition());
     return mocks;
@@ -2810,7 +2812,7 @@ public abstract class MockProvider {
   // Historic job log
 
   public static List<HistoricJobLog> createMockHistoricJobLogs() {
-    List<HistoricJobLog> mocks = new ArrayList<HistoricJobLog>();
+    List<HistoricJobLog> mocks = new ArrayList<>();
     mocks.add(createMockHistoricJobLog());
     return mocks;
   }
@@ -2858,7 +2860,7 @@ public abstract class MockProvider {
   // Historic decision instance
 
   public static List<HistoricDecisionInstance> createMockHistoricDecisionInstances() {
-    List<HistoricDecisionInstance> mockList = new ArrayList<HistoricDecisionInstance>();
+    List<HistoricDecisionInstance> mockList = new ArrayList<>();
     mockList.add(createMockHistoricDecisionInstance());
     return mockList;
   }
@@ -2931,7 +2933,7 @@ public abstract class MockProvider {
   }
 
   public static List<HistoricDecisionInputInstance> createMockHistoricDecisionInputInstances() {
-    List<HistoricDecisionInputInstance> mockInputs = new ArrayList<HistoricDecisionInputInstance>();
+    List<HistoricDecisionInputInstance> mockInputs = new ArrayList<>();
     mockInputs.add(createMockHistoricDecisionInput(EXAMPLE_HISTORIC_DECISION_STRING_VALUE));
     mockInputs.add(createMockHistoricDecisionInput(EXAMPLE_HISTORIC_DECISION_BYTE_ARRAY_VALUE));
     mockInputs.add(createMockHistoricDecisionInput(EXAMPLE_HISTORIC_DECISION_SERIALIZED_VALUE));
@@ -2954,7 +2956,7 @@ public abstract class MockProvider {
   }
 
   public static List<HistoricDecisionOutputInstance> createMockHistoricDecisionOutputInstances() {
-    List<HistoricDecisionOutputInstance> mockOutputs = new ArrayList<HistoricDecisionOutputInstance>();
+    List<HistoricDecisionOutputInstance> mockOutputs = new ArrayList<>();
     mockOutputs.add(createMockHistoricDecisionOutput(EXAMPLE_HISTORIC_DECISION_STRING_VALUE));
     mockOutputs.add(createMockHistoricDecisionOutput(EXAMPLE_HISTORIC_DECISION_BYTE_ARRAY_VALUE));
     mockOutputs.add(createMockHistoricDecisionOutput(EXAMPLE_HISTORIC_DECISION_SERIALIZED_VALUE));
@@ -3013,7 +3015,7 @@ public abstract class MockProvider {
   }
 
   public static List<ExternalTask> createMockExternalTasks() {
-    List<ExternalTask> mocks = new ArrayList<ExternalTask>();
+    List<ExternalTask> mocks = new ArrayList<>();
     mocks.add(createMockExternalTask());
     return mocks;
   }
@@ -3050,7 +3052,7 @@ public abstract class MockProvider {
   }
 
   public static List<Batch> createMockBatches() {
-    List<Batch> mockList = new ArrayList<Batch>();
+    List<Batch> mockList = new ArrayList<>();
     mockList.add(createMockBatch());
     return mockList;
   }
@@ -3077,7 +3079,7 @@ public abstract class MockProvider {
   }
 
   public static List<HistoricBatch> createMockHistoricBatches() {
-    List<HistoricBatch> mockList = new ArrayList<HistoricBatch>();
+    List<HistoricBatch> mockList = new ArrayList<>();
     mockList.add(createMockHistoricBatch());
     return mockList;
   }
@@ -3106,7 +3108,7 @@ public abstract class MockProvider {
   }
 
   public static List<BatchStatistics> createMockBatchStatisticsList() {
-    ArrayList<BatchStatistics> mockList = new ArrayList<BatchStatistics>();
+    ArrayList<BatchStatistics> mockList = new ArrayList<>();
     mockList.add(createMockBatchStatistics());
     return mockList;
   }
@@ -3140,7 +3142,7 @@ public abstract class MockProvider {
   }
 
   public static List<MessageCorrelationResult> createMessageCorrelationResultList(MessageCorrelationResultType type) {
-    List<MessageCorrelationResult> list = new ArrayList<MessageCorrelationResult>();
+    List<MessageCorrelationResult> list = new ArrayList<>();
     list.add(createMessageCorrelationResult(type));
     list.add(createMessageCorrelationResult(type));
     return list;
@@ -3158,7 +3160,7 @@ public abstract class MockProvider {
     when(anotherStatistics.getDecisionDefinitionKey()).thenReturn(ANOTHER_DECISION_DEFINITION_KEY);
     when(anotherStatistics.getEvaluations()).thenReturn(2);
 
-    List<HistoricDecisionInstanceStatistics> decisionResults = new ArrayList<HistoricDecisionInstanceStatistics>();
+    List<HistoricDecisionInstanceStatistics> decisionResults = new ArrayList<>();
     decisionResults.add(statistics);
     decisionResults.add(anotherStatistics);
 
@@ -3167,7 +3169,7 @@ public abstract class MockProvider {
 
   // historic external task log
   public static List<HistoricExternalTaskLog> createMockHistoricExternalTaskLogs() {
-    List<HistoricExternalTaskLog> mocks = new ArrayList<HistoricExternalTaskLog>();
+    List<HistoricExternalTaskLog> mocks = new ArrayList<>();
     mocks.add(createMockHistoricExternalTaskLog());
     return mocks;
   }

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricIncidentRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricIncidentRestServiceQueryTest.java
@@ -389,6 +389,7 @@ public class HistoricIncidentRestServiceQueryTest extends AbstractRestServiceTes
     String returnedJobDefinitionId = from(content).getString("[0].jobDefinitionId");
     Date returnedRemovalTime = DateTimeUtil.parseDate(from(content).getString("[0].removalTime"));
     String returnedRootProcessInstanceId = from(content).getString("[0].rootProcessInstanceId");
+    String returnedAnnotation = from(content).getString("[0].annotation");
 
     Assert.assertEquals(MockProvider.EXAMPLE_HIST_INCIDENT_ID, returnedId);
     Assert.assertEquals(MockProvider.EXAMPLE_HIST_INCIDENT_PROC_INST_ID, returnedProcessInstanceId);
@@ -411,6 +412,7 @@ public class HistoricIncidentRestServiceQueryTest extends AbstractRestServiceTes
     Assert.assertEquals(EXAMPLE_JOB_DEFINITION_ID, returnedJobDefinitionId);
     Assert.assertEquals(DateTimeUtil.parseDate(MockProvider.EXAMPLE_HIST_INCIDENT_REMOVAL_TIME), returnedRemovalTime);
     Assert.assertEquals(MockProvider.EXAMPLE_HIST_INCIDENT_ROOT_PROC_INST_ID, returnedRootProcessInstanceId);
+    Assert.assertEquals(MockProvider.EXAMPLE_USER_OPERATION_ANNOTATION, returnedAnnotation);
 
   }
 


### PR DESCRIPTION
* adds set and clear annotation methods to incident REST endpoint
* adds OpenAPI description of the new methods

related to CAM-13061