### PR TITLE
feat(engine-rest): add withoutDueDate filter for tasks

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/task-query-params.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/task-query-params.ftl
@@ -363,6 +363,13 @@
               for more information on available functions. The expression must evaluate to a
               `java.util.Date` or `org.joda.time.DateTime` object." />
 
+  <@lib.parameter name = "withoutDueDate"
+      location = "query"
+      type = "boolean"
+      defaultValue = "false"
+      desc = "Only include tasks which have no due date. Value may only be `true`, 
+              as `false` is the default behavior." />
+
   <@lib.parameter name = "followUpDate"
       location = "query"
       type = "string"

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/task/TaskQueryDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/task/TaskQueryDto.ftl
@@ -364,6 +364,13 @@
                 `java.util.Date` or `org.joda.time.DateTime` object." />
   
     <@lib.property
+        name = "withoutDueDate"
+        type = "boolean"
+        defaultValue = "false"
+        desc = "Only include tasks which have no due date. Value may only be `true`, 
+                as `false` is the default behavior." />
+  
+    <@lib.property
         name = "followUpDate"
         type = "string"
         format = "date-time"

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricTaskInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricTaskInstanceQueryDto.java
@@ -130,6 +130,7 @@ public class HistoricTaskInstanceQueryDto extends AbstractQueryDto<HistoricTaskI
   protected Date taskDueDate;
   protected Date taskDueDateBefore;
   protected Date taskDueDateAfter;
+  protected Boolean withoutTaskDueDate;
   protected Date taskFollowUpDate;
   protected Date taskFollowUpDateBefore;
   protected Date taskFollowUpDateAfter;
@@ -154,7 +155,7 @@ public class HistoricTaskInstanceQueryDto extends AbstractQueryDto<HistoricTaskI
   protected Boolean withoutCandidateGroups;
   protected List<VariableQueryParameterDto> taskVariables;
   protected List<VariableQueryParameterDto> processVariables;
-  
+
   protected Boolean variableValuesIgnoreCase;
   protected Boolean variableNamesIgnoreCase;
 
@@ -334,6 +335,11 @@ public class HistoricTaskInstanceQueryDto extends AbstractQueryDto<HistoricTaskI
   @CamundaQueryParam(value="taskDueDateAfter", converter=DateConverter.class)
   public void setTaskDueDateAfter(Date taskDueDateAfter) {
     this.taskDueDateAfter = taskDueDateAfter;
+  }
+
+  @CamundaQueryParam(value = "withoutTaskDueDate", converter = BooleanConverter.class)
+  public void setWithoutTaskDueDate(Boolean withoutTaskDueDate) {
+    this.withoutTaskDueDate = withoutTaskDueDate;
   }
 
   @CamundaQueryParam(value="taskFollowUpDate", converter=DateConverter.class)
@@ -578,6 +584,9 @@ public class HistoricTaskInstanceQueryDto extends AbstractQueryDto<HistoricTaskI
     }
     if (taskDueDateAfter != null) {
       query.taskDueAfter(taskDueDateAfter);
+    }
+    if (TRUE.equals(withoutTaskDueDate)) {
+      query.withoutTaskDueDate();
     }
     if (taskFollowUpDate != null) {
       query.taskFollowUpDate(taskFollowUpDate);

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/task/TaskQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/task/TaskQueryDto.java
@@ -171,6 +171,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
   private String dueBeforeExpression;
   private Date dueDate;
   private String dueDateExpression;
+  private Boolean withoutDueDate;
   private Date followUpAfter;
   private String followUpAfterExpression;
   private Date followUpBefore;
@@ -197,7 +198,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
   protected Boolean withoutCandidateGroups;
   protected Boolean withCandidateUsers;
   protected Boolean withoutCandidateUsers;
-  
+
   protected Boolean variableNamesIgnoreCase;
   protected Boolean variableValuesIgnoreCase;
 
@@ -526,6 +527,11 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     this.dueDateExpression = dueDateExpression;
   }
 
