### PR TITLE
chore(distro): add commons-dbcp to standalone webapps

### DIFF
--- a/distro/jbossas7/webapp-standalone/pom.xml
+++ b/distro/jbossas7/webapp-standalone/pom.xml
@@ -96,6 +96,10 @@
       <artifactId>java-uuid-generator</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-dbcp</groupId>
+      <artifactId>commons-dbcp</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
     </dependency>
@@ -115,6 +119,7 @@
       <groupId>org.camunda.template-engines</groupId>
       <artifactId>camunda-template-engines-freemarker</artifactId>
     </dependency>
+    
   </dependencies>
 
   <build>

--- a/distro/tomcat/webapp-standalone/pom.xml
+++ b/distro/tomcat/webapp-standalone/pom.xml
@@ -116,6 +116,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-dbcp</groupId>
+      <artifactId>commons-dbcp</artifactId>
+    </dependency>
     <!-- CAM-10374  -->
     <dependency>
       <groupId>com.sun.xml.bind</groupId>


### PR DESCRIPTION
* adds commons-dbcp as compile dependency to standalone webapps
  since they reference `org.apache.commons.dbcp.BasicDataSource`
  in the `applicationContext.xml`

related to CAM-13674