### PR TITLE
CAM-13631: feat(quarkus): add process engine start event

### DIFF
--- a/quarkus-extension/engine/deployment/src/main/java/org/camunda/bpm/quarkus/engine/extension/deployment/impl/CamundaEngineProcessor.java
+++ b/quarkus-extension/engine/deployment/src/main/java/org/camunda/bpm/quarkus/engine/extension/deployment/impl/CamundaEngineProcessor.java
@@ -129,7 +129,7 @@ public class CamundaEngineProcessor {
   @BuildStep
   @Record(RUNTIME_INIT)
   protected void deployProcessEngineResources(CamundaEngineRecorder recorder) {
-    recorder.fireProcessEngineStartEvent();
+    recorder.fireCamundaEngineStartEvent();
   }
 
   @BuildStep

--- a/quarkus-extension/engine/deployment/src/main/java/org/camunda/bpm/quarkus/engine/extension/deployment/impl/CamundaEngineProcessor.java
+++ b/quarkus-extension/engine/deployment/src/main/java/org/camunda/bpm/quarkus/engine/extension/deployment/impl/CamundaEngineProcessor.java
@@ -125,6 +125,13 @@ public class CamundaEngineProcessor {
         recorder.createProcessEngine(processEngineConfiguration)));
   }
 
+  @Consume(ProcessEngineBuildItem.class)
+  @BuildStep
+  @Record(RUNTIME_INIT)
+  protected void deployProcessEngineResources(CamundaEngineRecorder recorder) {
+    recorder.fireProcessEngineStartEvent();
+  }
+
   @BuildStep
   @Record(RUNTIME_INIT)
   protected void shutdown(CamundaEngineRecorder recorder,

--- a/quarkus-extension/engine/deployment/src/test/java/org/camunda/bpm/quarkus/engine/test/deployment/ProcessEngineMultipleDeploymentTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/camunda/bpm/quarkus/engine/test/deployment/ProcessEngineMultipleDeploymentTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.quarkus.engine.test.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.RepositoryService;
+import org.camunda.bpm.engine.repository.Deployment;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.camunda.bpm.quarkus.engine.extension.impl.ProcessEngineStartEvent;
+import org.camunda.bpm.quarkus.engine.test.helper.ProcessEngineAwareExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class ProcessEngineMultipleDeploymentTest {
+
+  @RegisterExtension
+  protected static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
+      .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+          .addClass(MyConfig.class)
+          .addAsResource("org/camunda/bpm/quarkus/engine/test/deployment/simpleServiceTaskProcess.bpmn"));
+
+  @ApplicationScoped
+  static class MyConfig {
+
+    BpmnModelInstance process1 = Bpmn.createExecutableProcess("process-one")
+        .startEvent()
+        .userTask()
+        .endEvent()
+        .done();
+
+    BpmnModelInstance process2 = Bpmn.createExecutableProcess("process-two")
+        .startEvent()
+        .serviceTask()
+          .camundaExpression("${true}")
+        .endEvent()
+        .done();
+
+    @Inject
+    RepositoryService repositoryService;
+
+    public void createDeployment1(@Observes ProcessEngineStartEvent event) {
+      repositoryService.createDeployment()
+          .name("deployment-1")
+          .addModelInstance("process-one.bpmn", process1)
+          .addModelInstance("process-two.bpmn", process2)
+          .deploy();
+    }
+
+    public void createDeployment2(@Observes ProcessEngineStartEvent event) {
+      repositoryService.createDeployment()
+          .name("deployment-2")
+          .addClasspathResource("org/camunda/bpm/quarkus/engine/test/deployment/simpleServiceTaskProcess.bpmn")
+          .deploy();
+    }
+
+  }
+
+  @Inject
+  public ProcessEngine processEngine;
+
+  @Test
+  public void shouldHaveDeployedResources() {
+    // given
+    RepositoryService repositoryService = processEngine.getRepositoryService();
+
+    // when
+    List<Deployment> deployments = repositoryService.createDeploymentQuery().list();
+    List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
+
+    // then
+    assertThat(deployments).hasSize(2);
+    assertThat(processDefinitions).hasSize(3);
+
+    List<String> deploymentNames = deployments.stream()
+        .map(Deployment::getName)
+        .collect(Collectors.toList());
+    assertThat(deploymentNames).contains("deployment-1", "deployment-2");
+  }
+
+}

