### PR TITLE
fix(engine): fix empty date form field retrieval

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/form/type/DateFormType.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/form/type/DateFormType.java
@@ -79,7 +79,7 @@ public class DateFormType extends AbstractFormFieldType {
 
   public TypedValue convertToFormValue(TypedValue modelValue) {
     if(modelValue.getValue() == null) {
-      return Variables.stringValue(null, modelValue.isTransient());
+      return Variables.stringValue("", modelValue.isTransient());
     } else if(modelValue.getType() == ValueType.DATE) {
       return Variables.stringValue(dateFormat.format(modelValue.getValue()), modelValue.isTransient());
     }


### PR DESCRIPTION
Retrieve empty string instead of `null`.

related to CAM-13803