### PR TITLE
fix(openapi): enable multiple return types in responses

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/utils.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/utils.ftl
@@ -255,15 +255,61 @@
         examples=[]
         last=false >
     "${code}": {
+        <#if code != "204">
+          "content": {
+            <@lib.responseContentMediaType
+                flatType = flatType
+                dto = dto
+                array = array
+                additionalProperties = additionalProperties
+                mediaType = mediaType
+                examples = examples />
+          },
+        </#if>
+          "description": "${removeIndentation(desc)}"
+    }
 
-       <#if code != "204">
-         "content": {
-           <#if mediaType == "application/xhtml+xml">
+    <#if !last> , </#if> <#-- if not a last response, add a comma-->
+</#macro>
+
+<#macro multiTypeResponse 
+        code 
+        desc
+        types=[]
+        last=false >
+    "${code}": {
+        <#if code != "204">
+          "content": {
+            <#list types as type >
+              <@lib.responseContentMediaType
+                  flatType = type["flatType"]
+                  dto = type["dto"]
+                  array = type["array"]
+                  additionalProperties = type["additionalProperties"]
+                  mediaType = type["mediaType"]
+                  examples = type["examples"] /><#sep>,
+            </#list>
+          },
+        </#if>
+          "description": "${removeIndentation(desc)}"
+     }
+
+    <#if !last> , </#if> <#-- if not a last response, add a comma-->
+</#macro>
+
+<#macro responseContentMediaType
+        flatType=""
+        dto=""
+        array=false
+        additionalProperties=false
+        mediaType="application/json"
+        examples=[] >
+           <#if mediaType == "application/xhtml+xml" | (mediaType == "application/json" & !array & flatType == "string")>
              "${mediaType}": {
                "schema": {
                  "type": "string",
                  "format": "binary",
-                 "description": "For `application/xhtml+xml` Responses, a byte stream is returned."
+                 "description": "For `${mediaType}` Responses, a byte stream is returned."
                }
            <#else>
              "${mediaType}": {
@@ -300,21 +346,15 @@
            </#if>
 
            <#if examples?size != 0>,
-             "examples": {
-               ${examples?join(", ")}
-             }
+               "examples": {
+                 ${examples?join(", ")}
+               }
            </#if>
 
-           }
-         },
-       </#if>
-
-       "description": "${removeIndentation(desc)}"
-     }
-
-    <#if !last> , </#if> <#-- if not a last response, add a comma-->
+             }
 </#macro>
 
+<#-- Generates a Server JSON object -->
 <#macro server
         url
         variables

--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/utils.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/utils.ftl
@@ -272,6 +272,7 @@
     <#if !last> , </#if> <#-- if not a last response, add a comma-->
 </#macro>
 
+<#-- Generates an HTTP multi type Response JSON object -->
 <#macro multiTypeResponse 
         code 
         desc
@@ -291,12 +292,13 @@
             </#list>
           },
         </#if>
-          "description": "${removeIndentation(desc)}"
-     }
+        "description": "${removeIndentation(desc)}"
+    }
 
     <#if !last> , </#if> <#-- if not a last response, add a comma-->
 </#macro>
 
