### PR TITLE
chore(engine): remove unused import from joda-time

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/DateTimeUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/DateTimeUtil.java
@@ -21,7 +21,6 @@ import java.util.TimeZone;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.joda.time.LocalTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 


### PR DESCRIPTION
* removes an unused import from `joda-time` that additionally causes
  WLS compat tests to fail due the class referenced by this unused import
  not being present on joda-time 1.2.1 (which is introduced by the profiles
  for this compat test)

related to CAM-13694