### PR TITLE
CAM-13207 DMN execution context

### DIFF
--- a/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnDecisionContext.java
+++ b/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnDecisionContext.java
@@ -1,0 +1,22 @@
+package org.camunda.bpm.dmn.engine;
+
+import org.camunda.bpm.engine.variable.context.VariableContext;
+
+/**
+ * Worker responsible for evaluating a decision.
+ * Created during {@link DmnEngine#evaluateDecision(DmnDecision, VariableContext)}.
+ *
+ * Which concrete implementation is created can be configured in
+ */
+public interface DmnDecisionContext {
+
+  /**
+   * Evaluate a decision with the given {@link VariableContext}
+   *
+   * @param decision the decision to evaluate
+   * @param variableContext the available variable context
+   * @return the result of the decision evaluation
+   */
+  DmnDecisionResult evaluateDecision(DmnDecision decision, VariableContext variableContext);
+
+}

--- a/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnDecisionContextFactory.java
+++ b/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnDecisionContextFactory.java
@@ -16,23 +16,16 @@
  */
 package org.camunda.bpm.dmn.engine;
 
-import org.camunda.bpm.engine.variable.context.VariableContext;
+import org.camunda.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
 
 /**
- * Worker responsible for evaluating a decision.
- * Created during {@link DmnEngine#evaluateDecision(DmnDecision, VariableContext)}.
- *
- * Which concrete implementation is created can be configured in
+ * Creates a new {@link DmnDecisionContext}.
  */