+  @CamundaQueryParam(value = "withoutDueDate", converter = BooleanConverter.class)
+  public void setWithoutDueDate(boolean withoutDueDate) {
+    this.withoutDueDate = withoutDueDate;
+  }
+
   @CamundaQueryParam(value = "followUpAfter", converter = DateConverter.class)
   public void setFollowUpAfter(Date followUpAfter) {
     this.followUpAfter = followUpAfter;
@@ -677,7 +683,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
   public void setCaseInstanceVariables(List<VariableQueryParameterDto> caseInstanceVariables) {
     this.caseInstanceVariables = caseInstanceVariables;
   }
-  
+
   @CamundaQueryParam(value = "variableNamesIgnoreCase", converter = BooleanConverter.class)
   public void setVariableNamesIgnoreCase(Boolean variableNamesCaseInsensitive) {
     this.variableNamesIgnoreCase = variableNamesCaseInsensitive;
@@ -954,6 +960,10 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     return dueDateExpression;
   }
 
+  public boolean getWithoutDueDate() {
+    return withoutDueDate;
+  }
+
   public Date getFollowUpAfter() {
     return followUpAfter;
   }
@@ -1037,7 +1047,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
   public List<TaskQueryDto> getOrQueries() {
     return orQueries;
   }
-  
+
   public Boolean isVariableNamesIgnoreCase() {
     return variableNamesIgnoreCase;
   }
@@ -1226,6 +1236,9 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     }
     if (dueDateExpression != null) {
       query.dueDateExpression(dueDateExpression);
+    }
+    if (TRUE.equals(withoutDueDate)) {
+      query.withoutDueDate();
     }
     if (followUpAfter != null) {
       query.followUpAfter(followUpAfter);
@@ -1563,8 +1576,10 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     dto.dueAfter = taskQuery.getDueAfter();
     dto.dueBefore = taskQuery.getDueBefore();
     dto.dueDate = taskQuery.getDueDate();
+    dto.withoutDueDate = taskQuery.isWithoutDueDate();
+
     dto.followUpAfter = taskQuery.getFollowUpAfter();
-    
+
     dto.variableNamesIgnoreCase = taskQuery.isVariableNamesIgnoreCase();
     dto.variableValuesIgnoreCase = taskQuery.isVariableValuesIgnoreCase();
 

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/FilterRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/FilterRestServiceInteractionTest.java
@@ -296,6 +296,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
     when(query.getOwner()).thenReturn(MockProvider.EXAMPLE_TASK_OWNER);
     when(query.getParentTaskId()).thenReturn(MockProvider.EXAMPLE_TASK_PARENT_TASK_ID);
     when(query.getTenantIds()).thenReturn(MockProvider.EXAMPLE_TENANT_ID_LIST.split(","));
+    when(query.isWithoutDueDate()).thenReturn(true);
     when(query.isWithoutTenantId()).thenReturn(true);
     when(query.isAssignedInternal()).thenReturn(true);
     when(query.isUnassignedInternal()).thenReturn(false);
@@ -342,6 +343,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
       .body("query.owner", equalTo(MockProvider.EXAMPLE_TASK_OWNER))
       .body("query.parentTaskId", equalTo(MockProvider.EXAMPLE_TASK_PARENT_TASK_ID))
       .body("query.tenantIdIn", hasItems(MockProvider.EXAMPLE_TENANT_ID, MockProvider.ANOTHER_EXAMPLE_TENANT_ID))
+      .body("query.withoutDueDate", equalTo(true))
       .body("query.assigned", equalTo(true))
       .body("query.unassigned", equalTo(false))
     .when()

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/TaskRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/TaskRestServiceQueryTest.java
@@ -84,12 +84,12 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
   protected static final String TASK_QUERY_URL = TEST_RESOURCE_ROOT_PATH + "/task";
   protected static final String TASK_COUNT_QUERY_URL = TASK_QUERY_URL + "/count";
-  
+
   private static final String SAMPLE_VAR_NAME = "varName";
   private static final String SAMPLE_VAR_VALUE = "varValue";
-  
+
   private TaskQuery mockQuery;
-  
+
   @Before
   public void setUpRuntimeData() {
     mockQuery = setUpMockTaskQuery(MockProvider.createMockTasks());
@@ -428,7 +428,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
   }
 
   private Map<String, Integer> getCompleteIntQueryParameters() {
-    Map<String, Integer> parameters = new HashMap<String, Integer>();
+    Map<String, Integer> parameters = new HashMap<>();
 
     parameters.put("maxPriority", 10);
     parameters.put("minPriority", 9);
@@ -438,7 +438,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
   }
 
   private Map<String, String[]> getCompleteStringArrayQueryParameters() {
-    Map<String, String[]> parameters = new HashMap<String, String[]>();
+    Map<String, String[]> parameters = new HashMap<>();
 
     String[] activityInstanceIds = { "anActivityInstanceId", "anotherActivityInstanceId" };
     String[] taskDefinitionKeys = { "aTaskDefinitionKey", "anotherTaskDefinitionKey" };
@@ -465,7 +465,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
   }
 
   private Map<String, String> getCompleteStringQueryParameters() {
-    Map<String, String> parameters = new HashMap<String, String>();
+    Map<String, String> parameters = new HashMap<>();
 
     parameters.put("processInstanceBusinessKey", "aBusinessKey");
     parameters.put("processInstanceBusinessKeyLike", "aBusinessKeyLike");
@@ -505,7 +505,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
   }
 
   private Map<String, Boolean> getCompleteBooleanQueryParameters() {
-    Map<String, Boolean> parameters = new HashMap<String, Boolean>();
+    Map<String, Boolean> parameters = new HashMap<>();
 
     parameters.put("assigned", true);
     parameters.put("unassigned", true);
@@ -516,6 +516,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     parameters.put("withoutCandidateGroups", true);
     parameters.put("withCandidateUsers", true);
     parameters.put("withoutCandidateUsers", true);
+    parameters.put("withoutDueDate", true);
 
     return parameters;
   }
@@ -580,6 +581,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     verify(mockQuery).withoutCandidateGroups();
     verify(mockQuery).withCandidateUsers();
     verify(mockQuery).withoutCandidateUsers();
+    verify(mockQuery).withoutDueDate();
   }
 
   @Test
@@ -630,7 +632,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
   @Test
   public void testDeprecatedDateParameters() {
-    Map<String, String> queryParameters = new HashMap<String, String>();
+    Map<String, String> queryParameters = new HashMap<>();
     queryParameters.put("due", withTimezone("2013-01-23T14:42:44"));
     queryParameters.put("created", withTimezone("2013-01-23T14:42:47"));
     queryParameters.put("followUp", withTimezone("2013-01-23T14:42:50"));
@@ -649,7 +651,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
   }
 
   private Map<String, String> getDateParameters() {
-    Map<String, String> parameters = new HashMap<String, String>();
+    Map<String, String> parameters = new HashMap<>();
     parameters.put("dueAfter", withTimezone("2013-01-23T14:42:42"));
     parameters.put("dueBefore", withTimezone("2013-01-23T14:42:43"));
     parameters.put("dueDate", withTimezone("2013-01-23T14:42:44"));
@@ -665,7 +667,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
   @Test
   public void testCandidateGroupInList() {
-    List<String> candidateGroups = new ArrayList<String>();
+    List<String> candidateGroups = new ArrayList<>();
     candidateGroups.add("boss");
     candidateGroups.add("worker");
     String queryParam = candidateGroups.get(0) + "," + candidateGroups.get(1);
@@ -847,7 +849,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
   }
 
   protected void executeAndVerifySortingAsPost(List<Map<String, Object>> sortingJson, Status expectedStatus) {
-    Map<String, Object> json = new HashMap<String, Object>();
+    Map<String, Object> json = new HashMap<>();
     json.put("sorting", sortingJson);
 
     given().contentType(POST_JSON_CONTENT_TYPE).body(json)
@@ -935,7 +937,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
     verify(mockQuery).taskVariableValueEquals(variableName, variableValue);
     reset(mockQuery);
-    
+
     given()
     .queryParam("taskVariables", queryValue)
     .queryParam("variableValuesIgnoreCase", true)
@@ -945,11 +947,11 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
       .statusCode(Status.OK.getStatusCode())
     .when()
       .get(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).taskVariableValueEquals(variableName, variableValue);
     reset(mockQuery);
-    
+
     given()
     .queryParam("taskVariables", queryValue)
     .queryParam("variableNamesIgnoreCase", true)
@@ -959,11 +961,11 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableNamesIgnoreCase();
     verify(mockQuery).taskVariableValueEquals(variableName, variableValue);
     reset(mockQuery);
-    
+
     given()
     .queryParam("taskVariables", queryValue)
     .queryParam("variableNamesIgnoreCase", true)
@@ -974,7 +976,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableNamesIgnoreCase();
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).taskVariableValueEquals(variableName, variableValue);
@@ -1051,7 +1053,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
     // like case-insensitive
     queryValue = variableName + "_like_" + variableValue;
-    
+
     given()
     .queryParam("taskVariables", queryValue)
     .queryParam("variableValuesIgnoreCase", true)
@@ -1061,7 +1063,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).taskVariableValueLike(variableName, variableValue);
 
