### PR TITLE
CAM-13386: [JobExecutor] Tenant filter

### DIFF
--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
@@ -162,6 +162,29 @@
     from ${prefix}ACT_RU_JOB RES
 
     where (RES.RETRIES_ &gt; 0)
+
+      <!-- Tenants Enabled -->
+      <if test="parameter.tenantIdsIn != null &amp;&amp; parameter.tenantIdsIn.length > 0">
+
+        and ( RES.TENANT_ID_ in
+        <foreach item="tenantId" index="index" collection="parameter.tenantIdsIn" open="(" separator="," close=")">
+          #{tenantId}
+        </foreach>
+        )
+
+      </if>
+
+      <!-- Tenants Disabled -->
+      <if test="parameter.tenantIdsNotIn != null &amp;&amp; parameter.tenantIdsNotIn.length > 0">
+
+        and ( RES.TENANT_ID_ not in
+        <foreach item="tenantId" index="index" collection="parameter.tenantIdsNotIn" open="(" separator="," close=")">
+          #{tenantId}
+        </foreach>
+        )
+
+      </if>
+
       and (RES.DUEDATE_ is null or RES.DUEDATE_ &lt;= #{parameter.now, jdbcType=TIMESTAMP})
       and (RES.LOCK_OWNER_ is null or RES.LOCK_EXP_TIME_ &lt; #{parameter.now, jdbcType=TIMESTAMP})
       and RES.SUSPENSION_STATE_ = 1

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
@@ -166,10 +166,14 @@
       <!-- Tenants Enabled -->
       <if test="parameter.tenantIdsIn != null &amp;&amp; parameter.tenantIdsIn.length > 0">
 
-        and ( RES.TENANT_ID_ in
-        <foreach item="tenantId" index="index" collection="parameter.tenantIdsIn" open="(" separator="," close=")">
-          #{tenantId}
-        </foreach>
+        and
+        (
+          RES.TENANT_ID_ IS NULL
+          or
+          RES.TENANT_ID_ in
+          <foreach item="tenantId" index="index" collection="parameter.tenantIdsIn" open="(" separator="," close=")">
+            #{tenantId}
+          </foreach>
         )
 
       </if>
@@ -177,10 +181,14 @@
       <!-- Tenants Disabled -->
       <if test="parameter.tenantIdsNotIn != null &amp;&amp; parameter.tenantIdsNotIn.length > 0">
 
-        and ( RES.TENANT_ID_ not in
-        <foreach item="tenantId" index="index" collection="parameter.tenantIdsNotIn" open="(" separator="," close=")">
-          #{tenantId}
-        </foreach>
+        and
+        (
+          RES.TENANT_ID_ IS NULL
+          or
+          RES.TENANT_ID_ not in
+          <foreach item="tenantId" index="index" collection="parameter.tenantIdsNotIn" open="(" separator="," close=")">
+            #{tenantId}
+          </foreach>
         )
 
       </if>


### PR DESCRIPTION
This is a feature we added to fit our specific use-case, which is to have a single database for multiple tenants, but split the workload of asynchronous jobs across separate engine instances.

The reasoning is that we have some fairly large differences in loads as produced by our tenants, and in some cases, one tenant would affect throughput of another.

So this change adds parameters to the job executor, to tell it for which tenants to process jobs.

It supports both a whitelist ("only fetch jobs for these tenants") and a blacklist ("don't fetch jobs for these tenants"), currently through a set of environment variables.

Now, I assume that it would be desirable to do this through a setting in eg. bpm-platform.xml, but before going that route, I'd like to know if there's even an interest for this in the upstream.

Please let me know what you guys think and if you'd be interested in having (a more polished version of) this as a PR.