### PR TITLE
CAM-13308: chore(ci): sidetrack pipeline is executed daily

### DIFF
--- a/.ci/sidetrack/Jenkinsfile
+++ b/.ci/sidetrack/Jenkinsfile
@@ -2,34 +2,6 @@
 // https://github.com/camunda/cambpm-jenkins-shared-library
 @Library(['camunda-ci', 'cambpm-jenkins-shared-library']) _
 
-/**
- * A method to perform a custom evaluation if certain stages in the Side track pipeline
- * should be evaluated. This is necessary since the Side Track pipeline triggers stage types
- * from the Main and Daily pipelines.
- *
- * Note: this method shouldn't be extracted to the shared library
- *       since it is specific to this pipeline.
- *
- * @param stageType - a String indicating the type of stage to be executed.
- * @return boolean. TRUE, if the stage should be triggered. Otherwise, FALSE.
- */
-boolean shouldTrigger(String stageType) {
-  def qaStages = ['sql-scripts', 'upgrade-database', 'instance-migration', 'old-engine', 'rolling-update', 'large-data-tests']
-  def unitStages = ['engine-unit', 'engine-unit-authorizations', 'webapp-unit', 'webapp-unit-authorizations']
-  if (params.UPSTREAM_PR) {
-    if (env.BRANCH_NAME == cambpmDefaultBranch()) {
-      // Downstream master run
-      return unitStages.contains(stageType)
-    } else {
-      // Downstream PR run
-      return cambpmWithLabels(cambpmGetLabels(stageType))
-    }
-  } else {
-    // Daily run
-    return qaStages.contains(stageType)
-  }
-}
-
 pipeline {
   agent {
     node {
@@ -81,7 +53,7 @@ pipeline {
           // see the .ci/config/matrices.yaml for the stage generation values
           // see .ci/config/stage-types.yaml for the stage configurations
           parallel(cambpmGetMatrixStages('sidetrack-stages', [], { stageInfo ->
-            return shouldTrigger(stageInfo.stageType)
+            return cambpmWithLabels(cambpmGetLabels(stageType))
           }))
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,9 @@ pipeline {
                 )
               }
 
-              if (cambpmWithLabels('all-db', 'cockroachdb', 'authorizations')) {
+              // the sidetrack pipeline should be triggered on daily,
+              // or PR builds only, master builds should be excluded
+              if (env.BRANCH_NAME != cambpmDefaultBranch() && cambpmWithLabels('all-db', 'cockroachdb', 'authorizations')) {
                 cambpmTriggerDownstream(
                   platformVersion + "/cambpm-ce/cambpm-sidetrack/${env.BRANCH_NAME}",
                   [string(name: 'UPSTREAM_PROJECT_NAME', value: env.JOB_NAME),


### PR DESCRIPTION
* Ensure that the Sidetrack pipeline is not triggered by upstream master builds. It should only be executed standalone (on a daily basis), and in the context of a PR. This is done to ensure that no results failures are missed due to a large number of builds.
* As the pipeline is only executed on the master branch daily, all the
  stages should be considered for execution.

Related to CAM-13308