### PR TITLE
CAM-13428: chore(engine): fix eventType filter javadoc

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/runtime/EventSubscriptionQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/runtime/EventSubscriptionQuery.java
@@ -32,7 +32,7 @@ public interface EventSubscriptionQuery extends Query<EventSubscriptionQuery, Ev
   EventSubscriptionQuery eventName(String eventName);
 
   /** Only select subscriptions for events with the given type. "message" selects message event subscriptions,
-   * "signal" selects signal event subscriptions, "compensation" selects compensation event subscriptions,
+   * "signal" selects signal event subscriptions, "compensate" selects compensation event subscriptions,
    * "conditional" selects conditional event subscriptions.**/
   EventSubscriptionQuery eventType(String eventType);
 


### PR DESCRIPTION
The correct `EventType` for Compensation events is `compensate`. (See https://github.com/camunda/camunda-bpm-platform/blob/master/engine/src/main/java/org/camunda/bpm/engine/impl/event/EventType.java#L32)

Related to CAM-13428