### PR TITLE
feat(webapp) - do not lose the modal start process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/webapps/package-lock.json
+++ b/webapps/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "camunda-bpm-webapp",
-  "version": "7.15.0-SNAPSHOT",
+  "version": "7.16.0-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/webapps/ui/tasklist/client/scripts/process/plugins/action/cam-tasklist-navbar-action-start-process-plugin.js
+++ b/webapps/ui/tasklist/client/scripts/process/plugins/action/cam-tasklist-navbar-action-start-process-plugin.js
@@ -118,6 +118,8 @@ var Controller = [
       modalResolved = false;
       var modalInstance = $modal.open({
         size: 'lg',
+        backdrop: 'static',
+        keyboard: false,
         controller: 'camProcessStartModalCtrl',
         template: template,
         resolve: {

--- a/webapps/ui/tasklist/plugins/standaloneTask/app/navbar/action/cam-tasklist-navbar-action-create-task-plugin.js
+++ b/webapps/ui/tasklist/plugins/standaloneTask/app/navbar/action/cam-tasklist-navbar-action-create-task-plugin.js
@@ -36,6 +36,8 @@ var Controller = [
     $scope.open = function() {
       var modalInstance = $modal.open({
         size: 'lg',
+        backdrop: 'static',
+        keyboard: false,
         controller: 'camCreateTaskModalCtrl',
         template: createTaskModalTemplate
       });


### PR DESCRIPTION
To improve the user experience that they report that by accident, creating a task or starting a process, after having filled in some fields, they accidentally clicked out of the modal, closing it and losing the information. I configured in the modal.open instruction so that the modal will only close if you click the close button, neither the "esc" key or clicking outside it closes now.