### PR TITLE
chore(quarkus-extension): disable engine-cdi interceptors by default

### DIFF
--- a/quarkus-extension/engine/deployment/src/main/resources/application.properties
+++ b/quarkus-extension/engine/deployment/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+quarkus.arc.exclude-types=\
+  org.camunda.bpm.engine.cdi.impl.annotation.CompleteTaskInterceptor,\
+  org.camunda.bpm.engine.cdi.impl.annotation.StartProcessInterceptor

--- a/quarkus-extension/engine/qa/src/test/java/org/camunda/bpm/engine/cdi/test/interceptor/CompleteTaskInterceptor.java
+++ b/quarkus-extension/engine/qa/src/test/java/org/camunda/bpm/engine/cdi/test/interceptor/CompleteTaskInterceptor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.cdi.test.interceptor;
+
+import org.camunda.bpm.engine.cdi.annotation.CompleteTask;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.Dependent;
+import javax.interceptor.Interceptor;
+
+@Dependent
+@Priority(0)
+@Interceptor
+@CompleteTask
+public class CompleteTaskInterceptor extends
+    org.camunda.bpm.engine.cdi.impl.annotation.CompleteTaskInterceptor {
+}

--- a/quarkus-extension/engine/qa/src/test/java/org/camunda/bpm/engine/cdi/test/interceptor/StartProcessInterceptor.java
+++ b/quarkus-extension/engine/qa/src/test/java/org/camunda/bpm/engine/cdi/test/interceptor/StartProcessInterceptor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.cdi.test.interceptor;
+
+import org.camunda.bpm.engine.cdi.annotation.StartProcess;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.Dependent;
+import javax.interceptor.Interceptor;
+
+@Dependent
+@Priority(0)
+@Interceptor
+@StartProcess
+public class StartProcessInterceptor extends
+    org.camunda.bpm.engine.cdi.impl.annotation.StartProcessInterceptor {
+}


### PR DESCRIPTION
related to CAM-13752