@@ -1082,7 +1084,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
     // not equals case-insensitive
     queryValue = variableName + "_neq_" + variableValue;
-    
+
     given()
     .queryParam("taskVariables", queryValue)
     .queryParam("variableValuesIgnoreCase", true)
@@ -1092,22 +1094,22 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).taskVariableValueNotEquals(variableName, variableValue);
   }
-  
+
   @Test
   public void testTaskVariableValueEqualsIgnoreCaseAsPost() {
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", SAMPLE_VAR_NAME);
     variableJson.put("operator", "eq");
     variableJson.put("value", SAMPLE_VAR_VALUE.toLowerCase());
 
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
 
-    Map<String, Object> json = new HashMap<String, Object>();
+    Map<String, Object> json = new HashMap<>();
     json.put("taskVariables", variables);
     json.put("variableValuesIgnoreCase", true);
 
@@ -1119,25 +1121,25 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
       .statusCode(Status.OK.getStatusCode())
       .when()
       .post(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).taskVariableValueEquals(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
   }
-  
+
   @Test
   public void testTaskVariableNameEqualsIgnoreCaseAsPost() {
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", SAMPLE_VAR_NAME.toLowerCase());
     variableJson.put("operator", "eq");
     variableJson.put("value", SAMPLE_VAR_VALUE);
-    
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
-    
-    Map<String, Object> json = new HashMap<String, Object>();
+
+    Map<String, Object> json = new HashMap<>();
     json.put("taskVariables", variables);
     json.put("variableNamesIgnoreCase", true);
-    
+
     given()
     .contentType(POST_JSON_CONTENT_TYPE)
     .body(json)
@@ -1146,13 +1148,13 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .post(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableNamesIgnoreCase();
     verify(mockQuery).taskVariableValueEquals(SAMPLE_VAR_NAME.toLowerCase(), SAMPLE_VAR_VALUE);
     reset(mockQuery);
-    
+
     json.put("variableValuesIgnoreCase", true);
-    
+
     given()
     .contentType(POST_JSON_CONTENT_TYPE)
     .body(json)
@@ -1161,23 +1163,23 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .post(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableNamesIgnoreCase();
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).taskVariableValueEquals(SAMPLE_VAR_NAME.toLowerCase(), SAMPLE_VAR_VALUE);
   }
-  
+
   @Test
   public void testTaskVariableValueNotEqualsIgnoreCaseAsPost() {
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", SAMPLE_VAR_NAME);
     variableJson.put("operator", "neq");
     variableJson.put("value", SAMPLE_VAR_VALUE.toLowerCase());
 
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
 
-    Map<String, Object> json = new HashMap<String, Object>();
+    Map<String, Object> json = new HashMap<>();
     json.put("taskVariables", variables);
     json.put("variableValuesIgnoreCase", true);
 
@@ -1189,25 +1191,25 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
       .statusCode(Status.OK.getStatusCode())
       .when()
       .post(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).taskVariableValueNotEquals(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
   }
 
   @Test
   public void testTaskVariableValueLikeIgnoreCaseAsPost() {
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", SAMPLE_VAR_NAME);
     variableJson.put("operator", "like");
     variableJson.put("value", SAMPLE_VAR_VALUE.toLowerCase());
 
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
 
-    Map<String, Object> json = new HashMap<String, Object>();
+    Map<String, Object> json = new HashMap<>();
     json.put("taskVariables", variables);
     json.put("variableValuesIgnoreCase", true);
-    
+
     given()
       .contentType(POST_JSON_CONTENT_TYPE)
       .body(json)
@@ -1216,7 +1218,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
       .statusCode(Status.OK.getStatusCode())
       .when()
       .post(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).taskVariableValueLike(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
   }
@@ -1242,7 +1244,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
     //equals case-insensitive
     queryValue = variableName + "_eq_" + variableValue;
-    
+
     given()
     .queryParam("processVariables", queryValue)
     .queryParam("variableValuesIgnoreCase", true)
@@ -1252,11 +1254,11 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).processVariableValueEquals(variableName, variableValue);
     reset(mockQuery);
-    
+
     given()
     .queryParam("processVariables", queryValue)
     .queryParam("variableNamesIgnoreCase", true)
@@ -1266,11 +1268,11 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableNamesIgnoreCase();
     verify(mockQuery).processVariableValueEquals(variableName, variableValue);
     reset(mockQuery);
-    
+
     given()
     .queryParam("processVariables", queryValue)
     .queryParam("variableNamesIgnoreCase", true)
@@ -1281,7 +1283,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableNamesIgnoreCase();
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).processVariableValueEquals(variableName, variableValue);
@@ -1359,7 +1361,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
     // like case-insensitive
     queryValue = variableName + "_like_" + variableValue;
-    
+
     given()
     .queryParam("processVariables", queryValue)
     .queryParam("variableValuesIgnoreCase", true)
@@ -1369,7 +1371,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).processVariableValueLike(variableName, variableValue);
 
@@ -1390,7 +1392,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
     // not equals case-insensitive
     queryValue = variableName + "_neq_" + variableValue;
-    
+
     given()
     .queryParam("processVariables", queryValue)
     .queryParam("variableValuesIgnoreCase", true)
@@ -1400,25 +1402,25 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).processVariableValueNotEquals(variableName, variableValue);
   }
 
   @Test
   public void testProcessVariableValueEqualsIgnoreCaseAsPost() {
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", SAMPLE_VAR_NAME);
     variableJson.put("operator", "eq");
     variableJson.put("value", SAMPLE_VAR_VALUE.toLowerCase());
 
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
 
-    Map<String, Object> json = new HashMap<String, Object>();
+    Map<String, Object> json = new HashMap<>();
     json.put("processVariables", variables);
     json.put("variableValuesIgnoreCase", true);
-    
+
     given()
       .contentType(POST_JSON_CONTENT_TYPE)
       .body(json)
@@ -1427,25 +1429,25 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
       .statusCode(Status.OK.getStatusCode())
       .when()
       .post(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).processVariableValueEquals(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
   }
-  
+
   @Test
   public void testProcessVariableNameEqualsIgnoreCaseAsPost() {
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", SAMPLE_VAR_NAME.toLowerCase());
     variableJson.put("operator", "eq");
     variableJson.put("value", SAMPLE_VAR_VALUE);
-    
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
-    
-    Map<String, Object> json = new HashMap<String, Object>();
+
+    Map<String, Object> json = new HashMap<>();
     json.put("processVariables", variables);
     json.put("variableNamesIgnoreCase", true);
-    
+
     given()
     .contentType(POST_JSON_CONTENT_TYPE)
     .body(json)
@@ -1454,11 +1456,11 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .post(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableNamesIgnoreCase();
     verify(mockQuery).processVariableValueEquals(SAMPLE_VAR_NAME.toLowerCase(), SAMPLE_VAR_VALUE);
     reset(mockQuery);
-    
+
     json.put("variableValuesIgnoreCase", true);
     given()
     .contentType(POST_JSON_CONTENT_TYPE)
@@ -1468,27 +1470,27 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .post(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableNamesIgnoreCase();
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).processVariableValueEquals(SAMPLE_VAR_NAME.toLowerCase(), SAMPLE_VAR_VALUE);
-    
+
   }
-  
+
   @Test
   public void testProcessVariableValueNotEqualsIgnoreCaseAsPost() {
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", SAMPLE_VAR_NAME);
     variableJson.put("operator", "neq");
     variableJson.put("value", SAMPLE_VAR_VALUE.toLowerCase());
-    
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
-    
-    Map<String, Object> json = new HashMap<String, Object>();
+
+    Map<String, Object> json = new HashMap<>();
     json.put("processVariables", variables);
     json.put("variableValuesIgnoreCase", true);
-    
+
     given()
       .contentType(POST_JSON_CONTENT_TYPE)
       .body(json)
@@ -1497,21 +1499,21 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
       .statusCode(Status.OK.getStatusCode())
       .when()
       .post(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).processVariableValueNotEquals(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
   }
   @Test
   public void testProcessVariableValueLikeIgnoreCaseAsPost() {
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", SAMPLE_VAR_NAME);
     variableJson.put("operator", "like");
     variableJson.put("value", SAMPLE_VAR_VALUE.toLowerCase());
-    
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
-    
-    Map<String, Object> json = new HashMap<String, Object>();
+
+    Map<String, Object> json = new HashMap<>();
     json.put("processVariables", variables);
     json.put("variableValuesIgnoreCase", true);
 
@@ -1527,7 +1529,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).processVariableValueLike(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
   }
-  
+
   @Test
   public void testCaseVariableParameters() {
     // equals
@@ -1549,7 +1551,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
     // equals case-insensitive
     queryValue = variableName + "_eq_" + variableValue;
-    
+
     given()
     .queryParam("caseInstanceVariables", queryValue)
     .queryParam("variableValuesIgnoreCase", true)
@@ -1559,7 +1561,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).caseInstanceVariableValueEquals(variableName, variableValue);
     reset(mockQuery);
@@ -1573,11 +1575,11 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableNamesIgnoreCase();
     verify(mockQuery).caseInstanceVariableValueEquals(variableName, variableValue);
     reset(mockQuery);
-    
+
     given()
     .queryParam("caseInstanceVariables", queryValue)
     .queryParam("variableNamesIgnoreCase", true)
@@ -1588,7 +1590,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableNamesIgnoreCase();
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).caseInstanceVariableValueEquals(variableName, variableValue);
@@ -1666,7 +1668,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
     // like case-insensitive
     queryValue = variableName + "_like_" + variableValue;
-    
+
     given()
     .queryParam("caseInstanceVariables", queryValue)
     .queryParam("variableValuesIgnoreCase", true)
@@ -1676,7 +1678,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).caseInstanceVariableValueLike(variableName, variableValue);
 
@@ -1697,7 +1699,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
     // not equals case-insensitive
     queryValue = variableName + "_neq_" + variableValue;
-    
+
     given()
     .queryParam("caseInstanceVariables", queryValue)
     .queryParam("variableValuesIgnoreCase", true)
@@ -1707,22 +1709,22 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).caseInstanceVariableValueNotEquals(variableName, variableValue);
   }
