### PR TITLE
CAM-13018: fix(engine): validate telemetry data

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -343,6 +343,18 @@
 
   <build>
     <!-- filter test configurations to inject properties -->
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>org/camunda/bpm/engine/product-info.properties</include>
+        </includes>
+      </resource>
+    </resources>
     <testResources>
       <testResource>
         <directory>src/test/resources</directory>

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -2745,7 +2745,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
 
     ProcessEngineDetails engineInfo = ParseUtil
-        .parseProcessEngineVersion(ProcessEngineConfigurationImpl.class.getPackage().getImplementationVersion(), true);
+        .parseProcessEngineVersion(true);
 
     Product product = new Product(PRODUCT_NAME, engineInfo.getVersion(), engineInfo.getEdition(), internals);
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryLogger.java
@@ -110,6 +110,11 @@ public class TelemetryLogger extends ProcessEngineLogger {
         "016", "{} request was successful.", getInitialMessageTextCapitalized(isInitialMessage));
   }
 
+  public void sendingTelemetryDataFails() {
+    logWarn("017","Cannot send the telemetry task data. Some of the data is invalid. " +
+        "Please check the product name, version, edition and installation id.");
+  }
+
   protected String getInitialMessageText(boolean isInitialMessage) {
     return isInitialMessage ? "initial " : "";
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryLogger.java
@@ -18,6 +18,8 @@ package org.camunda.bpm.engine.impl.telemetry;
 
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
+import org.camunda.bpm.engine.impl.telemetry.dto.Data;
+import org.camunda.bpm.engine.impl.telemetry.dto.Product;
 
 public class TelemetryLogger extends ProcessEngineLogger {
 
@@ -110,9 +112,17 @@ public class TelemetryLogger extends ProcessEngineLogger {
         "016", "{} request was successful.", getInitialMessageTextCapitalized(isInitialMessage));
   }
 
-  public void sendingTelemetryDataFails() {
+  public void sendingTelemetryDataFails(Data productData) {
+    Product product = productData.getProduct();
+    String installationId = productData.getInstallation();
     logWarn("017","Cannot send the telemetry task data. Some of the data is invalid. " +
         "Please check the product name, version, edition and installation id.");
+    logDebug("018", "Cannot send the telemetry task data. Some of the following product data is invalid: " +
+        "'{}' (name), '{}' (version), '{}' (edition), '{}' (UUIDv4 installation id). Please check it for errors.",
+      product.getName(),
+      product.getVersion(),
+      product.getEdition(),
+      installationId);
   }
 
   protected String getInitialMessageText(boolean isInitialMessage) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/TelemetryLogger.java
@@ -115,10 +115,10 @@ public class TelemetryLogger extends ProcessEngineLogger {
   public void sendingTelemetryDataFails(Data productData) {
     Product product = productData.getProduct();
     String installationId = productData.getInstallation();
-    logWarn("017","Cannot send the telemetry task data. Some of the data is invalid. " +
-        "Please check the product name, version, edition and installation id.");
-    logDebug("018", "Cannot send the telemetry task data. Some of the following product data is invalid: " +
-        "'{}' (name), '{}' (version), '{}' (edition), '{}' (UUIDv4 installation id). Please check it for errors.",
+    logWarn("017","Cannot send the telemetry data. Some of the data is invalid. " +
+        "Set this logger to DEBUG/FINE to see more details.");
+    logDebug("018", "Cannot send the telemetry task data. The following values must be non-empty " +
+        "Strings: '{}' (name), '{}' (version), '{}' (edition), '{}' (UUIDv4 installation id).",
       product.getName(),
       product.getVersion(),
       product.getEdition(),

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/reporter/TelemetrySendingTask.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/telemetry/reporter/TelemetrySendingTask.java
@@ -20,11 +20,11 @@ import static org.camunda.bpm.engine.impl.util.ConnectUtil.METHOD_NAME_POST;
 import static org.camunda.bpm.engine.impl.util.ConnectUtil.PARAM_NAME_RESPONSE_STATUS_CODE;
 import static org.camunda.bpm.engine.impl.util.ConnectUtil.addRequestTimeoutConfiguration;
 import static org.camunda.bpm.engine.impl.util.ConnectUtil.assembleRequestParameters;
+import static org.camunda.bpm.engine.impl.util.StringUtil.hasText;
 import static org.camunda.bpm.engine.management.Metrics.ACTIVTY_INSTANCE_START;
 import static org.camunda.bpm.engine.management.Metrics.EXECUTED_DECISION_ELEMENTS;
 import static org.camunda.bpm.engine.management.Metrics.EXECUTED_DECISION_INSTANCES;
 import static org.camunda.bpm.engine.management.Metrics.ROOT_PROCESS_INSTANCE_START;
-import static org.springframework.util.StringUtils.hasText;
 
 import java.net.HttpURLConnection;
 import java.util.HashMap;
@@ -64,7 +64,7 @@ public class TelemetrySendingTask extends TimerTask {
   protected static final TelemetryLogger LOG = ProcessEngineLogger.TELEMETRY_LOGGER;
   protected static final Set<String> METRICS_TO_REPORT = new HashSet<>();
   protected static final String TELEMETRY_INIT_MESSAGE_SENT_NAME = "camunda.telemetry.initial.message.sent";
-  protected static final String UUID4_PATTERN = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}";
+  protected static final String UUID4_PATTERN = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}";
 
   static {
     METRICS_TO_REPORT.add(ROOT_PROCESS_INSTANCE_START);
@@ -335,7 +335,7 @@ public class TelemetrySendingTask extends TimerTask {
         }
       } while (!requestSuccessful && triesLeft > 0);
     } else {
-      LOG.sendingTelemetryDataFails();
+      LOG.sendingTelemetryDataFails(staticData);
     }
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/EngineUtilLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/EngineUtilLogger.java
@@ -237,6 +237,6 @@ public class EngineUtilLogger extends ProcessEngineLogger {
 
   public void logMissingPropertiesFile(String file) {
     logWarn("032", "Could not find the '{}' file on the classpath. " +
-      "This file is used to determine the product version. If you have removed it, please restore it.", file);
+      "If you have removed it, please restore it.", file);
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/EngineUtilLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/EngineUtilLogger.java
@@ -234,4 +234,9 @@ public class EngineUtilLogger extends ProcessEngineLogger {
         + "This indicates that this is not supported by your JAXP implementation: {}",
         e.getMessage());
   }
+
+  public void logMissingProductInformationPropertiesFile() {
+    logWarn("032", "Could not find the product-info.properties file. " +
+      "This file is used to determine the product version. If you have removed it, please restore it.");
+  }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/EngineUtilLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/EngineUtilLogger.java
@@ -235,8 +235,8 @@ public class EngineUtilLogger extends ProcessEngineLogger {
         e.getMessage());
   }
 
-  public void logMissingProductInformationPropertiesFile() {
-    logWarn("032", "Could not find the product-info.properties file. " +
-      "This file is used to determine the product version. If you have removed it, please restore it.");
+  public void logMissingPropertiesFile(String file) {
+    logWarn("032", "Could not find the '{}' file on the classpath. " +
+      "This file is used to determine the product version. If you have removed it, please restore it.", file);
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/ParseUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/ParseUtil.java
@@ -104,13 +104,13 @@ public class ParseUtil {
     }
   }
 
-  public static ProcessEngineDetails parseProcessEngineVersion(String packageImplementationVersion, boolean trimSuffixEE) {
-    String version = packageImplementationVersion;
-    String edition = ProcessEngineDetails.EDITION_COMMUNITY;
+  public static ProcessEngineDetails parseProcessEngineVersion(boolean trimSuffixEE) {
+    String version = ProductPropertiesUtil.getProductVersion();
+    return parseProcessEngineVersion(version, trimSuffixEE);
+  }
 
-    if (version == null){
-      version = ProductPropertiesUtil.getProductVersion();
-    }
+  public static ProcessEngineDetails parseProcessEngineVersion(String version, boolean trimSuffixEE) {
+    String edition = ProcessEngineDetails.EDITION_COMMUNITY;
 
     if (version.contains("-ee")) {
       edition = ProcessEngineDetails.EDITION_ENTERPRISE;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/ParseUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/ParseUtil.java
@@ -108,7 +108,11 @@ public class ParseUtil {
     String version = packageImplementationVersion;
     String edition = ProcessEngineDetails.EDITION_COMMUNITY;
 
-    if (version != null && version.contains("-ee")) {
+    if (version == null){
+      version = ProductPropertiesUtil.getProductVersion();
+    }
+
+    if (version.contains("-ee")) {
       edition = ProcessEngineDetails.EDITION_ENTERPRISE;
       if (trimSuffixEE) {
         version = version.replace("-ee", ""); // trim `-ee` suffix

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/ProductPropertiesUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/ProductPropertiesUtil.java
@@ -34,7 +34,9 @@ public class ProductPropertiesUtil {
    * @return the current version of the product (e.g. <code>7.15.0-SNAPSHOT</code>)
    */
   public static String getProductVersion() {
-    return INSTANCE.getProperty(VERSION_PROPERTY);
+    // in case the `product-info.properties` file is missing,
+    // try to get the product version from the manifest
+    return INSTANCE.getProperty(VERSION_PROPERTY, ProductPropertiesUtil.class.getPackage().getImplementationVersion());
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/ProductPropertiesUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/ProductPropertiesUtil.java
@@ -1,0 +1,37 @@
+package org.camunda.bpm.engine.impl.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.camunda.bpm.engine.impl.ProcessEngineLogger;
+
+/**
+ * Provides product information data loaded from a *.properties file.
+ */
+public class ProductPropertiesUtil {
+
+  protected static final EngineUtilLogger LOG = ProcessEngineLogger.UTIL_LOGGER;
+  protected static final String PROPERTIES_FILE_PATH = "/org/camunda/bpm/engine/product-info.properties";
+  protected static final String VERSION_PROPERTY = "camunda.version";
+  protected static final Properties INSTANCE = getProperties();
+
+  protected static Properties getProperties() {
+    Properties productProperties = new Properties();
+    try (InputStream inputStream = ProductPropertiesUtil.class.getResourceAsStream(PROPERTIES_FILE_PATH)) {
+      productProperties.load(inputStream);
+    } catch (IOException e) {
+      LOG.logMissingProductInformationPropertiesFile();
+    }
+
+    return productProperties;
+  }
+
+  /**
+   * @return the current version of the product (e.g. <code>7.15.0-SNAPSHOT</code>)
+   */
+  public static String getProductVersion() {
+    return INSTANCE.getProperty(VERSION_PROPERTY);
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/PropertiesUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/PropertiesUtil.java
@@ -16,25 +16,27 @@
  */
 package org.camunda.bpm.engine.impl.util;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 
-/**
- * Provides product information data loaded from a *.properties file.
- */
-public class ProductPropertiesUtil {
+import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 
-  protected static final String PROPERTIES_FILE_PATH = "/org/camunda/bpm/engine/product-info.properties";
-  protected static final String VERSION_PROPERTY = "camunda.version";
-  protected static final Properties INSTANCE = PropertiesUtil.getProperties(PROPERTIES_FILE_PATH);
+public class PropertiesUtil {
 
-  protected ProductPropertiesUtil() {
-  }
+  protected static final EngineUtilLogger LOG = ProcessEngineLogger.UTIL_LOGGER;
 
   /**
-   * @return the current version of the product (e.g. <code>7.15.0-SNAPSHOT</code>)
+   * Reads a <code>.properties</code> file from the classpath and provides a {@link Properties} object.
    */
-  public static String getProductVersion() {
-    return INSTANCE.getProperty(VERSION_PROPERTY);
-  }
+  public static Properties getProperties(String propertiesFile) {
+    Properties productProperties = new Properties();
+    try (InputStream inputStream = ProductPropertiesUtil.class.getResourceAsStream(propertiesFile)) {
+      productProperties.load(inputStream);
+    } catch (IOException e) {
+      LOG.logMissingPropertiesFile(propertiesFile);
+    }
 
+    return productProperties;
+  }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/PropertiesUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/PropertiesUtil.java
@@ -16,7 +16,6 @@
  */
 package org.camunda.bpm.engine.impl.util;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/StringUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/StringUtil.java
@@ -199,6 +199,14 @@ public final class StringUtil {
     });
   }
 
+  /**
+   * @param string the String to check.
+   * @return a boolean <code>TRUE</code> if the String is not null and not empty. <code>FALSE</code> otherwise.
+   */
+  public boolean hasText(String string) {
+    return string != null && !string.isEmpty();
+  }
+
   public static String join(Iterator<String> iterator) {
     StringBuilder builder = new StringBuilder();
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/StringUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/StringUtil.java
@@ -203,7 +203,7 @@ public final class StringUtil {
    * @param string the String to check.
    * @return a boolean <code>TRUE</code> if the String is not null and not empty. <code>FALSE</code> otherwise.
    */
-  public boolean hasText(String string) {
+  public static boolean hasText(String string) {
     return string != null && !string.isEmpty();
   }
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/product-info.properties
+++ b/engine/src/main/resources/org/camunda/bpm/engine/product-info.properties
@@ -1,0 +1,1 @@
+camunda.version=${project.version}

--- a/engine/src/test/java/org/camunda/bpm/engine/impl/util/PropertiesUtilTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/impl/util/PropertiesUtilTest.java
@@ -18,8 +18,6 @@ package org.camunda.bpm.engine.impl.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Properties;
-
 import org.camunda.commons.testing.ProcessEngineLoggingRule;
 import org.camunda.commons.testing.WatchLogger;
 import org.junit.Rule;

--- a/engine/src/test/java/org/camunda/bpm/engine/impl/util/PropertiesUtilTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/impl/util/PropertiesUtilTest.java
@@ -16,29 +16,32 @@
  */
 package org.camunda.bpm.engine.impl.util;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Properties;
 
-import org.camunda.bpm.engine.impl.ProcessEngineLogger;
+import org.camunda.commons.testing.ProcessEngineLoggingRule;
+import org.camunda.commons.testing.WatchLogger;
+import org.junit.Rule;
+import org.junit.Test;
 
-public class PropertiesUtil {
+public class PropertiesUtilTest {
 
-  protected static final EngineUtilLogger LOG = ProcessEngineLogger.UTIL_LOGGER;
+  @Rule
+  public ProcessEngineLoggingRule loggingRule = new ProcessEngineLoggingRule();
 
-  /**
-   * Reads a <code>.properties</code> file from the classpath and provides a {@link Properties} object.
-   */
-  public static Properties getProperties(String propertiesFile) {
-    Properties productProperties = new Properties();
-    try (InputStream inputStream = ProductPropertiesUtil.class.getResourceAsStream(propertiesFile)) {
-      productProperties.load(inputStream);
-    } catch (IOException | NullPointerException e) {
-      // if `propertiesFile` is null, the file is missing, or an error occurs during reading
-      LOG.logMissingPropertiesFile(propertiesFile);
-    }
+  @Test
+  @WatchLogger(loggerNames = {"org.camunda.bpm.engine.util"}, level = "DEBUG")
+  public void shouldLogMissingFile() {
+    // given
+    String invalidFile = "/missingProps.properties";
 
-    return productProperties;
+    // when
+    PropertiesUtil.getProperties(invalidFile);
+
+    // then
+    String logMessage = String.format("Could not find the '%s' file on the classpath. " +
+        "If you have removed it, please restore it.", invalidFile);
+    assertThat(loggingRule.getFilteredLog(logMessage)).hasSize(1);
   }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/ProcessEngineDetailsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/ProcessEngineDetailsTest.java
@@ -21,7 +21,10 @@ import static org.camunda.bpm.engine.impl.util.ParseUtil.parseProcessEngineVersi
 import static org.camunda.bpm.engine.impl.util.ProcessEngineDetails.EDITION_COMMUNITY;
 import static org.camunda.bpm.engine.impl.util.ProcessEngineDetails.EDITION_ENTERPRISE;
 
+import java.io.IOException;
+
 import org.camunda.bpm.engine.impl.util.ProcessEngineDetails;
+import org.camunda.bpm.engine.test.util.TestconfigProperties;
 import org.junit.Test;
 
 public class ProcessEngineDetailsTest {
@@ -146,5 +149,17 @@ public class ProcessEngineDetailsTest {
     // then
     assertThat(engineInfo.getVersion()).isEqualTo("7.14.1-ee");
     assertThat(engineInfo.getEdition()).isEqualTo(EDITION_ENTERPRISE);
+  }
+
+  @Test
+  public void shouldAssertCurrentProcessEngineVersionFromPropertiesFile() throws IOException {
+    // when
+    // the version is not available from the package
+    ProcessEngineDetails engineInfo = parseProcessEngineVersion(null, false);
+
+    // then
+    // the version is read from the product-info.properties file
+    assertThat(engineInfo.getVersion()).isEqualTo(TestconfigProperties.getEngineVersion());
+    assertThat(engineInfo.getEdition()).isEqualTo(EDITION_COMMUNITY);
   }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/ProcessEngineDetailsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/ProcessEngineDetailsTest.java
@@ -21,8 +21,6 @@ import static org.camunda.bpm.engine.impl.util.ParseUtil.parseProcessEngineVersi
 import static org.camunda.bpm.engine.impl.util.ProcessEngineDetails.EDITION_COMMUNITY;
 import static org.camunda.bpm.engine.impl.util.ProcessEngineDetails.EDITION_ENTERPRISE;
 
-import java.io.IOException;
-
 import org.camunda.bpm.engine.impl.util.ProcessEngineDetails;
 import org.camunda.bpm.engine.test.util.TestconfigProperties;
 import org.junit.Test;
@@ -152,10 +150,10 @@ public class ProcessEngineDetailsTest {
   }
 
   @Test
-  public void shouldAssertCurrentProcessEngineVersionFromPropertiesFile() throws IOException {
+  public void shouldAssertCurrentProcessEngineVersionFromPropertiesFile() {
     // when
     // the version is not available from the package
-    ProcessEngineDetails engineInfo = parseProcessEngineVersion(null, false);
+    ProcessEngineDetails engineInfo = parseProcessEngineVersion(false);
 
     // then
     // the version is read from the product-info.properties file

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryReporterTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/mgmt/telemetry/TelemetryReporterTest.java
@@ -1368,10 +1368,10 @@ public class TelemetryReporterTest {
 
     // then
     verify(0, postRequestedFor(urlEqualTo(TELEMETRY_ENDPOINT_PATH)));
-    String warnLogMessage = "Cannot send the telemetry task data. Some of the data is invalid. " +
-        "Please check the product name, version, edition and installation id.";
-    String debugLogMessage = String.format("Cannot send the telemetry task data. Some of the following product data is " +
-      "invalid: '%s' (name), '%s' (version), '%s' (edition), '%s' (UUIDv4 installation id). Please check it for errors.",
+    String warnLogMessage = "Cannot send the telemetry data. Some of the data is invalid. " +
+        "Set this logger to DEBUG/FINE to see more details.";
+    String debugLogMessage = String.format("Cannot send the telemetry task data. The following values must be " +
+        "non-empty Strings: '%s' (name), '%s' (version), '%s' (edition), '%s' (UUIDv4 installation id).",
       name,
       version,
       edition,

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/db/SchemaLogEnsureSqlScriptTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/db/SchemaLogEnsureSqlScriptTest.java
@@ -18,7 +18,6 @@ package org.camunda.bpm.engine.test.standalone.db;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,7 +47,7 @@ public class SchemaLogEnsureSqlScriptTest extends SchemaLogTestCase {
   }
 
   @Test
-  public void ensureUpgradeScriptsUpdateSchemaLogVersion() throws IOException {
+  public void ensureUpgradeScriptsUpdateSchemaLogVersion() {
     List<String> scriptsForDB = new ArrayList<>();
     for (String file : folderContents.get(UPGRADE_SCRIPT_FOLDER)) {
       if (file.startsWith(dataBaseType)) {
@@ -109,7 +108,7 @@ public class SchemaLogEnsureSqlScriptTest extends SchemaLogTestCase {
     return false;
   }
 
-  protected String getCurrentMinorVersion() throws IOException {
+  protected String getCurrentMinorVersion() {
     String version = TestconfigProperties.getEngineVersion();
     // remove the patch version, and create a "clean" minor version
     int lastPos = version.lastIndexOf(".");

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/db/SchemaLogEnsureSqlScriptTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/db/SchemaLogEnsureSqlScriptTest.java
@@ -19,12 +19,11 @@ package org.camunda.bpm.engine.test.standalone.db;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 
 import org.camunda.bpm.engine.management.SchemaLogEntry;
+import org.camunda.bpm.engine.test.util.TestconfigProperties;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,10 +33,6 @@ import org.junit.Test;
  */
 public class SchemaLogEnsureSqlScriptTest extends SchemaLogTestCase {
 
-  protected static final String PROPERTIES_FILE_PATH = "/testconfig.properties";
-  protected static final String VERSION_PROPERTY = "camunda.version";
-
-  protected Properties connectionProperties;
   protected String currentSchemaVersion;
   protected String dataBaseType;
 
@@ -115,18 +110,7 @@ public class SchemaLogEnsureSqlScriptTest extends SchemaLogTestCase {
   }
 
   protected String getCurrentMinorVersion() throws IOException {
-    if (connectionProperties == null) {
-      InputStream propStream = null;
-      try {
-        propStream = SchemaLogEnsureSqlScriptTest.class.getResourceAsStream(PROPERTIES_FILE_PATH);
-        connectionProperties = new Properties();
-        connectionProperties.load(propStream);
-      } finally {
-        propStream.close();
-      }
-    }
-
-    String version = connectionProperties.getProperty(VERSION_PROPERTY);
+    String version = TestconfigProperties.getEngineVersion();
     // remove the patch version, and create a "clean" minor version
     int lastPos = version.lastIndexOf(".");
     version = version.substring(0, lastPos);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/util/TestconfigProperties.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/util/TestconfigProperties.java
@@ -1,26 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.bpm.engine.test.util;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.Properties;
+
+import org.camunda.bpm.engine.impl.util.PropertiesUtil;
 
 public class TestconfigProperties {
 
   protected static final String PROPERTIES_FILE_PATH = "/testconfig.properties";
   protected static final String VERSION_PROPERTY = "camunda.version";
+  protected static final Properties INSTANCE = PropertiesUtil.getProperties(PROPERTIES_FILE_PATH);
 
-  protected static Properties loadTestconfigProperties() throws IOException {
-    Properties configProps = new Properties();
-    try (InputStream propStream = TestconfigProperties.class.getResourceAsStream(PROPERTIES_FILE_PATH)) {
-      configProps = new Properties();
-      configProps.load(propStream);
-    }
-
-    return configProps;
+  protected TestconfigProperties() {
   }
 
-  public static String getEngineVersion() throws IOException {
-    return loadTestconfigProperties().getProperty(VERSION_PROPERTY);
+  public static String getEngineVersion() {
+    return INSTANCE.getProperty(VERSION_PROPERTY);
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/util/TestconfigProperties.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/util/TestconfigProperties.java
@@ -1,0 +1,26 @@
+package org.camunda.bpm.engine.test.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class TestconfigProperties {
+
+  protected static final String PROPERTIES_FILE_PATH = "/testconfig.properties";
+  protected static final String VERSION_PROPERTY = "camunda.version";
+
+  protected static Properties loadTestconfigProperties() throws IOException {
+    Properties configProps = new Properties();
+    try (InputStream propStream = TestconfigProperties.class.getResourceAsStream(PROPERTIES_FILE_PATH)) {
+      configProps = new Properties();
+      configProps.load(propStream);
+    }
+
+    return configProps;
+  }
+
+  public static String getEngineVersion() throws IOException {
+    return loadTestconfigProperties().getProperty(VERSION_PROPERTY);
+  }
+
+}


### PR DESCRIPTION
* Validate telemetry data before sending. Product version, name, and edition must not be null or empty. Telemetry installation id must be a
valid UUIDv4 String.
* Store the product version in a properties file for use-cases where the manifest file is not available (e.g. during testing).

Related to CAM-13018