### PR TITLE
feat(engine): add valueNotLike filter for task variables

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/history/HistoricTaskInstanceQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/history/HistoricTaskInstanceQuery.java
@@ -285,6 +285,13 @@ public interface HistoricTaskInstanceQuery  extends Query<HistoricTaskInstanceQu
 
   /**
    * Only select historic task instances which are part of a process that have a variable
+   * with the given name and not matching the given value.
+   * The syntax is that of SQL: for example usage: valueNotLike(%value%)
+   * */
+  HistoricTaskInstanceQuery processVariableValueNotLike(String variableName, Object variableValue);
+
+  /**
+   * Only select historic task instances which are part of a process that have a variable
    * with the given name and a value greater than the given one.
    */
   HistoricTaskInstanceQuery processVariableValueGreaterThan(String variableName, Object variableValue);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -322,6 +322,11 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
     return this;
   }
 
+  public HistoricTaskInstanceQuery processVariableValueNotLike(String variableName, Object variableValue) {
+    addVariable(variableName, variableValue, QueryOperator.NOT_LIKE, false, true);
+    return this;
+  }
+
   @Override
   public HistoricTaskInstanceQuery processVariableValueGreaterThan(String variableName, Object variableValue) {
     addVariable(variableName, variableValue, QueryOperator.GREATER_THAN, false, true);
@@ -441,6 +446,8 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
           throw new ProcessEngineException("Booleans and null cannot be used in 'less than or equal' condition");
         case LIKE:
           throw new ProcessEngineException("Booleans and null cannot be used in 'like' condition");
+        case NOT_LIKE:
+          throw new ProcessEngineException("Booleans and null cannot be used in 'not like' condition");
         default:
           break;
       }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/QueryOperator.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/QueryOperator.java
