### PR TITLE
feat(engine): allow exclusive scheduling of batch jobs

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ModificationBatchJobHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ModificationBatchJobHandler.java
@@ -43,7 +43,7 @@ public class ModificationBatchJobHandler extends AbstractBatchJobHandler<Modific
   }
 
   @Override
-  protected void postProcessJob(ModificationBatchConfiguration configuration, JobEntity job) {
+  protected void postProcessJob(ModificationBatchConfiguration configuration, JobEntity job, ModificationBatchConfiguration jobConfiguration) {
     if (job.getDeploymentId() == null) {
       CommandContext commandContext = Context.getCommandContext();
       ProcessDefinitionEntity processDefinitionEntity = commandContext.getProcessEngineConfiguration().getDeploymentCache()

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/RestartProcessInstancesJobHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/RestartProcessInstancesJobHandler.java
@@ -49,7 +49,7 @@ public class RestartProcessInstancesJobHandler extends AbstractBatchJobHandler<R
   }
 
   @Override
-  protected void postProcessJob(RestartProcessInstancesBatchConfiguration configuration, JobEntity job) {
+  protected void postProcessJob(RestartProcessInstancesBatchConfiguration configuration, JobEntity job, RestartProcessInstancesBatchConfiguration jobConfiguration) {
     if (job.getDeploymentId() == null) {
       CommandContext commandContext = Context.getCommandContext();
       ProcessDefinitionEntity processDefinitionEntity = commandContext.getProcessEngineConfiguration().getDeploymentCache()

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/AbstractBatchJobHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/AbstractBatchJobHandler.java
@@ -127,7 +127,7 @@ public abstract class AbstractBatchJobHandler<T extends BatchConfiguration> impl
 
       JobEntity job = createBatchJob(batch, configurationEntity);
       job.setDeploymentId(deploymentId);
-      postProcessJob(configuration, job);
+      postProcessJob(configuration, job, jobConfiguration);
       jobManager.insertAndHintJobExecutor(job);
 
       idsForJob.clear();
@@ -140,7 +140,7 @@ public abstract class AbstractBatchJobHandler<T extends BatchConfiguration> impl
 
   protected abstract T createJobConfiguration(T configuration, List<String> processIdsForJob);
 
-  protected void postProcessJob(T configuration, JobEntity job) {
+  protected void postProcessJob(T configuration, JobEntity job, T jobConfiguration) {
     // do nothing as default
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/variables/BatchSetVariablesHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/variables/BatchSetVariablesHandler.java
@@ -29,6 +29,7 @@ import org.camunda.bpm.engine.impl.jobexecutor.JobDeclaration;
 import org.camunda.bpm.engine.impl.json.JsonObjectConverter;
 import org.camunda.bpm.engine.impl.persistence.entity.ByteArrayEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.MessageEntity;
 
 import java.util.List;
@@ -83,6 +84,14 @@ public class BatchSetVariablesHandler extends AbstractBatchJobHandler<BatchConfi
   @Override
   public String getType() {
     return Batch.TYPE_SET_VARIABLES;
+  }
+
+  @Override
+  protected void postProcessJob(BatchConfiguration configuration, JobEntity job, BatchConfiguration jobConfiguration) {
+    // if there is only one process instance to adjust, set its ID to the job so exclusive scheduling is possible
+    if (jobConfiguration.getIds() != null && jobConfiguration.getIds().size() == 1) {
+      job.setProcessInstanceId(jobConfiguration.getIds().get(0));
+    }
   }
 
   protected ByteArrayEntity findByteArrayById(String byteArrayId, CommandContext commandContext) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/migration/batch/MigrationBatchJobHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/migration/batch/MigrationBatchJobHandler.java
@@ -73,7 +73,7 @@ public class MigrationBatchJobHandler extends AbstractBatchJobHandler<MigrationB
   }
 
   @Override
-  protected void postProcessJob(MigrationBatchConfiguration configuration, JobEntity job) {
+  protected void postProcessJob(MigrationBatchConfiguration configuration, JobEntity job, MigrationBatchConfiguration jobConfiguration) {
     if (job.getDeploymentId() == null) {
       CommandContext commandContext = Context.getCommandContext();
       String sourceProcessDefinitionId = configuration.getMigrationPlan().getSourceProcessDefinitionId();


### PR DESCRIPTION
* enables the SetVariables batch to be scheduled exclusively by the job
  executor by adding a process instance id to the job if it sets variables
  for exactly one process instance

related to CAM-13818