### PR TITLE
feat(engine+rest): set variables on process instance migration

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/VariableValueDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/VariableValueDto.ftl
@@ -32,7 +32,7 @@
 
                 * `transient`: Indicates whether the variable should be transient or
                 not. See [documentation](${docsUrl}/user-guide/process-engine/variables#transient-variables) for more informations.
-                (Not applicable for `decision-definition` and ` /process-instance/variables-async` endpoints)"
+                (Not applicable for `decision-definition`, ` /process-instance/variables-async`, and `/migration/executeAsync` endpoints)"
     />
 
 

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/migration/MigrationInstructionValidationReportDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/migration/MigrationInstructionValidationReportDto.ftl
@@ -9,7 +9,7 @@
         desc = "A migration instruction JSON object."
     />
 
-        <@lib.property
+    <@lib.property
         name = "failures"
         type = "array"
         itemType = "string"

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/migration/MigrationPlanDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/migration/MigrationPlanDto.ftl
@@ -20,6 +20,15 @@
         dto = "MigrationInstructionDto"
         desc = "A list of migration instructions which map equal activities. Each
                 migration instruction is a JSON object with the following properties:"
+    />
+
+    <@lib.property
+        name = "variables"
+        type = "object"
+        additionalProperties = true
+        dto = "VariableValueDto"
+        desc = "A map of variables which will be set into the process instances' scope.
+                Each key is a variable name and each value a JSON variable value object."
         last = true
     />
 

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/migration/MigrationPlanGenerationDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/migration/MigrationPlanGenerationDto.ftl
@@ -21,9 +21,17 @@
         type = "boolean"
         desc = "A boolean flag indicating whether instructions between events should be configured
                 to update the event triggers."
-        last = true
     />
 
+    <@lib.property
+        name = "variables"
+        type = "object"
+        additionalProperties = true
+        dto = "VariableValueDto"
+        desc = "A map of variables which will be set into the process instances' scope.
+                Each key is a variable name and each value a JSON variable value object."
+        last = true
+    />
 
 </@lib.dto>
 </#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/migration/MigrationPlanReportDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/migration/MigrationPlanReportDto.ftl
@@ -8,6 +8,16 @@
         dto = "MigrationInstructionValidationReportDto"
         desc = "The list of instruction validation reports. If no validation
                 errors are detected it is an empty list."
+    />
+
+    <@lib.property
+        name = "variableReports"
+        type = "object"
+        additionalProperties = true
+        dto = "MigrationVariableValidationReportDto"
+        desc = "A map of variable reports.
+                Each key is a variable name and each value a JSON object consisting of the variable's type, value,
+                value info object and a list of failures."
         last = true
     />
 

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/migration/MigrationVariableValidationReportDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/migration/MigrationVariableValidationReportDto.ftl
@@ -1,0 +1,13 @@
+<#macro dto_macro docsUrl="">
+<@lib.dto extends="VariableValueDto">
+
+    <@lib.property
+        name = "failures"
+        type = "array"
+        itemType = "string"
+        desc = "A list of variable validation report messages."
+        last = true
+    />
+
+</@lib.dto>
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/migration/execute/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/migration/execute/post.ftl
@@ -42,7 +42,17 @@
                              ],
                              "updateEventTrigger": true
                            }
-                         ]
+                         ],
+                         "variables": {
+                           "foo": {
+                             "type": "Object",
+                             "value": "[5,9]",
+                             "valueInfo": {
+                               "objectTypeName": "java.util.ArrayList",
+                               "serializationDataFormat": "application/json"
+                             }
+                           }
+                         }
                        },
                        "processInstanceIds": [
                          "aProcessInstance",
@@ -66,13 +76,20 @@
     <@lib.response
         code = "400"
         dto = "ExceptionDto"
+        desc = "Invalid variable value, for example if the value could not be parsed to an Integer value or the passed variable type is not supported.
+                See the  [Introduction](${docsUrl}/reference/rest/overview/#error-handling) for the error response format."
+    />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
         desc = "The request is not valid if one or more of the following statements apply:
 
                 * The provided migration plan is not valid, so an exception of type
                 `MigrationPlanValidationException` is returned.
                 * The provided migration plan is not valid for a specific process
                 instance it is applied to, so an exception of type
-                `MigrationInstructionInstanceValidationException` is returned.
+                `MigratingProcessInstanceValidationException` is returned.
                 * In case additional parameters of the request are unexpected, an
                 exception of type `InvalidRequestException` is returned.
 

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/migration/executeAsync/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/migration/executeAsync/post.ftl
@@ -42,7 +42,17 @@
                              ],
                              "updateEventTrigger": true
                            }
-                         ]
+                         ],
+                         "variables": {
+                           "foo": {
+                             "type": "Object",
+                             "value": "[5,9]",
+                             "valueInfo": {
+                               "objectTypeName": "java.util.ArrayList",
+                               "serializationDataFormat": "application/json"
+                             }
+                           }
+                         }
                        },
                        "processInstanceIds": [
                          "aProcessInstance",
@@ -77,6 +87,13 @@
                          "tenantId": "aTenantId"
                        }
                      }']
+    />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "Invalid variable value, for example if the value could not be parsed to an Integer value or the passed variable type is not supported.
+                See the  [Introduction](${docsUrl}/reference/rest/overview/#error-handling) for the error response format."
     />
 
     <@lib.response

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/migration/generate/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/migration/generate/post.ftl
@@ -19,7 +19,17 @@
                      "value": {
                        "sourceProcessDefinitionId": "aProcessDefinitionId1",
                        "targetProcessDefinitionId": "aProcessDefinitionId2",
-                       "updateEventTriggers": true
+                       "updateEventTriggers": true,
+                       "variables": {
+                         "foo": {
+                           "type": "Object",
+                           "value": "[5,6]",
+                           "valueInfo": {
+                             "objectTypeName": "java.util.ArrayList",
+                             "serializationDataFormat": "application/json"
+                           }
+                         }
+                       }
                      }
                    }']
   />
@@ -55,9 +65,26 @@
                              ],
                              "updateEventTrigger": true
                            }
-                         ]
+                         ],
+                         "variables": {
+                           "foo": {
+                             "type": "Object",
+                             "value": "[5,6]",
+                             "valueInfo": {
+                               "objectTypeName": "java.util.ArrayList",
+                               "serializationDataFormat": "application/json"
+                             }
+                           }
+                         }
                        }
                      }']
+    />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "Invalid variable value, for example if the value could not be parsed to an Integer value or the passed variable type is not supported.
+                See the  [Introduction](${docsUrl}/reference/rest/overview/#error-handling) for the error response format."
     />
 
     <@lib.response

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/migration/validate/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/migration/validate/post.ftl
@@ -37,7 +37,17 @@
                            ],
                            "updateEventTrigger": true
                          }
-                       ]
+                       ],
+                       "variables": {
+                         "foo": {
+                           "type": "Object",
+                           "value": "...",
+                           "valueInfo": {
+                             "objectTypeName": "java.util.ArrayList",
+                             "serializationDataFormat": "application/x-java-serialized-object"
+                           }
+                         }
+                       }
                      }
                    }']
   />
@@ -83,9 +93,29 @@
                                "failure2"
                              ]
                            }
-                         ]
+                         ],
+                         "variableReports": {
+                           "foo": {
+                             "type": "Object",
+                             "value": "...",
+                             "valueInfo": {
+                               "objectTypeName": "java.util.ArrayList",
+                               "serializationDataFormat": "application/x-java-serialized-object"
+                             },
+                             "failures": [
+                               "Cannot set variable with name foo. Java serialization format is prohibited"
+                             ]
+                           }
+                        }
                        }
                      }']
