### PR TITLE
chore(test): adjust script test to consider Spin env script

### DIFF
--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/scripttask/ScriptTaskGraalJsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/scripttask/ScriptTaskGraalJsTest.java
@@ -54,7 +54,7 @@ public class ScriptTaskGraalJsTest extends AbstractScriptTaskTest {
   @Before
   public void setup() {
     spinEnabled = processEngineConfiguration.getEnvScriptResolvers().stream()
-                      .anyMatch(resolver -> resolver.getClass().getSimpleName().equals("SpinScriptEnvResolver"));
+                    .anyMatch(resolver -> resolver.getClass().getSimpleName().equals("SpinScriptEnvResolver"));
     defaultScriptEngineResolver = processEngineConfiguration.getScriptEngineResolver();
     processEngineConfiguration.setConfigureScriptEngineHostAccess(configureHostAccess);
     processEngineConfiguration.setEnableScriptEngineLoadExternalResources(enableExternalResources);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/scripttask/ScriptTaskGraalJsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/scripttask/ScriptTaskGraalJsTest.java
@@ -49,9 +49,11 @@ public class ScriptTaskGraalJsTest extends AbstractScriptTaskTest {
   private static final String GRAALJS = "graal.js";
 
   protected ScriptEngineResolver defaultScriptEngineResolver;
+  protected boolean spinEnabled = false;
 
   @Before
   public void setup() {
+    spinEnabled = processEngineConfiguration.getEnvScriptResolvers().stream().anyMatch(resolver -> resolver.getClass().getSimpleName().equals("SpinScriptEnvResolver"));
     defaultScriptEngineResolver = processEngineConfiguration.getScriptEngineResolver();
     processEngineConfiguration.setConfigureScriptEngineHostAccess(configureHostAccess);
     processEngineConfiguration.setEnableScriptEngineLoadExternalResources(enableExternalResources);
@@ -142,7 +144,7 @@ public class ScriptTaskGraalJsTest extends AbstractScriptTaskTest {
       // THEN
       // this is not allowed in the JS ScriptEngine
         .isInstanceOf(ScriptEvaluationException.class)
-        .hasMessageContaining("TypeError");
+        .hasMessageContaining(spinEnabled ? "ReferenceError" : "TypeError");
     }
   }
 
@@ -181,7 +183,7 @@ public class ScriptTaskGraalJsTest extends AbstractScriptTaskTest {
       // THEN
       // this is not allowed in the JS ScriptEngine
         .isInstanceOf(ScriptEvaluationException.class)
-        .hasMessageContaining("TypeError");
+        .hasMessageContaining(spinEnabled ? "ReferenceError" : "TypeError");
     }
 
   }
@@ -193,9 +195,19 @@ public class ScriptTaskGraalJsTest extends AbstractScriptTaskTest {
 
     deployProcess(GRAALJS, scriptText);
 
-    ProcessInstance pi = runtimeService.startProcessInstanceByKey("testProcess");
-    Object variableValue = runtimeService.getVariable(pi.getId(), "foo");
-    assertNull(variableValue);
+    if (spinEnabled && !enableNashornCompat && !configureHostAccess) {
+      // WHEN
+      // we start an instance of this process
+      assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("testProcess"))
+      // THEN
+      // this Java access is not allowed for Spin Environment Script
+        .isInstanceOf(ScriptEvaluationException.class)
+        .hasMessageContaining("ReferenceError");
+    } else {
+      ProcessInstance pi = runtimeService.startProcessInstanceByKey("testProcess");
+      Object variableValue = runtimeService.getVariable(pi.getId(), "foo");
+      assertNull(variableValue);
+    }
 
   }
 
@@ -257,7 +269,10 @@ public class ScriptTaskGraalJsTest extends AbstractScriptTaskTest {
         // THEN
         // this is not allowed in the JS ScriptEngine
           .isInstanceOf(ScriptEvaluationException.class)
-          .hasMessageContaining(enableExternalResources && !configureHostAccess ? "TypeError" : "Operation is not allowed");
+          .hasMessageContaining(
+              (spinEnabled && !configureHostAccess) ? "ReferenceError" :
+              (enableExternalResources && !configureHostAccess) ? "TypeError" :
+              "Operation is not allowed");
       }
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/scripttask/ScriptTaskGraalJsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/scripttask/ScriptTaskGraalJsTest.java
@@ -53,7 +53,8 @@ public class ScriptTaskGraalJsTest extends AbstractScriptTaskTest {
 
   @Before
   public void setup() {
-    spinEnabled = processEngineConfiguration.getEnvScriptResolvers().stream().anyMatch(resolver -> resolver.getClass().getSimpleName().equals("SpinScriptEnvResolver"));
+    spinEnabled = processEngineConfiguration.getEnvScriptResolvers().stream()
+                      .anyMatch(resolver -> resolver.getClass().getSimpleName().equals("SpinScriptEnvResolver"));
     defaultScriptEngineResolver = processEngineConfiguration.getScriptEngineResolver();
     processEngineConfiguration.setConfigureScriptEngineHostAccess(configureHostAccess);
     processEngineConfiguration.setEnableScriptEngineLoadExternalResources(enableExternalResources);


### PR DESCRIPTION
* adjusts the `ScriptTaskGraalJsTest` to account for Spin environment
  scripts being executed before the actual test script which can lead
  to different error messages due to the Spin script trying to access
  a Java function

related to CAM-13517