### PR TITLE
feat(engine): add withoutDueDate filter for tasks

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/history/HistoricTaskInstanceQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/history/HistoricTaskInstanceQuery.java
@@ -323,6 +323,11 @@ public interface HistoricTaskInstanceQuery  extends Query<HistoricTaskInstanceQu
   HistoricTaskInstanceQuery taskDueAfter(Date dueDate);
 
   /**
+   * Only select select historic task instances that have no due date.
+   */
+  HistoricTaskInstanceQuery withoutTaskDueDate();
+
+  /**
    * Only select select historic task instances with the given follow-up date.
    */
   HistoricTaskInstanceQuery taskFollowUpDate(Date followUpDate);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
@@ -2159,6 +2159,10 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
       extendedQuery.dueAfter(this.getDueAfter());
     }
 
+    if (extendingQuery.isWithoutDueDate() || this.isWithoutDueDate()) {
+      extendedQuery.withoutDueDate();
+    }
+
     if (extendingQuery.getFollowUpDate() != null) {
       extendedQuery.followUpDate(extendingQuery.getFollowUpDate());
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/json/JsonTaskQueryConverter.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/json/JsonTaskQueryConverter.java
@@ -92,6 +92,7 @@ public class JsonTaskQueryConverter extends JsonObjectConverter<TaskQuery> {
   public static final String DUE_DATE = "dueDate";
   public static final String DUE_BEFORE = "dueBefore";
   public static final String DUE_AFTER = "dueAfter";
+  public static final String WITHOUT_DUE_DATE = "withoutDueDate";
   public static final String FOLLOW_UP = "followUp";
   public static final String FOLLOW_UP_DATE = "followUpDate";
   public static final String FOLLOW_UP_BEFORE = "followUpBefore";
@@ -195,6 +196,7 @@ public class JsonTaskQueryConverter extends JsonObjectConverter<TaskQuery> {
     JsonUtil.addDateField(json, DUE, query.getDueDate());
     JsonUtil.addDateField(json, DUE_BEFORE, query.getDueBefore());
     JsonUtil.addDateField(json, DUE_AFTER, query.getDueAfter());
+    JsonUtil.addDefaultField(json, WITHOUT_DUE_DATE, false, query.isWithoutDueDate());
     JsonUtil.addDateField(json, FOLLOW_UP, query.getFollowUpDate());
     JsonUtil.addDateField(json, FOLLOW_UP_BEFORE, query.getFollowUpBefore());
     JsonUtil.addDefaultField(json, FOLLOW_UP_NULL_ACCEPTED, false, query.isFollowUpNullAccepted());
@@ -445,6 +447,9 @@ public class JsonTaskQueryConverter extends JsonObjectConverter<TaskQuery> {
     }
     if (json.has(DUE_AFTER)) {
       query.dueAfter(new Date(JsonUtil.getLong(json, DUE_AFTER)));
+    }
+    if (json.has(WITHOUT_DUE_DATE)) {
+      query.withoutDueDate();
     }
     if (json.has(FOLLOW_UP)) {
       query.followUpDate(new Date(JsonUtil.getLong(json, FOLLOW_UP)));

--- a/engine/src/main/java/org/camunda/bpm/engine/task/TaskQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/task/TaskQuery.java
@@ -847,6 +847,11 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    */
   TaskQuery withoutTenantId();
 
+  /**
+   * Only select tasks which have no due date.
+   */
+  TaskQuery withoutDueDate();
+
   // ordering ////////////////////////////////////////////////////////////
 
   /**

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
@@ -488,6 +488,9 @@
                 and RES.DUE_DATE_ is not null
               </trim>
             </if>
+            <if test="query.withoutTaskDueDate">
+              ${queryType} RES.DUE_DATE_ is null
+            </if>
             <if test="query.followUpDate != null || query.followUpBefore != null || query.followUpAfter != null">
               ${queryType}
               <trim prefix="(" suffix=")" prefixOverrides="and|or">

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
@@ -521,6 +521,9 @@
                 and RES.DUE_DATE_ is not null
               </trim>
             </if>
+            <if test="query.withoutDueDate">
+              ${queryType} RES.DUE_DATE_ is null
+            </if>
             <if test="query.followUpDate != null || query.followUpBefore != null || query.followUpAfter != null">
               ${queryType}
               <trim prefix="(" suffix=")" prefixOverrides="and|or">

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/filter/FilterTaskQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/filter/FilterTaskQueryTest.java
@@ -79,7 +79,7 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
   protected Date testDate = new Date(0);
   protected String[] testActivityInstances = new String[] {"a", "b", "c"};
   protected String[] testKeys = new String[] {"d", "e"};
-  protected List<String> testCandidateGroups = new ArrayList<String>();
+  protected List<String> testCandidateGroups = new ArrayList<>();
   protected String[] testInstances = new String[] {"x", "y", "z"};
 
   protected String[] variableNames = new String[] {"a", "b", "c", "d", "e", "f"};
@@ -815,7 +815,7 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
   public void testExtendingTaskQueryListWithCandidateGroups() {
     TaskQuery query = taskService.createTaskQuery();
 
-    List<String> candidateGroups = new ArrayList<String>();
+    List<String> candidateGroups = new ArrayList<>();
     candidateGroups.add("accounting");
     query.taskCandidateGroupIn(candidateGroups);
 
@@ -1206,7 +1206,7 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
     query = extendedFilter.getQuery();
 
     List<QueryOrderingProperty> expectedOrderingProperties =
-        new ArrayList<QueryOrderingProperty>(sortQuery.getOrderingProperties());
+        new ArrayList<>(sortQuery.getOrderingProperties());
 
     verifyOrderingProperties(expectedOrderingProperties, query.getOrderingProperties());
 
@@ -1597,7 +1597,7 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
     String variableName = "variableName";
     String variableValueCamelCase = "someVariableValue";
     String variableValueLowerCase = variableValueCamelCase.toLowerCase();
-    Map<String, Object> variables = new HashMap<String, Object>();
+    Map<String, Object> variables = new HashMap<>();
 
     String caseDefinitionId = repositoryService.createCaseDefinitionQuery().singleResult().getId();
 
@@ -1688,7 +1688,7 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
     String variableName = "variableName";
     String variableValueCamelCase = "someVariableValue";
     String variableValueLowerCase = variableValueCamelCase.toLowerCase();
-    Map<String, Object> variables = new HashMap<String, Object>();
+    Map<String, Object> variables = new HashMap<>();
 
     variables.put(variableName, variableValueCamelCase);
     ProcessInstance instanceCamelCase = runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
@@ -1879,7 +1879,7 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
 
     // then
     List<QueryOrderingProperty> expectedOrderingProperties =
-        new ArrayList<QueryOrderingProperty>(query.getOrderingProperties());
+        new ArrayList<>(query.getOrderingProperties());
 
     verifyOrderingProperties(expectedOrderingProperties, ((TaskQueryImpl) filter.getQuery()).getOrderingProperties());
 
@@ -2034,6 +2034,25 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
 
     // then
     assertThat(filterService.count(filter.getId())).isEqualTo(1L);
+  }
+
+  @Test
+  public void testWithoutDueDate() {
+    // given
+    Task task = taskService.newTask();
+    task.setDueDate(new Date());
+    taskService.saveTask(task);
+
+    TaskQuery query = taskService.createTaskQuery()
+      .withoutDueDate();
+
+    filter.setQuery(query);
+
+    // when
+    filterService.saveFilter(filter);
+
+    // then
+    assertThat(filterService.count(filter.getId())).isEqualTo(3L);
   }
 
   @Test
@@ -2245,7 +2264,7 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
   }
 
 
-  protected void saveQuery(Query query) {
+  protected void saveQuery(TaskQuery query) {
     filter.setQuery(query);
     filterService.saveFilter(filter);
     filter = filterService.getFilter(filter.getId());

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/filter/FilterTaskQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/filter/FilterTaskQueryTest.java
@@ -2056,6 +2056,26 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
   }
 
   @Test
+  public void testExtendQueryByWithoutDueDate() {
+    // given
+    Task task = taskService.newTask();
+    task.setDueDate(new Date());
+    taskService.saveTask(task);
+
+    TaskQuery query = taskService.createTaskQuery();
+    saveQuery(query);
+
+    // assume
+    assertThat(filterService.count(filter.getId())).isEqualTo(4L);
+
+    // when
+    TaskQuery extendingQuery = taskService.createTaskQuery().withoutDueDate();
+
+    // then
+    assertThat(filterService.count(filter.getId(), extendingQuery)).isEqualTo(3L);
+  }
+
+  @Test
   public void testTaskIdInPositive() {
     // given
     List<Task> existingTasks = taskService.createTaskQuery().list();

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryExpressionTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryExpressionTest.java
@@ -16,6 +16,7 @@
  */
 package org.camunda.bpm.engine.test.api.task;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -601,6 +602,48 @@ public class TaskQueryExpressionTest {
 
     // then
     assertEquals(2, tasks.size());
+  }
+
+  @Test
+  public void shouldRejectDueDateExpressionAndWithoutDueDateCombination() {
+    assertThatThrownBy(() -> taskService.createTaskQuery().dueDateExpression("").withoutDueDate())
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("Invalid query usage");
+  }
+
+  @Test
+  public void shouldRejectWithoutDueDateAndDueDateExpressionCombination() {
+    assertThatThrownBy(() -> taskService.createTaskQuery().withoutDueDate().dueDateExpression(""))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("Invalid query usage");
+  }
+
+  @Test
+  public void shouldRejectDueAfterExpressionAndWithoutDueDateCombination() {
+    assertThatThrownBy(() -> taskService.createTaskQuery().dueAfterExpression("").withoutDueDate())
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("Invalid query usage");
+  }
+
+  @Test
+  public void shouldRejectWithoutDueDateAndDueAfterExpressionCombination() {
+    assertThatThrownBy(() -> taskService.createTaskQuery().withoutDueDate().dueAfterExpression(""))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("Invalid query usage");
+  }
+
+  @Test
+  public void shouldRejectDueBeforeExpressionAndWithoutDueDateCombination() {
+    assertThatThrownBy(() -> taskService.createTaskQuery().dueBeforeExpression("").withoutDueDate())
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("Invalid query usage");
+  }
+
+  @Test
+  public void shouldRejectWithoutDueDateAndDueBeforeExpressionCombination() {
+    assertThatThrownBy(() -> taskService.createTaskQuery().withoutDueDate().dueBeforeExpression(""))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("Invalid query usage");
   }
 
   @After

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryOrTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryOrTest.java
@@ -1115,11 +1115,20 @@ public class TaskQueryOrTest {
   @Test
   public void shouldTestDueDateCombinations() throws ParseException {
     HashMap<String, Date> dates = createFollowUpAndDueDateTasks();
+    taskService.saveTask(taskService.newTask());
 
     assertEquals(2, taskService.createTaskQuery()
       .or()
         .dueDate(dates.get("date"))
         .dueBefore(dates.get("oneHourAgo"))
+      .endOr()
+      .count());
+
+    assertEquals(3, taskService.createTaskQuery()
+      .or()
+        .dueDate(dates.get("date"))
+        .dueBefore(dates.get("oneHourAgo"))
+        .withoutDueDate()
       .endOr()
       .count());
 
@@ -1130,10 +1139,26 @@ public class TaskQueryOrTest {
       .endOr()
       .count());
 
+    assertEquals(3, taskService.createTaskQuery()
+      .or()
+        .dueDate(dates.get("date"))
+        .dueAfter(dates.get("oneHourLater"))
+        .withoutDueDate()
+      .endOr()
+      .count());
+
     assertEquals(2, taskService.createTaskQuery()
       .or()
         .dueBefore(dates.get("oneHourAgo"))
         .dueAfter(dates.get("oneHourLater"))
+      .endOr()
+      .count());
+
+    assertEquals(3, taskService.createTaskQuery()
+      .or()
+        .dueBefore(dates.get("oneHourAgo"))
+        .dueAfter(dates.get("oneHourLater"))
+        .withoutDueDate()
       .endOr()
       .count());
 
@@ -1144,11 +1169,28 @@ public class TaskQueryOrTest {
       .endOr()
       .count());
 
+    assertEquals(4, taskService.createTaskQuery()
+      .or()
+        .dueBefore(dates.get("oneHourLater"))
+        .dueAfter(dates.get("oneHourAgo"))
+        .withoutDueDate()
+      .endOr()
+      .count());
+
     assertEquals(3, taskService.createTaskQuery()
       .or()
         .dueDate(dates.get("date"))
         .dueBefore(dates.get("oneHourAgo"))
         .dueAfter(dates.get("oneHourLater"))
+      .endOr()
+      .count());
+
+    assertEquals(4, taskService.createTaskQuery()
+      .or()
+        .dueDate(dates.get("date"))
+        .dueBefore(dates.get("oneHourAgo"))
+        .dueAfter(dates.get("oneHourLater"))
+        .withoutDueDate()
       .endOr()
       .count());
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryOrTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryOrTest.java
@@ -649,6 +649,7 @@ public class HistoricTaskInstanceQueryOrTest {
   @Test
   public void shouldTestDueDateCombinations() throws ParseException {
     HashMap<String, Date> dates = createFollowUpAndDueDateTasks();
+    taskService.saveTask(taskService.newTask());
 
     assertEquals(2, historyService.createHistoricTaskInstanceQuery()
       .or()
@@ -657,6 +658,14 @@ public class HistoricTaskInstanceQueryOrTest {
       .endOr()
       .count());
 
+    assertEquals(3, historyService.createHistoricTaskInstanceQuery()
+        .or()
+          .taskDueDate(dates.get("date"))
+          .taskDueBefore(dates.get("oneHourAgo"))
+          .withoutTaskDueDate()
+        .endOr()
+        .count());
+
     assertEquals(2, historyService.createHistoricTaskInstanceQuery()
       .or()
         .taskDueDate(dates.get("date"))
@@ -664,12 +673,28 @@ public class HistoricTaskInstanceQueryOrTest {
       .endOr()
       .count());
 
+    assertEquals(3, historyService.createHistoricTaskInstanceQuery()
+        .or()
+          .taskDueDate(dates.get("date"))
+          .taskDueAfter(dates.get("oneHourLater"))
+          .withoutTaskDueDate()
+        .endOr()
+        .count());
+
     assertEquals(2, historyService.createHistoricTaskInstanceQuery()
       .or()
         .taskDueBefore(dates.get("oneHourAgo"))
         .taskDueAfter(dates.get("oneHourLater"))
       .endOr()
       .count());
+
+    assertEquals(3, historyService.createHistoricTaskInstanceQuery()
+        .or()
+          .taskDueBefore(dates.get("oneHourAgo"))
+          .taskDueAfter(dates.get("oneHourLater"))
+          .withoutTaskDueDate()
+        .endOr()
+        .count());
 
     assertEquals(3, historyService.createHistoricTaskInstanceQuery()
       .or()
@@ -678,6 +703,14 @@ public class HistoricTaskInstanceQueryOrTest {
       .endOr()
       .count());
 
+    assertEquals(4, historyService.createHistoricTaskInstanceQuery()
+        .or()
+          .taskDueBefore(dates.get("oneHourLater"))
+          .taskDueAfter(dates.get("oneHourAgo"))
+          .withoutTaskDueDate()
+        .endOr()
+        .count());
+
     assertEquals(3, historyService.createHistoricTaskInstanceQuery()
       .or()
         .taskDueDate(dates.get("date"))
@@ -685,6 +718,15 @@ public class HistoricTaskInstanceQueryOrTest {
         .taskDueAfter(dates.get("oneHourLater"))
       .endOr()
       .count());
+
+    assertEquals(4, historyService.createHistoricTaskInstanceQuery()
+        .or()
+          .taskDueDate(dates.get("date"))
+          .taskDueBefore(dates.get("oneHourAgo"))
+          .taskDueAfter(dates.get("oneHourLater"))
+          .withoutTaskDueDate()
+        .endOr()
+        .count());
   }
 
   @Test

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.fail;
 
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -697,6 +698,29 @@ public class HistoricTaskInstanceQueryTest extends PluggableProcessEngineTest {
     taskService.deleteTask("taskOne",true);
 
     ClockUtil.reset();
+  }
+
+  @Test
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+  public void shouldQueryForTasksWithoutDueDate() {
+    // given
+    Task taskOne = taskService.newTask("taskOne");
+    taskOne.setDueDate(new Date());
+    taskService.saveTask(taskOne);
+    Task taskTwo = taskService.newTask("taskTwo");
+    taskService.saveTask(taskTwo);
+
+    // when
+    taskService.complete(taskOne.getId());
+    taskService.complete(taskTwo.getId());
+
+    // then
+    assertThat(historyService.createHistoricTaskInstanceQuery().withoutTaskDueDate().count())
+      .isEqualTo(1L);
+
+    // cleanup
+    taskService.deleteTask("taskOne", true);
+    taskService.deleteTask("taskTwo", true);
   }
 
   private void assertThatListContainsOnlyExpectedElement(List<HistoricTaskInstance> instances, ProcessInstance instance) {


### PR DESCRIPTION
* adds query option to filter for (historic) tasks that do not have a due date
* adds query option to JSON task query converter for task filters

related to CAM-13153