### PR TITLE
CAM-11523: feat(openapi): add authorization endpoints

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/authorization-query-params.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/authorization-query-params.ftl
@@ -1,0 +1,40 @@
+
+<#assign sortByValues = [
+  '"resourceType"',
+  '"resourceId"'
+]>
+
+<#assign params = {
+  "id": {
+    "type": "string",
+    "desc": "Filter by the id of the authorization."
+  },
+  "type": {
+    "type": "integer",
+    "format": "int32",
+    "desc": "Filter by authorization type. (0=global, 1=grant, 2=revoke).
+             See the [User Guide](${docsUrl}/user-guide/process-engine/authorization-service/#authorization-type)
+             for more information about authorization types."
+  },
+  "userIdIn": {
+    "type": "array",
+    "itemType": "string",
+    "desc": "Filter by a comma-separated list of userIds."
+  },
+  "groupIdIn": {
+    "type": "array",
+    "itemType": "string",
+    "desc": "Filter by a comma-separated list of groupIds."
+  },
+  "resourceType": {
+    "type": "integer",
+    "format": "int32",
+    "desc": "Filter by an integer representation of the resource type. See the
+             [User Guide](${docsUrl}/user-guide/process-engine/authorization-service/#resources)
+             for a list of integer representations of resource types."
+  },
+  "resourceId": {
+    "type": "string",
+    "desc": "Filter by resource id."
+  }
+}>

--- a/engine-rest/engine-rest-openapi/src/main/templates/main.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/main.ftl
@@ -36,6 +36,7 @@
 
   ],
   "tags": [
+    {"name": "Authorization"},
     {"name": "Batch"},
     {"name": "Condition"},
     {"name": "Decision Definition"},

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/authorization/AuthorizationCheckResultDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/authorization/AuthorizationCheckResultDto.ftl
@@ -1,0 +1,30 @@
+<#macro dto_macro docsUrl="">
+<@lib.dto >
+    
+    <@lib.property
+        name = "permissionName"
+        type = "string"
+        desc = "Name of the permission which was checked."
+    />
+    
+    <@lib.property
+        name = "resourceName"
+        type = "string"
+        desc = "The name of the resource for which the permission check was performed."
+    />
+    
+    <@lib.property
+        name = "resourceId"
+        type = "string"
+        desc = "The id of the resource for which the permission check was performed."
+    />
+    
+    <@lib.property
+        name = "isAuthorized"
+        type = "boolean"
+        desc = "True / false for isAuthorized."
+        last = true
+    />
+
+</@lib.dto>
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/authorization/AuthorizationCreateDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/authorization/AuthorizationCreateDto.ftl
@@ -5,7 +5,9 @@
         name = "type"
         type = "integer"
         format = "int32"
-        desc = "The type of the authorization (0=global, 1=grant, 2=revoke)."
+        desc = "The type of the authorization (0=global, 1=grant, 2=revoke). See the
+                [User Guide](${docsUrl}/user-guide/process-engine/authorization-service.md#authorization-type)
+                for more information about authorization types."
     />
     
     <@lib.property

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/authorization/AuthorizationCreateDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/authorization/AuthorizationCreateDto.ftl
@@ -1,0 +1,49 @@
+<#macro dto_macro docsUrl="">
+<@lib.dto >
+
+    <@lib.property
+        name = "type"
+        type = "integer"
+        format = "int32"
+        desc = "The type of the authorization (0=global, 1=grant, 2=revoke)."
+    />
+    
+    <@lib.property
+        name = "permissions"
+        type = "array"
+        itemType = "string"
+        desc = "An array of Strings holding the permissions provided by this authorization."
+    />
+    
+    <@lib.property
+        name = "userId"
+        type = "string"
+        desc = "The id of the user this authorization has been created for. The value `*`
+                represents a global authorization ranging over all users."
+    />
+    
+    <@lib.property
+        name = "groupId"
+        type = "string"
+        desc = "The id of the group this authorization has been created for."
+    />
+    
+    <@lib.property
+        name = "resourceType"
+        type = "integer"
+        format = "int32"
+        desc = "An integer representing the resource type. See the
+                [User Guide](${docsUrl}/user-guide/process-engine/authorization-service/#resources)
+                for a list of integer representations of resource types."
+    />
+    
+    <@lib.property
+        name = "resourceId"
+        type = "string"
+        desc = "The resource Id. The value `*` represents an authorization ranging over all
+                instances of a resource."
+        last = true
+    />
+
+</@lib.dto>
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/authorization/AuthorizationDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/authorization/AuthorizationDto.ftl
@@ -1,0 +1,76 @@
+<#macro dto_macro docsUrl="">
+<@lib.dto >
+
+    <#-- NOTE: Any changes made to this Dto should be mirrored to the
+        AuthorizationUpdateDto (if the new/adjusted property can be updated) -->
+
+    <@lib.property
+        name = "id"
+        type = "string"
+        desc = "The id of the authorization."
+    />
+    
+    <@lib.property
+        name = "type"
+        type = "integer"
+        format = "int32"
+        desc = "The type of the authorization (0=global, 1=grant, 2=revoke)."
+    />
+    
+    <@lib.property
+        name = "permissions"
+        type = "array"
+        itemType = "string"
+        desc = "An array of Strings holding the permissions provided by this authorization."
+    />
+    
+    <@lib.property
+        name = "userId"
+        type = "string"
+        desc = "The id of the user this authorization has been created for. The value `*`
+                represents a global authorization ranging over all users."
+    />
+    
+    <@lib.property
+        name = "groupId"
+        type = "string"
+        desc = "The id of the group this authorization has been created for."
+    />
+    
+    <@lib.property
+        name = "resourceType"
+        type = "integer"
+        format = "int32"
+        desc = "An integer representing the resource type. See the
+                [User Guide](${docsUrl}/user-guide/process-engine/authorization-service/#resources)
+                for a list of integer representations of resource types."
+    />
+    
+    <@lib.property
+        name = "resourceId"
+        type = "string"
+        desc = "The resource Id. The value `*` represents an authorization ranging over all
+                instances of a resource."
+    />
+    
+    <@lib.property
+        name = "removalTime"
+        type = "string"
+        desc = "The removal time indicates the date a historic instance
+                authorization is cleaned up. A removal time can only be assigned to a historic
+                instance authorization. Can be `null` when not related to a historic instance
+                resource or when the removal time strategy is end and the root process instance
+                is not finished. Default format `yyyy-MM-dd'T'HH:mm:ss.SSSZ`."
+    />
+    
+    <@lib.property
+        name = "rootProcessInstanceId"
+        type = "string"
+        desc = "The process instance id of the root process instance the historic
+                instance authorization is related to. Can be `null` if not related to a historic instance
+                resource."
+        last = true
+    />
+
+</@lib.dto>
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/authorization/AuthorizationDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/authorization/AuthorizationDto.ftl
@@ -14,7 +14,9 @@
         name = "type"
         type = "integer"
         format = "int32"
-        desc = "The type of the authorization (0=global, 1=grant, 2=revoke)."
+        desc = "The type of the authorization (0=global, 1=grant, 2=revoke). See the
+                [User Guide](${docsUrl}/user-guide/process-engine/authorization-service.md#authorization-type)
+                for more information about authorization types."
     />
     
     <@lib.property
@@ -56,6 +58,7 @@
     <@lib.property
         name = "removalTime"
         type = "string"
+        format = "date-time"
         desc = "The removal time indicates the date a historic instance
                 authorization is cleaned up. A removal time can only be assigned to a historic
                 instance authorization. Can be `null` when not related to a historic instance

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/authorization/AuthorizationUpdateDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/authorization/AuthorizationUpdateDto.ftl
@@ -1,0 +1,42 @@
+<#macro dto_macro docsUrl="">
+<@lib.dto >
+    
+    <@lib.property
+        name = "permissions"
+        type = "array"
+        itemType = "string"
+        desc = "An array of Strings holding the permissions provided by this authorization."
+    />
+    
+    <@lib.property
+        name = "userId"
+        type = "string"
+        desc = "The id of the user this authorization has been created for. The value `*`
+                represents a global authorization ranging over all users."
+    />
+    
+    <@lib.property
+        name = "groupId"
+        type = "string"
+        desc = "The id of the group this authorization has been created for."
+    />
+    
+    <@lib.property
+        name = "resourceType"
+        type = "integer"
+        format = "int32"
+        desc = "An integer representing the resource type. See the
+                [User Guide](${docsUrl}/user-guide/process-engine/authorization-service/#resources)
+                for a list of integer representations of resource types."
+    />
+    
+    <@lib.property
+        name = "resourceId"
+        type = "string"
+        last = true
+        desc = "The resource Id. The value `*` represents an authorization ranging over all
+                instances of a resource."
+    />
+
+</@lib.dto>
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/check/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/check/get.ftl
@@ -1,0 +1,115 @@
+<#macro endpoint_macro docsUrl="">
+{
+  <@lib.endpointInfo
+      id = "isUserAuthorized"
+      tag = "Authorization"
+      summary = "Perform an Authorization Check"
+      desc = "Performs an authorization check for the currently authenticated user."
+  />
+
+  "parameters" : [
+
+      <@lib.parameter
+          name = "permissionName"
+          location = "query"
+          type = "string"
+          required = true
+          desc = "String value representing the permission name to check for."
+      />
+
+      <@lib.parameter
+          name = "resourceName"
+          location = "query"
+          type = "string"
+          required = true
+          desc = "String value for the name of the resource to check permissions for."
+      />
+
+      <@lib.parameter
+          name = "resourceType"
+          location = "query"
+          type = "integer"
+          format="int32"
+          required = true
+          desc = "An integer representing the resource type to check permissions for.
+                  See the [User Guide](${docsUrl}/user-guide/process-engine/authorization-service/#resources)
+                  for a list of integer representations of resource types."
+      />
+
+      <@lib.parameter
+          name = "resourceId"
+          location = "query"
+          type = "string"
+          desc = "The id of the resource to check permissions for. If left blank,
+                  a check for global permissions on the resource is performed."
+      />
+
+      <@lib.parameter
+          name = "userId"
+          location = "query"
+          type = "string"
+          desc = "The id of the user to check permissions for. The currently authenticated
+                  user must have a READ permission for the Authorization resource. If `userId` is
+                  blank, a check for the currently authenticated user is performed."
+          last = true
+      />
+
+  ],
+
+  "responses": {
+
+    <@lib.response
+        code = "200"
+        dto = "AuthorizationCheckResultDto"
+        desc = "Request successful."
+        examples = ['"example-1": {
+                       "summary": "Status 200.",
+                       "description": "GET `/authorization/check?permissionName=READ,resourceName=USER,resourceType=1,resourceId=jonny`",
+                       "value": {
+                         "permissionName": "READ",
+                         "resourceName": "USER",
+                         "resourceId": "jonny",
+                         "isAuthorized": true
+                       }
+                     }']
+    />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "Returned if some of the query parameters are invalid, for example if a permission
+                parameterName is not valid for the provided resourceType. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format."
+    />
+
+    <@lib.response
+        code = "401"
+        dto = "ExceptionDto"
+        desc = "The user is not authenticated. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format."
+    />
+
+    <@lib.response
+        code = "403"
+        dto = "ExceptionDto"
+        desc = "When a `userId` is passed and the user does not possess a READ permission for the
+                Authorization resource. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format."
+    />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        desc = "Authorization with given id does not exist. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format."
+        last = true
+    />
+
+  }
+
+}
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/count/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/count/get.ftl
@@ -1,0 +1,49 @@
+<#macro endpoint_macro docsUrl="">
+{
+  <@lib.endpointInfo
+      id = "getAuthorizationCount"
+      tag = "Authorization"
+      summary = "Get Authorization Count"
+      desc = "Queries for authorizations using a list of parameters and retrieves the count."
+  />
+
+  "parameters" : [
+
+    <#assign last = true >
+    <#include "/lib/commons/authorization-query-params.ftl" >
+    <@lib.parameters
+        object = params
+        last = last
+    />
+
+  ],
+
+  "responses": {
+
+    <@lib.response
+        code = "200"
+        dto = "CountResultDto"
+        desc = "Request successful."
+        examples = ['"example-1": {
+                       "summary": "Status 200.",
+                       "description": "GET `/authorization/count?userIdIn=jonny1,jonny2`",
+                       "value": {
+                         "count": 2
+                       }
+                     }']
+    />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "Returned if some of the query parameters are invalid, for example if a `sortOrder`
+                parameter is supplied, but no `sortBy` is specified. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format."
+        last = true
+    />
+
+  }
+
+}
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/create/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/create/post.ftl
@@ -1,0 +1,69 @@
+<#macro endpoint_macro docsUrl="">
+{
+  <@lib.endpointInfo
+      id = "createAuthorization"
+      tag = "Authorization"
+      summary = "Create a New Authorization"
+      desc = "Creates a new authorization."
+  />
+
+  <@lib.requestBody
+      mediaType = "application/json"
+      dto = "AuthorizationCreateDto"
+      examples = ['"example-1": {
+                     "summary": "POST `/authorization/create`",
+                     "value": {
+                       "type": 0,
+                       "permissions": [
+                         "CREATE",
+                         "READ"
+                       ],
+                       "userId": "*",
+                       "groupId": null,
+                       "resourceType": 1,
+                       "resourceId": "*"
+                     }
+                   }']
+  />
+
+  "responses": {
+
+    <@lib.response
+        code = "200"
+        dto = "AuthorizationDto"
+        desc = "Request successful."
+        examples = ['"example-1": {
+                       "summary": "Status 200.",
+                       "description": "POST `/authorization/create`"
+                     }']
+    />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "Returned if some of the properties in the request body are invalid, for example if
+                a permission parameter is not valid for the provided resourceType.
+                See the [Introduction](${docsUrl}/reference/rest/overview/#error-
+                handling) for the error response format."
+    />
+
+    <@lib.response
+        code = "403"
+        dto = "ExceptionDto"
+        desc = "The authenticated user is unauthorized to create an instance of this resource. See
+                the [Introduction](${docsUrl}/reference/rest/overview/#error-handling) for the error response format."
+    />
+
+    <@lib.response
+        code = "500"
+        dto = "ExceptionDto"
+        desc = "The authorization could not be updated due to an internal server error. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format."
+        last = true
+    />
+
+  }
+
+}
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/create/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/create/post.ftl
@@ -34,7 +34,23 @@
         desc = "Request successful."
         examples = ['"example-1": {
                        "summary": "Status 200.",
-                       "description": "POST `/authorization/create`"
+                       "description": "POST `/authorization/create`",
+                       "value": {
+                         "id":"anAuthorizationId",
+                         "type": 0,
+                         "permissions": ["CREATE", "READ"],
+                         "userId": "*",
+                         "groupId": null,
+                         "resourceType": 1,
+                         "resourceId": "*",
+                         "removalTime": "2018-02-10T14:33:19.000+0200",
+                         "rootProcessInstanceId": "f8259e5d-ab9d-11e8-8449-e4a7a094a9d6",
+                         "links":[
+                           {"method": "GET", href":"http://localhost:8080/engine-rest/authorization/anAuthorizationId", "rel":"self"},
+                           {"method": "PUT", href":"http://localhost:8080/engine-rest/authorization/anAuthorizationId", "rel":"update"},
+                           {"method": "DELETE", href":"http://localhost:8080/engine-rest/authorization/anAuthorizationId", "rel":"delete"}
+                         ]
+                       }
                      }']
     />
 
@@ -43,8 +59,8 @@
         dto = "ExceptionDto"
         desc = "Returned if some of the properties in the request body are invalid, for example if
                 a permission parameter is not valid for the provided resourceType.
-                See the [Introduction](${docsUrl}/reference/rest/overview/#error-
-                handling) for the error response format."
+                See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format."
     />
 
     <@lib.response

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/get.ftl
@@ -1,0 +1,79 @@
+<#macro endpoint_macro docsUrl="">
+{
+  <@lib.endpointInfo
+      id = "queryAuthorizations"
+      tag = "Authorization"
+      summary = "Get Authorizations"
+      desc = "Queries for a list of authorizations using a list of parameters.
+              The size of the result set can be retrieved by using the
+              [Get Authorization Count](${docsUrl}/reference/rest/authorization/get-query-count/) method."
+  />
+
+  "parameters" : [
+
+    <#assign last = false >
+    <#include "/lib/commons/authorization-query-params.ftl" >
+    <@lib.parameters
+        object = params
+        last = last
+    />
+    <#include "/lib/commons/sort-params.ftl">
+    <#assign last = true >
+    <#include "/lib/commons/pagination-params.ftl">
+
+  ],
+
+  "responses": {
+
+    <@lib.response
+        code = "200"
+        dto = "AuthorizationDto"
+        array = true
+        desc = "Request successful."
+        examples = ['"example-1": {
+                       "summary": "Status 200.",
+                       "description": "GET `/authorization?userIdIn=jonny1,jonny2`",
+                       "value": [
+                         {
+                           "id": "anAuthorizationId",
+                           "type": 0,
+                           "permissions": [
+                             "ALL"
+                           ],
+                           "userId": "jonny1",
+                           "groupId": null,
+                           "resourceType": 1,
+                           "resourceId": "*"
+                         },
+                         {
+                           "id": "anotherAuthorizationId",
+                           "type": 0,
+                           "permissions": [
+                             "CREATE",
+                             "READ"
+                           ],
+                           "userId": "jonny2",
+                           "groupId": null,
+                           "resourceType": 1,
+                           "resourceId": "*",
+                           "removalTime": "2018-02-10T14:33:19.000+0200",
+                           "rootProcessInstanceId": "f8259e5d-ab9d-11e8-8449-e4a7a094a9d6"
+                         }
+                       ]
+                     }']
+    />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "Returned if some of the query parameters are invalid, for example if a `sortOrder`
+                parameter is supplied, but no `sortBy` is specified. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format."
+        last = true
+    />
+
+  }
+
+}
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/options.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/options.ftl
@@ -7,14 +7,10 @@
       id = "availableOperationsAuthorization"
       tag = "Authorization"
       summary = "Authorization Resource Options"
-      desc = "The `/authorization` resource supports two custom OPTIONS requests, one for the
-              resource as such and one for individual authorization instances. The
-              OPTIONS request allows you to check for the set of available
-              operations that the currently authenticated user can perform on the
-              `/authorization` resource. Whether the user can perform an operation
-              or not may depend on various factors, including the users
-              authorizations to interact with this resource and the internal
-              configuration of the process engine."
+      desc = "The OPTIONS request allows you to check for the set of available operations that the currently
+              authenticated user can perform on the `/authorization` resource. Whether the user can perform an operation
+              or not may depend on various factors, including the users authorizations to interact with this
+              resource and the internal configuration of the process engine."
   />
 
   "responses": {
@@ -25,7 +21,26 @@
         desc = "Request successful."
         examples = ['"example-1": {
                        "summary": "Status 200.",
-                       "description": "OPTIONS `/authorization`"
+                       "description": "OPTIONS `/authorization`",
+                       "value": {
+                         "links": [
+                           {
+                             "method":"GET",
+                             "href":"http://localhost:8080/engine-rest/authorization",
+                             "rel":"list"
+                           },
+                           {
+                             "method":"GET",
+                             "href":"http://localhost:8080/engine-rest/authorization/count",
+                             "rel":"count"
+                           },
+                           {
+                             "method":"POST",
+                             "href":"http://localhost:8080/engine-rest/authorization/create",
+                             "rel":"create"
+                           }
+                         ]
+                       }
                      }']
         last = true
     />

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/options.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/options.ftl
@@ -1,0 +1,36 @@
+<#macro endpoint_macro docsUrl="">
+
+    <#-- NOTE: Any changes made to this file should be mirrored to the
+         ./{id}/options.ftl file as well -->
+{
+  <@lib.endpointInfo
+      id = "availableOperationsAuthorization"
+      tag = "Authorization"
+      summary = "Authorization Resource Options"
+      desc = "The `/authorization` resource supports two custom OPTIONS requests, one for the
+              resource as such and one for individual authorization instances. The
+              OPTIONS request allows you to check for the set of available
+              operations that the currently authenticated user can perform on the
+              `/authorization` resource. Whether the user can perform an operation
+              or not may depend on various factors, including the users
+              authorizations to interact with this resource and the internal
+              configuration of the process engine."
+  />
+
+  "responses": {
+
+    <@lib.response
+        code = "200"
+        dto = "ResourceOptionsDto"
+        desc = "Request successful."
+        examples = ['"example-1": {
+                       "summary": "Status 200.",
+                       "description": "OPTIONS `/authorization`"
+                     }']
+        last = true
+    />
+
+  }
+
+}
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/{id}/delete.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/{id}/delete.ftl
@@ -1,0 +1,50 @@
+<#macro endpoint_macro docsUrl="">
+{
+  <@lib.endpointInfo
+      id = "deleteAuthorization"
+      tag = "Authorization"
+      summary = "Delete Authorization"
+      desc = "Deletes an authorization by id."
+  />
+
+  "parameters" : [
+
+      <@lib.parameter
+          name = "id"
+          location = "path"
+          type = "string"
+          required = true
+          desc = "The id of the authorization to be deleted."
+          last = true
+      />
+
+  ],
+
+  "responses": {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful. This method returns no content."
+    />
+
+    <@lib.response
+        code = "403"
+        dto = "ExceptionDto"
+        desc = "If the authenticated user is unauthorized to delete the resource instance. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format."
+    />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        desc = "Authorization cannot be found. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format."
+        last = true
+    />
+
+  }
+
+}
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/{id}/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/{id}/get.ftl
@@ -1,0 +1,61 @@
+<#macro endpoint_macro docsUrl="">
+{
+  <@lib.endpointInfo
+      id = "getAuthorization"
+      tag = "Authorization"
+      summary = "Get Authorization"
+      desc = "Retrieves an authorization by id."
+  />
+
+  "parameters" : [
+
+      <@lib.parameter
+          name = "id"
+          location = "path"
+          type = "string"
+          required = true
+          desc = "The id of the authorization to be retrieved."
+          last = true
+      />
+
+  ],
+
+  "responses": {
+
+    <@lib.response
+        code = "200"
+        dto = "AuthorizationDto"
+        desc = "Request successful."
+        examples = ['"example-1": {
+                       "summary": "Status 200.",
+                       "description": "GET `/authorization/anAuthorizationId`",
+                       "value": {
+                         "id": "anAuthorizationId",
+                         "type": 0,
+                         "permissions": [
+                           "CREATE",
+                           "READ"
+                         ],
+                         "userId": "*",
+                         "groupId": null,
+                         "resourceType": 1,
+                         "resourceId": "*",
+                         "removalTime": "2018-02-10T14:33:19.000+0200",
+                         "rootProcessInstanceId": "f8259e5d-ab9d-11e8-8449-e4a7a094a9d6"
+                       }
+                     }']
+    />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        desc = "Authorization with given id does not exist. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format."
+        last = true
+    />
+
+  }
+
+}
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/{id}/options.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/{id}/options.ftl
@@ -7,14 +7,10 @@
       id = "availableOperationsAuthorizationInstance"
       tag = "Authorization"
       summary = "Authorization Resource Options"
-      desc = "The `/authorization` resource supports two custom OPTIONS requests, one for the
-              resource as such and one for individual authorization instances. The
-              OPTIONS request allows you to check for the set of available
-              operations that the currently authenticated user can perform on the
-              `/authorization` resource. Whether the user can perform an operation
-              or not may depend on various factors, including the users
-              authorizations to interact with this resource and the internal
-              configuration of the process engine."
+      desc = "The OPTIONS request allows you to check for the set of available operations that the currently
+              authenticated user can perform on a given instance of the `/authorization` resource.
+              Whether the user can perform an operation or not may depend on various factors, including the users
+              authorizations to interact with this resource and the internal configuration of the process engine."
   />
 
   "parameters" : [
@@ -38,7 +34,26 @@
         desc = "Request successful."
         examples = ['"example-1": {
                        "summary": "Status 200.",
-                       "description": "OPTIONS `/authorization/anAuthorizationId`"
+                       "description": "OPTIONS `/authorization/anAuthorizationId`",
+                       "value": {
+                         "links": [
+                           {
+                             "method":"GET",
+                             "href":"http://localhost:8080/engine-rest/authorization/anAuthorizationId",
+                             "rel":"self"
+                           },
+                           {
+                             "method":"PUT",
+                             "href":"http://localhost:8080/engine-rest/authorization/anAuthorizationId",
+                             "rel":"update"
+                           },
+                           {
+                             "method":"DELETE",
+                             "href":"http://localhost:8080/engine-rest/authorization/anAuthorizationId",
+                             "rel":"delete"
+                           }
+                         ]
+                       }
                      }']
         last = true
     />

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/{id}/options.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/{id}/options.ftl
@@ -1,0 +1,49 @@
+<#macro endpoint_macro docsUrl="">
+
+    <#-- NOTE: Any changes made to this file should be mirrored to the
+         ../options.ftl file as well -->
+{
+  <@lib.endpointInfo
+      id = "availableOperationsAuthorizationInstance"
+      tag = "Authorization"
+      summary = "Authorization Resource Options"
+      desc = "The `/authorization` resource supports two custom OPTIONS requests, one for the
+              resource as such and one for individual authorization instances. The
+              OPTIONS request allows you to check for the set of available
+              operations that the currently authenticated user can perform on the
+              `/authorization` resource. Whether the user can perform an operation
+              or not may depend on various factors, including the users
+              authorizations to interact with this resource and the internal
+              configuration of the process engine."
+  />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        desc = "The id of the authorization to be retrieved."
+        last = true
+    />
+
+  ],
+
+  "responses": {
+
+    <@lib.response
+        code = "200"
+        dto = "ResourceOptionsDto"
+        desc = "Request successful."
+        examples = ['"example-1": {
+                       "summary": "Status 200.",
+                       "description": "OPTIONS `/authorization/anAuthorizationId`"
+                     }']
+        last = true
+    />
+
+  }
+
+}
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/{id}/put.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/{id}/put.ftl
@@ -47,8 +47,8 @@
         dto = "ExceptionDto"
         desc = "Returned if some of the properties in the request body are invalid, for example if
                 a permission parameter is not valid for the provided resourceType.
-                See the [Introduction](${docsUrl}/reference/rest/overview/#error-
-                handling) for the error response format."
+                See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format."
     />
 
     <@lib.response

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/{id}/put.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/{id}/put.ftl
@@ -1,0 +1,80 @@
+<#macro endpoint_macro docsUrl="">
+{
+  <@lib.endpointInfo
+      id = "updateAuthorization"
+      tag = "Authorization"
+      summary = "Update an Authorization"
+      desc = "Updates an authorization by id."
+  />
+
+  "parameters" : [
+
+      <@lib.parameter
+          name = "id"
+          location = "path"
+          type = "string"
+          required = true
+          desc = "The id of the authorization to be updated."
+          last = true
+      />
+
+  ],
+
+  <@lib.requestBody
+      mediaType = "application/json"
+      dto = "AuthorizationUpdateDto"
+      examples = ['"example-1": {
+                     "summary": "PUT `/authorization/anAuthorizationId`",
+                     "value": {
+                       "permissions": 16,
+                       "userId": "*",
+                       "groupId": null,
+                       "resourceType": 1,
+                       "resourceId": "*"
+                     }
+                   }']
+  />
+
+  "responses": {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful. This method returns no content."
+    />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "Returned if some of the properties in the request body are invalid, for example if
+                a permission parameter is not valid for the provided resourceType.
+                See the [Introduction](${docsUrl}/reference/rest/overview/#error-
+                handling) for the error response format."
+    />
+
+    <@lib.response
+        code = "403"
+        dto = "ExceptionDto"
+        desc = "The authenticated user is unauthorized to update this resource. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format."
+    />
+
+    <@lib.response
+        code = "404"
+        dto = "ExceptionDto"
+        desc = "The authorization with the requested Id cannot be found."
+    />
+
+    <@lib.response
+        code = "500"
+        dto = "ExceptionDto"
+        desc = "The authorization could not be updated due to an internal server error. See the
+                [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                for the error response format."
+        last = true
+    />
+
+  }
+
+}
+</#macro>


### PR DESCRIPTION
* The `OPTIONS /authorization` and `OPTIONS /authorization/{id}` endpoints are documented in a single page. I created two separate files for them. They both contain a comment to notify devs to also update the other one.
* The `PUT /authorization/{id}` endpoint uses a subset of the `AuthorizationDto` properties. I decided to create a separate `AuthorizationUpdateDto` file for this purpose. This would prevent confusion about what properties are available for update. I also added a comment in the `AuthorizationDto` file to also update the `AuthorizationUpdateDto` if any changes are made. Other options that I considered were:
  * Create a parent FTL file with the `AuthorizationUpdateDto` properties, and extend the `AuthorizationDto` from it (I could also refactor the Java classes as well). However, in this case, it would be confusing, so I decided against it.

Related to CAM-11523