-public interface DmnDecisionContext {
+public interface DmnDecisionContextFactory {
 
   /**
-   * Evaluate a decision with the given {@link VariableContext}
-   *
-   * @param decision the decision to evaluate
-   * @param variableContext the available variable context
-   * @return the result of the decision evaluation
+   * @return new instance of {@link DmnDecisionContext}, defaults to {@link org.camunda.bpm.dmn.engine.impl.DefaultDmnDecisionContext}.
    */
-  DmnDecisionResult evaluateDecision(DmnDecision decision, VariableContext variableContext);
+  DmnDecisionContext createDecisionContext(DefaultDmnEngineConfiguration dmnEngineConfiguration);
 
 }

--- a/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnEngineConfiguration.java
+++ b/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/DmnEngineConfiguration.java
@@ -121,7 +121,7 @@ public abstract class DmnEngineConfiguration {
    * Set the list of pre decision evaluation listeners. They will be notified before
    * the default decision evaluation listeners.
    *
-   * @param decisionTableEvaluationListeners the list of pre decision table evaluation listeners
+   * @param decisionEvaluationListeners the list of pre decision table evaluation listeners
    */
   public abstract void setCustomPreDecisionEvaluationListeners(List<DmnDecisionEvaluationListener> decisionEvaluationListeners);
 
@@ -151,7 +151,7 @@ public abstract class DmnEngineConfiguration {
    * Set the list of post decision evaluation listeners. They will be notified after
    * the default decision evaluation listeners.
    *
-   * @param decisionTableEvaluationListeners the list of post decision evaluation listeners
+   * @param decisionEvaluationListeners the list of post decision evaluation listeners
    * @return this configuration
    */
 

--- a/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DefaultDmnDecisionContext.java
+++ b/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DefaultDmnDecisionContext.java
@@ -56,7 +56,7 @@ public class DefaultDmnDecisionContext implements DmnDecisionContext {
   public DefaultDmnDecisionContext(DefaultDmnEngineConfiguration configuration) {
     evaluationListeners = configuration.getDecisionEvaluationListeners();
 
-    evaluationHandlers = new HashMap<Class<? extends DmnDecisionLogic>, DmnDecisionLogicEvaluationHandler>();
+    evaluationHandlers = new HashMap<>();
     evaluationHandlers.put(DmnDecisionTableImpl.class, new DecisionTableEvaluationHandler(configuration));
     evaluationHandlers.put(DmnDecisionLiteralExpressionImpl.class, new DecisionLiteralExpressionEvaluationHandler(configuration));
   }

--- a/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DefaultDmnDecisionContext.java
+++ b/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DefaultDmnDecisionContext.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.camunda.bpm.dmn.engine.DmnDecision;
+import org.camunda.bpm.dmn.engine.DmnDecisionContext;
 import org.camunda.bpm.dmn.engine.DmnDecisionLogic;
 import org.camunda.bpm.dmn.engine.DmnDecisionResult;
 import org.camunda.bpm.dmn.engine.delegate.DmnDecisionEvaluationListener;
@@ -41,7 +42,7 @@ import org.camunda.bpm.model.dmn.HitPolicy;
 /**
  * Context which evaluates a decision on a given input
  */
-public class DefaultDmnDecisionContext {
+public class DefaultDmnDecisionContext implements DmnDecisionContext {
 
   protected static final DmnEngineLogger LOG = DmnEngineLogger.ENGINE_LOGGER;
 
@@ -60,13 +61,7 @@ public class DefaultDmnDecisionContext {
     evaluationHandlers.put(DmnDecisionLiteralExpressionImpl.class, new DecisionLiteralExpressionEvaluationHandler(configuration));
   }
 
-  /**
-   * Evaluate a decision with the given {@link VariableContext}
-   *
-   * @param decision the decision to evaluate
-   * @param variableContext the available variable context
-   * @return the result of the decision evaluation
-   */
+  @Override
   public DmnDecisionResult evaluateDecision(DmnDecision decision, VariableContext variableContext) {
 
     if(decision.getKey() == null) {

--- a/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DefaultDmnEngine.java
+++ b/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DefaultDmnEngine.java
@@ -22,12 +22,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
-import org.camunda.bpm.dmn.engine.DmnDecision;
-import org.camunda.bpm.dmn.engine.DmnDecisionRequirementsGraph;
-import org.camunda.bpm.dmn.engine.DmnDecisionResult;
-import org.camunda.bpm.dmn.engine.DmnDecisionTableResult;
-import org.camunda.bpm.dmn.engine.DmnEngine;
-import org.camunda.bpm.dmn.engine.DmnEngineConfiguration;
+import org.camunda.bpm.dmn.engine.*;
 import org.camunda.bpm.dmn.engine.impl.spi.transform.DmnTransformer;
 import org.camunda.bpm.engine.variable.Variables;
 import org.camunda.bpm.engine.variable.context.VariableContext;
@@ -119,7 +114,7 @@ public class DefaultDmnEngine implements DmnEngine {
     ensureNotNull("variableContext", variableContext);
 
     if (decision instanceof DmnDecisionImpl && decision.isDecisionTable()) {
-      DefaultDmnDecisionContext decisionContext = new DefaultDmnDecisionContext(dmnEngineConfiguration);
+      DmnDecisionContext decisionContext = dmnEngineConfiguration.createDecisionContext();
 
       DmnDecisionResult decisionResult = decisionContext.evaluateDecision(decision, variableContext);
       return DmnDecisionTableResultImpl.wrap(decisionResult);
@@ -178,7 +173,7 @@ public class DefaultDmnEngine implements DmnEngine {
     ensureNotNull("variableContext", variableContext);
 
     if (decision instanceof DmnDecisionImpl) {
-      DefaultDmnDecisionContext decisionContext = new DefaultDmnDecisionContext(dmnEngineConfiguration);
+      DmnDecisionContext decisionContext = dmnEngineConfiguration.createDecisionContext();
       return decisionContext.evaluateDecision(decision, variableContext);
     }
     else {

--- a/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DefaultDmnEngine.java
+++ b/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DefaultDmnEngine.java
@@ -45,10 +45,12 @@ public class DefaultDmnEngine implements DmnEngine {
     this.transformer = dmnEngineConfiguration.getTransformer();
   }
 
+  @Override
   public DmnEngineConfiguration getConfiguration() {
     return dmnEngineConfiguration;
   }
 
+  @Override
   public List<DmnDecision> parseDecisions(InputStream inputStream) {
     ensureNotNull("inputStream", inputStream);
     return transformer.createTransform()
@@ -56,6 +58,7 @@ public class DefaultDmnEngine implements DmnEngine {
       .transformDecisions();
   }
 
+  @Override
   public List<DmnDecision> parseDecisions(DmnModelInstance dmnModelInstance) {
     ensureNotNull("dmnModelInstance", dmnModelInstance);
     return transformer.createTransform()
@@ -63,6 +66,7 @@ public class DefaultDmnEngine implements DmnEngine {
       .transformDecisions();
   }
 
+  @Override
   public DmnDecision parseDecision(String decisionKey, InputStream inputStream) {
     ensureNotNull("decisionKey", decisionKey);
     List<DmnDecision> decisions = parseDecisions(inputStream);
@@ -74,6 +78,7 @@ public class DefaultDmnEngine implements DmnEngine {
     throw LOG.unableToFindDecisionWithKey(decisionKey);
   }
 
+  @Override
   public DmnDecision parseDecision(String decisionKey, DmnModelInstance dmnModelInstance) {
     ensureNotNull("decisionKey", decisionKey);
     List<DmnDecision> decisions = parseDecisions(dmnModelInstance);
@@ -85,6 +90,7 @@ public class DefaultDmnEngine implements DmnEngine {
     throw LOG.unableToFindDecisionWithKey(decisionKey);
   }
 
+  @Override
   public DmnDecisionRequirementsGraph parseDecisionRequirementsGraph(InputStream inputStream) {
     ensureNotNull("inputStream", inputStream);
     return transformer.createTransform()
@@ -92,6 +98,7 @@ public class DefaultDmnEngine implements DmnEngine {
       .transformDecisionRequirementsGraph();
   }
 
+  @Override
   public DmnDecisionRequirementsGraph parseDecisionRequirementsGraph(DmnModelInstance dmnModelInstance) {
     ensureNotNull("dmnModelInstance", dmnModelInstance);
     return transformer.createTransform()
@@ -99,12 +106,14 @@ public class DefaultDmnEngine implements DmnEngine {
       .transformDecisionRequirementsGraph();
   }
 
+  @Override
   public DmnDecisionTableResult evaluateDecisionTable(DmnDecision decision, Map<String, Object> variables) {
     ensureNotNull("decision", decision);
     ensureNotNull("variables", variables);
     return evaluateDecisionTable(decision, Variables.fromMap(variables).asVariableContext());
   }
 
+  @Override
   public DmnDecisionTableResult evaluateDecisionTable(DmnDecision decision, VariableContext variableContext) {
     ensureNotNull("decision", decision);
     ensureNotNull("variableContext", variableContext);
@@ -120,11 +129,13 @@ public class DefaultDmnEngine implements DmnEngine {
     }
   }
 
+  @Override
   public DmnDecisionTableResult evaluateDecisionTable(String decisionKey, InputStream inputStream, Map<String, Object> variables) {
     ensureNotNull("variables", variables);
     return evaluateDecisionTable(decisionKey, inputStream, Variables.fromMap(variables).asVariableContext());
   }
 
+  @Override
   public DmnDecisionTableResult evaluateDecisionTable(String decisionKey, InputStream inputStream, VariableContext variableContext) {
     ensureNotNull("decisionKey", decisionKey);
     List<DmnDecision> decisions = parseDecisions(inputStream);
@@ -136,11 +147,13 @@ public class DefaultDmnEngine implements DmnEngine {
     throw LOG.unableToFindDecisionWithKey(decisionKey);
   }
 
+  @Override
   public DmnDecisionTableResult evaluateDecisionTable(String decisionKey, DmnModelInstance dmnModelInstance, Map<String, Object> variables) {
     ensureNotNull("variables", variables);
     return evaluateDecisionTable(decisionKey, dmnModelInstance, Variables.fromMap(variables).asVariableContext());
   }
 
+  @Override
   public DmnDecisionTableResult evaluateDecisionTable(String decisionKey, DmnModelInstance dmnModelInstance, VariableContext variableContext) {
     ensureNotNull("decisionKey", decisionKey);
     List<DmnDecision> decisions = parseDecisions(dmnModelInstance);
@@ -152,12 +165,14 @@ public class DefaultDmnEngine implements DmnEngine {
     throw LOG.unableToFindDecisionWithKey(decisionKey);
   }
 
+  @Override
   public DmnDecisionResult evaluateDecision(DmnDecision decision, Map<String, Object> variables) {
     ensureNotNull("decision", decision);
     ensureNotNull("variables", variables);
     return evaluateDecision(decision, Variables.fromMap(variables).asVariableContext());
   }
 
+  @Override
   public DmnDecisionResult evaluateDecision(DmnDecision decision, VariableContext variableContext) {
     ensureNotNull("decision", decision);
     ensureNotNull("variableContext", variableContext);
@@ -171,11 +186,13 @@ public class DefaultDmnEngine implements DmnEngine {
     }
   }
 
+  @Override
   public DmnDecisionResult evaluateDecision(String decisionKey, InputStream inputStream, Map<String, Object> variables) {
     ensureNotNull("variables", variables);
     return evaluateDecision(decisionKey, inputStream, Variables.fromMap(variables).asVariableContext());
   }
 
+  @Override
   public DmnDecisionResult evaluateDecision(String decisionKey, InputStream inputStream, VariableContext variableContext) {
     ensureNotNull("decisionKey", decisionKey);
     List<DmnDecision> decisions = parseDecisions(inputStream);
@@ -187,11 +204,13 @@ public class DefaultDmnEngine implements DmnEngine {
     throw LOG.unableToFindDecisionWithKey(decisionKey);
   }
 
+  @Override
   public DmnDecisionResult evaluateDecision(String decisionKey, DmnModelInstance dmnModelInstance, Map<String, Object> variables) {
     ensureNotNull("variables", variables);
     return evaluateDecision(decisionKey, dmnModelInstance, Variables.fromMap(variables).asVariableContext());
   }
 
+  @Override
   public DmnDecisionResult evaluateDecision(String decisionKey, DmnModelInstance dmnModelInstance, VariableContext variableContext) {
     ensureNotNull("decisionKey", decisionKey);
     List<DmnDecision> decisions = parseDecisions(dmnModelInstance);

--- a/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DefaultDmnEngineConfiguration.java
+++ b/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/DefaultDmnEngineConfiguration.java
@@ -16,10 +16,8 @@
  */
 package org.camunda.bpm.dmn.engine.impl;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
+import org.camunda.bpm.dmn.engine.DmnDecisionContext;
+import org.camunda.bpm.dmn.engine.DmnDecisionContextFactory;
 import org.camunda.bpm.dmn.engine.DmnEngine;
 import org.camunda.bpm.dmn.engine.DmnEngineConfiguration;
 import org.camunda.bpm.dmn.engine.delegate.DmnDecisionEvaluationListener;
@@ -39,6 +37,11 @@ import org.camunda.bpm.dmn.feel.impl.juel.FeelEngineFactoryImpl;
 import org.camunda.bpm.dmn.feel.impl.scala.ScalaFeelEngineFactory;
 import org.camunda.bpm.dmn.feel.impl.scala.function.FeelCustomFunctionProvider;
 import org.camunda.bpm.model.dmn.impl.DmnModelConstants;
+import org.camunda.commons.utils.EnsureUtil;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 public class DefaultDmnEngineConfiguration extends DmnEngineConfiguration {
 
@@ -80,6 +83,7 @@ public class DefaultDmnEngineConfiguration extends DmnEngineConfiguration {
   protected String defaultLiteralExpressionLanguage = null;
 
   protected DmnTransformer transformer = new DefaultDmnTransformer();
+  protected DmnDecisionContextFactory dmnDecisionContextFactory = DefaultDmnDecisionContext::new;
 
   @Override
   public DmnEngine buildEngine() {
@@ -174,7 +178,7 @@ public class DefaultDmnEngineConfiguration extends DmnEngineConfiguration {
   }
 
   protected void initElProvider() {
-    if(elProvider == null) {
+    if (elProvider == null) {
       elProvider = new JuelElProvider();
     }
   }
@@ -280,6 +284,7 @@ public class DefaultDmnEngineConfiguration extends DmnEngineConfiguration {
     setCustomPostDecisionEvaluationListeners(decisionEvaluationListeners);
     return this;
   }
+
   /**
    * The list of decision table evaluation listeners of the configuration. Contains
    * the pre, default and post decision table evaluation listeners. Is set during
@@ -603,4 +608,35 @@ public class DefaultDmnEngineConfiguration extends DmnEngineConfiguration {
     return this;
   }
 
+  /**
+   * @return factory used to create new decision context.
+   */
+  public DmnDecisionContextFactory getDmnDecisionContextFactory() {
+    return dmnDecisionContextFactory;
+  }
+
+  /**
+   * @param dmnDecisionContextFactory the factory to create new {@link DmnDecisionContext}
+   */
+  public void setDmnDecisionContextFactory(DmnDecisionContextFactory dmnDecisionContextFactory) {
+    this.dmnDecisionContextFactory = dmnDecisionContextFactory;
+  }
+
+  /**
+   * @param dmnDecisionContextFactory the factory to create new {@link DmnDecisionContext}
+   * @return this
+   * @see #setDmnDecisionContextFactory(DmnDecisionContextFactory)
+   */
+  public DefaultDmnEngineConfiguration dmnDecisionContextFactory(DmnDecisionContextFactory dmnDecisionContextFactory) {
+    setDmnDecisionContextFactory(dmnDecisionContextFactory);
+    return this;
+  }
+
+  /**
+   * @return a new {@link DmnDecisionContext instance.}
+   */
+  public DmnDecisionContext createDecisionContext() {
+    EnsureUtil.ensureNotNull("dmnDecisionContextFactory", dmnDecisionContextFactory);
+    return dmnDecisionContextFactory.createDecisionContext(this);
+  }
 }


### PR DESCRIPTION
In order to allow hooking into the den decision evaluation, the engine should not create the context via `new`. Instead, it should use a factory which can be configured via the engineConfiguration.

See https://jira.camunda.com/browse/CAM-13207