--- a/quarkus-extension/engine/deployment/src/test/java/org/camunda/bpm/quarkus/engine/test/deployment/ProcessEngineMultipleDeploymentTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/camunda/bpm/quarkus/engine/test/deployment/ProcessEngineMultipleDeploymentTest.java
@@ -31,7 +31,7 @@ import org.camunda.bpm.engine.repository.Deployment;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
-import org.camunda.bpm.quarkus.engine.extension.impl.ProcessEngineStartEvent;
+import org.camunda.bpm.quarkus.engine.extension.event.CamundaEngineStartupEvent;
 import org.camunda.bpm.quarkus.engine.test.helper.ProcessEngineAwareExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -43,7 +43,6 @@ public class ProcessEngineMultipleDeploymentTest {
   @RegisterExtension
   protected static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
       .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-          .addClass(MyConfig.class)
           .addAsResource("org/camunda/bpm/quarkus/engine/test/deployment/simpleServiceTaskProcess.bpmn"));
 
   @ApplicationScoped
@@ -65,7 +64,7 @@ public class ProcessEngineMultipleDeploymentTest {
     @Inject
     RepositoryService repositoryService;
 
-    public void createDeployment1(@Observes ProcessEngineStartEvent event) {
+    public void createDeployment1(@Observes CamundaEngineStartupEvent event) {
       repositoryService.createDeployment()
           .name("deployment-1")
           .addModelInstance("process-one.bpmn", process1)
@@ -73,7 +72,7 @@ public class ProcessEngineMultipleDeploymentTest {
           .deploy();
     }
 
-    public void createDeployment2(@Observes ProcessEngineStartEvent event) {
+    public void createDeployment2(@Observes CamundaEngineStartupEvent event) {
       repositoryService.createDeployment()
           .name("deployment-2")
           .addClasspathResource("org/camunda/bpm/quarkus/engine/test/deployment/simpleServiceTaskProcess.bpmn")

--- a/quarkus-extension/engine/deployment/src/test/java/org/camunda/bpm/quarkus/engine/test/deployment/ProcessEngineSingleDeploymentTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/camunda/bpm/quarkus/engine/test/deployment/ProcessEngineSingleDeploymentTest.java
@@ -28,7 +28,7 @@ import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.repository.Deployment;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
-import org.camunda.bpm.quarkus.engine.extension.impl.ProcessEngineStartEvent;
+import org.camunda.bpm.quarkus.engine.extension.event.CamundaEngineStartupEvent;
 import org.camunda.bpm.quarkus.engine.test.helper.ProcessEngineAwareExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -40,7 +40,6 @@ public class ProcessEngineSingleDeploymentTest {
   @RegisterExtension
   protected static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
       .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-          .addClass(MyConfig.class)
           .addAsResource("org/camunda/bpm/quarkus/engine/test/deployment/simpleServiceTaskProcess.bpmn"));
 
   @ApplicationScoped
@@ -49,7 +48,7 @@ public class ProcessEngineSingleDeploymentTest {
     @Inject
     RepositoryService repositoryService;
 
-    public void createDeployment(@Observes ProcessEngineStartEvent event) {
+    public void createDeployment(@Observes CamundaEngineStartupEvent event) {
       repositoryService.createDeployment()
           .addClasspathResource("org/camunda/bpm/quarkus/engine/test/deployment/simpleServiceTaskProcess.bpmn")
           .deploy();

--- a/quarkus-extension/engine/deployment/src/test/java/org/camunda/bpm/quarkus/engine/test/deployment/ProcessEngineSingleDeploymentTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/camunda/bpm/quarkus/engine/test/deployment/ProcessEngineSingleDeploymentTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.quarkus.engine.test.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.util.List;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.RepositoryService;
+import org.camunda.bpm.engine.repository.Deployment;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.quarkus.engine.extension.impl.ProcessEngineStartEvent;
+import org.camunda.bpm.quarkus.engine.test.helper.ProcessEngineAwareExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class ProcessEngineSingleDeploymentTest {
+
+  @RegisterExtension
+  protected static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
+      .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+          .addClass(MyConfig.class)
+          .addAsResource("org/camunda/bpm/quarkus/engine/test/deployment/simpleServiceTaskProcess.bpmn"));
+
+  @ApplicationScoped
+  static class MyConfig {
+
+    @Inject
+    RepositoryService repositoryService;
+
+    public void createDeployment(@Observes ProcessEngineStartEvent event) {
+      repositoryService.createDeployment()
+          .addClasspathResource("org/camunda/bpm/quarkus/engine/test/deployment/simpleServiceTaskProcess.bpmn")
+          .deploy();
+    }
+
+  }
+
+  @Inject
+  public ProcessEngine processEngine;
+
+  @Test
+  public void shouldHaveDeployedResources() {
+    // given
+    RepositoryService repositoryService = processEngine.getRepositoryService();
+
+    // when
+    List<Deployment> deployments = repositoryService.createDeploymentQuery().list();
+    List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
+
+    // then
+    assertThat(deployments).hasSize(1);
+    assertThat(processDefinitions).hasSize(1);
+
+    Deployment deployment = deployments.get(0);
+    ProcessDefinition processDefinition = processDefinitions.get(0);
+    assertThat(processDefinition.getDeploymentId()).isEqualTo(deployment.getId());
+  }
+
+}

--- a/quarkus-extension/engine/deployment/src/test/resources/org/camunda/bpm/quarkus/engine/test/deployment/simpleServiceTaskProcess.bpmn
+++ b/quarkus-extension/engine/deployment/src/test/resources/org/camunda/bpm/quarkus/engine/test/deployment/simpleServiceTaskProcess.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_144rplc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="simpleServiceTaskProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0kwqjvm</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0kwqjvm" sourceRef="StartEvent_1" targetRef="Activity_02p298y" />
+    <bpmn:endEvent id="Event_0zpl8hb">
+      <bpmn:incoming>Flow_05ve86e</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_05ve86e" sourceRef="Activity_02p298y" targetRef="Event_0zpl8hb" />
+    <bpmn:serviceTask id="Activity_02p298y" name="Autocomplete Service Task" camunda:expression="${true}">
+      <bpmn:incoming>Flow_0kwqjvm</bpmn:incoming>
+      <bpmn:outgoing>Flow_05ve86e</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="simpleServiceTaskProcess">
+      <bpmndi:BPMNEdge id="Flow_0kwqjvm_di" bpmnElement="Flow_0kwqjvm">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05ve86e_di" bpmnElement="Flow_05ve86e">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0zpl8hb_di" bpmnElement="Event_0zpl8hb">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1vxgqyh_di" bpmnElement="Activity_02p298y">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/quarkus-extension/engine/runtime/src/main/java/org/camunda/bpm/quarkus/engine/extension/event/CamundaEngineStartupEvent.java
+++ b/quarkus-extension/engine/runtime/src/main/java/org/camunda/bpm/quarkus/engine/extension/event/CamundaEngineStartupEvent.java
@@ -14,10 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.camunda.bpm.quarkus.engine.extension.impl;
+package org.camunda.bpm.quarkus.engine.extension.event;
 
 /**
- * A CDI Event class fired when the Camunda process engine is bootstrapped successfully.
+ * Event class that is fired after Camunda engine startup.
+ *
+ * The event is fired after the Camunda engine has been bootstrapped,
+ * so it can be used to perform deployments to the engine.
+ *
+ * This event is observed in the following way:
+ *
+ * <code><pre>
+ *     void onCamundaEngineStart(@Observes CamundaEngineStartupEvent event) {
+ *         LOGGER.info("The Camunda engine is started");
+ *     }
+ * </pre></code>
  */
-public class ProcessEngineStartEvent {
+public class CamundaEngineStartupEvent {
 }

--- a/quarkus-extension/engine/runtime/src/main/java/org/camunda/bpm/quarkus/engine/extension/impl/CamundaEngineRecorder.java
+++ b/quarkus-extension/engine/runtime/src/main/java/org/camunda/bpm/quarkus/engine/extension/impl/CamundaEngineRecorder.java
@@ -33,6 +33,7 @@ import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.jobexecutor.JobExecutor;
 import org.camunda.bpm.quarkus.engine.extension.CamundaEngineConfig;
 import org.camunda.bpm.quarkus.engine.extension.QuarkusProcessEngineConfiguration;
+import org.camunda.bpm.quarkus.engine.extension.event.CamundaEngineStartupEvent;
 import org.eclipse.microprofile.context.ManagedExecutor;
 
 import javax.enterprise.inject.spi.BeanManager;
@@ -103,10 +104,11 @@ public class CamundaEngineRecorder {
     return new RuntimeValue<>(processEngine);
   }
 
-  public void fireProcessEngineStartEvent() {
-    // the 'fireEvent()' method is deprecated in CDI 2.0,
-    // but our CDI integration still supports CDI 1.0, so we continue to use it
-    Arc.container().beanManager().fireEvent(new ProcessEngineStartEvent());
+  public void fireCamundaEngineStartEvent() {
+    Arc.container().beanManager()
+        .getEvent()
+        .select(CamundaEngineStartupEvent.class)
+        .fire(new CamundaEngineStartupEvent());
   }
 
   public void registerShutdownTask(ShutdownContext shutdownContext,

--- a/quarkus-extension/engine/runtime/src/main/java/org/camunda/bpm/quarkus/engine/extension/impl/CamundaEngineRecorder.java
+++ b/quarkus-extension/engine/runtime/src/main/java/org/camunda/bpm/quarkus/engine/extension/impl/CamundaEngineRecorder.java
@@ -17,6 +17,7 @@
 package org.camunda.bpm.quarkus.engine.extension.impl;
 
 import io.quarkus.agroal.runtime.DataSources;
+import io.quarkus.arc.Arc;
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
@@ -100,6 +101,12 @@ public class CamundaEngineRecorder {
     runtimeContainerDelegate.registerProcessEngine(processEngine);
 
     return new RuntimeValue<>(processEngine);
+  }
+
+  public void fireProcessEngineStartEvent() {
+    // the 'fireEvent()' method is deprecated in CDI 2.0,
+    // but our CDI integration still supports CDI 1.0, so we continue to use it
+    Arc.container().beanManager().fireEvent(new ProcessEngineStartEvent());
   }
 
   public void registerShutdownTask(ShutdownContext shutdownContext,

--- a/quarkus-extension/engine/runtime/src/main/java/org/camunda/bpm/quarkus/engine/extension/impl/ProcessEngineStartEvent.java
+++ b/quarkus-extension/engine/runtime/src/main/java/org/camunda/bpm/quarkus/engine/extension/impl/ProcessEngineStartEvent.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.quarkus.engine.extension.impl;
+
+/**
+ * A CDI Event class fired when the Camunda process engine is bootstrapped successfully.
+ */
+public class ProcessEngineStartEvent {
+}


### PR DESCRIPTION
* Define a ProcessEngineStartEvent. This event is fired after the process engine is bootstrapped. It can be used to perform process engine deployments.

Related to CAM-13631