### PR TITLE
feat(engine): add valueNotLike filter for task variables

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/task-query-params.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/task-query-params.ftl
@@ -590,7 +590,8 @@
               `gteq` - greater than or equal to;
               `lt` - lower than;
               `lteq` - lower than or equal to;
-              `like`.
+              `like`;
+              `notLike`.
               `key` and `value` may not contain underscore or comma characters." />
 
   <@lib.parameter name = "caseInstanceVariables"

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/task/TaskQueryDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/task/TaskQueryDto.ftl
@@ -591,7 +591,8 @@
                 `gteq` - greater than or equal to;
                 `lt` - lower than;
                 `lteq` - lower than or equal to;
-                `like`.
+                `like`;
+                `notLike`.
                 `key` and `value` may not contain underscore or comma characters." />
   
     <@lib.property

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/ConditionQueryParameterDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/ConditionQueryParameterDto.java
@@ -39,6 +39,7 @@ public class ConditionQueryParameterDto {
   public static final String LESS_THAN_OPERATOR_NAME = "lt";
   public static final String LESS_THAN_OR_EQUALS_OPERATOR_NAME = "lteq";
   public static final String LIKE_OPERATOR_NAME = "like";
+  public static final String NOT_LIKE_OPERATOR_NAME = "notLike";
 
   protected static final Map<String, QueryOperator> NAME_OPERATOR_MAP = new HashMap<>();
 
@@ -50,6 +51,7 @@ public class ConditionQueryParameterDto {
     NAME_OPERATOR_MAP.put(LESS_THAN_OPERATOR_NAME, QueryOperator.LESS_THAN);
     NAME_OPERATOR_MAP.put(LESS_THAN_OR_EQUALS_OPERATOR_NAME, QueryOperator.LESS_THAN_OR_EQUAL);
     NAME_OPERATOR_MAP.put(LIKE_OPERATOR_NAME, QueryOperator.LIKE);
+    NAME_OPERATOR_MAP.put(NOT_LIKE_OPERATOR_NAME, QueryOperator.NOT_LIKE);
   };
 
   protected static final Map<QueryOperator, String> OPERATOR_NAME_MAP = new HashMap<>();
@@ -62,6 +64,7 @@ public class ConditionQueryParameterDto {
     OPERATOR_NAME_MAP.put(QueryOperator.LESS_THAN, LESS_THAN_OPERATOR_NAME);
     OPERATOR_NAME_MAP.put(QueryOperator.LESS_THAN_OR_EQUAL, LESS_THAN_OR_EQUALS_OPERATOR_NAME);
     OPERATOR_NAME_MAP.put(QueryOperator.LIKE, LIKE_OPERATOR_NAME);
+    OPERATOR_NAME_MAP.put(QueryOperator.NOT_LIKE, NOT_LIKE_OPERATOR_NAME);
   };
 
   protected String operator;

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricTaskInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricTaskInstanceQueryDto.java
@@ -695,6 +695,8 @@ public class HistoricTaskInstanceQueryDto extends AbstractQueryDto<HistoricTaskI
           query.processVariableValueLessThanOrEquals(variableName, variableValue);
         } else if (op.equals(VariableQueryParameterDto.LIKE_OPERATOR_NAME)) {
           query.processVariableValueLike(variableName, String.valueOf(variableValue));
+        } else if (op.equals(VariableQueryParameterDto.NOT_LIKE_OPERATOR_NAME)) {
+          query.processVariableValueNotLike(variableName, String.valueOf(variableValue));
         } else {
           throw new InvalidRequestException(Status.BAD_REQUEST, "Invalid process variable comparator specified: " + op);
         }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/task/TaskQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/task/TaskQueryDto.java
@@ -1380,6 +1380,8 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
           query.processVariableValueLessThanOrEquals(variableName, variableValue);
         } else if (op.equals(VariableQueryParameterDto.LIKE_OPERATOR_NAME)) {
           query.processVariableValueLike(variableName, String.valueOf(variableValue));
+        } else if (op.equals(VariableQueryParameterDto.NOT_LIKE_OPERATOR_NAME)) {
+          query.processVariableValueNotLike(variableName, String.valueOf(variableValue));
         } else {
           throw new InvalidRequestException(Status.BAD_REQUEST, "Invalid process variable comparator specified: " + op);
         }

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/TaskRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/TaskRestServiceQueryTest.java
@@ -1503,6 +1503,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).processVariableValueNotEquals(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
   }
+
   @Test
   public void testProcessVariableValueLikeIgnoreCaseAsPost() {
     Map<String, Object> variableJson = new HashMap<>();
@@ -1528,6 +1529,33 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
     verify(mockQuery).matchVariableValuesIgnoreCase();
     verify(mockQuery).processVariableValueLike(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
+  }
+
+  @Test
+  public void testProcessVariableValueNotLikeIgnoreCaseAsPost() {
+    Map<String, Object> variableJson = new HashMap<>();
+    variableJson.put("name", SAMPLE_VAR_NAME);
+    variableJson.put("operator", "notLike");
+    variableJson.put("value", SAMPLE_VAR_VALUE.toLowerCase());
+
+    List<Map<String, Object>> variables = new ArrayList<>();
+    variables.add(variableJson);
+
+    Map<String, Object> json = new HashMap<>();
+    json.put("processVariables", variables);
+    json.put("variableValuesIgnoreCase", true);
+
+    given()
+      .contentType(POST_JSON_CONTENT_TYPE)
+      .body(json)
+      .header("accept", MediaType.APPLICATION_JSON)
+      .expect()
+      .statusCode(Status.OK.getStatusCode())
+      .when()
+      .post(TASK_QUERY_URL);
+
+    verify(mockQuery).matchVariableValuesIgnoreCase();
+    verify(mockQuery).processVariableValueNotLike(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricTaskInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricTaskInstanceRestServiceQueryTest.java
@@ -2016,6 +2016,25 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
   }
 
   @Test
+  public void testQueryByProcessVariableNotLike() {
+    String variableName = "varName";
+    String variableValue = "varValue";
+    String variableParameter = variableName + "_notLike_" + variableValue;
+
+    String queryValue = variableParameter;
+
+    given()
+      .queryParam("processVariables", queryValue)
+    .then()
+      .expect()
+        .statusCode(Status.OK.getStatusCode())
+      .when()
+        .get(HISTORIC_TASK_INSTANCE_RESOURCE_URL);
+
+    verify(mockedQuery).processVariableValueNotLike(variableName, variableValue);
+  }
+
+  @Test
   public void testQueryByProcessVariableNotEquals() {
     String variableName = "varName";
     String variableValue = "varValue";


### PR DESCRIPTION
* adds query option to filter for (historic) tasks that do not have a variable
  with a value like the given one
* adds NOT_LIKE operator to query parameter conditions
* adds OpenAPI description for the new option

related to CAM-13173