### PR TITLE
fix(engine): correct OR task query JSON conversion

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/json/JsonTaskQueryConverter.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/json/JsonTaskQueryConverter.java
@@ -282,11 +282,17 @@ public class JsonTaskQueryConverter extends JsonObjectConverter<TaskQuery> {
 
   @Override
   public TaskQuery toObject(JsonObject json) {
-    TaskQueryImpl query = new TaskQueryImpl();
+    return toObject(json, false);
+  }
 
+  protected TaskQuery toObject(JsonObject json, boolean isOrQuery) {
+    TaskQueryImpl query = new TaskQueryImpl();
+    if (isOrQuery) {
+      query.setOrQueryActive();
+    }
     if (json.has(OR_QUERIES)) {
       for (JsonElement jsonElement : JsonUtil.getArray(json, OR_QUERIES)) {
-        query.addOrQuery((TaskQueryImpl) toObject(JsonUtil.getObject(jsonElement)));
+        query.addOrQuery((TaskQueryImpl) toObject(JsonUtil.getObject(jsonElement), true));
       }
     }
     if (json.has(TASK_ID)) {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/filter/FilterTaskQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/filter/FilterTaskQueryTest.java
@@ -1333,7 +1333,6 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
       orderingProperty.getQueryProperty().getFunction());
   }
 
-
   @Deployment(resources={"org/camunda/bpm/engine/test/api/task/oneTaskWithFormKeyProcess.bpmn20.xml"})
   @Test
     public void testInitializeFormKeysEnabled() {
@@ -2317,6 +2316,20 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
     assertEquals(2, extendingQueryTasks.size());
   }
 
+  @Test
+  public void shouldDeserializeOrQueryWithCandidateGroupAndUser() {
+    // given
+    TaskQuery query = taskService.createTaskQuery()
+        .or()
+          .taskCandidateGroup("foo")
+          .taskCandidateUser("bar")
+        .endOr();
+    JsonObject jsonObject = queryConverter.toJsonObject(query);
+
+    // when deserializing the query
+    // then there is no exception
+    queryConverter.toObject(jsonObject);
+  }
 
   protected void saveQuery(TaskQuery query) {
     filter.setQuery(query);


### PR DESCRIPTION
* initializes OR queries in task queries upon deserialization from JSON
  to flag them as OR queries before query options are set; options that
  rely on this flag can be set correctly this way

related to CAM-13572