### PR TITLE
Add condition delegates support

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/delegate/ConditionDelegate.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/delegate/ConditionDelegate.java
@@ -1,0 +1,7 @@
+package org.camunda.bpm.engine.delegate;
+
+public interface ConditionDelegate {
+
+    Boolean evaluate(DelegateExecution execution);
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/delegate/ConditionDelegateInvocation.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/delegate/ConditionDelegateInvocation.java
@@ -1,0 +1,22 @@
+package org.camunda.bpm.engine.impl.bpmn.delegate;
+
+import org.camunda.bpm.engine.delegate.ConditionDelegate;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.impl.delegate.DelegateInvocation;
+
+public class ConditionDelegateInvocation extends DelegateInvocation {
+
+    protected final ConditionDelegate delegateInstance;
+    protected final DelegateExecution execution;
+
+    public ConditionDelegateInvocation(ConditionDelegate delegateInstance, DelegateExecution execution) {
+        super(execution, null);
+        this.delegateInstance = delegateInstance;
+        this.execution = execution;
+    }
+
+    protected void invoke() throws Exception {
+        invocationResult = delegateInstance.evaluate(execution);
+    }
+
+}


### PR DESCRIPTION
Provides the ability to use delegates for Gateway Conditions.

Related: https://forum.camunda.org/t/gateway-expressions-do-not-support-delegate-executions/26400/5