### PR TITLE
fix(engine-rest): return withoutDueDate option when enabled

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/task/TaskQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/task/TaskQueryDto.java
@@ -528,7 +528,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
   }
 
   @CamundaQueryParam(value = "withoutDueDate", converter = BooleanConverter.class)
-  public void setWithoutDueDate(boolean withoutDueDate) {
+  public void setWithoutDueDate(Boolean withoutDueDate) {
     this.withoutDueDate = withoutDueDate;
   }
 
@@ -960,7 +960,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     return dueDateExpression;
   }
 
-  public boolean getWithoutDueDate() {
+  public Boolean getWithoutDueDate() {
     return withoutDueDate;
   }
 
@@ -1578,7 +1578,9 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     dto.dueAfter = taskQuery.getDueAfter();
     dto.dueBefore = taskQuery.getDueBefore();
     dto.dueDate = taskQuery.getDueDate();
-    dto.withoutDueDate = taskQuery.isWithoutDueDate();
+    if (taskQuery.isWithoutDueDate()) {
+      dto.withoutDueDate = taskQuery.isWithoutDueDate();
+    }
 
     dto.followUpAfter = taskQuery.getFollowUpAfter();
 

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/FilterRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/FilterRestServiceInteractionTest.java
@@ -51,6 +51,7 @@ import static org.camunda.bpm.engine.rest.helper.TaskQueryMatcher.hasName;
 import static org.camunda.bpm.engine.variable.Variables.stringValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
@@ -296,7 +297,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
     when(query.getOwner()).thenReturn(MockProvider.EXAMPLE_TASK_OWNER);
     when(query.getParentTaskId()).thenReturn(MockProvider.EXAMPLE_TASK_PARENT_TASK_ID);
     when(query.getTenantIds()).thenReturn(MockProvider.EXAMPLE_TENANT_ID_LIST.split(","));
-    when(query.isWithoutDueDate()).thenReturn(true);
+    when(query.isWithoutDueDate()).thenReturn(false);
     when(query.isWithoutTenantId()).thenReturn(true);
     when(query.isAssignedInternal()).thenReturn(true);
     when(query.isUnassignedInternal()).thenReturn(false);
@@ -343,9 +344,27 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
       .body("query.owner", equalTo(MockProvider.EXAMPLE_TASK_OWNER))
       .body("query.parentTaskId", equalTo(MockProvider.EXAMPLE_TASK_PARENT_TASK_ID))
       .body("query.tenantIdIn", hasItems(MockProvider.EXAMPLE_TENANT_ID, MockProvider.ANOTHER_EXAMPLE_TENANT_ID))
-      .body("query.withoutDueDate", equalTo(true))
+      .body("query.withoutDueDate", nullValue())
       .body("query.assigned", equalTo(true))
       .body("query.unassigned", equalTo(false))
+    .when()
+      .get(SINGLE_FILTER_URL);
+
+  }
+
+  @Test
+  public void shouldReturnWithoutDueDateForFilterWithEnabledOptionInTaskQuery() {
+    TaskQueryImpl query = mock(TaskQueryImpl.class);
+    when(query.isWithoutDueDate()).thenReturn(true);
+
+    filterMock = MockProvider.createMockFilter(EXAMPLE_FILTER_ID, query);
+    when(filterServiceMock.getFilter(EXAMPLE_FILTER_ID)).thenReturn(filterMock);
+
+    given()
+      .pathParam("id", MockProvider.EXAMPLE_FILTER_ID)
+    .then().expect()
+      .statusCode(Status.OK.getStatusCode())
+      .body("query.withoutDueDate", equalTo(true))
     .when()
       .get(SINGLE_FILTER_URL);
 


### PR DESCRIPTION
* returns the withoutDueDate query option for task queries
  in filters only when enabled

related to CAM-13154