### PR TITLE
CAM-13330: Add expression resolution support for formHandlerClass attribute

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
@@ -966,9 +966,14 @@ public class BpmnParse extends Parse {
         if (startEventElement.attribute("id").equals(processDefinition.getInitial().getId())) {
 
           StartFormHandler startFormHandler;
-          String startFormHandlerClassName = startEventElement.attributeNS(CAMUNDA_BPMN_EXTENSIONS_NS, "formHandlerClass");
-          if (startFormHandlerClassName != null) {
-            startFormHandler = (StartFormHandler) ReflectUtil.instantiate(startFormHandlerClassName);
+          String startFormHandlerAttributeValue = startEventElement.attributeNS(CAMUNDA_BPMN_EXTENSIONS_NS, "formHandlerClass");
+          if (startFormHandlerAttributeValue != null) {
+            Object expressionResult = expressionManager.createExpression(startFormHandlerAttributeValue).getValue(StartProcessVariableScope.getSharedInstance());
+            if (expressionResult instanceof StartFormHandler){
+              startFormHandler = (StartFormHandler) expressionResult;
+            } else {
+              startFormHandler = (StartFormHandler) ReflectUtil.instantiate((String) expressionResult);
+            }
           } else {
             startFormHandler = new DefaultStartFormHandler();
           }
@@ -2633,9 +2638,14 @@ public class BpmnParse extends Parse {
 
   public TaskDefinition parseTaskDefinition(Element taskElement, String taskDefinitionKey, ActivityImpl activity, ProcessDefinitionEntity processDefinition) {
     TaskFormHandler taskFormHandler;
-    String taskFormHandlerClassName = taskElement.attributeNS(CAMUNDA_BPMN_EXTENSIONS_NS, "formHandlerClass");
-    if (taskFormHandlerClassName != null) {
-      taskFormHandler = (TaskFormHandler) ReflectUtil.instantiate(taskFormHandlerClassName);
+    String taskFormHandlerAttributeValue = taskElement.attributeNS(CAMUNDA_BPMN_EXTENSIONS_NS, "formHandlerClass");
+    if (taskFormHandlerAttributeValue != null) {
+      Object expressionResult = expressionManager.createExpression(taskFormHandlerAttributeValue).getValue(StartProcessVariableScope.getSharedInstance());
+      if (expressionResult instanceof StartFormHandler){
+        taskFormHandler = (TaskFormHandler) expressionResult;
+      } else {
+        taskFormHandler = (TaskFormHandler) ReflectUtil.instantiate((String) expressionResult);
+      }
     } else {
       taskFormHandler = new DefaultTaskFormHandler();
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/parser/BpmnParse.java
@@ -974,9 +974,17 @@ public class BpmnParse extends Parse {
             } else {
               startFormHandler = (StartFormHandler) ReflectUtil.instantiate((String) expressionResult);
             }
+          String startFormHandlerClassName = startEventElement.attributeNS(CAMUNDA_BPMN_EXTENSIONS_NS, "formHandlerClass");
+          String startFormHandlerDelegateExpression = startEventElement.attributeNS(CAMUNDA_BPMN_EXTENSIONS_NS, "formHandlerDelegateExpression");
+
+          if (startFormHandlerClassName != null) {
+            startFormHandler = (StartFormHandler) ReflectUtil.instantiate(startFormHandlerClassName);
+          } else if (startFormHandlerDelegateExpression != null) {
+            startFormHandler = (StartFormHandler) expressionManager.createExpression(startFormHandlerDelegateExpression).getValue(StartProcessVariableScope.getSharedInstance());
           } else {
             startFormHandler = new DefaultStartFormHandler();
           }
+
           startFormHandler.parseConfiguration(startEventElement, deployment, processDefinition, this);
 
           processDefinition.setStartFormHandler(new DelegateStartFormHandler(startFormHandler, deployment));

--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/impl/BpmnModelConstants.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/impl/BpmnModelConstants.java
@@ -450,6 +450,7 @@ public final class BpmnModelConstants {
   public static final String CAMUNDA_ATTRIBUTE_EXCLUSIVE = "exclusive";
   public static final String CAMUNDA_ATTRIBUTE_EXPRESSION = "expression";
   public static final String CAMUNDA_ATTRIBUTE_FORM_HANDLER_CLASS = "formHandlerClass";
+  public static final String CAMUNDA_ATTRIBUTE_FORM_HANDLER_DELEGATE_EXPRESSION = "formHandlerDelegateExpression";
   public static final String CAMUNDA_ATTRIBUTE_FORM_KEY = "formKey";
   public static final String CAMUNDA_ATTRIBUTE_ID = "id";
   public static final String CAMUNDA_ATTRIBUTE_INITIATOR = "initiator";

--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/impl/instance/StartEventImpl.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/impl/instance/StartEventImpl.java
@@ -40,6 +40,7 @@ public class StartEventImpl extends CatchEventImpl implements StartEvent {
 
   protected static Attribute<Boolean> camundaAsyncAttribute;
   protected static Attribute<String> camundaFormHandlerClassAttribute;
+  protected static Attribute<String> camundaFormHandlerDelegateExpressionAttribute;
   protected static Attribute<String> camundaFormKeyAttribute;
   protected static Attribute<String> camundaInitiatorAttribute;
 
@@ -66,6 +67,10 @@ public class StartEventImpl extends CatchEventImpl implements StartEvent {
       .build();
 
     camundaFormHandlerClassAttribute = typeBuilder.stringAttribute(CAMUNDA_ATTRIBUTE_FORM_HANDLER_CLASS)
+      .namespace(CAMUNDA_NS)
+      .build();
+
+    camundaFormHandlerDelegateExpressionAttribute = typeBuilder.stringAttribute(CAMUNDA_ATTRIBUTE_FORM_HANDLER_DELEGATE_EXPRESSION)
       .namespace(CAMUNDA_NS)
       .build();
 
@@ -121,6 +126,14 @@ public class StartEventImpl extends CatchEventImpl implements StartEvent {
 
   public void setCamundaFormHandlerClass(String camundaFormHandlerClass) {
     camundaFormHandlerClassAttribute.setValue(this, camundaFormHandlerClass);
+  }
+
+  public String getCamundaFormHandlerDelegateExpression() {
+    return camundaFormHandlerDelegateExpressionAttribute.getValue(this);
+  }
+
+  public void setCamundaFormHandlerDelegateExpression(String camundaFormHandlerDelegateExpression) {
+    camundaFormHandlerDelegateExpressionAttribute.setValue(this, camundaFormHandlerDelegateExpression);
   }
 
   public String getCamundaFormKey() {

--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/impl/instance/UserTaskImpl.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/impl/instance/UserTaskImpl.java
@@ -25,6 +25,7 @@ import static org.camunda.bpm.model.bpmn.impl.BpmnModelConstants.CAMUNDA_ATTRIBU
 import static org.camunda.bpm.model.bpmn.impl.BpmnModelConstants.CAMUNDA_ATTRIBUTE_DUE_DATE;
 import static org.camunda.bpm.model.bpmn.impl.BpmnModelConstants.CAMUNDA_ATTRIBUTE_FOLLOW_UP_DATE;
 import static org.camunda.bpm.model.bpmn.impl.BpmnModelConstants.CAMUNDA_ATTRIBUTE_FORM_HANDLER_CLASS;
+import static org.camunda.bpm.model.bpmn.impl.BpmnModelConstants.CAMUNDA_ATTRIBUTE_FORM_HANDLER_DELEGATE_EXPRESSION;
 import static org.camunda.bpm.model.bpmn.impl.BpmnModelConstants.CAMUNDA_ATTRIBUTE_FORM_KEY;
 import static org.camunda.bpm.model.bpmn.impl.BpmnModelConstants.CAMUNDA_ATTRIBUTE_PRIORITY;
 import static org.camunda.bpm.model.bpmn.impl.BpmnModelConstants.CAMUNDA_NS;
@@ -64,6 +65,7 @@ public class UserTaskImpl extends TaskImpl implements UserTask {
   protected static Attribute<String> camundaDueDateAttribute;
   protected static Attribute<String> camundaFollowUpDateAttribute;
   protected static Attribute<String> camundaFormHandlerClassAttribute;
+  protected static Attribute<String> camundaFormHandlerDelegateExpressionAttribute;
   protected static Attribute<String> camundaFormKeyAttribute;
   protected static Attribute<String> camundaPriorityAttribute;
 
@@ -109,6 +111,10 @@ public class UserTaskImpl extends TaskImpl implements UserTask {
       .build();
 
     camundaFormHandlerClassAttribute = typeBuilder.stringAttribute(CAMUNDA_ATTRIBUTE_FORM_HANDLER_CLASS)
+      .namespace(CAMUNDA_NS)
+      .build();
+
+    camundaFormHandlerDelegateExpressionAttribute = typeBuilder.stringAttribute(CAMUNDA_ATTRIBUTE_FORM_HANDLER_DELEGATE_EXPRESSION)
       .namespace(CAMUNDA_NS)
       .build();
 
@@ -212,6 +218,14 @@ public class UserTaskImpl extends TaskImpl implements UserTask {
 
   public void setCamundaFormHandlerClass(String camundaFormHandlerClass) {
     camundaFormHandlerClassAttribute.setValue(this, camundaFormHandlerClass);
+  }
+
+  public String getCamundaFormHandlerDelegateExpression() {
+    return camundaFormHandlerDelegateExpressionAttribute.getValue(this);
+  }
+
+  public void setCamundaFormHandlerDelegateExpression(String camundaFormHandlerDelegateExpression) {
+    camundaFormHandlerDelegateExpressionAttribute.setValue(this, camundaFormHandlerDelegateExpression);
   }
 
   public String getCamundaFormKey() {

--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/instance/StartEvent.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/instance/StartEvent.java
@@ -50,6 +50,10 @@ public interface StartEvent extends CatchEvent {
 
   void setCamundaFormHandlerClass(String camundaFormHandlerClass);
 
+  String getCamundaFormHandlerDelegateExpression();
+
+  void setCamundaFormHandlerDelegateExpression(String camundaFormHandlerDelegateExpression);
+
   String getCamundaFormKey();
 
   void setCamundaFormKey(String camundaFormKey);

--- a/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/instance/UserTask.java
+++ b/model-api/bpmn-model/src/main/java/org/camunda/bpm/model/bpmn/instance/UserTask.java
@@ -70,6 +70,10 @@ public interface UserTask extends Task {
 
   void setCamundaFormHandlerClass(String camundaFormHandlerClass);
 
+  String getCamundaFormHandlerDelegateExpression();
+
+  void setCamundaFormHandlerDelegateExpression(String camundaFormHandlerDelegateExpression);
+
   String getCamundaFormKey();
 
   void setCamundaFormKey(String camundaFormKey);

--- a/model-api/bpmn-model/src/test/java/org/camunda/bpm/model/bpmn/CamundaExtensionsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/camunda/bpm/model/bpmn/CamundaExtensionsTest.java
@@ -510,6 +510,16 @@ public class CamundaExtensionsTest {
   }
 
   @Test
+  public void testFormHandlerDelegateExpression() {
+    assertThat(startEvent.getCamundaFormHandlerDelegateExpression()).isEqualTo(TEST_DELEGATE_EXPRESSION_XML);
+    assertThat(userTask.getCamundaFormHandlerDelegateExpression()).isEqualTo(TEST_DELEGATE_EXPRESSION_XML);
+    startEvent.setCamundaFormHandlerDelegateExpression(TEST_DELEGATE_EXPRESSION_API);
+    userTask.setCamundaFormHandlerDelegateExpression(TEST_DELEGATE_EXPRESSION_API);
+    assertThat(startEvent.getCamundaFormHandlerDelegateExpression()).isEqualTo(TEST_DELEGATE_EXPRESSION_API);
+    assertThat(userTask.getCamundaFormHandlerDelegateExpression()).isEqualTo(TEST_DELEGATE_EXPRESSION_API);
+  }
+
+  @Test
   public void testFormKey() {
     assertThat(startEvent.getCamundaFormKey()).isEqualTo(TEST_STRING_XML);
     assertThat(userTask.getCamundaFormKey()).isEqualTo(TEST_STRING_XML);

--- a/model-api/bpmn-model/src/test/java/org/camunda/bpm/model/bpmn/instance/StartEventTest.java
+++ b/model-api/bpmn-model/src/test/java/org/camunda/bpm/model/bpmn/instance/StartEventTest.java
@@ -40,6 +40,7 @@ public class StartEventTest extends BpmnModelElementInstanceTest {
       /** camunda extensions */
       new AttributeAssumption(CAMUNDA_NS, "async", false, false, false),
       new AttributeAssumption(CAMUNDA_NS, "formHandlerClass"),
+      new AttributeAssumption(CAMUNDA_NS, "formHandlerDelegateExpression"),
       new AttributeAssumption(CAMUNDA_NS, "formKey"),
       new AttributeAssumption(CAMUNDA_NS, "initiator")
     );

--- a/model-api/bpmn-model/src/test/java/org/camunda/bpm/model/bpmn/instance/UserTaskTest.java
+++ b/model-api/bpmn-model/src/test/java/org/camunda/bpm/model/bpmn/instance/UserTaskTest.java
@@ -46,6 +46,7 @@ public class UserTaskTest extends BpmnModelElementInstanceTest {
       new AttributeAssumption(CAMUNDA_NS, "dueDate"),
       new AttributeAssumption(CAMUNDA_NS, "followUpDate"),
       new AttributeAssumption(CAMUNDA_NS, "formHandlerClass"),
+      new AttributeAssumption(CAMUNDA_NS, "formHandlerDelegateExpression"),
       new AttributeAssumption(CAMUNDA_NS, "formKey"),
       new AttributeAssumption(CAMUNDA_NS, "priority")
     );

--- a/model-api/bpmn-model/src/test/resources/org/camunda/bpm/model/bpmn/CamundaExtensionsTest.xml
+++ b/model-api/bpmn-model/src/test/resources/org/camunda/bpm/model/bpmn/CamundaExtensionsTest.xml
@@ -22,6 +22,7 @@
     <startEvent id="startEvent"
         camunda:initiator="test"
         camunda:formHandlerClass="org.camunda.test.Test"
+        camunda:formHandlerDelegateExpression="${org.camunda.test.Test}"
         camunda:formKey="test"
         camunda:asyncBefore="true"
         camunda:asyncAfter="true"
@@ -56,6 +57,7 @@
         camunda:dueDate="2014-02-27"
         camunda:exclusive="false"
         camunda:formHandlerClass="org.camunda.test.Test"
+        camunda:formHandlerDelegateExpression="${org.camunda.test.Test}"
         camunda:formKey="test"
         camunda:priority="12"
         camunda:jobPriority="${test}">


### PR DESCRIPTION
Support for Start Forms and User Task Forms.
Provides the ability to use expressions to resolve a class instance and therefore use Beans.  Typical usage would involve using a Prototype scoped bean as the Default Form Handlers have a instance field to hold the Form Key.

User Task XML Config:

```xml
<bpmn:startEvent id="StartEvent_1" camunda:formHandlerClass="${mySpecialFormDataHandler}">
```

handlers:

```java
@Component("mySpecialFormDataHandler")
@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
public class MyHandler extends DefaultStartFormHandler {
    @Override
    public void submitFormVariables(VariableMap properties, VariableScope variableScope) {
        //Some validation goes here VALIDATION GOES HERE

        super.submitFormVariables(properties, variableScope);
    }
}

```


```java
@Component("mySpecialUserTaskFormDataHandler")
@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
public class MyUtHandler extends DefaultTaskFormHandler {
    @Override
    public void submitFormVariables(VariableMap properties, VariableScope variableScope) {
        //Some data validation logic goes here
        
        super.submitFormVariables(properties, variableScope);
    }
}
```

If the expression does not resolve to a class then the regular instantiation of the class instance through the full class path is used.

This allows enhanced Data validation to be provided before the execution listeners.  Allows for system level and special purpose built level validations to be used that are above the scope of the BPMN modeler's purview. 

Example: This can now be used to implement data structure validation on the variables being sent: Such as "XYZ variable names can or cannot be created or modified", "The JSON object must match a specific Schema, etc.