@@ -19,7 +19,7 @@ package org.camunda.bpm.engine.impl;
 
 /**
  * Used to indicate the operator that should be used to comparing values in a query clause.
- * 
+ *
  * @author Frederik Heremans
  */
 public enum QueryOperator {
@@ -29,5 +29,6 @@ public enum QueryOperator {
   GREATER_THAN_OR_EQUAL,
   LESS_THAN,
   LESS_THAN_OR_EQUAL,
-  LIKE
+  LIKE,
+  NOT_LIKE
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/TaskQueryImpl.java
@@ -774,6 +774,12 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   }
 
   @Override
+  public TaskQuery processVariableValueNotLike(String variableName, String variableValue) {
+    addVariable(variableName, variableValue, QueryOperator.NOT_LIKE, false, true);
+    return this;
+  }
+
+  @Override
   public TaskQuery processVariableValueGreaterThan(String variableName, Object variableValue) {
     addVariable(variableName, variableValue, QueryOperator.GREATER_THAN, false, true);
   	return this;
@@ -1167,6 +1173,8 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
         throw new ProcessEngineException("Booleans and null cannot be used in 'less than or equal' condition");
       case LIKE:
         throw new ProcessEngineException("Booleans and null cannot be used in 'like' condition");
+      case NOT_LIKE:
+        throw new ProcessEngineException("Booleans and null cannot be used in 'not like' condition");
       default:
         break;
       }

--- a/engine/src/main/java/org/camunda/bpm/engine/task/TaskQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/task/TaskQuery.java
@@ -540,6 +540,12 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
 
   /**
    * Only select tasks which are part of a process that have a variable
+   * with the given name and not matching the given value.
+   * The syntax is that of SQL: for example usage: valueNotLike(%value%)*/
+  TaskQuery processVariableValueNotLike(String variableName, String variableValue);
+
+  /**
+   * Only select tasks which are part of a process that have a variable
    * with the given name and a value greater than the given one.
    */
   TaskQuery processVariableValueGreaterThan(String variableName, Object variableValue);

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Commons.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Commons.xml
@@ -26,7 +26,7 @@
   <!-- This snippet is used by all queries that allow filtering by variable values -->
   <sql id="variableValueConditions">
 
-    <if test="queryVariableValue.operatorName.equals('NOT_EQUALS')">NOT</if><!-- NOT_EQUALS uses the same conditions as EQUALS -->
+    <if test="queryVariableValue.operatorName.equals('NOT_EQUALS') || queryVariableValue.operatorName.equals('NOT_LIKE')">NOT</if><!-- NOT_EQUALS and NOT_LIKE use the same conditions as EQUALS and LIKE -->
     (
     <foreach collection="queryVariableValue.valueConditions" item="valueCondition" separator="or">
       <trim prefix="(" prefixOverrides="and" suffix=")">
@@ -54,18 +54,18 @@
                 <otherwise>#{valueCondition.textValue}</otherwise>
               </choose>
               ${collationForCaseSensitivity}
-              <if test="queryVariableValue.operatorName.equals('LIKE')">ESCAPE ${escapeChar}</if>
+              <if test="queryVariableValue.operatorName.contains('LIKE')">ESCAPE ${escapeChar}</if>
             </otherwise>
           </choose>
         </if>
         <if test="valueCondition.textValue2 != null &amp;&amp; !valueCondition.type.equals('string')">
           and ${varPrefix}TEXT2_ is not null and ${varPrefix}TEXT2_
           <choose>
-            <when test="queryVariableValue.operatorName.equals('LIKE')">LIKE</when>
+            <when test="queryVariableValue.operatorName.contains('LIKE')">LIKE</when>
             <otherwise><include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.executionVariableOperator" /></otherwise>
           </choose>
           #{valueCondition.textValue2}
-          <if test="queryVariableValue.operatorName.equals('LIKE')">ESCAPE ${escapeChar}</if>
+          <if test="queryVariableValue.operatorName.contains('LIKE')">ESCAPE ${escapeChar}</if>
         </if>
     
         <if test="valueCondition.longValue != null">

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/filter/FilterTaskQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/filter/FilterTaskQueryTest.java
@@ -82,18 +82,19 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
   protected List<String> testCandidateGroups = new ArrayList<String>();
   protected String[] testInstances = new String[] {"x", "y", "z"};
 
-  protected String[] variableNames = new String[] {"a", "b", "c", "d", "e", "f"};
-  protected Object[] variableValues = new Object[] {1, 2, "3", "4", 5, 6};
+  protected String[] variableNames = new String[] {"a", "b", "c", "d", "e", "f", "g"};
+  protected Object[] variableValues = new Object[] {1, 2, "3", "4", "5", 6, 7};
   protected QueryOperator[] variableOperators = new QueryOperator[] {
       QueryOperator.EQUALS,
       QueryOperator.GREATER_THAN_OR_EQUAL,
       QueryOperator.LESS_THAN,
       QueryOperator.LIKE,
+      QueryOperator.NOT_LIKE,
       QueryOperator.NOT_EQUALS,
       QueryOperator.LESS_THAN_OR_EQUAL
   };
-  protected boolean[] isTaskVariable = new boolean[] {true, true, false, false, false, false};
-  protected boolean[] isProcessVariable = new boolean[] {false, false, true, true, false, false};
+  protected boolean[] isTaskVariable = new boolean[] {true, true, false, false, false, false, false};
+  protected boolean[] isProcessVariable = new boolean[] {false, false, true, true, true, false, false};
   protected User testUser;
   protected Group testGroup;
 
@@ -216,8 +217,9 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
     query.taskVariableValueGreaterThanOrEquals(variableNames[1], variableValues[1]);
     query.processVariableValueLessThan(variableNames[2], variableValues[2]);
     query.processVariableValueLike(variableNames[3], (String) variableValues[3]);
-    query.caseInstanceVariableValueNotEquals(variableNames[4], variableValues[4]);
-    query.caseInstanceVariableValueLessThanOrEquals(variableNames[5], variableValues[5]);
+    query.processVariableValueNotLike(variableNames[4], (String) variableValues[4]);
+    query.caseInstanceVariableValueNotEquals(variableNames[5], variableValues[5]);
+    query.caseInstanceVariableValueLessThanOrEquals(variableNames[6], variableValues[6]);
 
     query.dueDate(testDate);
     query.dueDateExpression(testString);
@@ -1749,6 +1751,20 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
     tasks = filterService.list(filter.getId(), extendingQuery);
     assertTrue(tasks.contains(taskCamelCase));
     assertTrue(tasks.contains(taskLowerCase));
+    assertFalse(tasks.contains(taskWithNoVariable));
+
+    // not like case-sensitive for comparison
+    extendingQuery = taskService.createTaskQuery().processVariableValueNotLike(variableName, "somevariable%");
+    tasks = filterService.list(filter.getId(), extendingQuery);
+    assertTrue(tasks.contains(taskCamelCase));
+    assertFalse(tasks.contains(taskLowerCase));
+    assertFalse(tasks.contains(taskWithNoVariable));
+
+    // not like case-insensitive
+    extendingQuery = taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike(variableName, "somevariable%");
+    tasks = filterService.list(filter.getId(), extendingQuery);
+    assertFalse(tasks.contains(taskCamelCase));
+    assertFalse(tasks.contains(taskLowerCase));
     assertFalse(tasks.contains(taskWithNoVariable));
 
     // variable name case-insensitive

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryOrTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryOrTest.java
@@ -43,6 +43,7 @@ import org.camunda.bpm.engine.task.TaskQuery;
 import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.engine.variable.Variables;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.junit.After;
@@ -593,6 +594,34 @@ public class TaskQueryOrTest {
       .or()
         .taskVariableValueEquals("aLongValue", 789L)
         .taskVariableValueGreaterThan("anEvenLongerValue", 999L)
+      .endOr();
+
+    // then
+    assertEquals(2, query.count());
+  }
+
+  @Test
+  public void shouldReturnTasksWithProcessVariableValueNotLikeOrEquals() {
+    // given
+    BpmnModelInstance aProcessDefinition = Bpmn.createExecutableProcess("process")
+      .startEvent()
+      .userTask()
+      .endEvent()
+      .done();
+
+    repositoryService
+      .createDeployment()
+      .addModelInstance("foo.bpmn", aProcessDefinition)
+      .deploy();
+
+    runtimeService.startProcessInstanceByKey("process", Variables.createVariables().putValue("stringVar", "stringVal"));
+    runtimeService.startProcessInstanceByKey("process", Variables.createVariables().putValue("stringVar", "stringVar"));
+
+    // when
+    TaskQuery query = taskService.createTaskQuery()
+      .or()
+        .processVariableValueNotLike("stringVar", "%Val")
+        .processVariableValueEquals("stringVar", "stringVal")
       .endOr();
 
     // then

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryTest.java
@@ -17,6 +17,7 @@
 package org.camunda.bpm.engine.test.api.task;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.camunda.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.camunda.bpm.engine.test.api.runtime.TestOrderingUtil.taskByAssignee;
 import static org.camunda.bpm.engine.test.api.runtime.TestOrderingUtil.taskByCaseExecutionId;
@@ -1490,10 +1491,8 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     assertEquals(0, taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("nonExistingVar", "stringVal%".toLowerCase()).count());
 
     // test with null value
-    try {
-      taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", null).count();
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
+    assertThatThrownBy(() -> taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", null).count())
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources="org/camunda/bpm/engine/test/api/task/TaskQueryTest.testProcessVariableValueEquals.bpmn20.xml")

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryTest.java
@@ -1464,10 +1464,8 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     assertEquals(0, taskService.createTaskQuery().processVariableValueNotLike("nonExistingVar", "string%").count());
 
     // test with null value
-    try {
-      taskService.createTaskQuery().processVariableValueNotLike("stringVar", null).count();
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
+    assertThatThrownBy(() -> taskService.createTaskQuery().processVariableValueNotLike("stringVar", null).count())
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources="org/camunda/bpm/engine/test/api/task/TaskQueryTest.testProcessVariableValueEquals.bpmn20.xml")

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryTest.java
@@ -1445,6 +1445,59 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
   @Deployment(resources="org/camunda/bpm/engine/test/api/task/TaskQueryTest.testProcessVariableValueEquals.bpmn20.xml")
   @Test
+  public void testProcessVariableValueNotLike() throws Exception {
+
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("stringVar", "stringValue");
+    runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
+
+    assertEquals(0, taskService.createTaskQuery().processVariableValueNotLike("stringVar", "stringVal%").count());
+    assertEquals(0, taskService.createTaskQuery().processVariableValueNotLike("stringVar", "%ngValue").count());
+    assertEquals(0, taskService.createTaskQuery().processVariableValueNotLike("stringVar", "%ngVal%").count());
+
+    assertEquals(1, taskService.createTaskQuery().processVariableValueNotLike("stringVar", "stringVar%").count());
+    assertEquals(1, taskService.createTaskQuery().processVariableValueNotLike("stringVar", "%ngVar").count());
+    assertEquals(1, taskService.createTaskQuery().processVariableValueNotLike("stringVar", "%ngVar%").count());
+
+    assertEquals(1, taskService.createTaskQuery().processVariableValueNotLike("stringVar", "stringVal").count());
+    assertEquals(0, taskService.createTaskQuery().processVariableValueNotLike("nonExistingVar", "string%").count());
+
+    // test with null value
+    try {
+      taskService.createTaskQuery().processVariableValueNotLike("stringVar", null).count();
+      fail("expected exception");
+    } catch (final ProcessEngineException e) {/*OK*/}
+  }
+
+  @Deployment(resources="org/camunda/bpm/engine/test/api/task/TaskQueryTest.testProcessVariableValueEquals.bpmn20.xml")
+  @Test
+  public void testProcessVariableValueNotLikeIgnoreCase() throws Exception {
+
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("stringVar", "stringValue");
+    runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
+
+    assertEquals(1, taskService.createTaskQuery().processVariableValueNotLike("stringVar", "stringVal%".toLowerCase()).count());
+    assertEquals(0, taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", "stringVal%".toLowerCase()).count());
+    assertEquals(0, taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", "%ngValue".toLowerCase()).count());
+    assertEquals(0, taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", "%ngVal%".toLowerCase()).count());
+
+    assertEquals(1, taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", "stringVar%".toLowerCase()).count());
+    assertEquals(1, taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", "%ngVar".toLowerCase()).count());
+    assertEquals(1, taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", "%ngVar%".toLowerCase()).count());
+
+    assertEquals(1, taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", "stringVal".toLowerCase()).count());
+    assertEquals(0, taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("nonExistingVar", "stringVal%".toLowerCase()).count());
+
+    // test with null value
+    try {
+      taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", null).count();
+      fail("expected exception");
+    } catch (final ProcessEngineException e) {/*OK*/}
+  }
+
+  @Deployment(resources="org/camunda/bpm/engine/test/api/task/TaskQueryTest.testProcessVariableValueEquals.bpmn20.xml")
+  @Test
   public void testProcessVariableValueCompare() throws Exception {
 
   	Map<String, Object> variables = new HashMap<String, Object>();

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryTest.java
@@ -17,6 +17,7 @@
 package org.camunda.bpm.engine.test.standalone.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -146,10 +147,8 @@ public class HistoricTaskInstanceQueryTest extends PluggableProcessEngineTest {
     assertEquals(0, historyService.createHistoricTaskInstanceQuery().processVariableValueNotLike("nonExistingVar", "string%").count());
 
     // test with null value
-    try {
-      historyService.createHistoricTaskInstanceQuery().processVariableValueNotLike("requester", null).count();
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
+    assertThatThrownBy(() -> historyService.createHistoricTaskInstanceQuery().processVariableValueNotLike("requester", null).count())
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")


### PR DESCRIPTION
* adds query option to filter for (historic) tasks that do not have a variable
  with a value like the given one
* adds query option to JSON task query converter for the same in task filters

related to CAM-13172