+    />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "Invalid variable value, for example if the value could not be parsed to an Integer value or the passed variable type is not supported.
+                See the  [Introduction](${docsUrl}/reference/rest/overview/#error-handling) for the error response format."
     />
 
     <@lib.response

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/migration/MigrationPlanGenerationDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/migration/MigrationPlanGenerationDto.java
@@ -16,6 +16,10 @@
  */
 package org.camunda.bpm.engine.rest.dto.migration;
 
+import org.camunda.bpm.engine.rest.dto.VariableValueDto;
+
+import java.util.Map;
+
 /**
  * @author Thorben Lindhauer
  *
@@ -25,6 +29,7 @@ public class MigrationPlanGenerationDto {
   protected String sourceProcessDefinitionId;
   protected String targetProcessDefinitionId;
   protected boolean updateEventTriggers;
+  protected Map<String, VariableValueDto> variables;
 
   public String getSourceProcessDefinitionId() {
     return sourceProcessDefinitionId;
@@ -48,6 +53,14 @@ public class MigrationPlanGenerationDto {
 
   public void setUpdateEventTriggers(boolean updateEventTriggers) {
     this.updateEventTriggers = updateEventTriggers;
+  }
+
+  public void setVariables(Map<String, VariableValueDto> variables) {
+    this.variables = variables;
+  }
+
+  public Map<String, VariableValueDto> getVariables() {
+    return variables;
   }
 
 }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/migration/MigrationPlanReportDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/migration/MigrationPlanReportDto.java
@@ -18,12 +18,14 @@ package org.camunda.bpm.engine.rest.dto.migration;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.camunda.bpm.engine.migration.MigrationPlanValidationReport;
 
 public class MigrationPlanReportDto {
 
   protected List<MigrationInstructionValidationReportDto> instructionReports;
+  protected Map<String, MigrationVariableValidationReportDto> variableReports;
 
   public List<MigrationInstructionValidationReportDto> getInstructionReports() {
     return instructionReports;
@@ -33,15 +35,25 @@ public class MigrationPlanReportDto {
     this.instructionReports = instructionReports;
   }
 
+  public Map<String, MigrationVariableValidationReportDto> getVariableReports() {
+    return variableReports;
+  }
+
+  public void setVariableReports(Map<String, MigrationVariableValidationReportDto> variableReports) {
+    this.variableReports = variableReports;
+  }
+
   public static MigrationPlanReportDto form(MigrationPlanValidationReport validationReport) {
     MigrationPlanReportDto dto = new MigrationPlanReportDto();
     dto.setInstructionReports(MigrationInstructionValidationReportDto.from(validationReport.getInstructionReports()));
+    dto.setVariableReports(MigrationVariableValidationReportDto.from(validationReport.getVariableReports()));
     return dto;
   }
 
   public static MigrationPlanReportDto emptyReport() {
     MigrationPlanReportDto dto = new MigrationPlanReportDto();
-    dto.setInstructionReports(Collections.<MigrationInstructionValidationReportDto>emptyList());
+    dto.setInstructionReports(Collections.emptyList());
+    dto.setVariableReports(Collections.emptyMap());
     return dto;
   }
 

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/migration/MigrationVariableValidationReportDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/migration/MigrationVariableValidationReportDto.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.rest.dto.migration;
+
+import org.camunda.bpm.engine.migration.MigrationVariableValidationReport;
+import org.camunda.bpm.engine.rest.dto.VariableValueDto;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MigrationVariableValidationReportDto extends VariableValueDto {
+
+  protected List<String> failures;
+
+  public List<String> getFailures() {
+    return failures;
+  }
+
+  public void setFailures(List<String> failures) {
+    this.failures = failures;
+  }
+
+  public static Map<String, MigrationVariableValidationReportDto> from(Map<String, MigrationVariableValidationReport> variableReports) {
+    Map<String, MigrationVariableValidationReportDto> dtos = new HashMap<>();
+    variableReports.forEach((name, report) ->
+        dtos.put(name, MigrationVariableValidationReportDto.from(report)));
+    return dtos;
+  }
+
+  public static MigrationVariableValidationReportDto from(MigrationVariableValidationReport variableReport) {
+    MigrationVariableValidationReportDto dto = new MigrationVariableValidationReportDto();
+    VariableValueDto valueDto = VariableValueDto.fromTypedValue(variableReport.getTypedValue());
+    dto.setType(valueDto.getType());
+    dto.setValue(valueDto.getValue());
+    dto.setValueInfo(valueDto.getValueInfo());
+    dto.setFailures(variableReport.getFailures());
+    return dto;
+  }
+
+}

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/impl/MigrationRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/impl/MigrationRestServiceImpl.java
@@ -41,7 +41,7 @@ import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import static org.camunda.bpm.engine.rest.dto.VariableValueDto.*;
+import static org.camunda.bpm.engine.rest.dto.VariableValueDto.toMap;
 
 public class MigrationRestServiceImpl extends AbstractRestProcessEngineAware implements MigrationRestService {
 

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/impl/MigrationRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/impl/MigrationRestServiceImpl.java
@@ -17,6 +17,7 @@
 package org.camunda.bpm.engine.rest.impl;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.core.Response.Status;
 
@@ -28,6 +29,7 @@ import org.camunda.bpm.engine.migration.MigrationPlan;
 import org.camunda.bpm.engine.migration.MigrationPlanExecutionBuilder;
 import org.camunda.bpm.engine.migration.MigrationPlanValidationException;
 import org.camunda.bpm.engine.rest.MigrationRestService;
+import org.camunda.bpm.engine.rest.dto.VariableValueDto;
 import org.camunda.bpm.engine.rest.dto.batch.BatchDto;
 import org.camunda.bpm.engine.rest.dto.migration.MigrationExecutionDto;
 import org.camunda.bpm.engine.rest.dto.migration.MigrationPlanDto;
@@ -38,6 +40,8 @@ import org.camunda.bpm.engine.rest.exception.InvalidRequestException;
 import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.camunda.bpm.engine.rest.dto.VariableValueDto.*;
 
 public class MigrationRestServiceImpl extends AbstractRestProcessEngineAware implements MigrationRestService {
 
@@ -57,6 +61,11 @@ public class MigrationRestServiceImpl extends AbstractRestProcessEngineAware imp
 
       if (generationDto.isUpdateEventTriggers()) {
         instructionsBuilder = instructionsBuilder.updateEventTriggers();
+      }
+
+      Map<String, VariableValueDto> variableDtos = generationDto.getVariables();
+      if (variableDtos != null) {
+        instructionsBuilder.setVariables(toMap(variableDtos, processEngine, objectMapper));
       }
 
       MigrationPlan migrationPlan = instructionsBuilder.build();
@@ -114,7 +123,7 @@ public class MigrationRestServiceImpl extends AbstractRestProcessEngineAware imp
 
   protected MigrationPlan createMigrationPlan(MigrationPlanDto migrationPlanDto) {
     try {
-      return MigrationPlanDto.toMigrationPlan(processEngine, migrationPlanDto);
+      return MigrationPlanDto.toMigrationPlan(processEngine, objectMapper, migrationPlanDto);
     }
     catch (MigrationPlanValidationException e) {
       throw e;

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockMigrationPlanBuilder.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockMigrationPlanBuilder.java
@@ -21,18 +21,21 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.camunda.bpm.engine.migration.MigrationInstruction;
 import org.camunda.bpm.engine.migration.MigrationInstructionBuilder;
 import org.camunda.bpm.engine.migration.MigrationInstructionsBuilder;
 import org.camunda.bpm.engine.migration.MigrationPlan;
 import org.camunda.bpm.engine.migration.MigrationPlanBuilder;
+import org.camunda.bpm.engine.variable.VariableMap;
 
 public class MockMigrationPlanBuilder {
 
   protected String sourceProcessDefinitionId;
   protected String targetProcessDefinitionId;
   protected List<MigrationInstruction> instructions = new ArrayList<MigrationInstruction>();
+  protected VariableMap variables;
 
   public MockMigrationPlanBuilder sourceProcessDefinitionId(String sourceProcessDefinitionId) {
     this.sourceProcessDefinitionId = sourceProcessDefinitionId;
@@ -81,6 +84,7 @@ public class MockMigrationPlanBuilder {
     when(migrationPlanMock.getSourceProcessDefinitionId()).thenReturn(sourceProcessDefinitionId);
     when(migrationPlanMock.getTargetProcessDefinitionId()).thenReturn(targetProcessDefinitionId);
     when(migrationPlanMock.getInstructions()).thenReturn(instructions);
+    when(migrationPlanMock.getVariables()).thenReturn(variables);
     return migrationPlanMock;
   }
 
@@ -94,6 +98,11 @@ public class MockMigrationPlanBuilder {
       .thenReturn(migrationPlanMock);
 
     return migrationPlanBuilderMock;
+  }
+
+  public MockMigrationPlanBuilder variables(VariableMap variables) {
+    this.variables = variables;
+    return this;
   }
 
   public static interface JoinedMigrationPlanBuilderMock extends MigrationPlanBuilder, MigrationInstructionBuilder, MigrationInstructionsBuilder {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/RestartProcessInstanceBuilderImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/RestartProcessInstanceBuilderImpl.java
@@ -57,6 +57,10 @@ public class RestartProcessInstanceBuilderImpl implements RestartProcessInstance
     this.processInstanceIds = new ArrayList<String>();
   }
 
+  public RestartProcessInstanceBuilderImpl(String processDefinitionId) {
+    this(null, processDefinitionId);
+  }
+
   @Override
   public RestartProcessInstanceBuilder startBeforeActivity(String activityId) {
     ensureNotNull(NotValidException.class, "activityId", activityId);
@@ -79,11 +83,7 @@ public class RestartProcessInstanceBuilderImpl implements RestartProcessInstance
   }
 
   public void execute() {
-    execute(true);
-  }
-
-  public void execute(boolean writeUserOperationLog) {
-    commandExecutor.execute(new RestartProcessInstancesCmd(commandExecutor, this, writeUserOperationLog));
+    commandExecutor.execute(new RestartProcessInstancesCmd(commandExecutor, this));
   }
 
   public Batch executeAsync() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/UpdateProcessInstancesSuspensionStateBuilderImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/UpdateProcessInstancesSuspensionStateBuilderImpl.java
@@ -40,6 +40,10 @@ public class UpdateProcessInstancesSuspensionStateBuilderImpl implements UpdateP
     this.commandExecutor = commandExecutor;
   }
 
+  public UpdateProcessInstancesSuspensionStateBuilderImpl(List<String> processInstanceIds) {
+    this.processInstanceIds = processInstanceIds;
+  }
+
   @Override
   public UpdateProcessInstancesSuspensionStateBuilder byProcessInstanceIds(List<String> processInstanceIds) {
     this.processInstanceIds.addAll(processInstanceIds);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/BatchEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/BatchEntity.java
@@ -339,7 +339,8 @@ public class BatchEntity implements Batch, DbEntity, HasDbReferences, Nameable, 
   public void delete(boolean cascadeToHistory, boolean deleteJobs) {
     CommandContext commandContext = Context.getCommandContext();
 
-    if (Batch.TYPE_SET_VARIABLES.equals(type)) {
+    if (Batch.TYPE_SET_VARIABLES.equals(type) ||
+        Batch.TYPE_PROCESS_INSTANCE_MIGRATION.equals(type)) {
       deleteVariables(commandContext);
     }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/job/SetJobRetriesJobHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/job/SetJobRetriesJobHandler.java
@@ -22,6 +22,7 @@ import org.camunda.bpm.engine.impl.batch.BatchJobConfiguration;
 import org.camunda.bpm.engine.impl.batch.BatchJobContext;
 import org.camunda.bpm.engine.impl.batch.BatchJobDeclaration;
 import org.camunda.bpm.engine.impl.batch.SetRetriesBatchConfiguration;
+import org.camunda.bpm.engine.impl.cmd.SetJobsRetriesCmd;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.jobexecutor.JobDeclaration;
 import org.camunda.bpm.engine.impl.persistence.entity.ByteArrayEntity;
@@ -64,17 +65,8 @@ public class SetJobRetriesJobHandler extends AbstractBatchJobHandler<SetRetriesB
 
     SetRetriesBatchConfiguration batchConfiguration = readConfiguration(configurationEntity.getBytes());
 
-    boolean initialLegacyRestrictions = commandContext.isRestrictUserOperationLogToAuthenticatedUsers();
-    commandContext.disableUserOperationLog();
-    commandContext.setRestrictUserOperationLogToAuthenticatedUsers(true);
-    try {
-      commandContext.getProcessEngineConfiguration()
-          .getManagementService()
-          .setJobRetries(batchConfiguration.getIds(), batchConfiguration.getRetries());
-    } finally {
-      commandContext.enableUserOperationLog();
-      commandContext.setRestrictUserOperationLogToAuthenticatedUsers(initialLegacyRestrictions);
-    }
+    commandContext.executeWithOperationLogPrevented(
+        new SetJobsRetriesCmd(batchConfiguration.getIds(), batchConfiguration.getRetries()));
 
     commandContext.getByteArrayManager().delete(configurationEntity);
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/variables/BatchSetVariablesHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/variables/BatchSetVariablesHandler.java
@@ -56,22 +56,9 @@ public class BatchSetVariablesHandler extends AbstractBatchJobHandler<BatchConfi
 
     List<String> processInstanceIds = batchConfiguration.getIds();
 
-    boolean initialLegacyRestrictions =
-        commandContext.isRestrictUserOperationLogToAuthenticatedUsers();
-
-    commandContext.disableUserOperationLog();
-    commandContext.setRestrictUserOperationLogToAuthenticatedUsers(true);
-
-    try {
-      for (String processInstanceId : processInstanceIds) {
-        new SetExecutionVariablesCmd(processInstanceId, variables, false, true)
-            .execute(commandContext);
-      }
-
-    } finally {
-      commandContext.enableUserOperationLog();
-      commandContext.setRestrictUserOperationLogToAuthenticatedUsers(initialLegacyRestrictions);
-
+    for (String processInstanceId : processInstanceIds) {
+      commandContext.executeWithOperationLogPrevented(
+          new SetExecutionVariablesCmd(processInstanceId, variables, false, true));
     }
 
     commandContext.getByteArrayManager().delete(byteArray);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/CreateMigrationPlanCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/CreateMigrationPlanCmd.java
@@ -16,6 +16,7 @@
  */
 package org.camunda.bpm.engine.impl.cmd;
 
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,6 +24,7 @@ import org.camunda.bpm.engine.BadUserRequestException;
 import org.camunda.bpm.engine.exception.NullValueException;
 import org.camunda.bpm.engine.impl.cfg.CommandChecker;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.core.variable.VariableUtil;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.migration.MigrationInstructionGenerator;
@@ -32,6 +34,7 @@ import org.camunda.bpm.engine.impl.migration.MigrationPlanImpl;
 import org.camunda.bpm.engine.impl.migration.validation.instruction.MigrationInstructionValidationReportImpl;
 import org.camunda.bpm.engine.impl.migration.validation.instruction.MigrationInstructionValidator;
 import org.camunda.bpm.engine.impl.migration.validation.instruction.MigrationPlanValidationReportImpl;
+import org.camunda.bpm.engine.impl.migration.validation.instruction.MigrationVariableValidationReportImpl;
 import org.camunda.bpm.engine.impl.migration.validation.instruction.ValidatingMigrationInstruction;
 import org.camunda.bpm.engine.impl.migration.validation.instruction.ValidatingMigrationInstructionImpl;
 import org.camunda.bpm.engine.impl.migration.validation.instruction.ValidatingMigrationInstructions;
@@ -42,6 +45,8 @@ import org.camunda.bpm.engine.impl.util.EngineUtilLogger;
 import org.camunda.bpm.engine.impl.util.EnsureUtil;
 import org.camunda.bpm.engine.migration.MigrationInstruction;
 import org.camunda.bpm.engine.migration.MigrationPlan;
+import org.camunda.bpm.engine.variable.VariableMap;
+import org.camunda.bpm.engine.variable.value.TypedValue;
 
 /**
  * @author Thorben Lindhauer
@@ -74,9 +79,54 @@ public class CreateMigrationPlanCmd implements Command<MigrationPlan> {
     instructions.addAll(migrationBuilder.getExplicitMigrationInstructions());
     migrationPlan.setInstructions(instructions);
 
-    validateMigrationPlan(commandContext, migrationPlan, sourceProcessDefinition, targetProcessDefinition);
+    VariableMap variables = migrationBuilder.getVariables();
+    if (variables != null) {
+      migrationPlan.setVariables(variables);
+    }
+
+    validateMigration(commandContext, migrationPlan, sourceProcessDefinition, targetProcessDefinition);
 
     return migrationPlan;
+  }
+
+  protected void validateMigration(CommandContext commandContext,
+                                   MigrationPlanImpl migrationPlan,
+                                   ProcessDefinitionEntity sourceProcessDefinition,
+                                   ProcessDefinitionEntity targetProcessDefinition) {
+    MigrationPlanValidationReportImpl planReport =
+        new MigrationPlanValidationReportImpl(migrationPlan);
+
+    VariableMap variables = migrationPlan.getVariables();
+    if (variables != null) {
+      validateVariables(variables, planReport);
+    }
+
+    validateMigrationInstructions(commandContext, planReport, migrationPlan,
+        sourceProcessDefinition, targetProcessDefinition);
+
+    if (planReport.hasReports()) {
+      throw LOG.failingMigrationPlanValidation(planReport);
+    }
+  }
+
+  protected void validateVariables(VariableMap variables,
+                                   MigrationPlanValidationReportImpl planReport) {
+    variables.keySet().forEach(name -> {
+
+      TypedValue valueTyped = variables.getValueTyped(name);
+
+      boolean javaSerializationProhibited = VariableUtil.isJavaSerializationProhibited(valueTyped);
+      if (javaSerializationProhibited) {
+
+        MigrationVariableValidationReportImpl report =
+            new MigrationVariableValidationReportImpl(valueTyped);
+
+        String failureMessage = MessageFormat.format(VariableUtil.ERROR_MSG, name);
+        report.addFailure(failureMessage);
+
+        planReport.addVariableReport(name, report);
+      }
+    });
   }
 
   protected ProcessDefinitionEntity getProcessDefinition(CommandContext commandContext, String id, String type) {
@@ -114,10 +164,14 @@ public class CreateMigrationPlanCmd implements Command<MigrationPlan> {
     return generatedInstructions.asMigrationInstructions();
   }
 
-  protected void validateMigrationPlan(CommandContext commandContext, MigrationPlanImpl migrationPlan, ProcessDefinitionImpl sourceProcessDefinition, ProcessDefinitionImpl targetProcessDefinition) {
+  protected void validateMigrationInstructions(CommandContext commandContext,
+                                               MigrationPlanValidationReportImpl planReport,
+                                               MigrationPlanImpl migrationPlan,
+                                               ProcessDefinitionImpl sourceProcessDefinition,
+                                               ProcessDefinitionImpl targetProcessDefinition) {
     List<MigrationInstructionValidator> migrationInstructionValidators = commandContext.getProcessEngineConfiguration().getMigrationInstructionValidators();
 
-    MigrationPlanValidationReportImpl planReport = new MigrationPlanValidationReportImpl(migrationPlan);
+
     ValidatingMigrationInstructions validatingMigrationInstructions = wrapMigrationInstructions(migrationPlan, sourceProcessDefinition, targetProcessDefinition, planReport);
 
     for (ValidatingMigrationInstruction validatingMigrationInstruction : validatingMigrationInstructions.getInstructions()) {
@@ -126,11 +180,6 @@ public class CreateMigrationPlanCmd implements Command<MigrationPlan> {
         planReport.addInstructionReport(instructionReport);
       }
     }
-
-    if (planReport.hasInstructionReports()) {
-      throw LOG.failingMigrationPlanValidation(planReport);
-    }
-
   }
 
   protected MigrationInstructionValidationReportImpl validateInstruction(ValidatingMigrationInstruction instruction, ValidatingMigrationInstructions instructions, List<MigrationInstructionValidator> migrationInstructionValidators) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/RestartProcessInstancesCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/RestartProcessInstancesCmd.java
@@ -55,13 +55,9 @@ public class RestartProcessInstancesCmd extends AbstractRestartProcessInstanceCm
 
   private final static CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
 
-  protected boolean writeUserOperationLog;
-
   public RestartProcessInstancesCmd(CommandExecutor commandExecutor,
-                                    RestartProcessInstanceBuilderImpl builder,
-                                    boolean writeUserOperationLog) {
+                                    RestartProcessInstanceBuilderImpl builder) {
     super(commandExecutor, builder);
-    this.writeUserOperationLog = writeUserOperationLog;
   }
 
   @Override
@@ -86,10 +82,7 @@ public class RestartProcessInstancesCmd extends AbstractRestartProcessInstanceCm
 
     checkAuthorization(commandContext, processDefinition);
 
-    if (writeUserOperationLog) {
-      writeUserOperationLog(commandContext, processDefinition,
-          processInstanceIds.size(), false);
-    }
+    writeUserOperationLog(commandContext, processDefinition, processInstanceIds.size(), false);
 
     final String processDefinitionId = builder.getProcessDefinitionId();
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/UpdateExternalTaskRetriesBuilderImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/UpdateExternalTaskRetriesBuilderImpl.java
@@ -44,6 +44,11 @@ public class UpdateExternalTaskRetriesBuilderImpl implements UpdateExternalTaskR
 
   protected int retries;
 
+  public UpdateExternalTaskRetriesBuilderImpl(List<String> externalTaskIds, int retries) {
+    this.externalTaskIds = externalTaskIds;
+    this.retries = retries;
+  }
+
   public UpdateExternalTaskRetriesBuilderImpl(CommandExecutor commandExecutor) {
     this.commandExecutor = commandExecutor;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/core/CoreLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/core/CoreLogger.java
@@ -61,6 +61,9 @@ public class CoreLogger extends ProcessEngineLogger {
       ));
   }
 
+  // We left out id 005!
+  // please skip it unless you backport it to all maintained versions to avoid inconsistencies
+
   public ProcessEngineException transientVariableException(String variableName) {
     return new ProcessEngineException(exceptionMessage(
         "006",

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/core/CoreLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/core/CoreLogger.java
@@ -21,8 +21,11 @@ import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.core.instance.CoreExecution;
 import org.camunda.bpm.engine.impl.core.operation.CoreAtomicOperation;
 import org.camunda.bpm.engine.impl.core.variable.CoreVariableInstance;
-import org.camunda.bpm.engine.impl.core.variable.VariableUtil;
 import org.camunda.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
+
+import java.text.MessageFormat;
+
+import static org.camunda.bpm.engine.impl.core.variable.VariableUtil.ERROR_MSG;
 
 /**
  * @author Daniel Meyer
@@ -58,14 +61,6 @@ public class CoreLogger extends ProcessEngineLogger {
       ));
   }
 
-  public ProcessEngineException missingVariableInstanceException(CoreVariableInstance variableInstance) {
-    return new ProcessEngineException(exceptionMessage(
-        "005",
-        "Cannot update variable instance with name {}. Variable does not exist",
-        variableInstance.getName()
-      ));
-  }
-
   public ProcessEngineException transientVariableException(String variableName) {
     return new ProcessEngineException(exceptionMessage(
         "006",
@@ -74,8 +69,9 @@ public class CoreLogger extends ProcessEngineLogger {
       ));
   }
 
-  public ProcessEngineException javaSerializationProhibitedException(String message) {
-    return new ProcessEngineException(exceptionMessage("007", message));
+  public ProcessEngineException javaSerializationProhibitedException(String variableName) {
+    return new ProcessEngineException(exceptionMessage("007",
+        MessageFormat.format(ERROR_MSG, variableName)));
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/batch/DeleteHistoricDecisionInstancesJobHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/batch/DeleteHistoricDecisionInstancesJobHandler.java
@@ -24,6 +24,7 @@ import org.camunda.bpm.engine.impl.batch.BatchConfiguration;
 import org.camunda.bpm.engine.impl.batch.BatchJobConfiguration;
 import org.camunda.bpm.engine.impl.batch.BatchJobContext;
 import org.camunda.bpm.engine.impl.batch.BatchJobDeclaration;
+import org.camunda.bpm.engine.impl.dmn.cmd.DeleteHistoricDecisionInstancesBulkCmd;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.jobexecutor.JobDeclaration;
 import org.camunda.bpm.engine.impl.persistence.entity.ByteArrayEntity;
@@ -61,17 +62,8 @@ public class DeleteHistoricDecisionInstancesJobHandler extends AbstractBatchJobH
 
     BatchConfiguration batchConfiguration = readConfiguration(configurationEntity.getBytes());
 
-    boolean initialLegacyRestrictions = commandContext.isRestrictUserOperationLogToAuthenticatedUsers();
-    commandContext.disableUserOperationLog();
-    commandContext.setRestrictUserOperationLogToAuthenticatedUsers(true);
-    try {
-      commandContext.getProcessEngineConfiguration()
-          .getHistoryService()
-          .deleteHistoricDecisionInstancesBulk(batchConfiguration.getIds());
-    } finally {
-      commandContext.enableUserOperationLog();
-      commandContext.setRestrictUserOperationLogToAuthenticatedUsers(initialLegacyRestrictions);
-    }
+    commandContext.executeWithOperationLogPrevented(
+        new DeleteHistoricDecisionInstancesBulkCmd(batchConfiguration.getIds()));
 
     commandContext.getByteArrayManager().delete(configurationEntity);
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandContext.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandContext.java
@@ -44,7 +44,6 @@ import org.camunda.bpm.engine.impl.cmmn.entity.runtime.CaseSentryPartManager;
 import org.camunda.bpm.engine.impl.cmmn.operation.CmmnAtomicOperation;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.context.ProcessApplicationContextUtil;
-import org.camunda.bpm.engine.impl.db.EnginePersistenceLogger;
 import org.camunda.bpm.engine.impl.db.entitymanager.DbEntityManager;
 import org.camunda.bpm.engine.impl.db.sql.DbSqlSession;
 import org.camunda.bpm.engine.impl.dmn.entity.repository.DecisionDefinitionManager;
@@ -656,4 +655,22 @@ public class CommandContext {
   public OptimizeManager getOptimizeManager() {
     return getSession(OptimizeManager.class);
   }
+
+  public <T> void executeWithOperationLogPrevented(Command<T> command) {
+    boolean initialLegacyRestrictions =
+        isRestrictUserOperationLogToAuthenticatedUsers();
+
+    disableUserOperationLog();
+    setRestrictUserOperationLogToAuthenticatedUsers(true);
+
+    try {
+      command.execute(this);
+
+    } finally {
+      enableUserOperationLog();
+      setRestrictUserOperationLogToAuthenticatedUsers(initialLegacyRestrictions);
+
+    }
+  }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/json/MigrationBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/json/MigrationBatchConfigurationJsonConverter.java
@@ -33,6 +33,7 @@ public class MigrationBatchConfigurationJsonConverter extends JsonObjectConverte
   public static final String PROCESS_INSTANCE_ID_MAPPINGS = "processInstanceIdMappings";
   public static final String SKIP_LISTENERS = "skipListeners";
   public static final String SKIP_IO_MAPPINGS = "skipIoMappings";
+  public static final String BATCH_ID = "batchId";
 
   public JsonObject toJsonObject(MigrationBatchConfiguration configuration) {
     JsonObject json = JsonUtil.createObject();
@@ -42,16 +43,19 @@ public class MigrationBatchConfigurationJsonConverter extends JsonObjectConverte
     JsonUtil.addListField(json, PROCESS_INSTANCE_ID_MAPPINGS, DeploymentMappingJsonConverter.INSTANCE, configuration.getIdMappings());
     JsonUtil.addField(json, SKIP_LISTENERS, configuration.isSkipCustomListeners());
     JsonUtil.addField(json, SKIP_IO_MAPPINGS, configuration.isSkipIoMappings());
+    JsonUtil.addField(json, BATCH_ID, configuration.getBatchId());
 
     return json;
   }
 
   public MigrationBatchConfiguration toObject(JsonObject json) {
-    MigrationBatchConfiguration configuration = new MigrationBatchConfiguration(readProcessInstanceIds(json), readIdMappings(json),
+    return new MigrationBatchConfiguration(
+        readProcessInstanceIds(json),
+        readIdMappings(json),
         JsonUtil.asJavaObject(JsonUtil.getObject(json, MIGRATION_PLAN), MigrationPlanJsonConverter.INSTANCE),
-        JsonUtil.getBoolean(json, SKIP_LISTENERS), JsonUtil.getBoolean(json, SKIP_IO_MAPPINGS));
-
-    return configuration;
+        JsonUtil.getBoolean(json, SKIP_LISTENERS),
+        JsonUtil.getBoolean(json, SKIP_IO_MAPPINGS),
+        JsonUtil.getString(json, BATCH_ID));
   }
 
   protected List<String> readProcessInstanceIds(JsonObject jsonObject) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/migration/AbstractMigrationCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/migration/AbstractMigrationCmd.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -82,6 +83,7 @@ public abstract class AbstractMigrationCmd {
       ProcessDefinitionEntity sourceProcessDefinition,
       ProcessDefinitionEntity targetProcessDefinition,
       int numInstances,
+      Map<String, Object> variables,
       boolean async) {
 
     List<PropertyChange> propertyChanges = new ArrayList<PropertyChange>();
@@ -91,6 +93,10 @@ public abstract class AbstractMigrationCmd {
     propertyChanges.add(new PropertyChange("nrOfInstances",
         null,
         numInstances));
+
+    if (variables != null) {
+      propertyChanges.add(new PropertyChange("nrOfSetVariables", null, variables.size()));
+    }
     propertyChanges.add(new PropertyChange("async", null, async));
 
     commandContext.getOperationLogManager()

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/migration/MigrationPlanBuilderImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/migration/MigrationPlanBuilderImpl.java
@@ -17,7 +17,9 @@
 package org.camunda.bpm.engine.impl.migration;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.camunda.bpm.engine.migration.MigrationPlanBuilder;
 import org.camunda.bpm.engine.impl.cmd.CreateMigrationPlanCmd;
@@ -25,6 +27,8 @@ import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 import org.camunda.bpm.engine.migration.MigrationInstructionBuilder;
 import org.camunda.bpm.engine.migration.MigrationInstructionsBuilder;
 import org.camunda.bpm.engine.migration.MigrationPlan;
+import org.camunda.bpm.engine.variable.VariableMap;
+import org.camunda.bpm.engine.variable.impl.VariableMapImpl;
 
 /**
  * @author Thorben Lindhauer
@@ -40,6 +44,7 @@ public class MigrationPlanBuilderImpl implements MigrationInstructionBuilder, Mi
 
   protected boolean mapEqualActivities = false;
   protected boolean updateEventTriggersForGeneratedInstructions = false;
+  protected VariableMap variables;
 
   public MigrationPlanBuilderImpl(CommandExecutor commandExecutor, String sourceProcessDefinitionId,
       String targetProcessDefinitionId) {
@@ -51,6 +56,16 @@ public class MigrationPlanBuilderImpl implements MigrationInstructionBuilder, Mi
 
   public MigrationInstructionsBuilder mapEqualActivities() {
     this.mapEqualActivities = true;
+    return this;
+  }
+
+  @Override
+  public MigrationPlanBuilder setVariables(Map<String, ?> variables) {
+    if (variables instanceof VariableMapImpl) {
+      this.variables = (VariableMapImpl) variables;
+    } else if (variables != null) {
+      this.variables = new VariableMapImpl(new HashMap<>(variables));
+    }
     return this;
   }
 
@@ -83,6 +98,10 @@ public class MigrationPlanBuilderImpl implements MigrationInstructionBuilder, Mi
 
   public boolean isMapEqualActivities() {
     return mapEqualActivities;
+  }
+
+  public VariableMap getVariables() {
+    return variables;
   }
 
   public boolean isUpdateEventTriggersForGeneratedInstructions() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/migration/MigrationPlanExecutionBuilderImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/migration/MigrationPlanExecutionBuilderImpl.java
@@ -93,11 +93,7 @@ public class MigrationPlanExecutionBuilderImpl implements MigrationPlanExecution
   }
 
   public void execute() {
-    execute(true);
-  }
-
-  public void execute(boolean writeOperationLog) {
-    commandExecutor.execute(new MigrateProcessInstanceCmd(this, writeOperationLog));
+    commandExecutor.execute(new MigrateProcessInstanceCmd(this, false));
   }
 
   public Batch executeAsync() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/migration/MigrationPlanImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/migration/MigrationPlanImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.camunda.bpm.engine.migration.MigrationInstruction;
 import org.camunda.bpm.engine.migration.MigrationPlan;
+import org.camunda.bpm.engine.variable.VariableMap;
 
 /**
  * @author Thorben Lindhauer
@@ -32,6 +33,8 @@ public class MigrationPlanImpl implements MigrationPlan {
   protected String targetProcessDefinitionId;
 
   protected List<MigrationInstruction> instructions;
+
+  protected VariableMap variables;
 
   public MigrationPlanImpl(String sourceProcessDefinitionId, String targetProcessDefinitionId) {
     this.sourceProcessDefinitionId = sourceProcessDefinitionId;
@@ -49,6 +52,15 @@ public class MigrationPlanImpl implements MigrationPlan {
 
   public String getTargetProcessDefinitionId() {
     return targetProcessDefinitionId;
+  }
+
+  @Override
+  public VariableMap getVariables() {
+    return variables;
+  }
+
+  public void setVariables(VariableMap variables) {
+    this.variables = variables;
   }
 
   public void setTargetProcessDefinitionId(String targetProcessDefinitionId) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/migration/batch/MigrationBatchConfiguration.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/migration/batch/MigrationBatchConfiguration.java
@@ -28,15 +28,25 @@ public class MigrationBatchConfiguration extends BatchConfiguration {
   protected boolean isSkipCustomListeners;
   protected boolean isSkipIoMappings;
 
-  public MigrationBatchConfiguration(List<String> ids) {
-    super(ids);
+  public MigrationBatchConfiguration(List<String> ids,
+                                     MigrationPlan migrationPlan,
+                                     boolean isSkipCustomListeners,
+                                     boolean isSkipIoMappings,
+                                     String batchId) {
+    this(ids, null, migrationPlan, isSkipCustomListeners, isSkipIoMappings, batchId);
   }
 
   public MigrationBatchConfiguration(List<String> ids,
-      MigrationPlan migrationPlan,
-      boolean isSkipCustomListeners,
-      boolean isSkipIoMappings) {
-    this(ids, null, migrationPlan, isSkipCustomListeners, isSkipIoMappings);
+                                     DeploymentMappings mappings,
+                                     MigrationPlan migrationPlan,
+                                     boolean isSkipCustomListeners,
+                                     boolean isSkipIoMappings,
+                                     String batchId) {
+    super(ids, mappings);
+    this.migrationPlan = migrationPlan;
+    this.isSkipCustomListeners = isSkipCustomListeners;
+    this.isSkipIoMappings = isSkipIoMappings;
+    this.batchId = batchId;
   }
 
   public MigrationBatchConfiguration(List<String> ids,
@@ -44,10 +54,7 @@ public class MigrationBatchConfiguration extends BatchConfiguration {
                                      MigrationPlan migrationPlan,
                                      boolean isSkipCustomListeners,
                                      boolean isSkipIoMappings) {
-    super(ids, mappings);
-    this.migrationPlan = migrationPlan;
-    this.isSkipCustomListeners = isSkipCustomListeners;
-    this.isSkipIoMappings = isSkipIoMappings;
+    this(ids, mappings, migrationPlan, isSkipCustomListeners, isSkipIoMappings, null);
   }
 
   public MigrationPlan getMigrationPlan() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/migration/validation/instruction/MigrationPlanValidationReportImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/migration/validation/instruction/MigrationPlanValidationReportImpl.java
@@ -17,16 +17,20 @@
 package org.camunda.bpm.engine.impl.migration.validation.instruction;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.camunda.bpm.engine.migration.MigrationInstructionValidationReport;
 import org.camunda.bpm.engine.migration.MigrationPlan;
 import org.camunda.bpm.engine.migration.MigrationPlanValidationReport;
+import org.camunda.bpm.engine.migration.MigrationVariableValidationReport;
 
 public class MigrationPlanValidationReportImpl implements MigrationPlanValidationReport {
 
   protected MigrationPlan migrationPlan;
-  protected List<MigrationInstructionValidationReport> instructionReports = new ArrayList<MigrationInstructionValidationReport>();
+  protected List<MigrationInstructionValidationReport> instructionReports = new ArrayList<>();
+  protected Map<String, MigrationVariableValidationReport> variableReports = new HashMap<>();
 
   public MigrationPlanValidationReportImpl(MigrationPlan migrationPlan) {
     this.migrationPlan = migrationPlan;
@@ -36,8 +40,18 @@ public class MigrationPlanValidationReportImpl implements MigrationPlanValidatio
     return migrationPlan;
   }
 
+  @Override
+  public boolean hasReports() {
+    return hasVariableReports() ||
+        hasInstructionReports();
+  }
+
   public void addInstructionReport(MigrationInstructionValidationReport instructionReport) {
     instructionReports.add(instructionReport);
+  }
+
+  public void addVariableReport(String variableName, MigrationVariableValidationReport variableReport) {
+    variableReports.put(variableName, variableReport);
   }
 
   public boolean hasInstructionReports() {
@@ -46,6 +60,16 @@ public class MigrationPlanValidationReportImpl implements MigrationPlanValidatio
 
   public List<MigrationInstructionValidationReport> getInstructionReports() {
     return instructionReports;
+  }
+
+  @Override
+  public boolean hasVariableReports() {
+    return !variableReports.isEmpty();
+  }
+
+  @Override
+  public Map<String, MigrationVariableValidationReport> getVariableReports() {
+    return variableReports;
   }
 
   public void writeTo(StringBuilder sb) {
@@ -61,6 +85,13 @@ public class MigrationPlanValidationReportImpl implements MigrationPlanValidatio
         sb.append("\t\t").append(failure).append("\n");
       }
     }
+
+    variableReports.forEach((name, report) -> {
+      sb.append("\t Migration variable ").append(name).append(" is not valid:\n");
+      for (String failure : report.getFailures()) {
+        sb.append("\t\t").append(failure).append("\n");
+      }
+    });
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/migration/validation/instruction/MigrationVariableValidationReportImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/migration/validation/instruction/MigrationVariableValidationReportImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.migration.validation.instruction;
+
+import org.camunda.bpm.engine.migration.MigrationVariableValidationReport;
+import org.camunda.bpm.engine.variable.value.TypedValue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MigrationVariableValidationReportImpl implements MigrationVariableValidationReport {
+
+  protected TypedValue typedValue;
+
+  protected List<String> failures = new ArrayList<>();
+
+  public MigrationVariableValidationReportImpl(TypedValue typedValue) {
+    this.typedValue = typedValue;
+  }
+
+  @Override
+  public <T extends TypedValue> T getTypedValue() {
+    return (T) typedValue;
+  }
+
+  public void addFailure(String failure) {
+    failures.add(failure);
+  }
+
+  public boolean hasFailures() {
+    return !failures.isEmpty();
+  }
+
+  public List<String> getFailures() {
+    return failures;
+  }
+
+  public String toString() {
+    return "MigrationVariableValidationReportImpl{" +
+      ", typedValue=" + typedValue +
+      ", failures=" + failures +
+      '}';
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/migration/MigrationPlan.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/migration/MigrationPlan.java
@@ -16,6 +16,8 @@
  */
 package org.camunda.bpm.engine.migration;
 
+import org.camunda.bpm.engine.variable.VariableMap;
+
 import java.util.List;
 
 /**
@@ -25,6 +27,9 @@ import java.util.List;
  * <p>A migration plan consists of a number of {@link MigrationInstruction}s that tell which
  *   activity maps to which. The set of instructions is complete, i.e. the migration logic does not perform
  *   migration steps that are not given by the instructions
+ *
+ * <p>A migration plan can include variables which will be set into the process instance scope
+ * after the migration.
  *
  * @author Thorben Lindhauer
  */
@@ -44,5 +49,10 @@ public interface MigrationPlan {
    * @return the id of the process definition that is migrated to
    */
   String getTargetProcessDefinitionId();
+
+  /**
+   * @return the variables to be set after the migration to the process instances' scope
+   */
+  VariableMap getVariables();
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/migration/MigrationPlanBuilder.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/migration/MigrationPlanBuilder.java
@@ -20,6 +20,8 @@ import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.authorization.Permissions;
 import org.camunda.bpm.engine.authorization.Resources;
 
+import java.util.Map;
+
 /**
  * @author Thorben Lindhauer
  *
@@ -32,6 +34,11 @@ public interface MigrationPlanBuilder {
    * level of sub process, and have the same id.
    */
   MigrationInstructionsBuilder mapEqualActivities();
+
+  /**
+   * @param variables which will be set into the process instance scope after the migration
+   */
+  MigrationPlanBuilder setVariables(Map<String, ?> variables);
 
   /**
    * Adds a migration instruction that maps activity instances of the source activity (of the source process definition)

--- a/engine/src/main/java/org/camunda/bpm/engine/migration/MigrationVariableValidationReport.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/migration/MigrationVariableValidationReport.java
@@ -16,43 +16,29 @@
  */
 package org.camunda.bpm.engine.migration;
 
+import org.camunda.bpm.engine.variable.value.TypedValue;
+
 import java.util.List;
-import java.util.Map;
 
 /**
- * Collects the migration validation reports for
- * all instructions and variables of the migration plan which contain failures.
+ * Collects the validation failures for a single migration
+ * variable.
  */
-public interface MigrationPlanValidationReport {
+public interface MigrationVariableValidationReport {
 
   /**
-   * @return the migration plan of the validation report
+   * @return the variable's {@link TypedValue}
    */
-  MigrationPlan getMigrationPlan();
+  <T extends TypedValue> T getTypedValue();
 
   /**
-   * @return {@code true} if either instruction or variable reports exist, {@code false} otherwise
+   * @return {@code true} if the report contains failures, {@code false} otherwise
    */
-  boolean hasReports();
+  boolean hasFailures();
 
   /**
-   * @return true if instructions reports exist, false otherwise
+   * @return the list of failure messages
    */
-  boolean hasInstructionReports();
-
-  /**
-   * @return {@code true} if variable reports exist, {@code false} otherwise
-   */
-  boolean hasVariableReports();
-
-  /**
-   * @return all instruction reports
-   */
-  List<MigrationInstructionValidationReport> getInstructionReports();
-
-  /**
-   * @return all variable reports
-   */
-  Map<String, MigrationVariableValidationReport> getVariableReports();
+  List<String> getFailures();
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/RestartProcessInstanceUserOperationLogTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/RestartProcessInstanceUserOperationLogTest.java
@@ -254,7 +254,7 @@ public class RestartProcessInstanceUserOperationLogTest {
   }
 
   @Test
-  public void shouldLogOnExecutionUnauthenticated() {
+  public void shouldNotLogOnExecutionUnauthenticated() {
     // given
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/RestartProcessInstanceUserOperationLogTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/RestartProcessInstanceUserOperationLogTest.java
@@ -44,7 +44,7 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 
 /**
- * 
+ *
  * @author Anna Pazola
  *
  */
@@ -70,6 +70,12 @@ public class RestartProcessInstanceUserOperationLogTest {
   @Before
   public void setClock() {
     ClockUtil.setCurrentTime(START_DATE);
+  }
+
+  @After
+  public void resetEngineConfig() {
+    rule.getProcessEngineConfiguration()
+        .setRestrictUserOperationLogToAuthenticatedUsers(true);
   }
 
   @Before
@@ -100,7 +106,7 @@ public class RestartProcessInstanceUserOperationLogTest {
 
     ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("process1");
     ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("process1");
-    
+
     runtimeService.deleteProcessInstance(processInstance1.getId(), "test");
     runtimeService.deleteProcessInstance(processInstance2.getId(), "test");
 
@@ -209,6 +215,26 @@ public class RestartProcessInstanceUserOperationLogTest {
   }
 
   @Test
+  public void shouldNotLogOnSyncExecutionUnauthenticated() {
+    // given
+    ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
+
+    ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
+    runtimeService.deleteProcessInstance(processInstance.getId(), "test");
+    Batch batch = runtimeService.restartProcessInstances(processDefinition.getId()).startBeforeActivity("user1").processInstanceIds(processInstance.getId()).executeAsync();
+
+    helper.completeSeedJobs(batch);
+
+    rule.getProcessEngineConfiguration().setRestrictUserOperationLogToAuthenticatedUsers(false);
+
+    // when
+    helper.executeJobs(batch);
+
+    // then
+    Assert.assertEquals(0, rule.getHistoryService().createUserOperationLogQuery().entityType(EntityTypes.PROCESS_INSTANCE).count());
+  }
+
+  @Test
   public void testNoCreationOnJobExecutorBatchJobExecution() {
     // given
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
@@ -219,6 +245,27 @@ public class RestartProcessInstanceUserOperationLogTest {
       .startAfterActivity("user1")
       .processInstanceIds(Arrays.asList(processInstance.getId()))
       .executeAsync();
+
+    // when
+    testRule.waitForJobExecutorToProcessAllJobs(5000L);
+
+    // then
+    Assert.assertEquals(0, rule.getHistoryService().createUserOperationLogQuery().count());
+  }
+
+  @Test
+  public void shouldLogOnExecutionUnauthenticated() {
+    // given
+    ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
+
+    ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
+    runtimeService.deleteProcessInstance(processInstance.getId(), "test");
+    runtimeService.restartProcessInstances(processDefinition.getId())
+      .startAfterActivity("user1")
+      .processInstanceIds(Arrays.asList(processInstance.getId()))
+      .executeAsync();
+
+    rule.getProcessEngineConfiguration().setRestrictUserOperationLogToAuthenticatedUsers(false);
 
     // when
     testRule.waitForJobExecutorToProcessAllJobs(5000L);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/MigrationPlanCreationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/MigrationPlanCreationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
 import static org.camunda.bpm.engine.test.util.MigrationPlanAssert.assertThat;
 import static org.camunda.bpm.engine.test.util.MigrationPlanAssert.migrate;
+import static org.camunda.bpm.engine.test.util.MigrationPlanAssert.variable;
 import static org.camunda.bpm.engine.test.util.MigrationPlanValidationReportAssert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -32,12 +33,19 @@ import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.api.runtime.migration.models.EventSubProcessModels;
 import org.camunda.bpm.engine.test.api.runtime.migration.models.ProcessModels;
 import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.engine.variable.value.ObjectValue;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.camunda.bpm.model.bpmn.builder.UserTaskBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Thorben Lindhauer
@@ -783,6 +791,298 @@ public class MigrationPlanCreationTest {
       .hasInstructions(
         migrate("eventSubProcessStart").to("eventSubProcessStart").updateEventTrigger(true)
       );
+  }
+
+  @Test
+  public void shouldSetVariable() {
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = runtimeService
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(Collections.singletonMap("foo", "bar"))
+        .mapEqualActivities()
+        .build();
+
+    assertThat(migrationPlan)
+        .hasSourceProcessDefinition(sourceProcessDefinition)
+        .hasTargetProcessDefinition(targetProcessDefinition)
+        .hasVariables(
+            variable().name("foo").value("bar")
+        );
+  }
+
+  @Test
+  public void shouldSetVariables() {
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("foo", "bar");
+    variables.put("bar", 5);
+
+    MigrationPlan migrationPlan = runtimeService
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(variables)
+        .mapEqualActivities()
+        .build();
+
+    assertThat(migrationPlan)
+        .hasSourceProcessDefinition(sourceProcessDefinition)
+        .hasTargetProcessDefinition(targetProcessDefinition)
+        .hasVariables(
+            variable().name("foo").value("bar"),
+            variable().name("bar").value(5)
+        );
+  }
+
+  @Test
+  public void shouldSetUntypedVariable() {
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = runtimeService
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(Variables.putValue("foo", "bar"))
+        .mapEqualActivities()
+        .build();
+
+    assertThat(migrationPlan)
+      .hasSourceProcessDefinition(sourceProcessDefinition)
+      .hasTargetProcessDefinition(targetProcessDefinition)
+      .hasVariables(
+          variable().name("foo").value("bar")
+      );
+  }
+
+  @Test
+  public void shouldSetUntypedVariables() {
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = runtimeService
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(
+            Variables.putValue("foo", "bar")
+                .putValue("bar", 5)
+        )
+        .mapEqualActivities()
+        .build();
+
+    assertThat(migrationPlan)
+        .hasSourceProcessDefinition(sourceProcessDefinition)
+        .hasTargetProcessDefinition(targetProcessDefinition)
+        .hasVariables(
+            variable().name("foo").value("bar"),
+            variable().name("bar").value(5)
+        );
+  }
+
+  @Test
+  public void shouldSetMapOfTypedVariable() {
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = runtimeService
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(Collections.singletonMap("foo", Variables.stringValue("bar")))
+        .mapEqualActivities()
+        .build();
+
+    assertThat(migrationPlan)
+        .hasSourceProcessDefinition(sourceProcessDefinition)
+        .hasTargetProcessDefinition(targetProcessDefinition)
+        .hasVariables(
+            variable().name("foo").value("bar").typed()
+        );
+  }
+
+  @Test
+  public void shouldSetVariableMapOfTypedVariable() {
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = runtimeService
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(
+            Variables.putValueTyped("foo", Variables.stringValue("bar"))
+        )
+        .mapEqualActivities()
+        .build();
+
+    assertThat(migrationPlan)
+        .hasSourceProcessDefinition(sourceProcessDefinition)
+        .hasTargetProcessDefinition(targetProcessDefinition)
+        .hasVariables(
+            variable().name("foo").value("bar").typed()
+        );
+  }
+
+  @Test
+  public void shouldSetTypedAndUntypedVariables() {
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = runtimeService
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(
+            Variables.putValue("foo", "bar")
+                .putValueTyped("bar", Variables.integerValue(5))
+        )
+        .mapEqualActivities()
+        .build();
+
+    assertThat(migrationPlan)
+        .hasSourceProcessDefinition(sourceProcessDefinition)
+        .hasTargetProcessDefinition(targetProcessDefinition)
+        .hasVariables(
+            variable().name("foo").value("bar"),
+            variable().name("bar").value(5).typed()
+        );
+  }
+
+  @Test
+  public void shouldSetNullVariables() {
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = runtimeService
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(null)
+        .mapEqualActivities()
+        .build();
+
+    assertThat(migrationPlan)
+        .hasSourceProcessDefinition(sourceProcessDefinition)
+        .hasTargetProcessDefinition(targetProcessDefinition)
+        .variablesNull();
+  }
+
+  @Test
+  public void shouldSetEmptyVariables() {
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = runtimeService
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(new HashMap<>())
+        .mapEqualActivities()
+        .build();
+
+    assertThat(migrationPlan)
+        .hasSourceProcessDefinition(sourceProcessDefinition)
+        .hasTargetProcessDefinition(targetProcessDefinition)
+        .variablesEmpty();
+  }
+
+  @Test
+  public void shouldThrowValidationExceptionDueToSerializationFormatForbiddenForVariable() {
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    try {
+      runtimeService
+          .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+          .setVariables(
+              Variables.putValueTyped("foo",
+                  Variables.serializedObjectValue()
+                      .serializedValue("[]")
+                      .objectTypeName(ArrayList.class.getName())
+                      .serializationDataFormat(Variables.SerializationDataFormats.JAVA.getName())
+                      .create())
+          )
+          .mapEqualActivities()
+          .build();
+      fail("Should not succeed");
+    } catch (MigrationPlanValidationException e) {
+      assertThat(e.getValidationReport())
+          .hasVariableFailures("foo",
+              "Cannot set variable with name foo. Java serialization format is prohibited");
+    }
+  }
+
+  @Test
+  public void shouldThrowValidationExceptionDueToSerializationFormatForbiddenForVariables() {
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    ObjectValue objectValue = Variables.serializedObjectValue()
+        .serializedValue("[]")
+        .objectTypeName(ArrayList.class.getName())
+        .serializationDataFormat(Variables.SerializationDataFormats.JAVA.getName())
+        .create();
+
+    try {
+      runtimeService
+          .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+          .setVariables(
+              Variables.putValueTyped("foo", objectValue)
+              .putValueTyped("bar", objectValue)
+          )
+          .mapEqualActivities()
+          .build();
+      fail("Should not succeed");
+    } catch (MigrationPlanValidationException e) {
+      assertThat(e.getValidationReport())
+          .hasVariableFailures("foo",
+              "Cannot set variable with name foo. Java serialization format is prohibited")
+          .hasVariableFailures("bar",
+              "Cannot set variable with name bar. Java serialization format is prohibited");
+    }
+  }
+
+  @Test
+  public void shouldThrowExceptionDueToInstructionsAndSerializationFormatForbiddenForVariable() {
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    ObjectValue objectValue = Variables.serializedObjectValue()
+        .serializedValue("[]")
+        .objectTypeName(ArrayList.class.getName())
+        .serializationDataFormat(Variables.SerializationDataFormats.JAVA.getName())
+        .create();
+
+    try {
+      runtimeService
+          .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+          .setVariables(Variables.putValueTyped("foo", objectValue))
+          .mapActivities("foo", "bar")
+          .mapActivities("bar", "foo")
+          .build();
+      fail("Should not succeed");
+    } catch (MigrationPlanValidationException e) {
+      assertThat(e.getValidationReport())
+          .hasVariableFailures("foo",
+              "Cannot set variable with name foo. Java serialization format is prohibited")
+          .hasInstructionFailures("foo",
+              "Source activity 'foo' does not exist", "Target activity 'bar' does not exist")
+          .hasInstructionFailures("bar",
+              "Source activity 'bar' does not exist", "Target activity 'foo' does not exist");
+    }
   }
 
   protected void assertExceptionMessage(Exception e, String message) {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/SetVariablesMigrationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/SetVariablesMigrationTest.java
@@ -1,0 +1,522 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.api.runtime.migration;
+
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.ExecutionListener;
+import org.camunda.bpm.engine.history.UserOperationLogEntry;
+import org.camunda.bpm.engine.migration.MigrationPlan;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.RequiredHistoryLevel;
+import org.camunda.bpm.engine.test.api.runtime.migration.models.ProcessModels;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.engine.variable.Variables;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.camunda.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
+import static org.camunda.bpm.engine.test.api.runtime.migration.models.ProcessModels.USER_TASK_ID;
+import static org.junit.Assert.assertNotNull;
+
+public class SetVariablesMigrationTest {
+
+  protected ProcessEngineRule rule = new ProvidedProcessEngineRule();
+  protected MigrationTestRule testHelper = new MigrationTestRule(rule);
+
+  @Rule
+  public RuleChain ruleChain = RuleChain.outerRule(rule).around(testHelper);
+
+  @After
+  public void clearAuthentication() {
+    rule.getIdentityService().clearAuthentication();
+  }
+
+  @After
+  public void resetEngineConfig() {
+    rule.getProcessEngineConfiguration()
+        .setRestrictUserOperationLogToAuthenticatedUsers(true);
+  }
+
+  @Test
+  public void shouldSetVariable() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(Collections.singletonMap("foo", "bar"))
+        .mapEqualActivities()
+        .build();
+
+    ProcessInstance processInstance = rule.getRuntimeService()
+        .startProcessInstanceById(sourceProcessDefinition.getId());
+
+    // when
+    testHelper.migrateProcessInstance(migrationPlan, processInstance);
+
+    // then
+    assertThat(testHelper.snapshotBeforeMigration.getVariables()).isEmpty();
+    assertThat(testHelper.snapshotAfterMigration.getVariables())
+        .extracting("name", "value", "executionId")
+        .containsExactly(tuple("foo", "bar", processInstance.getId()));
+  }
+
+  @Test
+  public void shouldSetVariables() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("foo", "bar");
+    variables.put("bar", 5);
+
+    MigrationPlan migrationPlan = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(variables)
+        .mapEqualActivities()
+        .build();
+
+    ProcessInstance processInstance = rule.getRuntimeService()
+        .startProcessInstanceById(sourceProcessDefinition.getId());
+
+    // when
+    testHelper.migrateProcessInstance(migrationPlan, processInstance);
+
+    // then
+    assertThat(testHelper.snapshotBeforeMigration.getVariables()).isEmpty();
+    assertThat(testHelper.snapshotAfterMigration.getVariables())
+        .extracting("name", "value", "executionId")
+        .containsExactlyInAnyOrder(
+            tuple("foo", "bar", processInstance.getId()),
+            tuple("bar", 5, processInstance.getId())
+        );
+  }
+
+  @Test
+  public void shouldSetUntypedVariable() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(Variables.putValue("foo", "bar"))
+        .mapEqualActivities()
+        .build();
+
+    ProcessInstance processInstance = rule.getRuntimeService()
+        .startProcessInstanceById(sourceProcessDefinition.getId());
+
+    // when
+    testHelper.migrateProcessInstance(migrationPlan, processInstance);
+
+    // then
+    assertThat(testHelper.snapshotBeforeMigration.getVariables()).isEmpty();
+    assertThat(testHelper.snapshotAfterMigration.getVariables())
+        .extracting("name", "value", "executionId")
+        .containsExactly(tuple("foo", "bar", processInstance.getId()));
+  }
+
+  @Test
+  public void shouldSetUntypedVariables() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(
+            Variables.putValue("foo", "bar")
+                .putValue("bar", 5)
+        )
+        .mapEqualActivities()
+        .build();
+
+    ProcessInstance processInstance = rule.getRuntimeService()
+        .startProcessInstanceById(sourceProcessDefinition.getId());
+
+    // when
+    testHelper.migrateProcessInstance(migrationPlan, processInstance);
+
+    // then
+    assertThat(testHelper.snapshotBeforeMigration.getVariables()).isEmpty();
+    assertThat(testHelper.snapshotAfterMigration.getVariables())
+        .extracting("name", "value", "executionId")
+        .containsExactlyInAnyOrder(
+            tuple("foo", "bar", processInstance.getId()),
+            tuple("bar", 5, processInstance.getId())
+        );
+  }
+
+  @Test
+  public void shouldSetMapOfTypedVariable() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(Collections.singletonMap("foo", Variables.shortValue((short)5)))
+        .mapEqualActivities()
+        .build();
+
+    ProcessInstance processInstance = rule.getRuntimeService()
+        .startProcessInstanceById(sourceProcessDefinition.getId());
+
+    // when
+    testHelper.migrateProcessInstance(migrationPlan, processInstance);
+
+    // then
+    assertThat(testHelper.snapshotBeforeMigration.getVariables()).isEmpty();
+    assertThat(testHelper.snapshotAfterMigration.getVariables())
+        .extracting("name", "value", "executionId")
+        .containsExactly(tuple("foo", (short)5, processInstance.getId()));
+  }
+
+  @Test
+  public void shouldSetVariableMapOfTypedVariable() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(
+            Variables.putValueTyped("foo", Variables.stringValue("bar"))
+        )
+        .mapEqualActivities()
+        .build();
+
+    ProcessInstance processInstance = rule.getRuntimeService()
+        .startProcessInstanceById(sourceProcessDefinition.getId());
+
+    // when
+    testHelper.migrateProcessInstance(migrationPlan, processInstance);
+
+    // then
+    assertThat(testHelper.snapshotBeforeMigration.getVariables()).isEmpty();
+    assertThat(testHelper.snapshotAfterMigration.getVariables())
+        .extracting("name", "value", "executionId")
+        .containsExactly(tuple("foo", "bar", processInstance.getId()));
+  }
+
+  @Test
+  public void shouldSetTypedAndUntypedVariables() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(
+            Variables.putValue("foo", "bar")
+                .putValueTyped("bar", Variables.integerValue(5))
+        )
+        .mapEqualActivities()
+        .build();
+
+    ProcessInstance processInstance = rule.getRuntimeService()
+        .startProcessInstanceById(sourceProcessDefinition.getId());
+
+    // when
+    testHelper.migrateProcessInstance(migrationPlan, processInstance);
+
+    // then
+    assertThat(testHelper.snapshotBeforeMigration.getVariables()).isEmpty();
+    assertThat(testHelper.snapshotAfterMigration.getVariables())
+        .extracting("name", "value", "executionId")
+        .containsExactlyInAnyOrder(
+            tuple("foo", "bar", processInstance.getId()),
+            tuple("bar", 5, processInstance.getId())
+        );
+  }
+
+  @Test
+  public void shouldSetNullVariables() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(null)
+        .mapEqualActivities()
+        .build();
+
+    ProcessInstance processInstance = rule.getRuntimeService()
+        .startProcessInstanceById(sourceProcessDefinition.getId());
+
+    // when
+    testHelper.migrateProcessInstance(migrationPlan, processInstance);
+
+    // then
+    assertThat(testHelper.snapshotBeforeMigration.getVariables()).isEmpty();
+    assertThat(testHelper.snapshotAfterMigration.getVariables()).isEmpty();
+  }
+
+  @Test
+  public void shouldSetEmptyVariables() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(new HashMap<>())
+        .mapEqualActivities()
+        .build();
+
+    ProcessInstance processInstance = rule.getRuntimeService()
+        .startProcessInstanceById(sourceProcessDefinition.getId());
+
+    // when
+    testHelper.migrateProcessInstance(migrationPlan, processInstance);
+
+    // then
+    assertThat(testHelper.snapshotBeforeMigration.getVariables()).isEmpty();
+    assertThat(testHelper.snapshotAfterMigration.getVariables()).isEmpty();
+  }
+
+  @Test
+  public void shouldSetTransientVariable() {
+    // given
+    ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(
+        modify(ProcessModels.ONE_TASK_PROCESS)
+            .activityBuilder(USER_TASK_ID)
+              .camundaExecutionListenerClass("end", ReadTransientVariableExecutionListener.class)
+            .done()
+        );
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(Variables.putValueTyped("foo", Variables.stringValue("bar", true)))
+        .mapEqualActivities()
+        .build();
+
+    ProcessInstance processInstance = rule.getRuntimeService()
+        .startProcessInstanceById(sourceProcessDefinition.getId());
+
+    // when
+    testHelper.migrateProcessInstance(migrationPlan, processInstance);
+
+    // then
+    assertThat(testHelper.snapshotBeforeMigration.getVariables()).isEmpty();
+    assertThat(testHelper.snapshotAfterMigration.getVariables()).isEmpty();
+  }
+
+  @Test
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+  public void shouldWriteOperationLog() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(
+            Variables.putValue("foo", "bar")
+                .putValueTyped("bar", Variables.integerValue(5))
+        )
+        .mapEqualActivities()
+        .build();
+
+    ProcessInstance processInstance = rule.getRuntimeService()
+        .startProcessInstanceById(sourceProcessDefinition.getId());
+
+    rule.getIdentityService().setAuthenticatedUserId("user");
+
+    // when
+    testHelper.migrateProcessInstance(migrationPlan, processInstance);
+
+    // then
+    List<UserOperationLogEntry> operationLogEntries = rule.getHistoryService()
+        .createUserOperationLogQuery()
+        .list();
+
+    assertThat(operationLogEntries)
+        .extracting("operationType", "userId", "property", "newValue")
+        .containsExactlyInAnyOrder(
+            tuple("Migrate", "user", "processDefinitionId", targetProcessDefinition.getId()),
+            tuple("Migrate", "user", "nrOfInstances", "1"),
+            tuple("Migrate", "user", "nrOfSetVariables", "2"),
+            tuple("Migrate", "user", "async", "false")
+        );
+  }
+
+  @Test
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+  public void shouldWriteOperationLogUnauthenticated() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(
+            Variables.putValue("foo", "bar")
+                .putValueTyped("bar", Variables.integerValue(5))
+        )
+        .mapEqualActivities()
+        .build();
+
+    ProcessInstance processInstance = rule.getRuntimeService()
+        .startProcessInstanceById(sourceProcessDefinition.getId());
+
+    rule.getProcessEngineConfiguration().setRestrictUserOperationLogToAuthenticatedUsers(false);
+
+    // when
+    testHelper.migrateProcessInstance(migrationPlan, processInstance);
+
+    // then
+    List<UserOperationLogEntry> operationLogEntries = rule.getHistoryService()
+        .createUserOperationLogQuery()
+        .list();
+
+    assertThat(operationLogEntries)
+        .extracting("operationType", "userId", "property", "newValue")
+        .containsExactlyInAnyOrder(
+            tuple("Migrate", null, "processDefinitionId", targetProcessDefinition.getId()),
+            tuple("Migrate", null, "nrOfInstances", "1"),
+            tuple("Migrate", null, "nrOfSetVariables", "2"),
+            tuple("Migrate", null, "async", "false")
+        );
+  }
+
+  @Test
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+  public void shouldWriteOperationLogForEmptyVariables() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .setVariables(new HashMap<>())
+        .mapEqualActivities()
+        .build();
+
+    ProcessInstance processInstance = rule.getRuntimeService()
+        .startProcessInstanceById(sourceProcessDefinition.getId());
+
+    rule.getIdentityService().setAuthenticatedUserId("user");
+
+    // when
+    testHelper.migrateProcessInstance(migrationPlan, processInstance);
+
+    // then
+    List<UserOperationLogEntry> operationLogEntries = rule.getHistoryService()
+        .createUserOperationLogQuery()
+        .list();
+
+    assertThat(operationLogEntries)
+        .extracting("operationType", "userId", "property", "newValue")
+        .containsExactlyInAnyOrder(
+            tuple("Migrate", "user", "processDefinitionId", targetProcessDefinition.getId()),
+            tuple("Migrate", "user", "nrOfInstances", "1"),
+            tuple("Migrate", "user", "nrOfSetVariables", "0"),
+            tuple("Migrate", "user", "async", "false")
+        );
+  }
+
+  @Test
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+  public void shouldNotWriteOperationLogForVariablesNull() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    MigrationPlan migrationPlan = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapEqualActivities()
+        .build();
+
+    ProcessInstance processInstance = rule.getRuntimeService()
+        .startProcessInstanceById(sourceProcessDefinition.getId());
+
+    rule.getIdentityService().setAuthenticatedUserId("user");
+
+    // when
+    testHelper.migrateProcessInstance(migrationPlan, processInstance);
+
+    // then
+    List<UserOperationLogEntry> operationLogEntries = rule.getHistoryService()
+        .createUserOperationLogQuery()
+        .list();
+
+    assertThat(operationLogEntries)
+        .extracting("operationType", "userId", "property", "newValue")
+        .containsExactlyInAnyOrder(
+            tuple("Migrate", "user", "processDefinitionId", targetProcessDefinition.getId()),
+            tuple("Migrate", "user", "nrOfInstances", "1"),
+            tuple("Migrate", "user", "async", "false")
+        );
+  }
+
+  // helper ////////////////////////////////////////////////////////////////////////////////////////
+
+  public static class ReadTransientVariableExecutionListener implements ExecutionListener {
+
+    @Override
+    public void notify(DelegateExecution execution) throws Exception {
+      Object variable = execution.getVariable("foo");
+      assertNotNull(variable);
+    }
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/batch/BatchSetVariablesMigrationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/migration/batch/BatchSetVariablesMigrationTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.api.runtime.migration.batch;
+
+import org.assertj.core.groups.Tuple;
+import org.camunda.bpm.engine.BadUserRequestException;
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.batch.Batch;
+import org.camunda.bpm.engine.history.UserOperationLogEntry;
+import org.camunda.bpm.engine.migration.MigrationPlan;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.engine.runtime.VariableInstance;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.RequiredHistoryLevel;
+import org.camunda.bpm.engine.test.api.runtime.migration.MigrationTestRule;
+import org.camunda.bpm.engine.test.api.runtime.migration.models.ProcessModels;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.engine.variable.Variables;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+
+public class BatchSetVariablesMigrationTest {
+
+  protected ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
+  protected MigrationTestRule migrationRule = new MigrationTestRule(engineRule);
+  protected BatchMigrationHelper helper = new BatchMigrationHelper(engineRule, migrationRule);
+  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
+
+  @Rule
+  public RuleChain ruleChain = RuleChain.outerRule(engineRule)
+      .around(migrationRule).around(testRule);
+
+  @After
+  public void removeBatches() {
+    helper.removeAllRunningAndHistoricBatches();
+  }
+
+  @After
+  public void clearAuthentication() {
+    engineRule.getIdentityService().clearAuthentication();
+  }
+
+  @After
+  public void resetEngineConfig() {
+    engineRule.getProcessEngineConfiguration()
+        .setRestrictUserOperationLogToAuthenticatedUsers(true);
+  }
+
+  @Test
+  public void shouldCreateBatchVariable() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        migrationRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        migrationRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    Batch batch = helper.migrateProcessInstancesAsync(5, sourceProcessDefinition,
+        targetProcessDefinition, Variables.putValue("foo", "bar"));
+
+    // when
+    helper.completeSeedJobs(batch);
+
+    // then
+    VariableInstance batchVariable = engineRule.getRuntimeService()
+        .createVariableInstanceQuery()
+        .batchIdIn(batch.getId())
+        .singleResult();
+
+    assertThat(batchVariable)
+        .extracting("name", "value")
+        .containsExactly("foo", "bar");
+  }
+
+  @Test
+  public void shouldCreateBatchVariables() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        migrationRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        migrationRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    // when
+    Batch batch = helper.migrateProcessInstancesAsync(5, sourceProcessDefinition,
+        targetProcessDefinition, Variables.putValue("foo", "bar").putValue("bar", "foo"));
+
+    // then
+    List<VariableInstance> batchVariables = engineRule.getRuntimeService()
+        .createVariableInstanceQuery()
+        .batchIdIn(batch.getId())
+        .list();
+
+    assertThat(batchVariables)
+        .extracting("name", "value")
+        .containsExactlyInAnyOrder(
+            tuple("foo", "bar"),
+            tuple("bar", "foo")
+        );
+  }
+
+  @Test
+  public void shouldRemoveBatchVariable() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        migrationRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        migrationRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    Batch batch = helper.migrateProcessInstancesAsync(5, sourceProcessDefinition,
+        targetProcessDefinition, Variables.putValue("foo", "bar"));
+
+    // when
+    helper.completeBatch(batch);
+
+    // then
+    List<VariableInstance> batchVariables = engineRule.getRuntimeService()
+        .createVariableInstanceQuery()
+        .batchIdIn(batch.getId())
+        .list();
+
+    assertThat(batchVariables).isEmpty();
+  }
+
+  @Test
+  public void shouldSetVariables() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        migrationRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        migrationRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    Batch batch = helper.migrateProcessInstancesAsync(5, sourceProcessDefinition,
+        targetProcessDefinition, Variables.putValue("foo", "bar"));
+
+    // when
+    helper.completeBatch(batch);
+
+    // then
+    List<VariableInstance> variables = engineRule.getRuntimeService()
+        .createVariableInstanceQuery()
+        .list();
+
+    assertThat(variables)
+        .extracting("processDefinitionId", "name", "value")
+        .containsExactlyInAnyOrder(
+            tuple(targetProcessDefinition.getId(), "foo", "bar"),
+            tuple(targetProcessDefinition.getId(), "foo", "bar"),
+            tuple(targetProcessDefinition.getId(), "foo", "bar"),
+            tuple(targetProcessDefinition.getId(), "foo", "bar"),
+            tuple(targetProcessDefinition.getId(), "foo", "bar")
+        );
+  }
+
+  @Test
+  public void shouldThrowException_TransientVariable() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        migrationRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        migrationRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    String processInstanceId = engineRule.getRuntimeService()
+        .startProcessInstanceById(sourceProcessDefinition.getId()).getId();
+
+    MigrationPlan migrationPlan = engineRule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapEqualActivities()
+        .setVariables(Variables.putValue("foo", Variables.stringValue("bar", true))).build();
+
+    // when/then
+    assertThatThrownBy(() -> engineRule.getRuntimeService()
+          .newMigration(migrationPlan)
+          .processInstanceIds(processInstanceId)
+          .executeAsync())
+        .isInstanceOf(BadUserRequestException.class)
+        .hasMessageContaining("ENGINE-13044 Setting transient variable 'foo' " +
+            "asynchronously is currently not supported.");
+  }
+
+  @Test
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+  public void shouldLogOperationOnCreation() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        testRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    // when
+    helper.migrateProcessInstancesAsync(5, sourceProcessDefinition,
+        targetProcessDefinition, Variables.putValue("foo", "bar"), true);
+
+    // then
+    List<UserOperationLogEntry> operationLogEntries = engineRule.getHistoryService()
+        .createUserOperationLogQuery()
+        .list();
+
+    assertThat(operationLogEntries)
+        .extracting("operationType", "userId", "property", "newValue")
+        .containsExactlyInAnyOrder(
+            Tuple.tuple("Migrate", "user", "processDefinitionId", targetProcessDefinition.getId()),
+            Tuple.tuple("Migrate", "user", "nrOfInstances", "5"),
+            Tuple.tuple("Migrate", "user", "nrOfSetVariables", "1"),
+            Tuple.tuple("Migrate", "user", "async", "true")
+        );
+  }
+
+  @Test
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+  public void shouldNotLogOperationOnExecution() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        testRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    Batch batch = helper.migrateProcessInstancesAsync(5, sourceProcessDefinition,
+        targetProcessDefinition, Variables.putValue("foo", "bar"));
+
+    engineRule.getIdentityService().setAuthenticatedUserId("user");
+
+    // when
+    helper.completeBatch(batch);
+
+    // then
+    List<UserOperationLogEntry> operationLogEntries = engineRule.getHistoryService()
+        .createUserOperationLogQuery()
+        .list();
+
+    assertThat(operationLogEntries)
+        .extracting("operationType")
+        .hasSize(7)
+        .containsOnly("Execute");
+  }
+
+  @Test
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+  public void shouldNotLogOperationOnExecutionUnauthenticated() {
+    // given
+    ProcessDefinition sourceProcessDefinition =
+        testRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    ProcessDefinition targetProcessDefinition =
+        testRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+
+    Batch batch = helper.migrateProcessInstancesAsync(5, sourceProcessDefinition,
+        targetProcessDefinition, Variables.putValue("foo", "bar"));
+
+    engineRule.getProcessEngineConfiguration()
+        .setRestrictUserOperationLogToAuthenticatedUsers(false);
+
+    // when
+    helper.completeBatch(batch);
+
+    // then
+    List<UserOperationLogEntry> operationLogEntries = engineRule.getHistoryService()
+        .createUserOperationLogQuery()
+        .list();
+
+    assertThat(operationLogEntries)
+        .extracting("operationType")
+        .hasSize(7)
+        .containsOnly("Execute");
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/util/MigrationPlanAssert.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/util/MigrationPlanAssert.java
@@ -18,17 +18,23 @@ package org.camunda.bpm.engine.test.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.camunda.bpm.engine.impl.migration.MigrationInstructionImpl;
 import org.camunda.bpm.engine.migration.MigrationInstruction;
 import org.camunda.bpm.engine.migration.MigrationPlan;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.engine.variable.impl.value.UntypedValueImpl;
+import org.camunda.bpm.engine.variable.value.TypedValue;
 
 public class MigrationPlanAssert {
 
@@ -66,11 +72,65 @@ public class MigrationPlanAssert {
     return this;
   }
 
+  public MigrationPlanAssert variablesNull() {
+    isNotNull();
+    assertNull(actual.getVariables());
+    return this;
+  }
+
+  public MigrationPlanAssert variablesEmpty() {
+    isNotNull();
+    assertTrue(actual.getVariables() != null && actual.getVariables().isEmpty());
+    return this;
+  }
+
+  public MigrationPlanAssert hasVariables(MigrationVariableAssert... variableAsserts) {
+    isNotNull();
+
+    Map<String, Object> notExpected = new HashMap<>(actual.getVariables());
+    List<MigrationVariableAssert> notFound = new ArrayList<>();
+    Collections.addAll(notFound, variableAsserts);
+
+    Arrays.stream(variableAsserts).forEachOrdered(variableAssert ->
+        actual.getVariables().keySet().stream()
+            .filter(name -> variableAssert.name.equals(name))
+            .forEachOrdered(name -> {
+              notFound.remove(variableAssert);
+              notExpected.remove(name);
+
+              org.assertj.core.api.Assertions.assertThat(name)
+                  .as("Variable name does not match for variable %s", name)
+                  .isEqualTo(variableAssert.name);
+
+              TypedValue typedValue = actual.getVariables().getValueTyped(name);
+              org.assertj.core.api.Assertions.assertThat(typedValue.getValue())
+                  .as("Variable value does not match for variable %s", name)
+                  .isEqualTo(variableAssert.value);
+              org.assertj.core.api.Assertions.assertThat(variableAssert.typed ? "typed" : "untyped")
+                  .as("Variable %s: value typed/untyped does not match", name)
+                  .isEqualTo(typedValue instanceof UntypedValueImpl ? "untyped" : "typed");
+            }));
+
+    if (!notExpected.isEmpty() || ! notFound.isEmpty()) {
+      StringBuilder builder = new StringBuilder();
+      builder.append("\nActual migration variables:\n\t")
+          .append(actual.getVariables()).append("\n");
+      if (!notExpected.isEmpty()) {
+        builder.append("Unexpected migration variables:\n\t").append(notExpected).append("\n");
+      }
+      if (!notFound.isEmpty()) {
+        builder.append("Migration variables missing:\n\t").append(notFound);
+      }
+      fail(builder.toString());
+    }
+    return this;
+  }
+
   public MigrationPlanAssert hasInstructions(MigrationInstructionAssert... instructionAsserts) {
     isNotNull();
 
-    List<MigrationInstruction> notExpected = new ArrayList<MigrationInstruction>(actual.getInstructions());
-    List<MigrationInstructionAssert> notFound = new ArrayList<MigrationInstructionAssert>();
+    List<MigrationInstruction> notExpected = new ArrayList<>(actual.getInstructions());
+    List<MigrationInstructionAssert> notFound = new ArrayList<>();
     Collections.addAll(notFound, instructionAsserts);
 
     for (MigrationInstructionAssert instructionAssert : instructionAsserts) {
@@ -144,6 +204,32 @@ public class MigrationPlanAssert {
       return new MigrationInstructionImpl(sourceActivityId, targetActivityId).toString();
     }
 
+  }
+
+  public static MigrationVariableAssert variable() {
+    return new MigrationVariableAssert();
+  }
+
+  public static class MigrationVariableAssert {
+
+    protected String name;
+    protected Object value;
+    protected boolean typed;
+
+    public MigrationVariableAssert name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public MigrationVariableAssert value(Object value) {
+      this.value = value;
+      return this;
+    }
+
+    public MigrationVariableAssert typed() {
+      this.typed = true;
+      return this;
+    }
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/util/MigrationPlanValidationReportAssert.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/util/MigrationPlanValidationReportAssert.java
@@ -42,6 +42,26 @@ public class MigrationPlanValidationReportAssert {
     return this;
   }
 
+  public MigrationPlanValidationReportAssert hasVariableFailures(String name,
+                                                                 String... expectedFailures) {
+    isNotNull();
+
+    List<String> failuresFound = new ArrayList<>();
+
+    actual.getVariableReports().entrySet()
+        .stream()
+        .filter(entry -> entry.getKey().equals(name))
+        .findFirst()
+        .ifPresent(entry -> failuresFound.addAll(entry.getValue().getFailures()));
+
+    org.assertj.core.api.Assertions.assertThat(failuresFound)
+        .as("Expected failures for variable name '%s':\n%sBut found failures:\n%s",
+            name, joinFailures(expectedFailures), joinFailures(failuresFound.toArray()))
+        .containsExactlyInAnyOrder(expectedFailures);
+
+    return this;
+  }
+
   public MigrationPlanValidationReportAssert hasInstructionFailures(String activityId, String... expectedFailures) {
     isNotNull();
 

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/context/SetVariablesMigrationContextSwitchTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/context/SetVariablesMigrationContextSwitchTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.integrationtest.functional.context;
+
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.migration.MigrationPlan;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.engine.runtime.Job;
+import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.integrationtest.functional.context.classes.MyPojo;
+import org.camunda.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+import org.camunda.bpm.integrationtest.util.TestContainer;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.fail;
+
+@RunWith(Arquillian.class)
+public class SetVariablesMigrationContextSwitchTest extends AbstractFoxPlatformIntegrationTest {
+
+  public static BpmnModelInstance oneTaskProcess(String key) {
+    return Bpmn.createExecutableProcess(key)
+      .startEvent()
+      .userTask("userTask")
+      .endEvent()
+      .done();
+  }
+
+  @Deployment(name = "sourceDeployment")
+  public static WebArchive createSourceDeployment() {
+    return initWebArchiveDeployment("sourceDeployment.war")
+        .addAsResource(modelAsAsset(oneTaskProcess("sourceOneTaskProcess")), "oneTaskProcess.bpmn20.xml");
+  }
+
+  @Deployment(name = "targetDeployment")
+  public static WebArchive createTargetDeployment() {
+    return initWebArchiveDeployment("targetDeployment.war")
+        .addClass(MyPojo.class)
+        .addAsResource(modelAsAsset(oneTaskProcess("targetOneTaskProcess")), "oneTaskProcess.bpmn20.xml");
+  }
+
+  @Deployment(name="clientDeployment")
+  public static WebArchive clientDeployment() {
+    WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "client.war")
+        .addClass(AbstractFoxPlatformIntegrationTest.class);
+
+    TestContainer.addContainerSpecificResources(webArchive);
+
+    return webArchive;
+
+  }
+
+  @Test
+  @OperateOnDeployment("clientDeployment")
+  public void shouldDeserializeObjectVariable_Async() {
+    // given
+    ProcessDefinition sourceDefinition = repositoryService
+        .createProcessDefinitionQuery()
+        .processDefinitionKey("sourceOneTaskProcess")
+        .singleResult();
+
+    ProcessDefinition targetDefinition = repositoryService
+        .createProcessDefinitionQuery()
+        .processDefinitionKey("targetOneTaskProcess")
+        .singleResult();
+
+    String pi = runtimeService.startProcessInstanceById(sourceDefinition.getId()).getId();
+
+    MigrationPlan migrationPlan = runtimeService.createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
+        .mapEqualActivities()
+        .setVariables(Variables.putValue("foo",
+            Variables.serializedObjectValue()
+                .objectTypeName("org.camunda.bpm.integrationtest.functional.context.classes.MyPojo")
+                .serializedValue("{\"name\": \"myName\", \"prio\": 5}")
+                .serializationDataFormat("application/json")
+                .create()))
+        .build();
+
+    runtimeService.newMigration(migrationPlan)
+        .processInstanceIds(Collections.singletonList(pi))
+        .executeAsync();
+
+    // execute seed jobs
+    List<Job> jobs = managementService.createJobQuery().list();
+    for (Job job : jobs) {
+      managementService.executeJob(job.getId());
+    }
+
+    // when: execute remaining batch jobs
+    jobs = managementService.createJobQuery().list();
+    for (Job job : jobs) {
+      try {
+        managementService.executeJob(job.getId());
+      } catch (ProcessEngineException ex) {
+        fail("No exception expected: " + ex.getMessage());
+      }
+    }
+
+    // then
+    Assert.assertNotNull(runtimeService.getVariableTyped(pi, "foo", false));
+  }
+
+  @Test
+  @OperateOnDeployment("clientDeployment")
+  public void shouldDeserializeObjectVariable_Sync() {
+    // given
+    ProcessDefinition sourceDefinition = repositoryService
+        .createProcessDefinitionQuery()
+        .processDefinitionKey("sourceOneTaskProcess")
+        .singleResult();
+
+    ProcessDefinition targetDefinition = repositoryService
+        .createProcessDefinitionQuery()
+        .processDefinitionKey("targetOneTaskProcess")
+        .singleResult();
+
+    String pi = runtimeService.startProcessInstanceById(sourceDefinition.getId()).getId();
+
+    MigrationPlan migrationPlan = runtimeService.createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
+        .mapEqualActivities()
+        .setVariables(Variables.putValue("foo",
+            Variables.serializedObjectValue()
+                .objectTypeName("org.camunda.bpm.integrationtest.functional.context.classes.MyPojo")
+                .serializedValue("{\"name\": \"myName\", \"prio\": 5}")
+                .serializationDataFormat("application/json")
+                .create()))
+        .build();
+
+    // when
+    runtimeService.newMigration(migrationPlan)
+        .processInstanceIds(Collections.singletonList(pi))
+        .execute();
+
+    // then
+    Assert.assertNotNull(runtimeService.getVariableTyped(pi, "foo", false));
+  }
+
+  protected static Asset modelAsAsset(BpmnModelInstance modelInstance) {
+    ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+    Bpmn.writeModelToStream(byteStream, modelInstance);
+
+    byte[] bytes = byteStream.toByteArray();
+    return new ByteArrayAsset(bytes);
+  }
+
+}

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/context/classes/MyPojo.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/context/classes/MyPojo.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.integrationtest.functional.context.classes;
+
+public class MyPojo {
+
+    public MyPojo() {
+    }
+
+    public String name;
+    public int prio;
+
+    public String getName() {
+      return name;
+    }
+
+    public int getPrio() {
+      return prio;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public void setPrio(int prio) {
+      this.prio = prio;
+    }
+
+  }

--- a/qa/test-db-instance-migration/test-fixture-715/src/main/java/org/camunda/bpm/qa/upgrade/TestFixture.java
+++ b/qa/test-db-instance-migration/test-fixture-715/src/main/java/org/camunda/bpm/qa/upgrade/TestFixture.java
@@ -19,6 +19,7 @@ package org.camunda.bpm.qa.upgrade;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.qa.upgrade.migration.CreateSetVariablesMigrationBatchScenario;
 
 public class TestFixture {
 
@@ -34,6 +35,8 @@ public class TestFixture {
 
     // register test scenarios
     ScenarioRunner runner = new ScenarioRunner(processEngine, ENGINE_VERSION);
+
+    runner.setupScenarios(CreateSetVariablesMigrationBatchScenario.class);
 
     // example scenario setup
     // runner.setupScenarios(ExampleScenario.class);

--- a/qa/test-db-instance-migration/test-fixture-715/src/main/java/org/camunda/bpm/qa/upgrade/migration/CreateSetVariablesMigrationBatchScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-715/src/main/java/org/camunda/bpm/qa/upgrade/migration/CreateSetVariablesMigrationBatchScenario.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.qa.upgrade.migration;
+
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.migration.MigrationPlan;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.qa.upgrade.DescribesScenario;
+import org.camunda.bpm.qa.upgrade.ScenarioSetup;
+
+public class CreateSetVariablesMigrationBatchScenario {
+
+  @Deployment
+  public static String sourceDeployment() {
+    return "org/camunda/bpm/qa/upgrade/migration/oneTaskProcess-source.bpmn20.xml";
+  }
+
+  @Deployment
+  public static String targetDeployment() {
+    return "org/camunda/bpm/qa/upgrade/migration/oneTaskProcess-target.bpmn20.xml";
+  }
+
+  @DescribesScenario("createSetVariablesMigrationBatchScenario")
+  public static ScenarioSetup createSetVariablesMigrationBatchScenario() {
+    return (engine, scenarioName) -> {
+      RuntimeService runtimeService = engine.getRuntimeService();
+      runtimeService.startProcessInstanceByKey("oneTaskProcess-source-715", scenarioName);
+
+      String sourceDefinition = engine.getRepositoryService().createProcessDefinitionQuery()
+          .processDefinitionKey("oneTaskProcess-source-715")
+          .singleResult()
+          .getId();
+
+      String targetDefinition = engine.getRepositoryService().createProcessDefinitionQuery()
+          .processDefinitionKey("oneTaskProcess-target-715")
+          .singleResult()
+          .getId();
+
+      String processInstanceId =
+          runtimeService.startProcessInstanceByKey("oneTaskProcess-source-715").getId();
+
+      MigrationPlan migrationPlan =
+          runtimeService.createMigrationPlan(sourceDefinition, targetDefinition)
+              .mapEqualActivities()
+              .build();
+
+      String batchId = runtimeService.newMigration(migrationPlan)
+          .processInstanceIds(processInstanceId)
+          .executeAsync()
+          .getId();
+
+      engine.getManagementService()
+          .setProperty("CreateSetVariablesMigrationBatchScenario.batch.id", batchId);
+    };
+  }
+
+}

--- a/qa/test-db-instance-migration/test-fixture-715/src/main/resources/org/camunda/bpm/qa/upgrade/migration/oneTaskProcess-source.bpmn20.xml
+++ b/qa/test-db-instance-migration/test-fixture-715/src/main/resources/org/camunda/bpm/qa/upgrade/migration/oneTaskProcess-source.bpmn20.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  targetNamespace="Examples">
+
+  <process id="oneTaskProcess-source-715" name="The One Task Process" isExecutable="true">
+    <documentation>This is a process for testing purposes</documentation>
+
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="firstTask" />
+    <userTask id="firstTask" name="First task" />
+    <sequenceFlow id="flow2" sourceRef="firstTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>

--- a/qa/test-db-instance-migration/test-fixture-715/src/main/resources/org/camunda/bpm/qa/upgrade/migration/oneTaskProcess-target.bpmn20.xml
+++ b/qa/test-db-instance-migration/test-fixture-715/src/main/resources/org/camunda/bpm/qa/upgrade/migration/oneTaskProcess-target.bpmn20.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  targetNamespace="Examples">
+
+  <process id="oneTaskProcess-target-715" name="The One Task Process" isExecutable="true">
+    <documentation>This is a process for testing purposes</documentation>
+
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="firstTask" />
+    <userTask id="firstTask" name="First task" />
+    <sequenceFlow id="flow2" sourceRef="firstTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7160/migration/SetVariablesMigrationBatchTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7160/migration/SetVariablesMigrationBatchTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.qa.upgrade.scenarios7160.migration;
+
+import org.camunda.bpm.engine.ManagementService;
+import org.camunda.bpm.engine.batch.Batch;
+import org.camunda.bpm.engine.runtime.Job;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.qa.upgrade.Origin;
+import org.camunda.bpm.qa.upgrade.ScenarioUnderTest;
+import org.camunda.bpm.qa.upgrade.UpgradeTestRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ScenarioUnderTest("CreateSetVariablesMigrationBatchScenario")
+@Origin("7.15.0")
+public class SetVariablesMigrationBatchTest {
+
+  @Rule
+  public UpgradeTestRule engineRule = new UpgradeTestRule();
+
+  ManagementService managementService;
+
+  @Before
+  public void assignServices() {
+    managementService = engineRule.getManagementService();
+  }
+
+  @Test
+  @ScenarioUnderTest("createSetVariablesMigrationBatchScenario.1")
+  public void shouldCompleteBatchSuccessfully() {
+    Map<String, String> properties = managementService.getProperties();
+
+    String batchId = properties.get("CreateSetVariablesMigrationBatchScenario.batch.id");
+    Batch batch = managementService.createBatchQuery()
+        .batchId(batchId)
+        .singleResult();
+
+    List<Job> jobs = managementService.createJobQuery()
+        .jobDefinitionId(batch.getSeedJobDefinitionId())
+        .list();
+
+    jobs.forEach(job -> managementService.executeJob(job.getId()));
+
+    jobs = managementService.createJobQuery()
+        .jobDefinitionId(batch.getBatchJobDefinitionId())
+        .list();
+
+    jobs.forEach(job -> managementService.executeJob(job.getId()));
+
+    jobs = managementService.createJobQuery()
+        .jobDefinitionId(batch.getMonitorJobDefinitionId())
+        .list();
+
+    jobs.forEach(job -> managementService.executeJob(job.getId()));
+
+    ProcessInstance processInstance = engineRule.getRuntimeService()
+        .createProcessInstanceQuery()
+        .processDefinitionKey("oneTaskProcess-target-715")
+        .singleResult();
+
+    assertThat(processInstance).isNotNull();
+  }
+
+}


### PR DESCRIPTION
* Available for synchronous and asynchronous execution
* When a batch is created, the variables are intermediately stored in the `ACT_RU_VARIABLE` table
* Set variables into the process instances' scope
* Variables are validated when configuring the migration plan
  * A `MigrationVariableValidationReport` contains the validation result
* Refactors the prevention of user operation logs in job handlers

related to CAM-13410