### PR TITLE
fix(engine): improve bad performing sql query for historic task query

### DIFF
--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
@@ -334,14 +334,14 @@
             </if>
 
             <if test="query.withoutCandidateGroups">
-              ${queryType} RES.ID_ not in (
-              select
-              TASK_ID_
+              ${queryType} not exists (
+              select 1
               from
               ${prefix}ACT_HI_IDENTITYLINK HIL
               <where>
                 HIL.TYPE_ = 'candidate' and HIL.GROUP_ID_ is not null
               </where>
+              AND HIL.TASK_ID_ = RES.ID_
               )
             </if>
 


### PR DESCRIPTION
NOT IN (SELECT ...) does not perform well on PostgreSQL. It uses a plain sub-plan which has a bad performance. See https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_NOT_IN

related to CAM-12938