### PR TITLE
fix(engine): bump Jersey to 2.34

### DIFF
--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -18,6 +18,15 @@
   <dependencyManagement>
     <dependencies>
 
+      <!-- https://jira.camunda.com/browse/CAM-13717 -->
+      <dependency>
+        <groupId>org.glassfish.jersey</groupId>
+        <artifactId>jersey-bom</artifactId>
+        <version>${version.jersey2}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
@@ -25,7 +34,7 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
-      
+
       <dependency>
         <groupId>org.graalvm.js</groupId>
         <artifactId>js</artifactId>

--- a/engine-rest/assembly/assembly-war-was9.xml
+++ b/engine-rest/assembly/assembly-war-was9.xml
@@ -26,6 +26,7 @@
       <includes>
         <include>org.camunda.bpm:camunda-engine-rest-jaxrs2:jar:*</include>
         <include>org.glassfish.jersey.containers:jersey-container-servlet:*</include>
+        <include>org.glassfish.jersey.inject:jersey-hk2:*</include>
       </includes>
     </dependencySet>
     <dependencySet>

--- a/engine-rest/assembly/assembly-war-wls.xml
+++ b/engine-rest/assembly/assembly-war-wls.xml
@@ -26,6 +26,7 @@
       <includes>
         <include>org.camunda.bpm:camunda-engine-rest-jaxrs2:jar:*</include>
         <include>org.glassfish.jersey.containers:jersey-container-servlet:*</include>
+        <include>org.glassfish.jersey.inject:jersey-hk2:*</include>
       </includes>
     </dependencySet>
 

--- a/engine-rest/assembly/pom.xml
+++ b/engine-rest/assembly/pom.xml
@@ -64,6 +64,12 @@
       <version>${version.jersey2}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.inject</groupId>
+      <artifactId>jersey-hk2</artifactId>
+      <version>${version.jersey2}</version>
+      <scope>provided</scope>
+    </dependency>
 
   </dependencies>
 

--- a/engine-rest/engine-rest-jaxrs2/pom.xml
+++ b/engine-rest/engine-rest-jaxrs2/pom.xml
@@ -210,6 +210,12 @@
           <version>${version.jersey2}</version>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.glassfish.jersey.inject</groupId>
+          <artifactId>jersey-hk2</artifactId>
+          <version>${version.jersey2}</version>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
       <build>
         <plugins>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -766,6 +766,12 @@
           <version>${version.jersey2}</version>
           <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.glassfish.jersey.inject</groupId>
+          <artifactId>jersey-hk2</artifactId>
+          <version>${version.jersey2}</version>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
       <build>
         <plugins>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -24,7 +24,7 @@
     <version.cxf>3.0.3</version.cxf>
     <version.resteasy>2.3.5.Final</version.resteasy>
     <version.resteasy3>3.14.0.Final</version.resteasy3>
-    <version.jersey2>2.25.1</version.jersey2>
+    <version.jersey2>2.34</version.jersey2>
     <version.groovy>2.4.13</version.groovy>
     <version.graal.js>21.1.0</version.graal.js>
     <version.icu.icu4j>68.2</version.icu.icu4j>


### PR DESCRIPTION
* bumps Jersey to 2.34 in REST API and web apps artifacts for WLS and WAS9
* bumps Jersey to 2.34 in Run manually as Spring Boot 2.5.x does not provide
  this update yet
* adds explicit HK2 injection framework dependency for REST API on WAS9 & WLS
  due to Jersey version bump above 2.26 (no HK2 included by default anymore)

related to CAM-13717