### PR TITLE
Fix CAM-13205

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/deploy/cache/CmmnModelInstanceCache.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/deploy/cache/CmmnModelInstanceCache.java
@@ -17,8 +17,8 @@
 package org.camunda.bpm.engine.impl.persistence.deploy.cache;
 
 import org.camunda.bpm.engine.impl.cmmn.entity.repository.CaseDefinitionEntity;
-import org.camunda.bpm.engine.impl.dmn.entity.repository.DecisionDefinitionQueryImpl;
-import org.camunda.bpm.engine.repository.DecisionDefinition;
+import org.camunda.bpm.engine.impl.cmmn.entity.repository.CaseDefinitionQueryImpl;
+import org.camunda.bpm.engine.repository.CaseDefinition;
 import org.camunda.bpm.model.cmmn.Cmmn;
 import org.camunda.bpm.model.cmmn.CmmnModelInstance;
 
@@ -50,8 +50,8 @@ public class CmmnModelInstanceCache extends ModelInstanceCache<CmmnModelInstance
   }
 
   @Override
-  protected List<DecisionDefinition> getAllDefinitionsForDeployment(String deploymentId) {
-    return new DecisionDefinitionQueryImpl()
+  protected List<CaseDefinition> getAllDefinitionsForDeployment(String deploymentId) {
+    return new CaseDefinitionQueryImpl()
         .deploymentId(deploymentId)
         .list();
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/deploy/cache/DeploymentCache.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/deploy/cache/DeploymentCache.java
@@ -309,13 +309,13 @@ public class DeploymentCache {
 
   public void removeDeployment(String deploymentId) {
     bpmnModelInstanceCache.removeAllDefinitionsByDeploymentId(deploymentId);
-    if(Context.getProcessEngineConfiguration().isCmmnEnabled()) {
+    if (Context.getProcessEngineConfiguration().isCmmnEnabled()) {
       cmmnModelInstanceCache.removeAllDefinitionsByDeploymentId(deploymentId);
     }
-    if(Context.getProcessEngineConfiguration().isDmnEnabled()) {
+    if (Context.getProcessEngineConfiguration().isDmnEnabled()) {
       dmnModelInstanceCache.removeAllDefinitionsByDeploymentId(deploymentId);
+      removeAllDecisionRequirementsDefinitionsByDeploymentId(deploymentId);
     }
-    removeAllDecisionRequirementsDefinitionsByDeploymentId(deploymentId);
   }
 
   protected void removeAllDecisionRequirementsDefinitionsByDeploymentId(String deploymentId) {

--- a/engine/src/test/java/org/camunda/bpm/application/impl/embedded/EmbeddedProcessApplicationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/application/impl/embedded/EmbeddedProcessApplicationTest.java
@@ -16,10 +16,7 @@
  */
 package org.camunda.bpm.application.impl.embedded;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.List;
 import java.util.Set;
@@ -29,6 +26,7 @@ import org.camunda.bpm.container.RuntimeContainerDelegate;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.impl.ProcessEngineImpl;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.repository.Deployment;
 import org.camunda.bpm.engine.repository.ProcessApplicationDeployment;
 import org.camunda.bpm.engine.repository.Resource;
@@ -106,6 +104,29 @@ public class EmbeddedProcessApplicationTest extends PluggableProcessEngineTest {
     assertTrue(configuration.isJobExecutorPreferTimerJobs());
     assertTrue(configuration.isJobExecutorAcquireByDueDate());
     assertEquals(5, configuration.getJdbcMaxActiveConnections());
+
+    processApplication.undeploy();
+
+  }
+
+  @Test
+  public void testDeployAppWithoutDmn() {
+
+    TestApplicationWithoutDmn processApplication = new TestApplicationWithoutDmn();
+    processApplication.deploy();
+
+    ProcessEngine processEngine = BpmPlatform.getProcessEngineService().getProcessEngine("embeddedEngine");
+    assertNotNull(processEngine);
+    assertEquals("embeddedEngine", processEngine.getName());
+
+    ProcessEngineConfigurationImpl configuration = ((ProcessEngineImpl) processEngine).getProcessEngineConfiguration();
+
+    // assert engine properties specified
+    assertTrue(configuration.isJobExecutorDeploymentAware());
+    assertTrue(configuration.isJobExecutorPreferTimerJobs());
+    assertTrue(configuration.isJobExecutorAcquireByDueDate());
+    assertEquals(5, configuration.getJdbcMaxActiveConnections());
+    assertFalse(configuration.isDmnEnabled());
 
     processApplication.undeploy();
 

--- a/engine/src/test/java/org/camunda/bpm/application/impl/embedded/TestApplicationWithoutDmn.java
+++ b/engine/src/test/java/org/camunda/bpm/application/impl/embedded/TestApplicationWithoutDmn.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.application.impl.embedded;
+
+import org.camunda.bpm.application.ProcessApplication;
+import org.camunda.bpm.application.impl.EmbeddedProcessApplication;
+
+/**
+ * @author Daniel Meyer
+ *
+ */
+@ProcessApplication(
+    name="test-app",
+    deploymentDescriptors={"org/camunda/bpm/application/impl/embedded/deployment-without-dmn.xml"}
+)
+public class TestApplicationWithoutDmn extends EmbeddedProcessApplication {
+	public TestApplicationWithoutDmn() {
+		setDefaultDeployToEngineName("embeddedEngine");
+	}
+}

--- a/engine/src/test/resources/org/camunda/bpm/application/impl/embedded/deployment-without-dmn.xml
+++ b/engine/src/test/resources/org/camunda/bpm/application/impl/embedded/deployment-without-dmn.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<process-application
+  xmlns="http://www.camunda.org/schema/1.0/ProcessApplication"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.camunda.org/schema/1.0/ProcessApplication http://www.camunda.org/schema/1.0/ProcessApplication ">
+
+  <process-engine name="embeddedEngine">
+
+    <configuration>org.camunda.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration</configuration>
+    
+    <properties>
+        <property name="jdbcUrl">jdbc:h2:mem:embeddedEngine</property>
+        <property name="jobExecutorDeploymentAware">true</property>
+        <property name="jobExecutorPreferTimerJobs">true</property>
+        <property name="jobExecutorAcquireByDueDate">true</property>
+        <property name="jdbcMaxActiveConnections">5</property>
+        <property name="dmnEnabled">false</property>
+    </properties>
+    
+  </process-engine>
+
+    <process-archive name="pa1">
+
+        <resource>org/camunda/bpm/application/impl/embedded/StartToEndTest.testStartToEnd.bpmn20.xml</resource>
+
+        <properties>
+            <property name="isScanForProcessDefinitions">false</property>
+            <property name="isDeleteUponUndeploy">true</property>
+        </properties>
+
+    </process-archive>
+
+</process-application>


### PR DESCRIPTION
- don't attempt to remove decision requirements if DMN is disabled.
- extend existing unit test EmbeddedProcessApplicationTest.testDeployAppWithCustomEngine to reproduce the problem (without the above change it would *not* fail, but still log an exception).
- also fix a related bug in CmmnModelInstanceCache: getAllDefinitionsForDeployment erroneously returned DMN instead of CMMN definitions.
- additionally clarify error message in DeployProcessArchiveStep when the default process *engine* cannot be found.