+<#-- Generates a content media type JSON object for HTTP response -->
 <#macro responseContentMediaType
         flatType=""
         dto=""

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/history/process-instance/report/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/history/process-instance/report/get.ftl
@@ -60,14 +60,16 @@
 
   "responses" : {
 
-    <@lib.response
+    <@lib.multiTypeResponse
         code = "200"
-        dto = "DurationReportResultDto"
-        array = true
         desc = "Request successful."
-        examples = ['"example-1": {
-                       "summary": "GET `/history/process-instance/report?reportType=duration&periodUnit=quarter&processDefinitionKeyIn=invoice`",
-                       "value": [
+        types = [
+          {
+            "dto": "DurationReportResultDto",
+            "array": true,
+            "examples": ['"example-1": {
+                            "summary": "GET `/history/process-instance/report?reportType=duration&periodUnit=quarter&processDefinitionKeyIn=invoice`",
+                            "value": [
                                   {
                                     "period": 1,
                                     "periodUnit": "QUARTER",
@@ -97,17 +99,16 @@
                                     "average": 150000
                                   }
                                 ]
-                     }'] />
-
-    <@lib.response
-        code = "200"
-        mediaType = "application/csv"
-        desc = "Request successful. In case of an expected application/csv response to retrieve the result as a csv file." />
-
-    <@lib.response
-        code = "200"
-        mediaType = "text/csv"
-        desc = "Request successful. In case of an expected text/csv response to retrieve the result as a csv file." />
+                          }'
+                        ]
+          },
+          {
+            "mediaType": "application/csv"
+          },
+          {
+            "mediaType": "text/csv"
+          }
+        ] />
 
     <@lib.response
         code = "400"

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/process-definition/{id}/deployed-start-form/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/process-definition/{id}/deployed-start-form/get.ftl
@@ -20,11 +20,13 @@
 
   "responses" : {
 
-    <@lib.response
+    <@lib.multiTypeResponse
         code = "200"
-        mediaType = "application/xhtml+xml"
         desc = "Request successful."
-        examples = ['"example-1": {
+        types = [
+          {
+            "mediaType": "application/xhtml+xml",
+            "examples": ['"example-1": {
                        "summary": "Status 200 Response",
                        "description": "Resonse for GET `/process-definition/processDefinitionId/deployed-start-form`",
                        "value": "<form role=\\"form\\" name=\\"invoiceForm\\"
@@ -47,7 +49,13 @@
                                   </div>
 
                                 </form>"
-                     }'] />
+                     }']
+          },
+          {
+            "mediaType": "application/json",
+            "flatType": "string"
+          }
+        ] />
 
     <@lib.response
         code = "200"

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/process-definition/{id}/deployed-start-form/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/process-definition/{id}/deployed-start-form/get.ftl
@@ -58,11 +58,6 @@
         ] />
 
     <@lib.response
-        code = "200"
-        mediaType = "application/json"
-        desc = "Request successful." />
-
-    <@lib.response
         code = "400"
         dto = "ExceptionDto"
         desc = "The form key has wrong format.  See the

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/deployed-form/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/deployed-form/get.ftl
@@ -22,39 +22,40 @@
 
   "responses" : {
 
-    <@lib.response
+    <@lib.multiTypeResponse
         code = "200"
-        mediaType = "application/xhtml+xml"
         desc = "Request successful."
-        examples = ['"example-1": {
-                       "summary": "Status 200 Response",
-                       "description": "Resonse for GET `/task/taskId/deployed-form`",
-                       "value": "<form role=\\"form\\" name=\\"invoiceForm\\"
-                                      class=\\"form-horizontal\\">
-
-                                  <div class=\\"form-group\\">
-                                    <label class=\\"control-label col-md-4\\"
-                                           for=\\"creditor\\">Creditor</label>
-                                    <div class=\\"col-md-8\\">
-                                      <input cam-variable-name=\\"creditor\\"
-                                             cam-variable-type=\\"String\\"
-                                             id=\\"creditor\\"
-                                             class=\\"form-control\\"
-                                             type=\\"text\\"
-                                             required />
-                                      <div class=\\"help\\">
-                                        (e.g. &quot;Great Pizza for Everyone Inc.&quot;)
-                                      </div>
-                                    </div>
-                                  </div>
-
-                                </form>"
-                     }'] />
-
-    <@lib.response
-        code = "200"
-        mediaType = "application/json"
-        desc = "Request successful." />
+        types = [
+          {
+            "mediaType": "application/xhtml+xml",
+            "examples": ['"example-1": {
+                            "summary": "Status 200 Response",
+                            "description": "Resonse for GET `/task/taskId/deployed-form`",
+                            "value": "<form role=\\"form\\" name=\\"invoiceForm\\"
+                                            class=\\"form-horizontal\\">
+                                        <div class=\\"form-group\\">
+                                          <label class=\\"control-label col-md-4\\"
+                                                 for=\\"creditor\\">Creditor</label>
+                                          <div class=\\"col-md-8\\">
+                                            <input cam-variable-name=\\"creditor\\"
+                                                   cam-variable-type=\\"String\\"
+                                                   id=\\"creditor\\"
+                                                   class=\\"form-control\\"
+                                                   type=\\"text\\"
+                                                   required />
+                                            <div class=\\"help\\">
+                                            (e.g. &quot;Great Pizza for Everyone Inc.&quot;)
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </form>"
+                          }']
+          },
+          {
+            "mediaType": "application/json",
+            "flatType": "string"
+          }
+        ] />
 
     <@lib.response
         code = "400"


### PR DESCRIPTION
* adds a macro for multiple content types per response
* uses the new macro for endpoints with multiple possible types* adds the second media type return value manually as
  extending the macro for this one-time use is overly complex

related to CAM-13106