### PR TITLE
feat(engine): improve ext task handleFailure robustness

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/ExternalTaskService.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/ExternalTaskService.java
@@ -194,6 +194,9 @@ public interface ExternalTaskService {
    * <p>If <code>retries</code> is 0, an incident with the given error message is created. The incident gets resolved,
    * once the number of retries is increased again.</p>
    *
+   * <p>Exceptions raised in evaluating expressions of error event definitions attached to the task will be ignored by this method
+   * and the event definitions considered as not-matching.</p>
+   *
    * @param externalTaskId the id of the external task to report a failure for
    * @param workerId the id of the worker that reports the failure
    * @param errorMessage short error message related to this failure. This message can be retrieved via
@@ -220,6 +223,9 @@ public interface ExternalTaskService {
    *
    * <p>If <code>retries</code> is 0, an incident with the given error message is created. The incident gets resolved,
    * once the number of retries is increased again.</p>
+   *
+   * <p>Exceptions raised in evaluating expressions of error event definitions attached to the task will be ignored by this method
+   * and the event definitions considered as not-matching.</p>
    *
    * @param externalTaskId the id of the external task to report a failure for
    * @param workerId the id of the worker that reports the failure
@@ -249,7 +255,10 @@ public interface ExternalTaskService {
    *
    * <p>If <code>retries</code> is 0, an incident with the given error message is created. The incident gets resolved,
    * once the number of retries is increased again.</p>
-   * 
+   *
+   * <p>Exceptions raised in evaluating expressions of error event definitions attached to the task will be ignored by this method
+   * and the event definitions considered as not-matching.</p>
+   *
    * Variables passed with the <code>variables</code> or <code>localVariables</code> parameter will be set before any
    * output mapping is performed.
    *

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/EnginePersistenceLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/EnginePersistenceLogger.java
@@ -30,7 +30,6 @@ import org.camunda.bpm.engine.SuspendedEntityInteractionException;
 import org.camunda.bpm.engine.WrongDbException;
 import org.camunda.bpm.engine.exception.NotValidException;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
-import org.camunda.bpm.engine.impl.bpmn.parser.CamundaErrorEventDefinition;
 import org.camunda.bpm.engine.impl.db.entitymanager.cache.CachedDbEntity;
 import org.camunda.bpm.engine.impl.db.entitymanager.cache.DbEntityState;
 import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
@@ -846,8 +845,4 @@ public class EnginePersistenceLogger extends ProcessEngineLogger {
       taskId);
   }
 
-  public void errorEventDefinitionEvaluationException(String taskId, CamundaErrorEventDefinition errorEventDefinition, Exception exception) {
-    logDebug("109", "Evaluation of error event definition's expression {} on external task {} failed and will be considered as not-fulfilled. "
-        + "Received exception: {}", errorEventDefinition.getExpression(), taskId, exception.getMessage());
-  }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/EnginePersistenceLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/EnginePersistenceLogger.java
@@ -30,6 +30,7 @@ import org.camunda.bpm.engine.SuspendedEntityInteractionException;
 import org.camunda.bpm.engine.WrongDbException;
 import org.camunda.bpm.engine.exception.NotValidException;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
+import org.camunda.bpm.engine.impl.bpmn.parser.CamundaErrorEventDefinition;
 import org.camunda.bpm.engine.impl.db.entitymanager.cache.CachedDbEntity;
 import org.camunda.bpm.engine.impl.db.entitymanager.cache.DbEntityState;
 import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
@@ -837,11 +838,16 @@ public class EnginePersistenceLogger extends ProcessEngineLogger {
         "Error while fetching the telemetry initial message status property from the database: {}", exception.getMessage());
   }
 
-	
+
   public void logTaskWithoutExecution(String taskId) {
     logDebug("108",
       "Execution of external task {} is null. This indicates that the task was concurrently completed or deleted. "
       + "It is not returned by the current fetch and lock command.",
       taskId);
+  }
+
+  public void errorEventDefinitionEvaluationException(String taskId, CamundaErrorEventDefinition errorEventDefinition, Exception exception) {
+    logDebug("109", "Evaluation of error event definition's expression {} on external task {} failed and will be considered as not-fulfilled. "
+        + "Received exception: {}", errorEventDefinition.getExpression(), taskId, exception.getMessage());
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/externaltask/ExternalTaskLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/externaltask/ExternalTaskLogger.java
@@ -18,26 +18,39 @@ package org.camunda.bpm.engine.impl.externaltask;
 
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
+import org.camunda.bpm.engine.impl.bpmn.parser.CamundaErrorEventDefinition;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
 
 /**
  * Represents the logger for the external task.
- * 
+ *
  * @author Christopher Zell <christopher.zell@camunda.com>
  */
 public class ExternalTaskLogger extends ProcessEngineLogger {
-  
+
   /**
    * Logs that the priority could not be determined in the given context.
-   * 
+   *
    * @param execution the context that is used for determining the priority
    * @param value the default value
-   * @param e the exception which was catched
+   * @param e the exception which was caught
    */
   public void couldNotDeterminePriority(ExecutionEntity execution, Object value, ProcessEngineException e) {
     logWarn(
         "001",
         "Could not determine priority for external task created in context of execution {}. Using default priority {}",
         execution, value, e);
+  }
+
+  /**
+   * Logs that the error event definition expression could not be evaluated and will be considered as false
+   *
+   * @param taskId the context of the definition
+   * @param errorEventDefinition the definition whose expression failed
+   * @param exception the exception that was caught
+   */
+  public void errorEventDefinitionEvaluationException(String taskId, CamundaErrorEventDefinition errorEventDefinition, Exception exception) {
+    logDebug("002", "Evaluation of error event definition's expression {} on external task {} failed and will be considered as 'false'. "
+        + "Received exception: {}", errorEventDefinition.getExpression(), taskId, exception.getMessage());
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExternalTaskEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExternalTaskEntity.java
@@ -523,7 +523,7 @@ public class ExternalTaskEntity implements ExternalTask, DbEntity,
       return camundaErrorEventDefinition.getExpression() != null && Boolean.TRUE.equals(camundaErrorEventDefinition.getExpression().getValue(getExecution()));
     } catch (Exception exception) {
       if (continueOnException) {
-        LOG.errorEventDefinitionEvaluationException(id, camundaErrorEventDefinition, exception);
+        ProcessEngineLogger.EXTERNAL_TASK_LOGGER.errorEventDefinitionEvaluationException(id, camundaErrorEventDefinition, exception);
         return false;
       }
       throw exception;

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.externalTaskWithNestedErrorEventDefinitionVariableExpression.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.externalTaskWithNestedErrorEventDefinitionVariableExpression.bpmn20.xml
@@ -4,8 +4,8 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0h3dhqj</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_0h3dhqj" sourceRef="StartEvent_1" targetRef="Activity_0vvwq4z" />
-    <bpmn:serviceTask id="Activity_0vvwq4z" camunda:type="external" camunda:topic="externalTaskTopic">
+    <bpmn:sequenceFlow id="Flow_0h3dhqj" sourceRef="StartEvent_1" targetRef="externalTask" />
+    <bpmn:serviceTask id="externalTask" camunda:type="external" camunda:topic="externalTaskTopic">
       <bpmn:extensionElements>
         <camunda:errorEventDefinition id="CamundaErrorEventDefinition" errorRef="Error_0x9vl7b" expression="${foo=='bar'}" />
       </bpmn:extensionElements>
@@ -15,8 +15,8 @@
     <bpmn:endEvent id="Event_1wwk2pk">
       <bpmn:incoming>Flow_0a7f6ee</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_0a7f6ee" sourceRef="Activity_0vvwq4z" targetRef="Event_1wwk2pk" />
-    <bpmn:boundaryEvent id="Event_0yr7j48" attachedToRef="Activity_0vvwq4z">
+    <bpmn:sequenceFlow id="Flow_0a7f6ee" sourceRef="externalTask" targetRef="Event_1wwk2pk" />
+    <bpmn:boundaryEvent id="Event_0yr7j48" attachedToRef="externalTask">
       <bpmn:outgoing>Flow_16v0wqf</bpmn:outgoing>
       <bpmn:errorEventDefinition id="ErrorEventDefinition_1fek3uu" errorRef="Error_0x9vl7b" />
     </bpmn:boundaryEvent>
@@ -53,7 +53,7 @@
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0r35yvc_di" bpmnElement="Activity_0vvwq4z">
+      <bpmndi:BPMNShape id="Activity_0r35yvc_di" bpmnElement="externalTask">
         <dc:Bounds x="270" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1wwk2pk_di" bpmnElement="Event_1wwk2pk">


### PR DESCRIPTION
* continues the default behavior of `ExternalTask#failed` when
  the evaluation of an error event definition fails due
  to the expression evaluation

related to CAM-13305