-  
+
   @Test
   public void testCaseInstanceVariableValueEqualsIgnoreCaseAsPost() {
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", SAMPLE_VAR_NAME);
     variableJson.put("operator", "eq");
     variableJson.put("value", SAMPLE_VAR_VALUE.toLowerCase());
-    
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
-    
-    Map<String, Object> json = new HashMap<String, Object>();
+
+    Map<String, Object> json = new HashMap<>();
     json.put("caseInstanceVariables", variables);
     json.put("variableValuesIgnoreCase", true);
 
@@ -1734,25 +1736,25 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
       .statusCode(Status.OK.getStatusCode())
       .when()
       .post(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).caseInstanceVariableValueEquals(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
   }
 
   @Test
   public void testCaseInstanceVariableNameEqualsIgnoreCaseAsPost() {
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", SAMPLE_VAR_NAME.toLowerCase());
     variableJson.put("operator", "eq");
     variableJson.put("value", SAMPLE_VAR_VALUE);
-    
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
-    
-    Map<String, Object> json = new HashMap<String, Object>();
+
+    Map<String, Object> json = new HashMap<>();
     json.put("caseInstanceVariables", variables);
     json.put("variableNamesIgnoreCase", true);
-    
+
     given()
     .contentType(POST_JSON_CONTENT_TYPE)
     .body(json)
@@ -1761,11 +1763,11 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .statusCode(Status.OK.getStatusCode())
     .when()
     .post(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableNamesIgnoreCase();
     verify(mockQuery).caseInstanceVariableValueEquals(SAMPLE_VAR_NAME.toLowerCase(), SAMPLE_VAR_VALUE);
     reset(mockQuery);
-    
+
     json.put("variableValuesIgnoreCase", true);
     given()
     .contentType(POST_JSON_CONTENT_TYPE)
@@ -1780,18 +1782,18 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).caseInstanceVariableValueEquals(SAMPLE_VAR_NAME.toLowerCase(), SAMPLE_VAR_VALUE);
   }
-  
+
   @Test
   public void testCaseInstanceVariableValueNotEqualsIgnoreCaseAsPost() {
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", SAMPLE_VAR_NAME);
     variableJson.put("operator", "neq");
     variableJson.put("value", SAMPLE_VAR_VALUE.toLowerCase());
-    
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
-    
-    Map<String, Object> json = new HashMap<String, Object>();
+
+    Map<String, Object> json = new HashMap<>();
     json.put("caseInstanceVariables", variables);
     json.put("variableValuesIgnoreCase", true);
 
@@ -1803,22 +1805,22 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
       .statusCode(Status.OK.getStatusCode())
       .when()
       .post(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).caseInstanceVariableValueNotEquals(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
   }
-  
+
   @Test
   public void testCaseInstanceVariableValueLikeIgnoreCaseAsPost() {
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", SAMPLE_VAR_NAME);
     variableJson.put("operator", "like");
     variableJson.put("value", SAMPLE_VAR_VALUE.toLowerCase());
-    
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
-    
-    Map<String, Object> json = new HashMap<String, Object>();
+
+    Map<String, Object> json = new HashMap<>();
     json.put("caseInstanceVariables", variables);
     json.put("variableValuesIgnoreCase", true);
 
@@ -1830,7 +1832,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
       .statusCode(Status.OK.getStatusCode())
       .when()
       .post(TASK_QUERY_URL);
-    
+
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).caseInstanceVariableValueLike(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
   }
@@ -1863,21 +1865,21 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     String anotherVariableName = "anotherVarName";
     Integer anotherVariableValue = 30;
 
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", variableName);
     variableJson.put("operator", "eq");
     variableJson.put("value", variableValue);
 
-    Map<String, Object> anotherVariableJson = new HashMap<String, Object>();
+    Map<String, Object> anotherVariableJson = new HashMap<>();
     anotherVariableJson.put("name", anotherVariableName);
     anotherVariableJson.put("operator", "neq");
     anotherVariableJson.put("value", anotherVariableValue);
 
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
     variables.add(anotherVariableJson);
 
-    Map<String, Object> json = new HashMap<String, Object>();
+    Map<String, Object> json = new HashMap<>();
     json.put("taskVariables", variables);
 
     given().contentType(POST_JSON_CONTENT_TYPE).body(json)
@@ -1918,21 +1920,21 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     String anotherVariableName = "anotherVarName";
     Integer anotherVariableValue = 30;
 
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", variableName);
     variableJson.put("operator", "eq");
     variableJson.put("value", variableValue);
 
-    Map<String, Object> anotherVariableJson = new HashMap<String, Object>();
+    Map<String, Object> anotherVariableJson = new HashMap<>();
     anotherVariableJson.put("name", anotherVariableName);
     anotherVariableJson.put("operator", "neq");
     anotherVariableJson.put("value", anotherVariableValue);
 
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
     variables.add(anotherVariableJson);
 
-    Map<String, Object> json = new HashMap<String, Object>();
+    Map<String, Object> json = new HashMap<>();
     json.put("processVariables", variables);
 
     given()
@@ -1977,21 +1979,21 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     String anotherVariableName = "anotherVarName";
     Integer anotherVariableValue = 30;
 
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", variableName);
     variableJson.put("operator", "eq");
     variableJson.put("value", variableValue);
 
-    Map<String, Object> anotherVariableJson = new HashMap<String, Object>();
+    Map<String, Object> anotherVariableJson = new HashMap<>();
     anotherVariableJson.put("name", anotherVariableName);
     anotherVariableJson.put("operator", "neq");
     anotherVariableJson.put("value", anotherVariableValue);
 
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
     variables.add(anotherVariableJson);
 
-    Map<String, Object> json = new HashMap<String, Object>();
+    Map<String, Object> json = new HashMap<>();
     json.put("caseInstanceVariables", variables);
 
     given()
@@ -2011,7 +2013,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
   @Test
   public void testCompletePostParameters() {
 
-    Map<String, Object> queryParameters = new HashMap<String, Object>();
+    Map<String, Object> queryParameters = new HashMap<>();
     Map<String, String> stringQueryParameters = getCompleteStringQueryParameters();
     Map<String, Integer> intQueryParameters = getCompleteIntQueryParameters();
     Map<String, Boolean> booleanQueryParameters = getCompleteBooleanQueryParameters();
@@ -2022,7 +2024,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     queryParameters.putAll(booleanQueryParameters);
     queryParameters.putAll(stringArrayQueryParameters);
 
-    List<String> candidateGroups = new ArrayList<String>();
+    List<String> candidateGroups = new ArrayList<>();
     candidateGroups.add("boss");
     candidateGroups.add("worker");
 
@@ -2074,7 +2076,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
     ValueGenerator generator = new ValueGenerator(testExpression);
 
-    Map<String, String> params = new HashMap<String, String>();
+    Map<String, String> params = new HashMap<>();
     params.put("assigneeExpression", generator.getValue("assigneeExpression"));
     params.put("assigneeLikeExpression", generator.getValue("assigneeLikeExpression"));
     params.put("ownerExpression", generator.getValue("ownerExpression"));

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
@@ -2421,6 +2421,10 @@ public abstract class MockProvider {
   }
 
   public static HistoricTaskInstance createMockHistoricTaskInstance(String tenantId) {
+    return createMockHistoricTaskInstance(tenantId, EXAMPLE_HISTORIC_TASK_INST_DUE_DATE);
+  }
+
+  public static HistoricTaskInstance createMockHistoricTaskInstance(String tenantId, String dueDateString) {
     HistoricTaskInstance taskInstance = mock(HistoricTaskInstance.class);
 
     when(taskInstance.getId()).thenReturn(EXAMPLE_HISTORIC_TASK_INST_ID);
@@ -2439,7 +2443,7 @@ public abstract class MockProvider {
     when(taskInstance.getDurationInMillis()).thenReturn(EXAMPLE_HISTORIC_TASK_INST_DURATION);
     when(taskInstance.getTaskDefinitionKey()).thenReturn(EXAMPLE_HISTORIC_TASK_INST_DEF_KEY);
     when(taskInstance.getPriority()).thenReturn(EXAMPLE_HISTORIC_TASK_INST_PRIORITY);
-    when(taskInstance.getDueDate()).thenReturn(DateTimeUtil.parseDate(EXAMPLE_HISTORIC_TASK_INST_DUE_DATE));
+    when(taskInstance.getDueDate()).thenReturn(dueDateString == null ? null : DateTimeUtil.parseDate(dueDateString));
     when(taskInstance.getFollowUpDate()).thenReturn(DateTimeUtil.parseDate(EXAMPLE_HISTORIC_TASK_INST_FOLLOW_UP_DATE));
     when(taskInstance.getParentTaskId()).thenReturn(EXAMPLE_HISTORIC_TASK_INST_PARENT_TASK_ID);
     when(taskInstance.getCaseDefinitionKey()).thenReturn(EXAMPLE_HISTORIC_TASK_INST_CASE_DEF_KEY);

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricTaskInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricTaskInstanceRestServiceQueryTest.java
@@ -47,7 +47,6 @@ import org.camunda.bpm.engine.impl.calendar.DateTimeUtil;
 import org.camunda.bpm.engine.rest.AbstractRestServiceTest;
 import org.camunda.bpm.engine.rest.exception.InvalidRequestException;
 import org.camunda.bpm.engine.rest.helper.MockProvider;
-import org.camunda.bpm.engine.rest.spi.impl.MockedProcessEngineProvider;
 import org.camunda.bpm.engine.rest.util.OrderingBuilder;
 import org.camunda.bpm.engine.rest.util.container.TestContainerRule;
 import org.junit.Assert;
@@ -366,7 +365,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   @Test
   public void testSecondarySortingAsPost() {
     InOrder inOrder = Mockito.inOrder(mockedQuery);
-    Map<String, Object> json = new HashMap<String, Object>();
+    Map<String, Object> json = new HashMap<>();
     json.put("sorting", OrderingBuilder.create()
       .orderBy("owner").desc()
       .orderBy("priority").asc()
@@ -512,7 +511,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskIdAsPost() {
     String taskId = MockProvider.EXAMPLE_HISTORIC_TASK_INST_ID;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskId", taskId);
 
     given()
@@ -540,7 +539,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByProcessInstanceIdAsPost() {
     String processInstanceId = MockProvider.EXAMPLE_HISTORIC_TASK_INST_PROC_INST_ID;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("processInstanceId", processInstanceId);
 
     given()
@@ -568,7 +567,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByProcessInstanceBusinessKeyAsPost() {
     String processInstanceBusinessKey = MockProvider.EXAMPLE_HISTORIC_TASK_INST_PROC_INST_BUSINESS_KEY;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("processInstanceBusinessKey", processInstanceBusinessKey);
 
     given()
@@ -596,7 +595,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByProcessInstanceBusinessKeyLikeAsPost() {
     String processInstanceBusinessKeyLike = MockProvider.EXAMPLE_HISTORIC_TASK_INST_PROC_INST_BUSINESS_KEY;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("processInstanceBusinessKeyLike", processInstanceBusinessKeyLike);
 
     given()
@@ -622,11 +621,11 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByProcessInstanceBusinessKeyInAsPost() {
     String businessKey1 = "aBusinessKey";
     String businessKey2 = "anotherBusinessKey";
-    List<String> processInstanceBusinessKeyIn = new ArrayList<String>();
+    List<String> processInstanceBusinessKeyIn = new ArrayList<>();
     processInstanceBusinessKeyIn.add(businessKey1);
     processInstanceBusinessKeyIn.add(businessKey2);
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("processInstanceBusinessKeyIn", processInstanceBusinessKeyIn);
 
     given()
@@ -654,7 +653,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByExecutionIdAsPost() {
     String executionId = MockProvider.EXAMPLE_HISTORIC_TASK_INST_EXEC_ID;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("executionId", executionId);
 
     given()
@@ -682,10 +681,10 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByActivityInstanceIdAsPost() {
     String activityInstanceId = MockProvider.EXAMPLE_HISTORIC_TASK_INST_ACT_INST_ID;
 
-    List<String> activityInstanceIds = new ArrayList<String>();
+    List<String> activityInstanceIds = new ArrayList<>();
     activityInstanceIds.add(activityInstanceId);
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("activityInstanceIdIn", activityInstanceIds);
 
     given()
@@ -715,11 +714,11 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     String activityInstanceId = MockProvider.EXAMPLE_HISTORIC_TASK_INST_ACT_INST_ID;
     String anotherActivityInstanceId = "anotherActivityInstanceId";
 
-    List<String> activityInstanceIds = new ArrayList<String>();
+    List<String> activityInstanceIds = new ArrayList<>();
     activityInstanceIds.add(activityInstanceId);
     activityInstanceIds.add(anotherActivityInstanceId);
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("activityInstanceIdIn", activityInstanceIds);
 
     given()
@@ -747,7 +746,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByProcessDefinitionIdAsPost() {
     String processDefinitionId = MockProvider.EXAMPLE_HISTORIC_TASK_INST_PROC_DEF_ID;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("processDefinitionId", processDefinitionId);
 
     given()
@@ -775,7 +774,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByProcessDefinitionKeyAsPost() {
     String processDefinitionKey = "aProcDefKey";
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("processDefinitionKey", processDefinitionKey);
 
     given()
@@ -803,7 +802,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByProcessDefinitionNameAsPost() {
     String processDefinitionName = "aProcDefName";
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("processDefinitionName", processDefinitionName);
 
     given()
@@ -831,7 +830,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskNameAsPost() {
     String taskName = "aTaskName";
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskName", taskName);
 
     given()
@@ -859,7 +858,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskNameLikeAsPost() {
     String taskNameLike = "aTaskNameLike";
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskNameLike", taskNameLike);
 
     given()
@@ -887,7 +886,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskDescriptionAsPost() {
     String taskDescription = MockProvider.EXAMPLE_HISTORIC_TASK_INST_DESCRIPTION;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskDescription", taskDescription);
 
     given()
@@ -915,7 +914,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskDescriptionLikeAsPost() {
     String taskDescriptionLike = "aTaskDescriptionLike";
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskDescriptionLike", taskDescriptionLike);
 
     given()
@@ -943,7 +942,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskDefinitionKeyAsPost() {
     String taskDefinitionKey = MockProvider.EXAMPLE_HISTORIC_TASK_INST_DEF_KEY;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskDefinitionKey", taskDefinitionKey);
 
     given()
@@ -971,7 +970,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskDeleteReasonAsPost() {
     String taskDeleteReason = MockProvider.EXAMPLE_HISTORIC_TASK_INST_DELETE_REASON;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskDeleteReason", taskDeleteReason);
 
     given()
@@ -999,7 +998,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskDeleteReasonLikeAsPost() {
     String taskDeleteReasonLike = "aTaskDeleteReasonLike";
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskDeleteReasonLike", taskDeleteReasonLike);
 
     given()
@@ -1027,7 +1026,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskAssigneeAsPost() {
     String taskAssignee = MockProvider.EXAMPLE_HISTORIC_TASK_INST_ASSIGNEE;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskAssignee", taskAssignee);
 
     given()
@@ -1055,7 +1054,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskAssigneeLikeAsPost() {
     String taskAssigneeLike = "aTaskAssigneeLike";
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskAssigneeLike", taskAssigneeLike);
 
     given()
@@ -1083,7 +1082,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskOwnerAsPost() {
     String taskOwner = MockProvider.EXAMPLE_HISTORIC_TASK_INST_OWNER;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskOwner", taskOwner);
 
     given()
@@ -1111,7 +1110,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskOwnerLikeAsPost() {
     String taskOwnerLike = "aTaskOwnerLike";
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskOwnerLike", taskOwnerLike);
 
     given()
@@ -1139,7 +1138,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskPriorityAsPost() {
     int taskPriority = MockProvider.EXAMPLE_HISTORIC_TASK_INST_PRIORITY;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskPriority", taskPriority);
 
     given()
@@ -1163,7 +1162,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
 
   @Test
   public void testQueryByAssignedAsPost() {
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("assigned", true);
 
     given()
@@ -1187,7 +1186,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
 
   @Test
   public void testQueryByWithCandidateGroupsAsPost() {
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("withCandidateGroups", true);
 
     given()
@@ -1211,7 +1210,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
 
   @Test
   public void testQueryByWithoutCandidateGroupsAsPost() {
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("withoutCandidateGroups", true);
 
     given()
@@ -1235,7 +1234,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
 
   @Test
   public void testQueryByUnassignedAsPost() {
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("unassigned", true);
 
     given()
@@ -1259,7 +1258,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
 
   @Test
   public void testQueryByFinishedAsPost() {
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("finished", true);
 
     given()
@@ -1283,7 +1282,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
 
   @Test
   public void testQueryByUnfinishedAsPost() {
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("unfinished", true);
 
     given()
@@ -1307,7 +1306,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
 
   @Test
   public void testQueryByProcessFinishedAsPost() {
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("processFinished", true);
 
     given()
@@ -1331,7 +1330,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
 
   @Test
   public void testQueryByProcessUnfinishedAsPost() {
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("processUnfinished", true);
 
     given()
@@ -1359,7 +1358,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskParentTaskIdAsPost() {
     String taskParentTaskId = MockProvider.EXAMPLE_HISTORIC_TASK_INST_PARENT_TASK_ID;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskParentTaskId", taskParentTaskId);
 
     given()
@@ -1387,7 +1386,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskDueDateAsPost() {
     String due = MockProvider.EXAMPLE_HISTORIC_TASK_INST_DUE_DATE;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskDueDate", DateTimeUtil.parseDate(due));
 
     given()
@@ -1415,7 +1414,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskDueDateBeforeAsPost() {
     String due = MockProvider.EXAMPLE_HISTORIC_TASK_INST_DUE_DATE;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskDueDateBefore", DateTimeUtil.parseDate(due));
 
     given()
@@ -1443,7 +1442,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskDueDateAfterAsPost() {
     String due = MockProvider.EXAMPLE_HISTORIC_TASK_INST_DUE_DATE;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskDueDateAfter", DateTimeUtil.parseDate(due));
 
     given()
@@ -1453,6 +1452,60 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
       .when().post(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
 
     verify(mockedQuery).taskDueAfter(DateTimeUtil.parseDate(due));
+  }
+
+  @Test
+  public void testQueryWithoutTaskDueDateQueryParameter() {
+    // given
+    mockedQuery = setUpMockHistoricTaskInstanceQuery(Collections.singletonList(
+        MockProvider.createMockHistoricTaskInstance(MockProvider.EXAMPLE_TENANT_ID, null)));
+
+    // when
+    Response response = given()
+          .queryParam("withoutTaskDueDate", true)
+        .then().expect()
+          .statusCode(Status.OK.getStatusCode())
+        .when()
+          .get(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
+
+    // then
+    verify(mockedQuery).withoutTaskDueDate();
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(1);
+
+    String returnedTaskDueDate = from(content).getString("[0].due");
+    assertThat(returnedTaskDueDate).isEqualTo(null);
+  }
+
+  @Test
+  public void testQueryWithoutTaskDueDatePostParameter() {
+    // given
+    mockedQuery = setUpMockHistoricTaskInstanceQuery(Collections.singletonList(
+        MockProvider.createMockHistoricTaskInstance(MockProvider.EXAMPLE_TENANT_ID, null)));
+    Map<String, Object> queryParameters = Collections.singletonMap("withoutTaskDueDate", (Object) true);
+
+    // when
+    Response response = given()
+          .contentType(POST_JSON_CONTENT_TYPE)
+          .body(queryParameters)
+        .expect()
+          .statusCode(Status.OK.getStatusCode())
+        .when()
+          .post(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
+
+    // then
+    verify(mockedQuery).withoutTaskDueDate();
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> definitions = from(content).getList("");
+    assertThat(definitions).hasSize(1);
+
+    String returnedTaskDueDate = from(content).getString("[0].due");
+    assertThat(returnedTaskDueDate).isEqualTo(null);
   }
 
   @Test
@@ -1471,7 +1524,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskFollowUpDateAsPost() {
     String followUp = MockProvider.EXAMPLE_HISTORIC_TASK_INST_FOLLOW_UP_DATE;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskFollowUpDate", DateTimeUtil.parseDate(followUp));
 
     given()
@@ -1499,7 +1552,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskFollowUpDateBeforeAsPost() {
     String followUp = MockProvider.EXAMPLE_HISTORIC_TASK_INST_FOLLOW_UP_DATE;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskFollowUpDateBefore", DateTimeUtil.parseDate(followUp));
 
     given()
@@ -1527,7 +1580,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByTaskFollowUpDateAfterAsPost() {
     String followUp = MockProvider.EXAMPLE_HISTORIC_TASK_INST_FOLLOW_UP_DATE;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskFollowUpDateAfter", DateTimeUtil.parseDate(followUp));
 
     given()
@@ -1572,7 +1625,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     public void testQueryByStartedBeforeAsPost() {
       String startedBefore = MockProvider.EXAMPLE_HISTORIC_TASK_INST_START_TIME;
 
-      Map<String, Object> params = new HashMap<String, Object>();
+      Map<String, Object> params = new HashMap<>();
       params.put("startedBefore", DateTimeUtil.parseDate(startedBefore));
 
       given()
@@ -1601,7 +1654,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     public void testQueryByStartedAfterAsPost() {
       String startedAfter = MockProvider.EXAMPLE_HISTORIC_TASK_INST_START_TIME;
 
-      Map<String, Object> params = new HashMap<String, Object>();
+      Map<String, Object> params = new HashMap<>();
       params.put("startedAfter", DateTimeUtil.parseDate(startedAfter));
 
       given()
@@ -1630,7 +1683,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     public void testQueryByFinishedBeforeAsPost() {
       String finishedBefore = MockProvider.EXAMPLE_HISTORIC_TASK_INST_END_TIME;
 
-      Map<String, Object> params = new HashMap<String, Object>();
+      Map<String, Object> params = new HashMap<>();
       params.put("finishedBefore", DateTimeUtil.parseDate(finishedBefore));
 
       given()
@@ -1659,7 +1712,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     public void testQueryByFinishedAfterAsPost() {
       String finishedAfter = MockProvider.EXAMPLE_HISTORIC_TASK_INST_END_TIME;
 
-      Map<String, Object> params = new HashMap<String, Object>();
+      Map<String, Object> params = new HashMap<>();
       params.put("finishedAfter", DateTimeUtil.parseDate(finishedAfter));
 
       given()
@@ -1695,9 +1748,9 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     String variableName = "varName";
     String variableValue = "varValue";
     String variableParameter = variableName + "_eq_" + variableValue;
-    
+
     String queryValue = variableParameter;
-    
+
     given()
     .queryParam("taskVariables", queryValue)
     .queryParam("variableValuesIgnoreCase", true)
@@ -1706,7 +1759,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
-    
+
     verify(mockedQuery).matchVariableValuesIgnoreCase();
     verify(mockedQuery).taskVariableValueEquals(variableName, variableValue);
   }
@@ -1716,9 +1769,9 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     String variableName = "varName";
     String variableValue = "varValue";
     String variableParameter = variableName + "_eq_" + variableValue;
-    
+
     String queryValue = variableParameter;
-    
+
     given()
     .queryParam("taskVariables", queryValue)
     .queryParam("variableNamesIgnoreCase", true)
@@ -1727,7 +1780,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
-    
+
     verify(mockedQuery).matchVariableNamesIgnoreCase();
     verify(mockedQuery).taskVariableValueEquals(variableName, variableValue);
   }
@@ -1737,9 +1790,9 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     String variableName = "varName";
     String variableValue = "varValue";
     String variableParameter = variableName + "_eq_" + variableValue;
-    
+
     String queryValue = variableParameter;
-    
+
     given()
     .queryParam("taskVariables", queryValue)
     .queryParam("variableNamesIgnoreCase", true)
@@ -1749,7 +1802,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     .statusCode(Status.OK.getStatusCode())
     .when()
     .get(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
-    
+
     verify(mockedQuery).matchVariableNamesIgnoreCase();
     verify(mockedQuery).matchVariableValuesIgnoreCase();
     verify(mockedQuery).taskVariableValueEquals(variableName, variableValue);
@@ -1760,15 +1813,15 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     String variableName = "varName";
     String variableValue = "varValue";
 
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", variableName);
     variableJson.put("operator", "eq");
     variableJson.put("value", variableValue);
 
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskVariables", variables);
 
     given()
@@ -1824,15 +1877,15 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     String variableName = "varName";
     String variableValue = "varValue";
 
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", variableName);
     variableJson.put("operator", invalidComparator);
     variableJson.put("value", variableValue);
 
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("taskVariables", variables);
 
     given()
@@ -1986,15 +2039,15 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     String variableName = "varName";
     String variableValue = "varValue";
 
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", variableName);
     variableJson.put("operator", "eq");
     variableJson.put("value", variableValue);
 
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("processVariables", variables);
 
     given()
@@ -2050,15 +2103,15 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     String variableName = "varName";
     String variableValue = "varValue";
 
-    Map<String, Object> variableJson = new HashMap<String, Object>();
+    Map<String, Object> variableJson = new HashMap<>();
     variableJson.put("name", variableName);
     variableJson.put("operator", invalidComparator);
     variableJson.put("value", variableValue);
 
-    List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
+    List<Map<String, Object>> variables = new ArrayList<>();
     variables.add(variableJson);
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("processVariables", variables);
 
     given()
@@ -2090,7 +2143,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByCaseDefinitionIdAsPost() {
     String caseDefinitionId = MockProvider.EXAMPLE_HISTORIC_TASK_INST_CASE_DEF_ID;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("caseDefinitionId", caseDefinitionId);
 
     given()
@@ -2118,7 +2171,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByCaseDefinitionKeyAsPost() {
     String caseDefinitionKey = "aCaseDefKey";
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("caseDefinitionKey", caseDefinitionKey);
 
     given()
@@ -2146,7 +2199,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByCaseDefinitionNameAsPost() {
     String caseDefinitionName = "aCaseDefName";
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("caseDefinitionName", caseDefinitionName);
 
     given()
@@ -2174,7 +2227,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByCaseInstanceIdAsPost() {
     String caseInstanceId = MockProvider.EXAMPLE_HISTORIC_TASK_INST_CASE_INST_ID;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("caseInstanceId", caseInstanceId);
 
     given()
@@ -2202,7 +2255,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testQueryByCaseExecutionIdAsPost() {
     String caseExecutionId = MockProvider.EXAMPLE_HISTORIC_TASK_INST_CASE_EXEC_ID;
 
-    Map<String, Object> params = new HashMap<String, Object>();
+    Map<String, Object> params = new HashMap<>();
     params.put("caseExecutionId", caseExecutionId);
 
     given()
@@ -2243,7 +2296,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   public void testTenantIdListPostParameter() {
     mockedQuery = setUpMockHistoricTaskInstanceQuery(createMockHistoricTaskInstancesTwoTenants());
 
-    Map<String, Object> queryParameters = new HashMap<String, Object>();
+    Map<String, Object> queryParameters = new HashMap<>();
     queryParameters.put("tenantIdIn", MockProvider.EXAMPLE_TENANT_ID_LIST.split(","));
 
     Response response = given()
@@ -2387,11 +2440,11 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     String taskDefinitionKey1 = "aTaskDefinitionKey";
     String taskDefinitionKey2 = "anotherTaskDefinitionKey";
 
-    List<String> taskDefinitionKeys = new ArrayList<String>();
+    List<String> taskDefinitionKeys = new ArrayList<>();
     taskDefinitionKeys.add(taskDefinitionKey1);
     taskDefinitionKeys.add(taskDefinitionKey2);
 
-    Map<String, Object> queryParameters = new HashMap<String, Object>();
+    Map<String, Object> queryParameters = new HashMap<>();
     queryParameters.put("taskDefinitionKeyIn", taskDefinitionKeys);
 
     given()


### PR DESCRIPTION
* adds query option to filter for (historic) tasks that do not have a due date
* adds query option to task query converter for task filters

related to CAM-13154