### PR TITLE
CAM-13763: chore(maven): bump javadoc plugin version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -254,7 +254,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <configuration>
             <failOnError>false</failOnError>
-            <additionalparam>-Xdoclint:none</additionalparam>
+            <doclint>none</doclint>
             <quiet>true</quiet>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <version.camunda.template-engines>2.0.0</version.camunda.template-engines>
     <version.camunda.ee.xslt-plugin>1.1.0</version.camunda.ee.xslt-plugin>
     <version.feel-scala>1.13.1</version.feel-scala>
+    <plugin.version.javadoc>3.0.1</plugin.version.javadoc>
   </properties>
 
   <build>


### PR DESCRIPTION
* Version 2.9.1 of the maven-javadoc-plugin has a bug when running on
  JDK 11. To run releases on JDK 11, version 3.0.1 must be used, where
the plugin is fixed.

Related to CAM-13763