### PR TITLE
fix(engine): fix set variables batch operation classloading bug

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AbstractSetVariableCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AbstractSetVariableCmd.java
@@ -30,16 +30,26 @@ public abstract class AbstractSetVariableCmd extends AbstractVariableCmd {
 
   protected Map<String, ? extends Object> variables;
 
+  protected boolean skipJavaSerializationFormatCheck;
+
   public AbstractSetVariableCmd(String entityId, Map<String, ? extends Object> variables, boolean isLocal) {
     super(entityId, isLocal);
     this.variables = variables;
   }
 
+  public AbstractSetVariableCmd(String entityId,
+                                Map<String, ? extends Object> variables,
+                                boolean isLocal,
+                                boolean skipJavaSerializationFormatCheck) {
+    this(entityId, variables, isLocal);
+    this.skipJavaSerializationFormatCheck = skipJavaSerializationFormatCheck;
+  }
+
   protected void executeOperation(AbstractVariableScope scope) {
     if (isLocal) {
-      scope.setVariablesLocal(variables);
+      scope.setVariablesLocal(variables, skipJavaSerializationFormatCheck);
     } else {
-      scope.setVariables(variables);
+      scope.setVariables(variables, skipJavaSerializationFormatCheck);
     }
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SetExecutionVariablesCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SetExecutionVariablesCmd.java
@@ -34,8 +34,15 @@ public class SetExecutionVariablesCmd extends AbstractSetVariableCmd {
 
   private static final long serialVersionUID = 1L;
 
+  public SetExecutionVariablesCmd(String executionId,
+                                  Map<String, ?> variables,
+                                  boolean isLocal,
+                                  boolean skipJavaSerializationFormatCheck) {
+    super(executionId, variables, isLocal, skipJavaSerializationFormatCheck);
+  }
+
   public SetExecutionVariablesCmd(String executionId, Map<String, ? extends Object> variables, boolean isLocal) {
-    super(executionId, variables, isLocal);
+    super(executionId, variables, isLocal, false);
   }
 
   protected ExecutionEntity getEntity() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/core/CoreLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/core/CoreLogger.java
@@ -21,6 +21,7 @@ import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.core.instance.CoreExecution;
 import org.camunda.bpm.engine.impl.core.operation.CoreAtomicOperation;
 import org.camunda.bpm.engine.impl.core.variable.CoreVariableInstance;
+import org.camunda.bpm.engine.impl.core.variable.VariableUtil;
 import org.camunda.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
 
 /**
@@ -73,12 +74,8 @@ public class CoreLogger extends ProcessEngineLogger {
       ));
   }
 
-  public ProcessEngineException javaSerializationProhibitedException(String variableName) {
-    return new ProcessEngineException(exceptionMessage(
-        "007",
-        "Cannot set variable with name {}. Java serialization format is prohibited",
-        variableName
-      ));
+  public ProcessEngineException javaSerializationProhibitedException(String message) {
+    return new ProcessEngineException(exceptionMessage("007", message));
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/core/variable/VariableUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/core/variable/VariableUtil.java
@@ -20,6 +20,8 @@ import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.core.CoreLogger;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.persistence.entity.VariableInstanceEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.util.TypedValueField;
 import org.camunda.bpm.engine.impl.variable.serializer.TypedValueSerializer;
 import org.camunda.bpm.engine.impl.variable.serializer.VariableSerializerFactory;
@@ -28,18 +30,23 @@ import org.camunda.bpm.engine.variable.Variables;
 import org.camunda.bpm.engine.variable.value.SerializableValue;
 import org.camunda.bpm.engine.variable.value.TypedValue;
 
+import java.text.MessageFormat;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 public class VariableUtil {
 
-  public static CoreLogger CORE_LOGGER = ProcessEngineLogger.CORE_LOGGER;
+  public static final CoreLogger CORE_LOGGER = ProcessEngineLogger.CORE_LOGGER;
+
+  public static final String ERROR_MSG = "Cannot set variable with name {0}. Java serialization format is prohibited";
 
   /**
    * Checks, if Java serialization will be used and if it is allowed to be used.
-   * @param variableName
    * @param value
    */
-  public static void checkJavaSerialization(String variableName, TypedValue value) {
+  public static boolean isJavaSerializationProhibited(TypedValue value) {
     ProcessEngineConfigurationImpl processEngineConfiguration =
         Context.getProcessEngineConfiguration();
 
@@ -50,8 +57,6 @@ public class VariableUtil {
 
       // if Java serialization is prohibited
       if (!serializableValue.isDeserialized()) {
-
-        String javaSerializationDataFormat = Variables.SerializationDataFormats.JAVA.getName();
         String requestedDataFormat = serializableValue.getSerializationDataFormat();
 
         if (requestedDataFormat == null) {
@@ -66,10 +71,16 @@ public class VariableUtil {
           }
         }
 
-        if (javaSerializationDataFormat.equals(requestedDataFormat)) {
-          throw CORE_LOGGER.javaSerializationProhibitedException(variableName);
-        }
+        return Variables.SerializationDataFormats.JAVA.getName().equals(requestedDataFormat);
       }
+    }
+    return false;
+  }
+
+  public static void checkJavaSerialization(String variableName, TypedValue value) {
+    if (isJavaSerializationProhibited(value)) {
+      String message = MessageFormat.format(ERROR_MSG, variableName);
+      throw CORE_LOGGER.javaSerializationProhibitedException(message);
     }
   }
 
@@ -89,6 +100,20 @@ public class VariableUtil {
         setVariableFunction.apply(variableName, value);
       }
     }
+  }
+
+  public static Map<String, ?> findBatchVariablesSerialized(String batchId, CommandContext commandContext) {
+    List<VariableInstanceEntity> variableInstances = commandContext.getVariableInstanceManager()
+        .findVariableInstancesByBatchId(batchId);
+    return variableInstances.stream().collect(variablesCollector());
+  }
+
+  protected static Collector<VariableInstanceEntity, ?, Map<String, TypedValue>> variablesCollector() {
+    return Collectors.toMap(VariableInstanceEntity::getName, VariableUtil::getSerializedValue);
+  }
+
+  protected static TypedValue getSerializedValue(VariableInstanceEntity variableInstanceEntity) {
+    return variableInstanceEntity.getTypedValue(false);
   }
 
   @FunctionalInterface

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/TaskEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/TaskEntity.java
@@ -1658,8 +1658,8 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
   }
 
   @Override
-  public void setVariablesLocal(Map<String, ?> variables) {
-    super.setVariablesLocal(variables);
+  public void setVariablesLocal(Map<String, ?> variables, boolean skipJavaSerializationFormatCheck) {
+    super.setVariablesLocal(variables, skipJavaSerializationFormatCheck);
     Context.getCommandContext().getDbEntityManager().forceUpdate(this);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
@@ -274,12 +274,8 @@ public class VariableInstanceEntity implements VariableInstance, CoreVariableIns
     return typedValueField.getTypedValue(isTransient);
   }
 
-  public TypedValue getTypedValueWithImplicitUpdatesSkipped() {
-    return typedValueField.getTypedValueWithImplicitUpdatesSkipped(isTransient);
-  }
-
   public TypedValue getTypedValue(boolean deserializeValue) {
-    return typedValueField.getTypedValue(deserializeValue, isTransient, false);
+    return typedValueField.getTypedValue(deserializeValue, isTransient);
   }
 
   public void setValue(TypedValue value) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/util/TypedValueField.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/util/TypedValueField.java
@@ -79,20 +79,10 @@ public class TypedValueField implements DbEntityLifecycleAware, CommandContextLi
   }
 
   public TypedValue getTypedValue(boolean asTransientValue) {
-    return getTypedValue(true, asTransientValue, false);
-  }
-
-  public TypedValue getTypedValueWithImplicitUpdatesSkipped(boolean asTransientValue) {
-    return getTypedValue(true, asTransientValue, true);
+    return getTypedValue(true, asTransientValue);
   }
 
   public TypedValue getTypedValue(boolean deserializeValue, boolean asTransientValue) {
-    return getTypedValue(deserializeValue, asTransientValue, false);
-  }
-
-  public TypedValue getTypedValue(boolean deserializeValue,
-                                  boolean asTransientValue,
-                                  boolean skipImplicitUpdates) {
     if (Context.getCommandContext() != null) {
       // in some circumstances we must invalidate the cached value instead of returning it
 
@@ -114,7 +104,7 @@ public class TypedValueField implements DbEntityLifecycleAware, CommandContextLi
       try {
         cachedValue = getSerializer().readValue(valueFields, deserializeValue, asTransientValue);
 
-        if (!skipImplicitUpdates && notifyOnImplicitUpdates && isMutableValue(cachedValue)) {
+        if (notifyOnImplicitUpdates && isMutableValue(cachedValue)) {
           Context.getCommandContext().registerCommandContextListener(this);
         }
 

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/migration/MigrationContextSwitchClassesTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/migration/MigrationContextSwitchClassesTest.java
@@ -106,14 +106,6 @@ public class MigrationContextSwitchClassesTest extends AbstractFoxPlatformIntegr
 
   }
 
-  protected static Asset modelAsAsset(BpmnModelInstance modelInstance) {
-    ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
-    Bpmn.writeModelToStream(byteStream, modelInstance);
-
-    byte[] bytes = byteStream.toByteArray();
-    return new ByteArrayAsset(bytes);
-  }
-
   @Test
   @OperateOnDeployment("clientDeployment")
   public void testCallStartListenerInTargetContext() {
@@ -176,4 +168,13 @@ public class MigrationContextSwitchClassesTest extends AbstractFoxPlatformIntegr
     // then
     Assert.assertTrue((Boolean)runtimeService.getVariable(pi, RemovalListener.VARIABLE_NAME));
   }
+
+  protected static Asset modelAsAsset(BpmnModelInstance modelInstance) {
+    ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+    Bpmn.writeModelToStream(byteStream, modelInstance);
+
+    byte[] bytes = byteStream.toByteArray();
+    return new ByteArrayAsset(bytes);
+  }
+
 }

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/jobexecutor/classes/MyPojo.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/jobexecutor/classes/MyPojo.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.integrationtest.jobexecutor.classes;
+
+public class MyPojo {
+
+    public MyPojo() {
+    }
+
+    public String name;
+    public int prio;
+
+    public String getName() {
+      return name;
+    }
+
+    public int getPrio() {
+      return prio;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public void setPrio(int prio) {
+      this.prio = prio;
+    }
+
+  }

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/util/AbstractFoxPlatformIntegrationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/util/AbstractFoxPlatformIntegrationTest.java
@@ -18,7 +18,16 @@ package org.camunda.bpm.integrationtest.util;
 
 import org.camunda.bpm.BpmPlatform;
 import org.camunda.bpm.ProcessEngineService;
-import org.camunda.bpm.engine.*;
+import org.camunda.bpm.engine.CaseService;
+import org.camunda.bpm.engine.DecisionService;
+import org.camunda.bpm.engine.FormService;
+import org.camunda.bpm.engine.HistoryService;
+import org.camunda.bpm.engine.IdentityService;
+import org.camunda.bpm.engine.ManagementService;
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.RepositoryService;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.impl.ProcessEngineImpl;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.jobexecutor.JobExecutor;


### PR DESCRIPTION
If a class is only present in a process application, the object variable cannot be deserialized in the job execution handler.

related to CAM-13435