### PR TITLE
chore(engine-cdi): fix javadocs of BusinessProcessScoped annotation

### DIFF
--- a/engine-cdi/src/main/java/org/camunda/bpm/engine/cdi/annotation/BusinessProcessScoped.java
+++ b/engine-cdi/src/main/java/org/camunda/bpm/engine/cdi/annotation/BusinessProcessScoped.java
@@ -30,7 +30,9 @@ import javax.enterprise.context.RequestScoped;
  * BusinessProcessScoped beans are stored as process variables in a
  * ProcessInstance.
  * <p />
- * Note: A BusinessProcessScoped bean instances must be {@link Serializable}.
+ * Note: {@code @BusinessProcessScoped} bean instances must be "passivation capable", 
+ *       meaning the bean defining classes must implement the {@link Serializable} 
+ *       interface and their references (dependencies) must be "passivation capable" as well.
  * <p />
  * Note: BusinessProcessScoped is not capable of managing local process variables,
  * and there is currently also no respective other implementation for that. Please use

--- a/engine-cdi/src/main/java/org/camunda/bpm/engine/cdi/annotation/BusinessProcessScoped.java
+++ b/engine-cdi/src/main/java/org/camunda/bpm/engine/cdi/annotation/BusinessProcessScoped.java
@@ -16,6 +16,7 @@
  */
 package org.camunda.bpm.engine.cdi.annotation;
 
+import java.io.Serializable;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -23,14 +24,13 @@ import java.lang.annotation.Target;
 
 import javax.enterprise.context.ConversationScoped;
 import javax.enterprise.context.RequestScoped;
-import javax.enterprise.inject.spi.PassivationCapable;
 
 /**
  * Declare a bean to be BusinessProcessScoped. Instances of
  * BusinessProcessScoped beans are stored as process variables in a
  * ProcessInstance.
  * <p />
- * Note: BusinessProcessScoped beans need to be {@link PassivationCapable}.
+ * Note: A BusinessProcessScoped bean instances must be {@link Serializable}.
  * <p />
  * Note: BusinessProcessScoped is not capable of managing local process variables,
  * and there is currently also no respective other implementation for that. Please use


### PR DESCRIPTION
A `BusinessProcessScoped` bean instance must be `Serializable`.

related to CAM-13744