### PR TITLE
chore(engine): enable custom script engine resolution

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/application/impl/ProcessApplicationScriptEnvironment.java
+++ b/engine/src/main/java/org/camunda/bpm/application/impl/ProcessApplicationScriptEnvironment.java
@@ -25,6 +25,7 @@ import javax.script.ScriptEngineManager;
 
 import org.camunda.bpm.application.ProcessApplicationInterface;
 import org.camunda.bpm.engine.impl.scripting.ExecutableScript;
+import org.camunda.bpm.engine.impl.scripting.engine.DefaultScriptEngineResolver;
 import org.camunda.bpm.engine.impl.scripting.engine.ScriptEngineResolver;
 
 /**
@@ -36,7 +37,7 @@ public class ProcessApplicationScriptEnvironment {
   protected ProcessApplicationInterface processApplication;
 
   protected ScriptEngineResolver processApplicationScriptEngineResolver;
-  protected Map<String, List<ExecutableScript>> environmentScripts = new HashMap<String, List<ExecutableScript>>();
+  protected Map<String, List<ExecutableScript>> environmentScripts = new HashMap<>();
 
   public ProcessApplicationScriptEnvironment(ProcessApplicationInterface processApplication) {
     this.processApplication = processApplication;
@@ -58,7 +59,7 @@ public class ProcessApplicationScriptEnvironment {
     if(processApplicationScriptEngineResolver == null) {
       synchronized (this) {
         if(processApplicationScriptEngineResolver == null) {
-          processApplicationScriptEngineResolver = new ScriptEngineResolver(new ScriptEngineManager(getProcessApplicationClassloader()));
+          processApplicationScriptEngineResolver = new DefaultScriptEngineResolver(new ScriptEngineManager(getProcessApplicationClassloader()));
         }
       }
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/engine/DefaultScriptEngineResolver.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/engine/DefaultScriptEngineResolver.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.scripting.engine;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptEngineManager;
+
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.context.Context;
+
+public class DefaultScriptEngineResolver implements ScriptEngineResolver {
+
+  protected final ScriptEngineManager scriptEngineManager;
+
+  protected Map<String, ScriptEngine> cachedEngines = new HashMap<>();
+
+  public DefaultScriptEngineResolver(ScriptEngineManager scriptEngineManager) {
+    this.scriptEngineManager = scriptEngineManager;
+  }
+
+  public void addScriptEngineFactory(ScriptEngineFactory scriptEngineFactory) {
+    scriptEngineManager.registerEngineName(scriptEngineFactory.getEngineName(), scriptEngineFactory);
+  }
+
+  public ScriptEngineManager getScriptEngineManager() {
+    return scriptEngineManager;
+  }
+
+  /**
+   * Returns a cached script engine or creates a new script engine if no such engine is currently cached.
+   *
+   * @param language the language (such as 'groovy' for the script engine)
+   * @return the cached engine or null if no script engine can be created for the given language
+   */
+  public ScriptEngine getScriptEngine(String language, boolean resolveFromCache) {
+
+    ScriptEngine scriptEngine = null;
+
+    if (resolveFromCache) {
+      scriptEngine = cachedEngines.get(language);
+
+      if (scriptEngine == null) {
+        scriptEngine = getScriptEngine(language);
+
+        if (scriptEngine != null && isCachable(scriptEngine)) {
+          cachedEngines.put(language, scriptEngine);
+        }
+      }
+
+    } else {
+      scriptEngine = getScriptEngine(language);
+    }
+
+    return scriptEngine;
+  }
+
+  protected ScriptEngine getScriptEngine(String language) {
+    ScriptEngine scriptEngine = null;
+    if (ScriptingEngines.JAVASCRIPT_SCRIPTING_LANGUAGE.equalsIgnoreCase(language) ||
+        ScriptingEngines.ECMASCRIPT_SCRIPTING_LANGUAGE.equalsIgnoreCase(language)) {
+      scriptEngine = getJavaScriptScriptEngine(language);
+    } else {
+      scriptEngine = scriptEngineManager.getEngineByName(language);
+    }
+
+    if (scriptEngine != null) {
+      configureScriptEngines(language, scriptEngine);
+    }
+    return scriptEngine;
+  }
+
+  protected ScriptEngine getJavaScriptScriptEngine(String language) {
+    ScriptEngine scriptEngine = null;
+    ProcessEngineConfigurationImpl config = Context.getProcessEngineConfiguration();
+    if (config != null && config.getScriptEngineNameJavaScript() != null) {
+      scriptEngine = scriptEngineManager.getEngineByName(config.getScriptEngineNameJavaScript());
+    } else {
+      scriptEngine = scriptEngineManager.getEngineByName(ScriptingEngines.DEFAULT_JS_SCRIPTING_LANGUAGE);
+      if (scriptEngine == null) {
+        // default engine is not available, try to fetch any existing JS script engine
+        scriptEngine = scriptEngineManager.getEngineByName(language);
+      }
+    }
+    return scriptEngine;
+  }
+
+  /**
+   * Allows checking whether the script engine can be cached.
+   *
+   * @param scriptEngine the script engine to check.
+   * @return true if the script engine may be cached.
+   */
+  protected boolean isCachable(ScriptEngine scriptEngine) {
+    // Check if script-engine supports multithreading. If true it can be cached.
+    Object threadingParameter = scriptEngine.getFactory().getParameter("THREADING");
+    return threadingParameter != null;
+  }
+
+  protected void configureScriptEngines(String language, ScriptEngine scriptEngine) {
+    if (ScriptingEngines.GROOVY_SCRIPTING_LANGUAGE.equals(language)) {
+      configureGroovyScriptEngine(scriptEngine);
+    }
+
+    if (ScriptingEngines.GRAAL_JS_SCRIPT_ENGINE_NAME.equals(scriptEngine.getFactory().getEngineName())) {
+      configureGraalJsScriptEngine(scriptEngine);
+    }
+  }
+
+  /**
+   * Allows providing custom configuration for the groovy script engine.
+   * @param scriptEngine the groovy script engine to configure.
+   */
+  protected void configureGroovyScriptEngine(ScriptEngine scriptEngine) {
+    // make sure Groovy compiled scripts only hold weak references to java methods
+    scriptEngine.getContext().setAttribute("#jsr223.groovy.engine.keep.globals", "weak", ScriptContext.ENGINE_SCOPE);
+  }
+
+  /**
+   * Allows providing custom configuration for the Graal JS script engine.
+   * @param scriptEngine the Graal JS script engine to configure.
+   */
+  protected void configureGraalJsScriptEngine(ScriptEngine scriptEngine) {
+    ProcessEngineConfigurationImpl config = Context.getProcessEngineConfiguration();
+    if (config != null) {
+      if (config.isConfigureScriptEngineHostAccess()) {
+        // make sure Graal JS can provide access to the host and can lookup classes
+        scriptEngine.getContext().setAttribute("polyglot.js.allowHostAccess", true, ScriptContext.ENGINE_SCOPE);
+        scriptEngine.getContext().setAttribute("polyglot.js.allowHostClassLookup", true, ScriptContext.ENGINE_SCOPE);
+      }
+      if (config.isEnableScriptEngineLoadExternalResources()) {
+        // make sure Graal JS can load external scripts
+        scriptEngine.getContext().setAttribute("polyglot.js.allowIO", true, ScriptContext.ENGINE_SCOPE);
+      }
+      if (config.isEnableScriptEngineNashornCompatibility()) {
+        // enable Nashorn compatibility mode
+        scriptEngine.getContext().setAttribute("polyglot.js.nashorn-compat", true, ScriptContext.ENGINE_SCOPE);
+      }
+    }
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/engine/ScriptEngineResolver.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/engine/ScriptEngineResolver.java
@@ -16,39 +16,15 @@
  */
 package org.camunda.bpm.engine.impl.scripting.engine;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
 import javax.script.ScriptEngineManager;
 
-import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.camunda.bpm.engine.impl.context.Context;
+public interface ScriptEngineResolver {
 
-/**
- * @author Thorben Lindhauer
- *
- */
-public class ScriptEngineResolver {
+  void addScriptEngineFactory(ScriptEngineFactory scriptEngineFactory);
 
-  protected final ScriptEngineManager scriptEngineManager;
-
-  protected Map<String, ScriptEngine> cachedEngines = new HashMap<>();
-
-  public ScriptEngineResolver(ScriptEngineManager scriptEngineManager) {
-    this.scriptEngineManager = scriptEngineManager;
-  }
-
-  public void addScriptEngineFactory(ScriptEngineFactory scriptEngineFactory) {
-    scriptEngineManager.registerEngineName(scriptEngineFactory.getEngineName(), scriptEngineFactory);
-  }
-
-  public ScriptEngineManager getScriptEngineManager() {
-    return scriptEngineManager;
-  }
-
+  ScriptEngineManager getScriptEngineManager();
 
   /**
    * Returns a cached script engine or creates a new script engine if no such engine is currently cached.
@@ -56,109 +32,5 @@ public class ScriptEngineResolver {
    * @param language the language (such as 'groovy' for the script engine)
    * @return the cached engine or null if no script engine can be created for the given language
    */
-  public ScriptEngine getScriptEngine(String language, boolean resolveFromCache) {
-
-    ScriptEngine scriptEngine = null;
-
-    if (resolveFromCache) {
-      scriptEngine = cachedEngines.get(language);
-
-      if (scriptEngine == null) {
-        scriptEngine = getScriptEngine(language);
-
-        if (scriptEngine != null && isCachable(scriptEngine)) {
-          cachedEngines.put(language, scriptEngine);
-        }
-      }
-
-    } else {
-      scriptEngine = getScriptEngine(language);
-    }
-
-    return scriptEngine;
-  }
-
-  protected ScriptEngine getScriptEngine(String language) {
-    ScriptEngine scriptEngine = null;
-    if (ScriptingEngines.JAVASCRIPT_SCRIPTING_LANGUAGE.equalsIgnoreCase(language) ||
-        ScriptingEngines.ECMASCRIPT_SCRIPTING_LANGUAGE.equalsIgnoreCase(language)) {
-      scriptEngine = getJavaScriptScriptEngine(language);
-    } else {
-      scriptEngine = scriptEngineManager.getEngineByName(language);
-    }
-
-    if (scriptEngine != null) {
-
-      if (ScriptingEngines.GROOVY_SCRIPTING_LANGUAGE.equals(language)) {
-        configureGroovyScriptEngine(scriptEngine);
-      }
-
-      if (ScriptingEngines.GRAAL_JS_SCRIPT_ENGINE_NAME.equals(scriptEngine.getFactory().getEngineName())) {
-        configureGraalJsScriptEngine(scriptEngine);
-      }
-
-    }
-    return scriptEngine;
-  }
-
-  protected ScriptEngine getJavaScriptScriptEngine(String language) {
-    ScriptEngine scriptEngine = null;
-    ProcessEngineConfigurationImpl config = Context.getProcessEngineConfiguration();
-    if (config != null && config.getScriptEngineNameJavaScript() != null) {
-      scriptEngine = scriptEngineManager.getEngineByName(config.getScriptEngineNameJavaScript());
-    } else {
-      scriptEngine = scriptEngineManager.getEngineByName(ScriptingEngines.DEFAULT_JS_SCRIPTING_LANGUAGE);
-      if (scriptEngine == null) {
-        // default engine is not available, try to fetch any existing JS script engine
-        scriptEngine = scriptEngineManager.getEngineByName(language);
-      }
-    }
-    return scriptEngine;
-  }
-
-  /**
-   * Allows checking whether the script engine can be cached.
-   *
-   * @param scriptEngine the script engine to check.
-   * @return true if the script engine may be cached.
-   */
-  protected boolean isCachable(ScriptEngine scriptEngine) {
-    // Check if script-engine supports multithreading. If true it can be cached.
-    Object threadingParameter = scriptEngine.getFactory().getParameter("THREADING");
-    return threadingParameter != null;
-  }
-
-  /**
-   * Allows providing custom configuration for the groovy script engine.
-   * @param scriptEngine the groovy script engine to configure.
-   */
-  protected void configureGroovyScriptEngine(ScriptEngine scriptEngine) {
-
-    // make sure Groovy compiled scripts only hold weak references to java methods
-    scriptEngine.getContext().setAttribute("#jsr223.groovy.engine.keep.globals", "weak", ScriptContext.ENGINE_SCOPE);
-  }
-
-  /**
-   * Allows providing custom configuration for the Graal JS script engine.
-   * @param scriptEngine the Graal JS script engine to configure.
-   */
-  protected void configureGraalJsScriptEngine(ScriptEngine scriptEngine) {
-    ProcessEngineConfigurationImpl config = Context.getProcessEngineConfiguration();
-    if (config != null) {
-      if (config.isConfigureScriptEngineHostAccess()) {
-        // make sure Graal JS can provide access to the host and can lookup classes
-        scriptEngine.getContext().setAttribute("polyglot.js.allowHostAccess", true, ScriptContext.ENGINE_SCOPE);
-        scriptEngine.getContext().setAttribute("polyglot.js.allowHostClassLookup", true, ScriptContext.ENGINE_SCOPE);
-      }
-      if (config.isEnableScriptEngineLoadExternalResources()) {
-        // make sure Graal JS can load external scripts
-        scriptEngine.getContext().setAttribute("polyglot.js.allowIO", true, ScriptContext.ENGINE_SCOPE);
-      }
-      if (config.isEnableScriptEngineNashornCompatibility()) {
-        // enable Nashorn compatibility mode
-        scriptEngine.getContext().setAttribute("polyglot.js.nashorn-compat", true, ScriptContext.ENGINE_SCOPE);
-      }
-    }
-  }
-
+  ScriptEngine getScriptEngine(String language, boolean resolveFromCache);
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/engine/ScriptingEngines.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/engine/ScriptingEngines.java
@@ -64,13 +64,13 @@ public class ScriptingEngines implements DmnScriptEngineResolver {
 
   protected boolean enableScriptEngineCaching = true;
 
-  public ScriptingEngines(ScriptBindingsFactory scriptBindingsFactory) {
-    this(new ScriptEngineManager());
+  public ScriptingEngines(ScriptBindingsFactory scriptBindingsFactory, ScriptEngineResolver scriptEngineResolver) {
+    this(scriptEngineResolver);
     this.scriptBindingsFactory = scriptBindingsFactory;
   }
 
-  public ScriptingEngines(ScriptEngineManager scriptEngineManager) {
-    this.scriptEngineResolver = new ScriptEngineResolver(scriptEngineManager);
+  public ScriptingEngines(ScriptEngineResolver scriptEngineResolver) {
+    this.scriptEngineResolver = scriptEngineResolver;
   }
 
   public boolean isEnableScriptEngineCaching() {
@@ -158,5 +158,9 @@ public class ScriptingEngines implements DmnScriptEngineResolver {
 
   public void setScriptBindingsFactory(ScriptBindingsFactory scriptBindingsFactory) {
     this.scriptBindingsFactory = scriptBindingsFactory;
+  }
+
+  public void setScriptEngineResolver(ScriptEngineResolver scriptEngineResolver) {
+    this.scriptEngineResolver = scriptEngineResolver;
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/env/ScriptingEnvironment.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/env/ScriptingEnvironment.java
@@ -52,7 +52,7 @@ import org.camunda.bpm.engine.impl.scripting.engine.ScriptingEngines;
 public class ScriptingEnvironment {
 
   /** the cached environment scripts per script language */
-  protected Map<String, List<ExecutableScript>> env = new HashMap<String, List<ExecutableScript>>();
+  protected Map<String, List<ExecutableScript>> env = new HashMap<>();
 
   /** the resolvers */
   protected List<ScriptEnvResolver> envResolvers;
@@ -89,10 +89,8 @@ public class ScriptingEnvironment {
 
   public Object execute(ExecutableScript script, VariableScope scope, Bindings bindings, ScriptEngine scriptEngine) {
 
-    final String scriptLanguage = script.getLanguage();
-
     // first, evaluate the env scripts (if any)
-    List<ExecutableScript> envScripts = getEnvScripts(scriptLanguage);
+    List<ExecutableScript> envScripts = getEnvScripts(script, scriptEngine);
     for (ExecutableScript envScript : envScripts) {
       envScript.execute(scriptEngine, scope, bindings);
     }
@@ -131,6 +129,14 @@ public class ScriptingEnvironment {
     }
   }
 
+  protected List<ExecutableScript> getEnvScripts(ExecutableScript script, ScriptEngine scriptEngine) {
+    List<ExecutableScript> envScripts = getEnvScripts(script.getLanguage().toLowerCase());
+    if (envScripts.isEmpty()) {
+      envScripts = getEnvScripts(scriptEngine.getFactory().getLanguageName().toLowerCase());
+    }
+    return envScripts;
+  }
+
   /**
    * Returns the env scripts for the given language. Performs lazy initialization of the env scripts.
    *
@@ -160,7 +166,7 @@ public class ScriptingEnvironment {
    */
   protected List<ExecutableScript> initEnvForLanguage(String language) {
 
-    List<ExecutableScript> scripts = new ArrayList<ExecutableScript>();
+    List<ExecutableScript> scripts = new ArrayList<>();
     for (ScriptEnvResolver resolver : envResolvers) {
       String[] resolvedScripts = resolver.resolve(language);
       if(resolvedScripts != null) {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/scripting/AbstractScriptEnvironmentTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/scripting/AbstractScriptEnvironmentTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.standalone.scripting;
+
+import javax.script.Bindings;
+import javax.script.ScriptEngine;
+
+import java.util.concurrent.Callable;
+
+import org.camunda.bpm.application.ProcessApplicationInterface;
+import org.camunda.bpm.application.impl.EmbeddedProcessApplication;
+import org.camunda.bpm.engine.impl.context.Context;
+import org.camunda.bpm.engine.impl.interceptor.Command;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.scripting.ScriptFactory;
+import org.camunda.bpm.engine.impl.scripting.SourceExecutableScript;
+import org.camunda.bpm.engine.impl.scripting.engine.ScriptingEngines;
+import org.camunda.bpm.engine.impl.scripting.env.ScriptEnvResolver;
+import org.camunda.bpm.engine.impl.scripting.env.ScriptingEnvironment;
+import org.camunda.bpm.engine.test.util.PluggableProcessEngineTest;
+import org.junit.After;
+import org.junit.Before;
+
+public abstract class AbstractScriptEnvironmentTest extends PluggableProcessEngineTest {
+
+  protected final String processPath = "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml";
+
+  protected ScriptEnvResolver resolver;
+  protected ScriptFactory scriptFactory;
+  protected EmbeddedProcessApplication processApplication;
+
+  @Before
+  public void setUp() {
+    scriptFactory = processEngineConfiguration.getScriptFactory();
+    resolver = getResolver();
+    processEngineConfiguration.getEnvScriptResolvers().add(resolver);
+    processApplication = new EmbeddedProcessApplication();
+  }
+
+  @After
+  public void tearDown() {
+    processEngineConfiguration.getEnvScriptResolvers().remove(resolver);
+  }
+
+  protected abstract ScriptEnvResolver getResolver();
+  protected abstract String getScript();
+
+  protected void executeScript(final ProcessApplicationInterface processApplication, String language) {
+    processEngineConfiguration.getCommandExecutorTxRequired()
+      .execute(new Command<Void>() {
+        public Void execute(CommandContext commandContext) {
+          return Context.executeWithinProcessApplication(new Callable<Void>() {
+
+            public Void call() throws Exception {
+              ScriptingEngines scriptingEngines = processEngineConfiguration.getScriptingEngines();
+              ScriptEngine scriptEngine = scriptingEngines.getScriptEngineForLanguage(language);
+
+              SourceExecutableScript script = createScript(language, getScript());
+
+              ScriptingEnvironment scriptingEnvironment = processEngineConfiguration.getScriptingEnvironment();
+              Bindings bindings = scriptingEngines.createBindings(scriptEngine, null);
+              scriptingEnvironment.execute(script, null, bindings, scriptEngine);
+
+              return null;
+            }
+          }, processApplication.getReference());
+        }
+      });
+  }
+
+  protected SourceExecutableScript createScript(String language, String source) {
+    return (SourceExecutableScript) scriptFactory.createScriptFromSource(language, source);
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/scripting/ScriptEngineNameJavaScriptTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/scripting/ScriptEngineNameJavaScriptTest.java
@@ -30,6 +30,7 @@ import org.camunda.bpm.application.impl.EmbeddedProcessApplication;
 import org.camunda.bpm.engine.exception.NullValueException;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.context.Context;
+import org.camunda.bpm.engine.impl.scripting.engine.DefaultScriptEngineResolver;
 import org.camunda.bpm.engine.impl.scripting.engine.ScriptingEngines;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
@@ -129,13 +130,13 @@ public class ScriptEngineNameJavaScriptTest {
   @Test
   public void shouldFallbackToAnyEngineForJavaScriptIfDefaultUnavailable() {
     // given
-    ScriptEngineManager scriptEngineManager = mock(ScriptEngineManager.class);
+    ScriptEngineManager mockScriptEngineManager = mock(ScriptEngineManager.class);
     ScriptEngine mockScriptEngine = mock(ScriptEngine.class);
     ScriptEngineFactory mockScriptEngineFactory = mock(ScriptEngineFactory.class);
-    ScriptingEngines scriptingEngines = new ScriptingEngines(scriptEngineManager);
+    ScriptingEngines scriptingEngines = new ScriptingEngines(new DefaultScriptEngineResolver(mockScriptEngineManager));
 
-    when(scriptEngineManager.getEngineByName(ScriptingEngines.GRAAL_JS_SCRIPT_ENGINE_NAME)).thenReturn(null);
-    when(scriptEngineManager.getEngineByName(ScriptingEngines.JAVASCRIPT_SCRIPTING_LANGUAGE)).thenReturn(mockScriptEngine);
+    when(mockScriptEngineManager.getEngineByName(ScriptingEngines.GRAAL_JS_SCRIPT_ENGINE_NAME)).thenReturn(null);
+    when(mockScriptEngineManager.getEngineByName(ScriptingEngines.JAVASCRIPT_SCRIPTING_LANGUAGE)).thenReturn(mockScriptEngine);
     when(mockScriptEngine.getFactory()).thenReturn(mockScriptEngineFactory);
     when(mockScriptEngineFactory.getEngineName()).thenReturn("foo");
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <version.uuid-generator>3.2.0</version.uuid-generator>
     <version.camunda.commons>1.10.0</version.camunda.commons>
     <version.camunda.connect>1.5.2</version.camunda.connect>
-    <version.camunda.spin>1.10.1</version.camunda.spin>
+    <version.camunda.spin>1.11.0-SNAPSHOT</version.camunda.spin>
     <version.camunda.template-engines>2.0.0</version.camunda.template-engines>
     <version.camunda.ee.xslt-plugin>1.1.0</version.camunda.ee.xslt-plugin>
     <version.feel-scala>1.13.1</version.feel-scala>

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/deployment/war/beans/GroovyProcessEnginePlugin.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/deployment/war/beans/GroovyProcessEnginePlugin.java
@@ -16,9 +16,12 @@
  */
 package org.camunda.bpm.integrationtest.deployment.war.beans;
 
+import javax.script.ScriptEngineManager;
+
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.cfg.ProcessEnginePlugin;
+import org.camunda.bpm.engine.impl.scripting.engine.DefaultScriptEngineResolver;
 import org.camunda.bpm.engine.impl.scripting.engine.ScriptBindingsFactory;
 import org.camunda.bpm.engine.impl.scripting.engine.ScriptingEngines;
 
@@ -33,7 +36,8 @@ public class GroovyProcessEnginePlugin implements ProcessEnginePlugin {
   public void postInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
     processEngineConfiguration.setScriptingEngines(
         new ScriptingEngines(
-            new ScriptBindingsFactory(processEngineConfiguration.getResolverFactories())
+            new ScriptBindingsFactory(processEngineConfiguration.getResolverFactories()),
+            new DefaultScriptEngineResolver(new ScriptEngineManager())
         )
     );
   }

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/scriptengine/AbstractScriptEngineSupportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/scriptengine/AbstractScriptEngineSupportTest.java
@@ -36,16 +36,20 @@ public abstract class AbstractScriptEngineSupportTest extends AbstractFoxPlatfor
 
   public static final String PROCESS_ID = "testProcess";
   public static final String EXAMPLE_SCRIPT = "execution.setVariable('foo', 'bar')";
+  public static final String EXAMPLE_SPIN_SCRIPT = "execution.setVariable('bar', S('<baz/>').name())";
 
   public String processInstanceId;
 
-  protected static StringAsset createScriptTaskProcess(String scriptFormat, String scriptText) {
+  protected static StringAsset createScriptTaskProcess(String scriptFormat, String scriptTextPlain, String scriptTextSpin) {
     BpmnModelInstance modelInstance = Bpmn.createExecutableProcess(PROCESS_ID)
       .startEvent()
       .scriptTask()
         .scriptFormat(scriptFormat)
-        .scriptText(scriptText)
-        .userTask()
+        .scriptText(scriptTextPlain)
+      .scriptTask()
+        .scriptFormat(scriptFormat)
+        .scriptText(scriptTextSpin)
+      .userTask()
       .endEvent()
       .done();
     return new StringAsset(Bpmn.convertToString(modelInstance));
@@ -59,8 +63,11 @@ public abstract class AbstractScriptEngineSupportTest extends AbstractFoxPlatfor
   @After
   public void variableFooShouldBeBar() {
     Object foo = runtimeService.getVariable(processInstanceId, "foo");
+    Object bar = runtimeService.getVariable(processInstanceId, "bar");
     assertNotNull(foo);
+    assertNotNull(bar);
     assertEquals("bar", foo);
+    assertEquals("baz", bar);
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/scriptengine/GroovyScriptEngineSupportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/scriptengine/GroovyScriptEngineSupportTest.java
@@ -28,7 +28,7 @@ public class GroovyScriptEngineSupportTest extends AbstractScriptEngineSupportTe
   public static WebArchive createProcessApplication() {
     return initWebArchiveDeployment()
       .addClass(AbstractScriptEngineSupportTest.class)
-      .addAsResource(createScriptTaskProcess("groovy", EXAMPLE_SCRIPT), "process.bpmn20.xml");
+      .addAsResource(createScriptTaskProcess("groovy", EXAMPLE_SCRIPT, EXAMPLE_SPIN_SCRIPT), "process.bpmn20.xml");
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/scriptengine/JavascriptScriptEngineSupportGraalJsTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/scriptengine/JavascriptScriptEngineSupportGraalJsTest.java
@@ -25,7 +25,7 @@ public class JavascriptScriptEngineSupportGraalJsTest extends AbstractScriptEngi
   public static WebArchive createProcessApplication() {
     return initWebArchiveDeployment()
       .addClass(AbstractScriptEngineSupportTest.class)
-      .addAsResource(createScriptTaskProcess("graal.js", EXAMPLE_SCRIPT), "process.bpmn20.xml");
+      .addAsResource(createScriptTaskProcess("graal.js", EXAMPLE_SCRIPT, EXAMPLE_SPIN_SCRIPT), "process.bpmn20.xml");
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/scriptengine/JavascriptScriptEngineSupportNashornTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/scriptengine/JavascriptScriptEngineSupportNashornTest.java
@@ -25,7 +25,7 @@ public class JavascriptScriptEngineSupportNashornTest extends AbstractScriptEngi
   public static WebArchive createProcessApplication() {
     return initWebArchiveDeployment()
       .addClass(AbstractScriptEngineSupportTest.class)
-      .addAsResource(createScriptTaskProcess("nashorn", EXAMPLE_SCRIPT), "process.bpmn20.xml");
+      .addAsResource(createScriptTaskProcess("nashorn", EXAMPLE_SCRIPT, EXAMPLE_SPIN_SCRIPT), "process.bpmn20.xml");
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/scriptengine/JavascriptScriptEngineSupportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/scriptengine/JavascriptScriptEngineSupportTest.java
@@ -28,7 +28,7 @@ public class JavascriptScriptEngineSupportTest extends AbstractScriptEngineSuppo
   public static WebArchive createProcessApplication() {
     return initWebArchiveDeployment()
       .addClass(AbstractScriptEngineSupportTest.class)
-      .addAsResource(createScriptTaskProcess("javascript", EXAMPLE_SCRIPT), "process.bpmn20.xml");
+      .addAsResource(createScriptTaskProcess("javascript", EXAMPLE_SCRIPT, EXAMPLE_SPIN_SCRIPT), "process.bpmn20.xml");
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/scriptengine/PythonScriptEngineSupportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/scriptengine/PythonScriptEngineSupportTest.java
@@ -28,7 +28,7 @@ public class PythonScriptEngineSupportTest extends AbstractScriptEngineSupportTe
   public static WebArchive createProcessApplication() {
     return initWebArchiveDeployment()
       .addClass(AbstractScriptEngineSupportTest.class)
-      .addAsResource(createScriptTaskProcess("python", EXAMPLE_SCRIPT), "process.bpmn20.xml");
+      .addAsResource(createScriptTaskProcess("python", EXAMPLE_SCRIPT, EXAMPLE_SPIN_SCRIPT), "process.bpmn20.xml");
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/scriptengine/RubyScriptEngineSupportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/scriptengine/RubyScriptEngineSupportTest.java
@@ -28,7 +28,7 @@ public class RubyScriptEngineSupportTest extends AbstractScriptEngineSupportTest
   public static WebArchive createProcessApplication() {
     return initWebArchiveDeployment()
       .addClass(AbstractScriptEngineSupportTest.class)
-      .addAsResource(createScriptTaskProcess("ruby", "$" + EXAMPLE_SCRIPT), "process.bpmn20.xml");
+      .addAsResource(createScriptTaskProcess("ruby", "$" + EXAMPLE_SCRIPT, "$" + EXAMPLE_SPIN_SCRIPT), "process.bpmn20.xml");
   }
 
 }


### PR DESCRIPTION
* bumps Spin to latest snapshot version
* adds engine configuration option for script engine resolver
* provides a default resolver
* resolves environment scripts for script engine language as a fallback
  if none are found for the script's language itself (e.g. looks for
  'ecmascript' environment scripts for 'graal.js' script language)
* adds Spin scripting QA tests

related to CAM-13517