### PR TITLE
add additional constructor to SpringExpressionManager

### DIFF
--- a/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringExpressionManager.java
+++ b/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringExpressionManager.java
@@ -54,6 +54,15 @@ public class SpringExpressionManager extends ExpressionManager {
     super(beans);
     this.applicationContext = applicationContext;
   }
+  
+  /**
+   * @param applicationContext
+   *          the applicationContext to use.
+   * @see #SpringExpressionManager(ApplicationContext, Map)
+   */
+  public SpringExpressionManager(ApplicationContext applicationContext) {
+    this(applicationContext, null);
+  }
 
   @Override
   protected ELResolver createElResolver() {


### PR DESCRIPTION
I had to create a SpringExpressionManager Bean and found it very confusing, that the constructor has two arguments that are nullable and change semantics if they are  ...  so at least for the "regular" use case of adding all beans of the spring context to the Camunda expression management, I'd prefer to just pass the applicationContext.