### PR TITLE
CAM-13771: remove spring-boot-loader-tools dependency

### DIFF
--- a/spring-boot-starter/starter/pom.xml
+++ b/spring-boot-starter/starter/pom.xml
@@ -33,11 +33,6 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-orm</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-loader-tools</artifactId>
-    </dependency>
-    
 
     <dependency>
       <groupId>org.camunda.bpm</groupId>


### PR DESCRIPTION
- it is not needed

related to CAM-13771