### PR TITLE
fix(engine): prevent deadlock on SQL Server in cleanup

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
@@ -585,6 +585,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     addDatabaseSpecificStatement(MSSQL, "selectEventSubscriptionsByNameAndExecution", "selectEventSubscriptionsByNameAndExecution_mssql");
     addDatabaseSpecificStatement(MSSQL, "selectEventSubscriptionsByExecutionAndType", "selectEventSubscriptionsByExecutionAndType_mssql");
     addDatabaseSpecificStatement(MSSQL, "selectHistoricDecisionInstancesByNativeQuery", "selectHistoricDecisionInstancesByNativeQuery_mssql_or_db2");
+    addDatabaseSpecificStatement(MSSQL, "deleteByteArraysByRemovalTime", "deleteByteArraysByRemovalTime_mssql");
 
     // related to CAM-13094
     addDatabaseSpecificStatement(MSSQL, "updateAttachmentsByRootProcessInstanceId", "updateAttachmentsByRootProcessInstanceId_mssql");

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/VariableInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/VariableInstance.xml
@@ -884,6 +884,17 @@
        ${limitAfterWithoutOffset})
   </delete>
 
+  <delete id="deleteByteArraysByRemovalTime_mssql"
+          parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject">
+    <bind name="date" value="'REMOVAL_TIME_'"/>
+    <bind name="reportPeriodUnitName" value="'MINUTE'"/>
+    delete ${limitBeforeWithoutOffset} from ${prefix}ACT_GE_BYTEARRAY
+    where REMOVAL_TIME_ &lt;= #{parameter.removalTime}
+    <include refid="andWhereMinuteInDateBetweenSql"/>
+    ${limitAfterWithoutOffset}
+    OPTION (LOOP JOIN)
+  </delete>
+
   <!-- BYTE ARRAY RESULTMAP -->
 
   <resultMap id="byteArrayResultMap" type="org.camunda.bpm.engine.impl.persistence.entity.ByteArrayEntity">


### PR DESCRIPTION
* Adds a SQL Server-specific database hint to use loop joins when
  deleting from the byte array table to prevent full table scans
  for foreign key constraint checks on database instances with a
  small load. This will lead to less locked rows and therefore also
  a much lower possibility of running into deadlocks. Loop joins
  will be used automatically on SQL Server for instances with
  higher loads.

related to CAM-13683