### PR TITLE
fix(engine): fix after migration, user task is not active anymore

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/migration/instance/MigratingActivityInstance.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/migration/instance/MigratingActivityInstance.java
@@ -588,6 +588,7 @@ public class MigratingActivityInstance extends MigratingScopeInstance implements
 
       parentExecution.setActivity(representativeExecution.getActivity());
       parentExecution.setActivityInstanceId(representativeExecution.getActivityInstanceId());
+      parentExecution.setActive(representativeExecution.isActive());
 
       representativeExecution.remove();
       representativeExecution = parentExecution;


### PR DESCRIPTION
A scope user task (with attached boundary event) which was migrated to a non-scope user task did not show up after the migration when querying for activity instance statistics by process definition id (like we do in Cockpit on process definition runtime view). This was caused by not setting the `PvmExecutionImpl#isActive` flag of the parent execution to the value of the to be removed child execution.

related to CAM-13354