### PR TITLE
feat(engine): adds asynchronous message correlation API

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/RuntimeService.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/RuntimeService.java
@@ -43,6 +43,7 @@ import org.camunda.bpm.engine.runtime.Execution;
 import org.camunda.bpm.engine.runtime.ExecutionQuery;
 import org.camunda.bpm.engine.runtime.Incident;
 import org.camunda.bpm.engine.runtime.IncidentQuery;
+import org.camunda.bpm.engine.runtime.MessageCorrelationAsyncBuilder;
 import org.camunda.bpm.engine.runtime.MessageCorrelationBuilder;
 import org.camunda.bpm.engine.runtime.ModificationBuilder;
 import org.camunda.bpm.engine.runtime.NativeExecutionQuery;
@@ -2168,6 +2169,17 @@ public interface RuntimeService {
    *          or no {@link Permissions#UPDATE_INSTANCE} permission on {@link Resources#PROCESS_DEFINITION}.
    */
   void correlateMessage(String messageName, String businessKey, Map<String, Object> correlationKeys, Map<String, Object> processVariables);
+
+  /**
+   * Define a complex asynchronous message correlation using a fluent builder.
+   *
+   * @param messageName the name of the message. Corresponds to the 'name' element
+   * of the message defined in BPMN 2.0 Xml.
+   * Can be null to correlate by other criteria only.
+   *
+   * @return the fluent builder for defining the asynchronous message correlation.
+   */
+  MessageCorrelationAsyncBuilder createMessageCorrelationAsync(String messageName);
 
   /**
    * Define a modification of a process instance in terms of activity cancellations

--- a/engine/src/main/java/org/camunda/bpm/engine/authorization/BatchPermissions.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/authorization/BatchPermissions.java
@@ -92,7 +92,10 @@ public enum BatchPermissions implements Permission {
   CREATE_BATCH_SET_REMOVAL_TIME("CREATE_BATCH_SET_REMOVAL_TIME", 65536),
 
   /** Indicates that CREATE_BATCH_SET_VARIABLES interactions are permitted */
-  CREATE_BATCH_SET_VARIABLES("CREATE_BATCH_SET_VARIABLES", 131_072);
+  CREATE_BATCH_SET_VARIABLES("CREATE_BATCH_SET_VARIABLES", 131_072),
+
+  /** Indicates that CREATE_BATCH_CORRELATE_MESSAGE interactions are permitted */
+  CREATE_BATCH_CORRELATE_MESSAGE("CREATE_BATCH_CORRELATE_MESSAGE", 262_144);
 
   protected static final Resource[] RESOURCES = new Resource[] { Resources.BATCH };
 

--- a/engine/src/main/java/org/camunda/bpm/engine/batch/Batch.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/batch/Batch.java
@@ -48,6 +48,7 @@ public interface Batch {
   String TYPE_DECISION_SET_REMOVAL_TIME = "decision-set-removal-time";
   String TYPE_BATCH_SET_REMOVAL_TIME = "batch-set-removal-time";
   String TYPE_SET_VARIABLES = "set-variables";
+  String TYPE_CORRELATE_MESSAGE = "correlate-message";
 
   /**
    * @return the id of the batch

--- a/engine/src/main/java/org/camunda/bpm/engine/history/UserOperationLogEntry.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/history/UserOperationLogEntry.java
@@ -66,74 +66,76 @@ public interface UserOperationLogEntry {
 
   /** @deprecated Please use {@link EntityTypes#TASK} instead. */
   @Deprecated
-  public static String ENTITY_TYPE_TASK = EntityTypes.TASK;
+  String ENTITY_TYPE_TASK = EntityTypes.TASK;
   /** @deprecated Please use {@link EntityTypes#IDENTITY_LINK} instead. */
   @Deprecated
-  public static String ENTITY_TYPE_IDENTITY_LINK = EntityTypes.IDENTITY_LINK;
+  String ENTITY_TYPE_IDENTITY_LINK = EntityTypes.IDENTITY_LINK;
   /** @deprecated Please use {@link EntityTypes#ATTACHMENT} instead. */
   @Deprecated
-  public static String ENTITY_TYPE_ATTACHMENT = EntityTypes.ATTACHMENT;
+  String ENTITY_TYPE_ATTACHMENT = EntityTypes.ATTACHMENT;
 
-  public static String OPERATION_TYPE_ASSIGN = "Assign";
-  public static String OPERATION_TYPE_CLAIM = "Claim";
-  public static String OPERATION_TYPE_COMPLETE = "Complete";
-  public static String OPERATION_TYPE_CREATE = "Create";
-  public static String OPERATION_TYPE_DELEGATE = "Delegate";
-  public static String OPERATION_TYPE_DELETE = "Delete";
-  public static String OPERATION_TYPE_RESOLVE = "Resolve";
-  public static String OPERATION_TYPE_SET_OWNER = "SetOwner";
-  public static String OPERATION_TYPE_SET_PRIORITY = "SetPriority";
-  public static String OPERATION_TYPE_UPDATE = "Update";
-  public static String OPERATION_TYPE_ACTIVATE = "Activate";
-  public static String OPERATION_TYPE_SUSPEND = "Suspend";
-  public static String OPERATION_TYPE_MIGRATE = "Migrate";
-  public static String OPERATION_TYPE_ADD_USER_LINK = "AddUserLink";
-  public static String OPERATION_TYPE_DELETE_USER_LINK = "DeleteUserLink";
-  public static String OPERATION_TYPE_ADD_GROUP_LINK = "AddGroupLink";
-  public static String OPERATION_TYPE_DELETE_GROUP_LINK = "DeleteGroupLink";
-  public static String OPERATION_TYPE_SET_DUEDATE = "SetDueDate";
-  public static String OPERATION_TYPE_RECALC_DUEDATE = "RecalculateDueDate";
-  public static String OPERATION_TYPE_UNLOCK = "Unlock";
-  public static String OPERATION_TYPE_EXECUTE = "Execute";
-  public static String OPERATION_TYPE_EVALUATE = "Evaluate";
+  String OPERATION_TYPE_ASSIGN = "Assign";
+  String OPERATION_TYPE_CLAIM = "Claim";
+  String OPERATION_TYPE_COMPLETE = "Complete";
+  String OPERATION_TYPE_CREATE = "Create";
+  String OPERATION_TYPE_DELEGATE = "Delegate";
+  String OPERATION_TYPE_DELETE = "Delete";
+  String OPERATION_TYPE_RESOLVE = "Resolve";
+  String OPERATION_TYPE_SET_OWNER = "SetOwner";
+  String OPERATION_TYPE_SET_PRIORITY = "SetPriority";
+  String OPERATION_TYPE_UPDATE = "Update";
+  String OPERATION_TYPE_ACTIVATE = "Activate";
+  String OPERATION_TYPE_SUSPEND = "Suspend";
+  String OPERATION_TYPE_MIGRATE = "Migrate";
+  String OPERATION_TYPE_ADD_USER_LINK = "AddUserLink";
+  String OPERATION_TYPE_DELETE_USER_LINK = "DeleteUserLink";
+  String OPERATION_TYPE_ADD_GROUP_LINK = "AddGroupLink";
+  String OPERATION_TYPE_DELETE_GROUP_LINK = "DeleteGroupLink";
+  String OPERATION_TYPE_SET_DUEDATE = "SetDueDate";
+  String OPERATION_TYPE_RECALC_DUEDATE = "RecalculateDueDate";
+  String OPERATION_TYPE_UNLOCK = "Unlock";
+  String OPERATION_TYPE_EXECUTE = "Execute";
+  String OPERATION_TYPE_EVALUATE = "Evaluate";
 
-  public static String OPERATION_TYPE_ADD_ATTACHMENT = "AddAttachment";
-  public static String OPERATION_TYPE_DELETE_ATTACHMENT = "DeleteAttachment";
+  String OPERATION_TYPE_ADD_ATTACHMENT = "AddAttachment";
+  String OPERATION_TYPE_DELETE_ATTACHMENT = "DeleteAttachment";
 
-  public static String OPERATION_TYPE_SUSPEND_JOB_DEFINITION = "SuspendJobDefinition";
-  public static String OPERATION_TYPE_ACTIVATE_JOB_DEFINITION = "ActivateJobDefinition";
-  public static String OPERATION_TYPE_SUSPEND_PROCESS_DEFINITION = "SuspendProcessDefinition";
-  public static String OPERATION_TYPE_ACTIVATE_PROCESS_DEFINITION = "ActivateProcessDefinition";
+  String OPERATION_TYPE_SUSPEND_JOB_DEFINITION = "SuspendJobDefinition";
+  String OPERATION_TYPE_ACTIVATE_JOB_DEFINITION = "ActivateJobDefinition";
+  String OPERATION_TYPE_SUSPEND_PROCESS_DEFINITION = "SuspendProcessDefinition";
+  String OPERATION_TYPE_ACTIVATE_PROCESS_DEFINITION = "ActivateProcessDefinition";
 
-  public static String OPERATION_TYPE_CREATE_HISTORY_CLEANUP_JOB = "CreateHistoryCleanupJobs";
-  public static String OPERATION_TYPE_UPDATE_HISTORY_TIME_TO_LIVE = "UpdateHistoryTimeToLive";
-  public static String OPERATION_TYPE_DELETE_HISTORY = "DeleteHistory";
+  String OPERATION_TYPE_CREATE_HISTORY_CLEANUP_JOB = "CreateHistoryCleanupJobs";
+  String OPERATION_TYPE_UPDATE_HISTORY_TIME_TO_LIVE = "UpdateHistoryTimeToLive";
+  String OPERATION_TYPE_DELETE_HISTORY = "DeleteHistory";
 
-  public static String OPERATION_TYPE_MODIFY_PROCESS_INSTANCE = "ModifyProcessInstance";
-  public static String OPERATION_TYPE_RESTART_PROCESS_INSTANCE  = "RestartProcessInstance";
-  public static String OPERATION_TYPE_SUSPEND_JOB = "SuspendJob";
-  public static String OPERATION_TYPE_ACTIVATE_JOB = "ActivateJob";
-  public static String OPERATION_TYPE_SET_JOB_RETRIES = "SetJobRetries";
-  public static String OPERATION_TYPE_SET_EXTERNAL_TASK_RETRIES = "SetExternalTaskRetries";
-  public static String OPERATION_TYPE_SET_VARIABLE = "SetVariable";
+  String OPERATION_TYPE_MODIFY_PROCESS_INSTANCE = "ModifyProcessInstance";
+  String OPERATION_TYPE_RESTART_PROCESS_INSTANCE  = "RestartProcessInstance";
+  String OPERATION_TYPE_SUSPEND_JOB = "SuspendJob";
+  String OPERATION_TYPE_ACTIVATE_JOB = "ActivateJob";
+  String OPERATION_TYPE_SET_JOB_RETRIES = "SetJobRetries";
+  String OPERATION_TYPE_SET_EXTERNAL_TASK_RETRIES = "SetExternalTaskRetries";
+  String OPERATION_TYPE_SET_VARIABLE = "SetVariable";
   String OPERATION_TYPE_SET_VARIABLES = "SetVariables";
 
-  public static String OPERATION_TYPE_REMOVE_VARIABLE = "RemoveVariable";
-  public static String OPERATION_TYPE_MODIFY_VARIABLE = "ModifyVariable";
+  String OPERATION_TYPE_REMOVE_VARIABLE = "RemoveVariable";
+  String OPERATION_TYPE_MODIFY_VARIABLE = "ModifyVariable";
 
-  public static String OPERATION_TYPE_SUSPEND_BATCH = "SuspendBatch";
-  public static String OPERATION_TYPE_ACTIVATE_BATCH = "ActivateBatch";
-  
-  public static String OPERATION_TYPE_CREATE_INCIDENT = "CreateIncident";
+  String OPERATION_TYPE_SUSPEND_BATCH = "SuspendBatch";
+  String OPERATION_TYPE_ACTIVATE_BATCH = "ActivateBatch";
 
-  public static String OPERATION_TYPE_SET_REMOVAL_TIME = "SetRemovalTime";
+  String OPERATION_TYPE_CREATE_INCIDENT = "CreateIncident";
+
+  String OPERATION_TYPE_SET_REMOVAL_TIME = "SetRemovalTime";
 
   String OPERATION_TYPE_SET_ANNOTATION = "SetAnnotation";
   String OPERATION_TYPE_CLEAR_ANNOTATION = "ClearAnnotation";
 
-  public static String CATEGORY_ADMIN = "Admin";
-  public static String CATEGORY_OPERATOR = "Operator";
-  public static String CATEGORY_TASK_WORKER = "TaskWorker";
+  String OPERATION_TYPE_CORRELATE_MESSAGE = "CorrelateMessage";
+
+  String CATEGORY_ADMIN = "Admin";
+  String CATEGORY_OPERATOR = "Operator";
+  String CATEGORY_TASK_WORKER = "TaskWorker";
 
   /** The unique identifier of this log entry. */
   String getId();
@@ -192,7 +194,7 @@ public interface UserOperationLogEntry {
    * created with a common operationId. This allows grouping multiple entries which are part of a composite operation.
    */
   String getOperationId();
-  
+
   /** External task reference. */
   String getExternalTaskId();
 
@@ -221,7 +223,7 @@ public interface UserOperationLogEntry {
 
   /** The time the historic user operation log will be removed. */
   Date getRemovalTime();
-  
+
   /** The category this entry is associated with */
   String getCategory();
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/GetDeployedTaskFormCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/GetDeployedTaskFormCmd.java
@@ -16,8 +16,6 @@
  */
 package org.camunda.bpm.engine.impl;
 
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.BadUserRequestException;
 import org.camunda.bpm.engine.form.FormData;
 import org.camunda.bpm.engine.impl.cfg.CommandChecker;
@@ -42,13 +40,7 @@ public class GetDeployedTaskFormCmd extends AbstractGetDeployedFormCmd {
 
   @Override
   protected FormData getFormData() {
-    return commandContext.runWithoutAuthorization(new Callable<FormData>() {
-
-      @Override
-      public FormData call() throws Exception {
-        return new GetTaskFormCmd(taskId).execute(commandContext);
-      }
-    });
+    return commandContext.runWithoutAuthorization(new GetTaskFormCmd(taskId));
   }
 
   @Override

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/MessageCorrelationAsyncBuilderImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/MessageCorrelationAsyncBuilderImpl.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl;
+
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
+
+import java.util.List;
+import java.util.Map;
+
+import org.camunda.bpm.engine.batch.Batch;
+import org.camunda.bpm.engine.history.HistoricProcessInstanceQuery;
+import org.camunda.bpm.engine.impl.cmd.batch.CorrelateAllMessageBatchCmd;
+import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
+import org.camunda.bpm.engine.runtime.MessageCorrelationAsyncBuilder;
+import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
+import org.camunda.bpm.engine.variable.impl.VariableMapImpl;
+
+public class MessageCorrelationAsyncBuilderImpl implements MessageCorrelationAsyncBuilder {
+
+  protected CommandExecutor commandExecutor;
+
+  protected String messageName;
+  protected Map<String, Object> payloadProcessInstanceVariables;
+
+  protected List<String> processInstanceIds;
+  protected ProcessInstanceQuery processInstanceQuery;
+  protected HistoricProcessInstanceQuery historicProcessInstanceQuery;
+
+  public MessageCorrelationAsyncBuilderImpl(CommandExecutor commandExecutor, String messageName) {
+    this(messageName);
+    ensureNotNull("commandExecutor", commandExecutor);
+    this.commandExecutor = commandExecutor;
+  }
+
+  private MessageCorrelationAsyncBuilderImpl(String messageName) {
+    this.messageName = messageName;
+  }
+
+  public MessageCorrelationAsyncBuilder processInstanceIds(List<String> ids) {
+    ensureNotNull("processInstanceIds", ids);
+    this.processInstanceIds = ids;
+    return this;
+  }
+
+  @Override
+  public MessageCorrelationAsyncBuilder processInstanceQuery(ProcessInstanceQuery processInstanceQuery) {
+    ensureNotNull("processInstanceQuery", processInstanceQuery);
+    this.processInstanceQuery = processInstanceQuery;
+    return this;
+  }
+
+  @Override
+  public MessageCorrelationAsyncBuilder historicProcessInstanceQuery(HistoricProcessInstanceQuery historicProcessInstanceQuery) {
+    ensureNotNull("historicProcessInstanceQuery", historicProcessInstanceQuery);
+    this.historicProcessInstanceQuery = historicProcessInstanceQuery;
+    return this;
+  }
+
+  public MessageCorrelationAsyncBuilder setVariable(String variableName, Object variableValue) {
+    ensureNotNull("variableName", variableName);
+    ensurePayloadProcessInstanceVariablesInitialized();
+    payloadProcessInstanceVariables.put(variableName, variableValue);
+    return this;
+  }
+
+  public MessageCorrelationAsyncBuilder setVariables(Map<String, Object> variables) {
+    if (variables != null) {
+      ensurePayloadProcessInstanceVariablesInitialized();
+      payloadProcessInstanceVariables.putAll(variables);
+    }
+    return this;
+  }
+
+  protected void ensurePayloadProcessInstanceVariablesInitialized() {
+    if (payloadProcessInstanceVariables == null) {
+      payloadProcessInstanceVariables = new VariableMapImpl();
+    }
+  }
+
+  @Override
+  public Batch correlateAllAsync() {
+    return commandExecutor.execute(new CorrelateAllMessageBatchCmd(this));
+  }
+
+  // getters //////////////////////////////////
+
+  public CommandExecutor getCommandExecutor() {
+    return commandExecutor;
+  }
+
+  public String getMessageName() {
+    return messageName;
+  }
+
+  public List<String> getProcessInstanceIds() {
+    return processInstanceIds;
+  }
+
+  public ProcessInstanceQuery getProcessInstanceQuery() {
+    return processInstanceQuery;
+  }
+
+  public HistoricProcessInstanceQuery getHistoricProcessInstanceQuery() {
+    return historicProcessInstanceQuery;
+  }
+
+  public Map<String, Object> getPayloadProcessInstanceVariables() {
+    return payloadProcessInstanceVariables;
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/MessageCorrelationBuilderImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/MessageCorrelationBuilderImpl.java
@@ -16,10 +16,11 @@
  */
 package org.camunda.bpm.engine.impl;
 
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureFalse;
+
 import java.util.Arrays;
 import java.util.List;
-import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
-
 import java.util.Map;
 
 import org.camunda.bpm.engine.impl.cmd.CommandLogger;
@@ -63,6 +64,7 @@ public class MessageCorrelationBuilderImpl implements MessageCorrelationBuilder 
   protected boolean isTenantIdSet = false;
 
   protected boolean startMessagesOnly = false;
+  protected boolean executionsOnly = false;
 
   public MessageCorrelationBuilderImpl(CommandExecutor commandExecutor, String messageName) {
     this(messageName);
@@ -203,7 +205,14 @@ public class MessageCorrelationBuilderImpl implements MessageCorrelationBuilder 
 
   @Override
   public MessageCorrelationBuilder startMessageOnly() {
+    ensureFalse("Either startMessageOnly or executionsOnly can be set", executionsOnly);
     startMessagesOnly = true;
+    return this;
+  }
+
+  public MessageCorrelationBuilder executionsOnly() {
+    ensureFalse("Either startMessageOnly or executionsOnly can be set", startMessagesOnly);
+    executionsOnly = true;
     return this;
   }
 
@@ -368,6 +377,10 @@ public class MessageCorrelationBuilderImpl implements MessageCorrelationBuilder 
 
   public boolean isTenantIdSet() {
     return isTenantIdSet;
+  }
+
+  public boolean isExecutionsOnly() {
+    return executionsOnly;
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/RuntimeServiceImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/RuntimeServiceImpl.java
@@ -46,6 +46,7 @@ import org.camunda.bpm.engine.impl.cmd.ResolveIncidentCmd;
 import org.camunda.bpm.engine.impl.cmd.SetAnnotationForIncidentCmd;
 import org.camunda.bpm.engine.impl.cmd.SetExecutionVariablesCmd;
 import org.camunda.bpm.engine.impl.cmd.SignalCmd;
+import org.camunda.bpm.engine.impl.cmd.batch.CorrelateAllMessageBatchCmd;
 import org.camunda.bpm.engine.impl.cmd.batch.DeleteProcessInstanceBatchCmd;
 import org.camunda.bpm.engine.impl.cmd.batch.variables.SetVariablesToProcessInstancesBatchCmd;
 import org.camunda.bpm.engine.impl.migration.MigrationPlanBuilderImpl;
@@ -61,6 +62,7 @@ import org.camunda.bpm.engine.runtime.EventSubscriptionQuery;
 import org.camunda.bpm.engine.runtime.ExecutionQuery;
 import org.camunda.bpm.engine.runtime.Incident;
 import org.camunda.bpm.engine.runtime.IncidentQuery;
+import org.camunda.bpm.engine.runtime.MessageCorrelationAsyncBuilder;
 import org.camunda.bpm.engine.runtime.MessageCorrelationBuilder;
 import org.camunda.bpm.engine.runtime.ModificationBuilder;
 import org.camunda.bpm.engine.runtime.NativeExecutionQuery;
@@ -716,6 +718,11 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
       .processInstanceBusinessKey(businessKey)
       .setVariables(processVariables)
       .correlate();
+  }
+
+  @Override
+  public MessageCorrelationAsyncBuilder createMessageCorrelationAsync(String messageName) {
+    return new MessageCorrelationAsyncBuilderImpl(commandExecutor, messageName);
   }
 
   @Override

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/BatchEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/BatchEntity.java
@@ -340,7 +340,8 @@ public class BatchEntity implements Batch, DbEntity, HasDbReferences, Nameable, 
     CommandContext commandContext = Context.getCommandContext();
 
     if (Batch.TYPE_SET_VARIABLES.equals(type) ||
-        Batch.TYPE_PROCESS_INSTANCE_MIGRATION.equals(type)) {
+        Batch.TYPE_PROCESS_INSTANCE_MIGRATION.equals(type) ||
+        Batch.TYPE_CORRELATE_MESSAGE.equals(type)) {
       deleteVariables(commandContext);
     }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/message/MessageCorrelationBatchConfiguration.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/message/MessageCorrelationBatchConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.batch.message;
+
+import java.util.List;
+
+import org.camunda.bpm.engine.impl.batch.BatchConfiguration;
+import org.camunda.bpm.engine.impl.batch.DeploymentMappings;
+
+public class MessageCorrelationBatchConfiguration extends BatchConfiguration {
+
+  protected String messageName;
+
+  public MessageCorrelationBatchConfiguration(List<String> ids,
+                                     String messageName,
+                                     String batchId) {
+    this(ids, null, messageName, batchId);
+  }
+
+  public MessageCorrelationBatchConfiguration(List<String> ids,
+                                     DeploymentMappings mappings,
+                                     String messageName,
+                                     String batchId) {
+    super(ids, mappings);
+    this.messageName = messageName;
+    this.batchId = batchId;
+  }
+
+  public MessageCorrelationBatchConfiguration(List<String> ids,
+                                     DeploymentMappings mappings,
+                                     String messageName) {
+    this(ids, mappings, messageName, null);
+  }
+
+  public String getMessageName() {
+    return messageName;
+  }
+
+  public void setMessageName(String messageName) {
+    this.messageName = messageName;;
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/message/MessageCorrelationBatchJobHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/message/MessageCorrelationBatchJobHandler.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.batch.message;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.camunda.bpm.engine.batch.Batch;
+import org.camunda.bpm.engine.impl.MessageCorrelationBuilderImpl;
+import org.camunda.bpm.engine.impl.batch.AbstractBatchJobHandler;
+import org.camunda.bpm.engine.impl.batch.BatchJobConfiguration;
+import org.camunda.bpm.engine.impl.batch.BatchJobContext;
+import org.camunda.bpm.engine.impl.batch.BatchJobDeclaration;
+import org.camunda.bpm.engine.impl.cmd.CorrelateAllMessageCmd;
+import org.camunda.bpm.engine.impl.core.variable.VariableUtil;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.jobexecutor.JobDeclaration;
+import org.camunda.bpm.engine.impl.json.MessageCorrelationBatchConfigurationJsonConverter;
+import org.camunda.bpm.engine.impl.persistence.entity.ByteArrayEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.MessageEntity;
+import org.camunda.bpm.engine.runtime.MessageCorrelationBuilder;
+import org.camunda.bpm.engine.variable.impl.VariableMapImpl;
+
+/**
+ * Job handler for message correlation jobs. The jobs correlate a message to a
+ * list of process instances.
+ */
+public class MessageCorrelationBatchJobHandler extends AbstractBatchJobHandler<MessageCorrelationBatchConfiguration> {
+
+  public static final BatchJobDeclaration JOB_DECLARATION = new BatchJobDeclaration(Batch.TYPE_CORRELATE_MESSAGE);
+
+  public String getType() {
+    return Batch.TYPE_CORRELATE_MESSAGE;
+  }
+
+  public JobDeclaration<BatchJobContext, MessageEntity> getJobDeclaration() {
+    return JOB_DECLARATION;
+  }
+
+  protected MessageCorrelationBatchConfigurationJsonConverter getJsonConverterInstance() {
+    return MessageCorrelationBatchConfigurationJsonConverter.INSTANCE;
+  }
+
+  @Override
+  protected MessageCorrelationBatchConfiguration createJobConfiguration(MessageCorrelationBatchConfiguration configuration, List<String> processIdsForJob) {
+    return new MessageCorrelationBatchConfiguration(
+        processIdsForJob,
+        configuration.getMessageName(),
+        configuration.getBatchId());
+  }
+
+  @Override
+  protected void postProcessJob(MessageCorrelationBatchConfiguration configuration, JobEntity job, MessageCorrelationBatchConfiguration jobConfiguration) {
+    // if there is only one process instance to adjust, set its ID to the job so exclusive scheduling is possible
+    if (jobConfiguration.getIds() != null && jobConfiguration.getIds().size() == 1) {
+      job.setProcessInstanceId(jobConfiguration.getIds().get(0));
+    }
+  }
+
+  @Override
+  public void execute(BatchJobConfiguration configuration, ExecutionEntity execution, CommandContext commandContext, String tenantId) {
+    ByteArrayEntity configurationEntity = commandContext
+        .getDbEntityManager()
+        .selectById(ByteArrayEntity.class, configuration.getConfigurationByteArrayId());
+
+    MessageCorrelationBatchConfiguration batchConfiguration = readConfiguration(configurationEntity.getBytes());
+    String batchId = batchConfiguration.getBatchId();
+
+    MessageCorrelationBuilderImpl correlationBuilder = new MessageCorrelationBuilderImpl(commandContext, batchConfiguration.getMessageName());
+    correlationBuilder.executionsOnly();
+    setVariables(batchId, correlationBuilder, commandContext);
+    for (String id : batchConfiguration.getIds()) {
+      correlationBuilder.processInstanceId(id);
+      commandContext.executeWithOperationLogPrevented(new CorrelateAllMessageCmd(correlationBuilder, false, false));
+    }
+
+    commandContext.getByteArrayManager().delete(configurationEntity);
+  }
+
+  protected void setVariables(String batchId,
+                              MessageCorrelationBuilder correlationBuilder,
+                              CommandContext commandContext) {
+    Map<String, ?> variables = null;
+    if (batchId != null) {
+      variables = VariableUtil.findBatchVariablesSerialized(batchId, commandContext);
+      if (variables != null) {
+        correlationBuilder.setVariables(new VariableMapImpl(new HashMap<>(variables)));
+      }
+    }
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -107,6 +107,7 @@ import org.camunda.bpm.engine.impl.batch.deletion.DeleteHistoricProcessInstances
 import org.camunda.bpm.engine.impl.batch.deletion.DeleteProcessInstancesJobHandler;
 import org.camunda.bpm.engine.impl.batch.externaltask.SetExternalTaskRetriesJobHandler;
 import org.camunda.bpm.engine.impl.batch.job.SetJobRetriesJobHandler;
+import org.camunda.bpm.engine.impl.batch.message.MessageCorrelationBatchJobHandler;
 import org.camunda.bpm.engine.impl.batch.removaltime.BatchSetRemovalTimeJobHandler;
 import org.camunda.bpm.engine.impl.batch.removaltime.DecisionSetRemovalTimeJobHandler;
 import org.camunda.bpm.engine.impl.batch.removaltime.ProcessSetRemovalTimeJobHandler;
@@ -1380,6 +1381,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
       BatchSetVariablesHandler batchSetVariablesHandler = new BatchSetVariablesHandler();
       batchHandlers.put(batchSetVariablesHandler.getType(), batchSetVariablesHandler);
+
+      MessageCorrelationBatchJobHandler messageCorrelationJobHandler = new MessageCorrelationBatchJobHandler();
+      batchHandlers.put(messageCorrelationJobHandler.getType(), messageCorrelationJobHandler);
     }
 
     if (customBatchJobHandlers != null) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AbstractGetDeployedFormCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AbstractGetDeployedFormCmd.java
@@ -17,8 +17,6 @@
 package org.camunda.bpm.engine.impl.cmd;
 
 import java.io.InputStream;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.BadUserRequestException;
 import org.camunda.bpm.engine.exception.DeploymentResourceNotFoundException;
 import org.camunda.bpm.engine.exception.NotFoundException;
@@ -82,12 +80,8 @@ public abstract class AbstractGetDeployedFormCmd implements Command<InputStream>
 
   protected InputStream getResourceForCamundaFormRef(CamundaFormRef camundaFormRef,
       String deploymentId) {
-    CamundaFormDefinition definition = commandContext.runWithoutAuthorization(new Callable<CamundaFormDefinition>() {
-      @Override
-      public CamundaFormDefinition call() throws Exception {
-        return new GetCamundaFormDefinitionCmd(camundaFormRef, deploymentId).execute(commandContext);
-      }
-    });
+    CamundaFormDefinition definition = commandContext.runWithoutAuthorization(
+        new GetCamundaFormDefinitionCmd(camundaFormRef, deploymentId));
 
     if (definition == null) {
       throw new NotFoundException("No Camunda Form Definition was found for Camunda Form Ref: " + camundaFormRef);
@@ -99,14 +93,8 @@ public abstract class AbstractGetDeployedFormCmd implements Command<InputStream>
   protected InputStream getDeploymentResource(String deploymentId, String resourceName) {
     GetDeploymentResourceCmd getDeploymentResourceCmd = new GetDeploymentResourceCmd(deploymentId, resourceName);
     try {
-      return commandContext.runWithoutAuthorization(new Callable<InputStream>() {
-        @Override
-        public InputStream call() throws Exception {
-          return getDeploymentResourceCmd.execute(commandContext);
-        }
-      });
-    }
-    catch (DeploymentResourceNotFoundException e) {
+      return commandContext.runWithoutAuthorization(getDeploymentResourceCmd);
+    } catch (DeploymentResourceNotFoundException e) {
       throw new NotFoundException("The form with the resource name '" + resourceName + "' cannot be found in deployment with id " + deploymentId, e);
     }
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AbstractInstantiationCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AbstractInstantiationCmd.java
@@ -20,8 +20,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.exception.NotValidException;
 import org.camunda.bpm.engine.impl.ActivityExecutionTreeMapping;
@@ -146,11 +144,7 @@ public abstract class AbstractInstantiationCmd extends AbstractProcessInstanceMo
       scopeExecution = flowScopeExecutions.iterator().next();
     }
     else {
-      ActivityInstance tree = commandContext.runWithoutAuthorization(new Callable<ActivityInstance>() {
-        public ActivityInstance call() throws Exception {
-          return new GetActivityInstanceCmd(processInstanceId).execute(commandContext);
-        }
-      });
+      ActivityInstance tree = commandContext.runWithoutAuthorization(new GetActivityInstanceCmd(processInstanceId));
 
       ActivityInstance ancestorInstance = findActivityInstance(tree, ancestorActivityInstanceId);
       EnsureUtil.ensureNotNull(NotValidException.class,

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AbstractSetStateCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AbstractSetStateCmd.java
@@ -18,8 +18,6 @@ package org.camunda.bpm.engine.impl.cmd;
 
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.jobexecutor.JobHandlerConfiguration;
@@ -62,12 +60,7 @@ public abstract class AbstractSetStateCmd implements Command<Void> {
           // pre-requirement: the necessary authorization check
           // for included resources should be done before this
           // call.
-          commandContext.runWithoutAuthorization(new Callable<Void>() {
-            public Void call() throws Exception {
-              cmd.execute(commandContext);
-              return null;
-            }
-          });
+          commandContext.runWithoutAuthorization(cmd);
         }
       }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/ActivityCancellationCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/ActivityCancellationCmd.java
@@ -21,8 +21,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.camunda.bpm.engine.impl.pvm.process.ProcessDefinitionImpl;
@@ -117,12 +115,7 @@ public class ActivityCancellationCmd extends AbstractProcessInstanceModification
   }
 
   public ActivityInstance getActivityInstanceTree(final CommandContext commandContext) {
-    return commandContext.runWithoutAuthorization(new Callable<ActivityInstance>() {
-      @Override
-      public ActivityInstance call() throws Exception {
-        return new GetActivityInstanceCmd(processInstanceId).execute(commandContext);
-      }
-    });
+    return commandContext.runWithoutAuthorization(new GetActivityInstanceCmd(processInstanceId));
   }
 
   public String getActivityId() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/ActivityInstanceCancellationCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/ActivityInstanceCancellationCmd.java
@@ -16,8 +16,6 @@
  */
 package org.camunda.bpm.engine.impl.cmd;
 
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.exception.NotValidException;
 import org.camunda.bpm.engine.impl.ActivityExecutionTreeMapping;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
@@ -53,11 +51,7 @@ public class ActivityInstanceCancellationCmd extends AbstractInstanceCancellatio
     // rebuild the mapping because the execution tree changes with every iteration
     ActivityExecutionTreeMapping mapping = new ActivityExecutionTreeMapping(commandContext, processInstanceId);
 
-    ActivityInstance instance = commandContext.runWithoutAuthorization(new Callable<ActivityInstance>() {
-      public ActivityInstance call() throws Exception {
-        return new GetActivityInstanceCmd(processInstanceId).execute(commandContext);
-      }
-    });
+    ActivityInstance instance = commandContext.runWithoutAuthorization(new GetActivityInstanceCmd(processInstanceId));
 
     ActivityInstance instanceToCancel = findActivityInstance(instance, activityInstanceId);
     EnsureUtil.ensureNotNull(NotValidException.class,

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteDeploymentCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteDeploymentCmd.java
@@ -22,8 +22,6 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.application.ProcessApplicationReference;
 import org.camunda.bpm.engine.history.UserOperationLogEntry;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
@@ -84,13 +82,8 @@ public class DeleteDeploymentCmd implements Command<Void>, Serializable {
       Context.getProcessEngineConfiguration().getCommandExecutorTxRequiresNew());
 
     try {
-      commandContext.runWithoutAuthorization(new Callable<Void>() {
-        public Void call() throws Exception {
-          new UnregisterProcessApplicationCmd(deploymentId, false).execute(commandContext);
-          new UnregisterDeploymentCmd(Collections.singleton(deploymentId)).execute(commandContext);
-          return null;
-        }
-      });
+      commandContext.runWithoutAuthorization(new UnregisterProcessApplicationCmd(deploymentId, false));
+      commandContext.runWithoutAuthorization(new UnregisterDeploymentCmd(Collections.singleton(deploymentId)));
     } finally {
       try {
         commandContext.getTransactionContext().addTransactionListener(TransactionState.ROLLED_BACK, listener);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/GetDeployedStartFormCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/GetDeployedStartFormCmd.java
@@ -16,8 +16,6 @@
  */
 package org.camunda.bpm.engine.impl.cmd;
 
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.BadUserRequestException;
 import org.camunda.bpm.engine.form.FormData;
 import org.camunda.bpm.engine.impl.cfg.CommandChecker;
@@ -43,12 +41,7 @@ public class GetDeployedStartFormCmd extends AbstractGetDeployedFormCmd {
 
   @Override
   protected FormData getFormData() {
-    return commandContext.runWithoutAuthorization(new Callable<FormData>() {
-      @Override
-      public FormData call() throws Exception {
-        return new GetStartFormCmd(processDefinitionId).execute(commandContext);
-      }
-    });
+    return commandContext.runWithoutAuthorization(new GetStartFormCmd(processDefinitionId));
   }
 
   @Override

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/GetDeploymentProcessDiagramCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/GetDeploymentProcessDiagramCmd.java
@@ -18,8 +18,6 @@ package org.camunda.bpm.engine.impl.cmd;
 
 import java.io.InputStream;
 import java.io.Serializable;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.cfg.CommandChecker;
 import org.camunda.bpm.engine.impl.context.Context;
@@ -64,11 +62,8 @@ public class GetDeploymentProcessDiagramCmd implements Command<InputStream>, Ser
       return null;
     } else {
 
-      InputStream processDiagramStream = commandContext.runWithoutAuthorization(new Callable<InputStream>() {
-        public InputStream call() throws Exception {
-          return new GetDeploymentResourceCmd(deploymentId, resourceName).execute(commandContext);
-        }
-      });
+      InputStream processDiagramStream = commandContext.runWithoutAuthorization(
+          new GetDeploymentResourceCmd(deploymentId, resourceName));
 
       return processDiagramStream;
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/GetDeploymentProcessDiagramLayoutCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/GetDeploymentProcessDiagramLayoutCmd.java
@@ -18,8 +18,6 @@ package org.camunda.bpm.engine.impl.cmd;
 
 import java.io.InputStream;
 import java.io.Serializable;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.bpmn.diagram.ProcessDiagramLayoutFactory;
 import org.camunda.bpm.engine.impl.cfg.CommandChecker;
@@ -59,17 +57,11 @@ public class GetDeploymentProcessDiagramLayoutCmd implements Command<DiagramLayo
       checker.checkReadProcessDefinition(processDefinition);
     }
 
-    InputStream processModelStream = commandContext.runWithoutAuthorization(new Callable<InputStream>() {
-      public InputStream call() throws Exception {
-        return new GetDeploymentProcessModelCmd(processDefinitionId).execute(commandContext);
-      }
-    });
+    InputStream processModelStream = commandContext.runWithoutAuthorization(
+        new GetDeploymentProcessModelCmd(processDefinitionId));
 
-    InputStream processDiagramStream = commandContext.runWithoutAuthorization(new Callable<InputStream>() {
-      public InputStream call() throws Exception {
-        return new GetDeploymentProcessDiagramCmd(processDefinitionId).execute(commandContext);
-      }
-    });
+    InputStream processDiagramStream = commandContext.runWithoutAuthorization(
+        new GetDeploymentProcessDiagramCmd(processDefinitionId));
 
     return new ProcessDiagramLayoutFactory().getProcessDiagramLayout(processModelStream, processDiagramStream);
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/GetDeploymentProcessModelCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/GetDeploymentProcessModelCmd.java
@@ -18,8 +18,6 @@ package org.camunda.bpm.engine.impl.cmd;
 
 import java.io.InputStream;
 import java.io.Serializable;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.cfg.CommandChecker;
 import org.camunda.bpm.engine.impl.context.Context;
@@ -59,11 +57,8 @@ public class GetDeploymentProcessModelCmd implements Command<InputStream>, Seria
     final String deploymentId = processDefinition.getDeploymentId();
     final String resourceName = processDefinition.getResourceName();
 
-    InputStream processModelStream = commandContext.runWithoutAuthorization(new Callable<InputStream>() {
-      public InputStream call() throws Exception {
-        return new GetDeploymentResourceCmd(deploymentId, resourceName).execute(commandContext);
-      }
-    });
+    InputStream processModelStream = commandContext.runWithoutAuthorization(
+        new GetDeploymentResourceCmd(deploymentId, resourceName));
 
     return processModelStream;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/GetStartFormVariablesCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/GetStartFormVariablesCmd.java
@@ -17,8 +17,6 @@
 package org.camunda.bpm.engine.impl.cmd;
 
 import java.util.Collection;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.form.FormField;
 import org.camunda.bpm.engine.form.StartFormData;
 import org.camunda.bpm.engine.impl.cfg.CommandChecker;
@@ -41,11 +39,7 @@ public class GetStartFormVariablesCmd extends AbstractGetFormVariablesCmd {
   }
 
   public VariableMap execute(final CommandContext commandContext) {
-    StartFormData startFormData = commandContext.runWithoutAuthorization(new Callable<StartFormData>() {
-      public StartFormData call() throws Exception {
-        return new GetStartFormCmd(resourceId).execute(commandContext);
-      }
-    });
+    StartFormData startFormData = commandContext.runWithoutAuthorization(new GetStartFormCmd(resourceId));
 
     ProcessDefinition definition = startFormData.getProcessDefinition();
     checkGetStartFormVariables((ProcessDefinitionEntity) definition, commandContext);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/ModifyProcessInstanceCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/ModifyProcessInstanceCmd.java
@@ -19,8 +19,6 @@ package org.camunda.bpm.engine.impl.cmd;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.history.UserOperationLogEntry;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.ProcessInstanceModificationBuilderImpl;
@@ -112,12 +110,8 @@ public class ModifyProcessInstanceCmd implements Command<Void> {
     for (final AbstractProcessInstanceModificationCommand instruction : builder.getModificationOperations()) {
       if (instruction instanceof ActivityCancellationCmd
           && ((ActivityCancellationCmd) instruction).cancelCurrentActiveActivityInstances) {
-        ActivityInstance activityInstanceTree = commandContext.runWithoutAuthorization(new Callable<ActivityInstance>() {
-          @Override
-          public ActivityInstance call() throws Exception {
-            return new GetActivityInstanceCmd(((ActivityCancellationCmd) instruction).processInstanceId).execute(commandContext);
-          }
-        });
+        ActivityInstance activityInstanceTree = commandContext.runWithoutAuthorization(
+            new GetActivityInstanceCmd(((ActivityCancellationCmd) instruction).processInstanceId));
         ((ActivityCancellationCmd) instruction).setActivityInstanceTreeToCancel(activityInstanceTree);
       }
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/ProcessInstanceModificationCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/ProcessInstanceModificationCmd.java
@@ -22,13 +22,10 @@ import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.BadUserRequestException;
 import org.camunda.bpm.engine.impl.ModificationBuilderImpl;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.ProcessInstanceModificationBuilderImpl;
-import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
@@ -124,8 +121,7 @@ public class ProcessInstanceModificationCmd extends AbstractModificationCmd<Void
       else {
 
         if (activityInstanceTree == null) {
-          activityInstanceTree = commandContext.runWithoutAuthorization(() ->
-              new GetActivityInstanceCmd(processInstanceId).execute(commandContext));
+          activityInstanceTree = commandContext.runWithoutAuthorization(new GetActivityInstanceCmd(processInstanceId));
         }
 
         ActivityCancellationCmd cancellationInstruction = (ActivityCancellationCmd) instruction;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/TransitionInstanceCancellationCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/TransitionInstanceCancellationCmd.java
@@ -16,8 +16,6 @@
  */
 package org.camunda.bpm.engine.impl.cmd;
 
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.exception.NotValidException;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
@@ -44,11 +42,7 @@ public class TransitionInstanceCancellationCmd extends AbstractInstanceCancellat
   }
 
   protected ExecutionEntity determineSourceInstanceExecution(final CommandContext commandContext) {
-    ActivityInstance instance = commandContext.runWithoutAuthorization(new Callable<ActivityInstance>() {
-      public ActivityInstance call() throws Exception {
-        return new GetActivityInstanceCmd(processInstanceId).execute(commandContext);
-      }
-    });
+    ActivityInstance instance = commandContext.runWithoutAuthorization(new GetActivityInstanceCmd(processInstanceId));
     TransitionInstance instanceToCancel = findTransitionInstance(instance, transitionInstanceId);
     EnsureUtil.ensureNotNull(NotValidException.class,
         describeFailure("Transition instance '" + transitionInstanceId + "' does not exist"),

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/batch/CorrelateAllMessageBatchCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/batch/CorrelateAllMessageBatchCmd.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.cmd.batch;
+
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureAtLeastOneNotNull;
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotEmpty;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.camunda.bpm.engine.BadUserRequestException;
+import org.camunda.bpm.engine.authorization.BatchPermissions;
+import org.camunda.bpm.engine.batch.Batch;
+import org.camunda.bpm.engine.history.HistoricProcessInstanceQuery;
+import org.camunda.bpm.engine.history.UserOperationLogEntry;
+import org.camunda.bpm.engine.impl.HistoricProcessInstanceQueryImpl;
+import org.camunda.bpm.engine.impl.MessageCorrelationAsyncBuilderImpl;
+import org.camunda.bpm.engine.impl.ProcessInstanceQueryImpl;
+import org.camunda.bpm.engine.impl.batch.BatchConfiguration;
+import org.camunda.bpm.engine.impl.batch.BatchElementConfiguration;
+import org.camunda.bpm.engine.impl.batch.builder.BatchBuilder;
+import org.camunda.bpm.engine.impl.batch.message.MessageCorrelationBatchConfiguration;
+import org.camunda.bpm.engine.impl.core.variable.VariableUtil;
+import org.camunda.bpm.engine.impl.interceptor.Command;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.persistence.entity.PropertyChange;
+import org.camunda.bpm.engine.impl.util.CollectionUtil;
+import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
+
+public class CorrelateAllMessageBatchCmd implements Command<Batch> {
+
+  protected String messageName;
+  protected Map<String, Object> variables;
+
+  protected List<String> processInstanceIds;
+  protected ProcessInstanceQuery processInstanceQuery;
+  protected HistoricProcessInstanceQuery historicProcessInstanceQuery;
+
+  public CorrelateAllMessageBatchCmd(MessageCorrelationAsyncBuilderImpl asyncBuilder) {
+    this.messageName = asyncBuilder.getMessageName();
+    this.variables = asyncBuilder.getPayloadProcessInstanceVariables();
+    this.processInstanceIds = asyncBuilder.getProcessInstanceIds();
+    this.processInstanceQuery = asyncBuilder.getProcessInstanceQuery();
+    this.historicProcessInstanceQuery = asyncBuilder.getHistoricProcessInstanceQuery();
+  }
+
+  @Override
+  public Batch execute(CommandContext commandContext) {
+    ensureAtLeastOneNotNull(
+        "No process instances found.",
+        processInstanceIds,
+        processInstanceQuery,
+        historicProcessInstanceQuery
+    );
+
+    BatchElementConfiguration elementConfiguration = collectProcessInstanceIds(commandContext);
+
+    List<String> ids = elementConfiguration.getIds();
+    ensureNotEmpty(BadUserRequestException.class, "Process instance ids cannot be empty", "process instance ids", ids);
+
+    Batch batch = new BatchBuilder(commandContext)
+        .type(Batch.TYPE_CORRELATE_MESSAGE)
+        .config(getConfiguration(elementConfiguration))
+        .permission(BatchPermissions.CREATE_BATCH_CORRELATE_MESSAGE)
+        .operationLogHandler(this::writeUserOperationLog)
+        .build();
+
+    if (variables != null) {
+      VariableUtil.setVariablesByBatchId(variables, batch.getId());
+    }
+
+    return batch;
+  }
+
+  protected BatchElementConfiguration collectProcessInstanceIds(CommandContext commandContext) {
+
+    BatchElementConfiguration elementConfiguration = new BatchElementConfiguration();
+
+    if (!CollectionUtil.isEmpty(processInstanceIds)) {
+      ProcessInstanceQueryImpl query = new ProcessInstanceQueryImpl();
+      query.processInstanceIds(new HashSet<>(processInstanceIds));
+
+      elementConfiguration.addDeploymentMappings(
+          commandContext.runWithoutAuthorization(query::listDeploymentIdMappings), processInstanceIds);
+    }
+
+    if (processInstanceQuery != null) {
+      elementConfiguration.addDeploymentMappings(((ProcessInstanceQueryImpl) processInstanceQuery).listDeploymentIdMappings());
+    }
+
+    if (historicProcessInstanceQuery != null) {
+      elementConfiguration.addDeploymentMappings(((HistoricProcessInstanceQueryImpl) historicProcessInstanceQuery).listDeploymentIdMappings());
+    }
+
+    return elementConfiguration;
+  }
+
+  protected BatchConfiguration getConfiguration(BatchElementConfiguration elementConfiguration) {
+    return new MessageCorrelationBatchConfiguration(
+        elementConfiguration.getIds(),
+        elementConfiguration.getMappings(),
+        messageName);
+  }
+
+  protected void writeUserOperationLog(CommandContext commandContext, int instancesCount) {
+    List<PropertyChange> propChanges = new ArrayList<>();
+
+    propChanges.add(new PropertyChange("messageName", null, messageName));
+    propChanges.add(new PropertyChange("nrOfInstances", null, instancesCount));
+    propChanges.add(new PropertyChange("nrOfVariables", null, variables == null ? 0 : variables.size()));
+    propChanges.add(new PropertyChange("async", null, true));
+
+    commandContext.getOperationLogManager()
+        .logProcessInstanceOperation(UserOperationLogEntry.OPERATION_TYPE_CORRELATE_MESSAGE, propChanges);
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmmn/cmd/GetDeploymentCaseDiagramCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmmn/cmd/GetDeploymentCaseDiagramCmd.java
@@ -18,8 +18,6 @@ package org.camunda.bpm.engine.impl.cmmn.cmd;
 
 import java.io.InputStream;
 import java.io.Serializable;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.cfg.CommandChecker;
 import org.camunda.bpm.engine.impl.cmd.GetDeploymentResourceCmd;
@@ -65,11 +63,7 @@ public class GetDeploymentCaseDiagramCmd implements Command<InputStream>, Serial
 
     if (resourceName != null) {
 
-      caseDiagramStream = commandContext.runWithoutAuthorization(new Callable<InputStream>() {
-        public InputStream call() throws Exception {
-          return new GetDeploymentResourceCmd(deploymentId, resourceName).execute(commandContext);
-        }
-      });
+      caseDiagramStream = commandContext.runWithoutAuthorization(new GetDeploymentResourceCmd(deploymentId, resourceName));
     }
 
     return caseDiagramStream;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmmn/cmd/GetDeploymentCaseModelCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmmn/cmd/GetDeploymentCaseModelCmd.java
@@ -20,8 +20,6 @@ import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 import java.io.InputStream;
 import java.io.Serializable;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.impl.cfg.CommandChecker;
 import org.camunda.bpm.engine.impl.cmd.GetDeploymentResourceCmd;
 import org.camunda.bpm.engine.impl.cmmn.entity.repository.CaseDefinitionEntity;
@@ -58,11 +56,8 @@ public class GetDeploymentCaseModelCmd implements Command<InputStream>, Serializ
     final String deploymentId = caseDefinition.getDeploymentId();
     final String resourceName = caseDefinition.getResourceName();
 
-    InputStream inputStream = commandContext.runWithoutAuthorization(new Callable<InputStream>() {
-      public InputStream call() throws Exception {
-        return new GetDeploymentResourceCmd(deploymentId, resourceName).execute(commandContext);
-      }
-    });
+    InputStream inputStream = commandContext.runWithoutAuthorization(
+        new GetDeploymentResourceCmd(deploymentId, resourceName));
 
     return inputStream;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/cmd/GetDeploymentDecisionDiagramCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/cmd/GetDeploymentDecisionDiagramCmd.java
@@ -18,7 +18,6 @@ package org.camunda.bpm.engine.impl.dmn.cmd;
 
 import java.io.InputStream;
 import java.io.Serializable;
-import java.util.concurrent.Callable;
 import org.camunda.bpm.engine.impl.cmd.GetDeploymentResourceCmd;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
@@ -45,11 +44,7 @@ public class GetDeploymentDecisionDiagramCmd implements Command<InputStream>, Se
     final String resourceName = decisionDefinition.getDiagramResourceName();
 
     if (resourceName != null ) {
-      return commandContext.runWithoutAuthorization(new Callable<InputStream>() {
-        public InputStream call() throws Exception {
-          return new GetDeploymentResourceCmd(deploymentId, resourceName).execute(commandContext);
-        }
-      });
+      return commandContext.runWithoutAuthorization(new GetDeploymentResourceCmd(deploymentId, resourceName));
     }
     else {
       return null;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/cmd/GetDeploymentDecisionModelCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/cmd/GetDeploymentDecisionModelCmd.java
@@ -18,8 +18,6 @@ package org.camunda.bpm.engine.impl.dmn.cmd;
 
 import java.io.InputStream;
 import java.io.Serializable;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.impl.cmd.GetDeploymentResourceCmd;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
@@ -44,11 +42,7 @@ public class GetDeploymentDecisionModelCmd implements Command<InputStream>, Seri
     final String deploymentId = decisionDefinition.getDeploymentId();
     final String resourceName = decisionDefinition.getResourceName();
 
-    return commandContext.runWithoutAuthorization(new Callable<InputStream>() {
-      public InputStream call() throws Exception {
-        return new GetDeploymentResourceCmd(deploymentId, resourceName).execute(commandContext);
-      }
-    });
+    return commandContext.runWithoutAuthorization(new GetDeploymentResourceCmd(deploymentId, resourceName));
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/cmd/GetDeploymentDecisionRequirementsDiagramCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/cmd/GetDeploymentDecisionRequirementsDiagramCmd.java
@@ -18,8 +18,6 @@ package org.camunda.bpm.engine.impl.dmn.cmd;
 
 import java.io.InputStream;
 import java.io.Serializable;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.impl.cmd.GetDeploymentResourceCmd;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
@@ -46,11 +44,7 @@ public class GetDeploymentDecisionRequirementsDiagramCmd implements Command<Inpu
     final String resourceName = decisionRequirementsDefinition.getDiagramResourceName();
 
     if (resourceName != null ) {
-      return commandContext.runWithoutAuthorization(new Callable<InputStream>() {
-        public InputStream call() throws Exception {
-          return new GetDeploymentResourceCmd(deploymentId, resourceName).execute(commandContext);
-        }
-      });
+      return commandContext.runWithoutAuthorization(new GetDeploymentResourceCmd(deploymentId, resourceName));
     }
     else {
       return null;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/cmd/GetDeploymentDecisionRequirementsModelCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/cmd/GetDeploymentDecisionRequirementsModelCmd.java
@@ -18,8 +18,6 @@ package org.camunda.bpm.engine.impl.dmn.cmd;
 
 import java.io.InputStream;
 import java.io.Serializable;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.impl.cmd.GetDeploymentResourceCmd;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
@@ -44,11 +42,7 @@ public class GetDeploymentDecisionRequirementsModelCmd implements Command<InputS
     final String deploymentId = decisionRequirementsDefinition.getDeploymentId();
     final String resourceName = decisionRequirementsDefinition.getResourceName();
 
-    return commandContext.runWithoutAuthorization(new Callable<InputStream>() {
-      public InputStream call() throws Exception {
-        return new GetDeploymentResourceCmd(deploymentId, resourceName).execute(commandContext);
-      }
-    });
+    return commandContext.runWithoutAuthorization(new GetDeploymentResourceCmd(deploymentId, resourceName));
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandContext.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandContext.java
@@ -544,6 +544,15 @@ public class CommandContext {
 
   public <T> T runWithoutAuthorization(Callable<T> runnable) {
     CommandContext commandContext = Context.getCommandContext();
+    return runWithoutAuthorization(runnable, commandContext);
+  }
+
+  public <T> T runWithoutAuthorization(Command<T> command) {
+    CommandContext commandContext = Context.getCommandContext();
+    return runWithoutAuthorization(() -> command.execute(commandContext), commandContext);
+  }
+
+  protected <T> T runWithoutAuthorization(Callable<T> runnable, CommandContext commandContext) {
     boolean authorizationEnabled = commandContext.isAuthorizationCheckEnabled();
     try {
       commandContext.disableAuthorizationCheck();

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/json/MessageCorrelationBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/json/MessageCorrelationBatchConfigurationJsonConverter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.json;
+
+import org.camunda.bpm.engine.impl.batch.DeploymentMappingJsonConverter;
+import org.camunda.bpm.engine.impl.batch.DeploymentMappings;
+import org.camunda.bpm.engine.impl.batch.message.MessageCorrelationBatchConfiguration;
+import org.camunda.bpm.engine.impl.util.JsonUtil;
+import com.google.gson.JsonObject;
+
+import java.util.List;
+
+public class MessageCorrelationBatchConfigurationJsonConverter extends JsonObjectConverter<MessageCorrelationBatchConfiguration> {
+
+  public static final MessageCorrelationBatchConfigurationJsonConverter INSTANCE = new MessageCorrelationBatchConfigurationJsonConverter();
+
+  public static final String MESSAGE_NAME = "messageName";
+  public static final String PROCESS_INSTANCE_IDS = "processInstanceIds";
+  public static final String PROCESS_INSTANCE_ID_MAPPINGS = "processInstanceIdMappings";
+  public static final String BATCH_ID = "batchId";
+
+  public JsonObject toJsonObject(MessageCorrelationBatchConfiguration configuration) {
+    JsonObject json = JsonUtil.createObject();
+
+    JsonUtil.addField(json, MESSAGE_NAME, configuration.getMessageName());
+    JsonUtil.addListField(json, PROCESS_INSTANCE_IDS, configuration.getIds());
+    JsonUtil.addListField(json, PROCESS_INSTANCE_ID_MAPPINGS, DeploymentMappingJsonConverter.INSTANCE, configuration.getIdMappings());
+    JsonUtil.addField(json, BATCH_ID, configuration.getBatchId());
+
+    return json;
+  }
+
+  public MessageCorrelationBatchConfiguration toObject(JsonObject json) {
+    return new MessageCorrelationBatchConfiguration(
+        readProcessInstanceIds(json),
+        readIdMappings(json),
+        JsonUtil.getString(json, MESSAGE_NAME, null),
+        JsonUtil.getString(json, BATCH_ID));
+  }
+
+  protected List<String> readProcessInstanceIds(JsonObject jsonObject) {
+    return JsonUtil.asStringList(JsonUtil.getArray(jsonObject, PROCESS_INSTANCE_IDS));
+  }
+
+  protected DeploymentMappings readIdMappings(JsonObject json) {
+    return JsonUtil.asList(JsonUtil.getArray(json, PROCESS_INSTANCE_ID_MAPPINGS), DeploymentMappingJsonConverter.INSTANCE, DeploymentMappings::new);
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/deploy/DeleteDeploymentFailListener.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/deploy/DeleteDeploymentFailListener.java
@@ -16,7 +16,6 @@
  */
 package org.camunda.bpm.engine.impl.persistence.deploy;
 
-import java.util.concurrent.Callable;
 import org.camunda.bpm.application.ProcessApplicationReference;
 import org.camunda.bpm.engine.impl.cfg.TransactionListener;
 import org.camunda.bpm.engine.impl.cmd.RegisterDeploymentCmd;
@@ -47,13 +46,10 @@ public class DeleteDeploymentFailListener implements TransactionListener {
 
     @Override
     public Void execute(final CommandContext commandContext) {
-      commandContext.runWithoutAuthorization((Callable<Void>) () -> {
-        new RegisterDeploymentCmd(deploymentId).execute(commandContext);
-        if (processApplicationReference != null) {
-          new RegisterProcessApplicationCmd(deploymentId, processApplicationReference).execute(commandContext);
-        }
-        return null;
-      });
+      commandContext.runWithoutAuthorization(new RegisterDeploymentCmd(deploymentId));
+      if (processApplicationReference != null) {
+        commandContext.runWithoutAuthorization(new RegisterProcessApplicationCmd(deploymentId, processApplicationReference));
+      }
       return null;
     }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/deploy/DeploymentFailListener.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/deploy/DeploymentFailListener.java
@@ -18,8 +18,6 @@ package org.camunda.bpm.engine.impl.persistence.deploy;
 
 import java.util.Collections;
 import java.util.Set;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.impl.cfg.TransactionListener;
 import org.camunda.bpm.engine.impl.cmd.UnregisterDeploymentCmd;
 import org.camunda.bpm.engine.impl.interceptor.Command;
@@ -51,10 +49,7 @@ public class DeploymentFailListener implements TransactionListener {
     @Override
     public Void execute(final CommandContext commandContext) {
 
-      commandContext.runWithoutAuthorization((Callable<Void>) () -> {
-        new UnregisterDeploymentCmd(deploymentIds).execute(commandContext);
-        return null;
-      });
+      commandContext.runWithoutAuthorization(new UnregisterDeploymentCmd(deploymentIds));
 
       return null;
     }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/deploy/cache/ModelInstanceCache.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/deploy/cache/ModelInstanceCache.java
@@ -28,7 +28,6 @@ import org.camunda.commons.utils.cache.Cache;
 
 import java.io.InputStream;
 import java.util.List;
-import java.util.concurrent.Callable;
 
 /**
  * @author: Johannes Heinemann
@@ -64,11 +63,8 @@ public abstract class ModelInstanceCache<InstanceType extends ModelInstance, Def
 
   protected InstanceType loadAndCacheBpmnModelInstance(final DefinitionType definitionEntity) {
     final CommandContext commandContext = Context.getCommandContext();
-    InputStream bpmnResourceInputStream = commandContext.runWithoutAuthorization(new Callable<InputStream>() {
-      public InputStream call() throws Exception {
-        return new GetDeploymentResourceCmd(definitionEntity.getDeploymentId(), definitionEntity.getResourceName()).execute(commandContext);
-      }
-    });
+    InputStream bpmnResourceInputStream = commandContext.runWithoutAuthorization(
+        new GetDeploymentResourceCmd(definitionEntity.getDeploymentId(), definitionEntity.getResourceName()));
 
     try {
       InstanceType bpmnModelInstance = readModelFromStream(bpmnResourceInputStream);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/DeploymentManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/DeploymentManager.java
@@ -18,8 +18,6 @@ package org.camunda.bpm.engine.impl.persistence.entity;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.Callable;
-
 import org.camunda.bpm.engine.authorization.Resources;
 import org.camunda.bpm.engine.impl.DeploymentQueryImpl;
 import org.camunda.bpm.engine.impl.Page;
@@ -110,18 +108,12 @@ public class DeploymentManager extends AbstractManager {
       // Represents no problem if only one process definition is deleted
       // in a transaction! We have to set the instances flag to false.
       final CommandContext commandContext = Context.getCommandContext();
-      commandContext.runWithoutAuthorization(new Callable<Void>() {
-        public Void call() throws Exception {
-          DeleteProcessDefinitionsByIdsCmd cmd = new DeleteProcessDefinitionsByIdsCmd(
+      commandContext.runWithoutAuthorization(new DeleteProcessDefinitionsByIdsCmd(
               Arrays.asList(processDefinitionId),
               cascade,
               false,
               skipCustomListeners,
-              false);
-          cmd.execute(commandContext);
-          return null;
-        }
-      });
+              false));
     }
 
     deleteCaseDeployment(deploymentId, cascade);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/runtime/CorrelationSet.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/runtime/CorrelationSet.java
@@ -29,6 +29,7 @@ public class CorrelationSet {
   protected final String processDefinitionId;
   protected final String tenantId;
   protected final boolean isTenantIdSet;
+  protected final boolean isExecutionsOnly;
 
   public CorrelationSet(MessageCorrelationBuilderImpl builder) {
     this.businessKey = builder.getBusinessKey();
@@ -38,6 +39,7 @@ public class CorrelationSet {
     this.processDefinitionId = builder.getProcessDefinitionId();
     this.tenantId = builder.getTenantId();
     this.isTenantIdSet = builder.isTenantIdSet();
+    this.isExecutionsOnly = builder.isExecutionsOnly();
   }
 
   public String getBusinessKey() {
@@ -68,10 +70,15 @@ public class CorrelationSet {
     return isTenantIdSet;
   }
 
+  public boolean isExecutionsOnly() {
+    return isExecutionsOnly;
+  }
+
   @Override
   public String toString() {
     return "CorrelationSet [businessKey=" + businessKey + ", processInstanceId=" + processInstanceId + ", processDefinitionId=" + processDefinitionId
-        + ", correlationKeys=" + correlationKeys + ", localCorrelationKeys=" + localCorrelationKeys + ", tenantId=" + tenantId + ", isTenantIdSet=" + isTenantIdSet + "]";
+        + ", correlationKeys=" + correlationKeys + ", localCorrelationKeys=" + localCorrelationKeys + ", tenantId=" + tenantId +
+        ", isTenantIdSet=" + isTenantIdSet + ", isExecutionsOnly=" + isExecutionsOnly + "]";
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/EnsureUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/EnsureUtil.java
@@ -363,6 +363,10 @@ public final class EnsureUtil {
     }
   }
 
+  public static void ensureFalse(String message, boolean value) {
+    ensureTrue(message, !value);
+  }
+
   protected static String determineResourceWhitelistPattern(ProcessEngineConfiguration processEngineConfiguration, String resourceType) {
     String resourcePattern = null;
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/JsonUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/JsonUtil.java
@@ -596,11 +596,15 @@ public final class JsonUtil {
   }
 
   public static String getString(JsonObject json, String memberName) {
+    return getString(json, memberName, "");
+  }
+
+  public static String getString(JsonObject json, String memberName, String defaultString) {
     if (json != null && memberName != null && json.has(memberName)) {
       return getString(json.get(memberName));
 
     } else {
-      return "";
+      return defaultString;
 
     }
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/runtime/MessageCorrelationAsyncBuilder.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/runtime/MessageCorrelationAsyncBuilder.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.runtime;
+
+import java.util.List;
+import java.util.Map;
+
+import org.camunda.bpm.engine.AuthorizationException;
+import org.camunda.bpm.engine.BadUserRequestException;
+import org.camunda.bpm.engine.authorization.BatchPermissions;
+import org.camunda.bpm.engine.authorization.Resources;
+import org.camunda.bpm.engine.batch.Batch;
+import org.camunda.bpm.engine.exception.NullValueException;
+import org.camunda.bpm.engine.history.HistoricProcessInstanceQuery;
+
+/**
+ * A fluent builder for defining asynchronous message correlation
+ */
+public interface MessageCorrelationAsyncBuilder {
+
+  /**
+   * <p>
+   * Correlate the message such that the process instances with the given ids
+   * are selected.
+   * </p>
+   *
+   * @param ids
+   *          the ids of the process instances to correlate to; at least one of
+   *          {@link #processInstanceIds(List)},
+   *          {@link #processInstanceQuery(ProcessInstanceQuery)}, or
+   *          {@link #historicProcessInstanceQuery(HistoricProcessInstanceQuery)}
+   *          has to be set.
+   * @return the builder
+   * @throws NullValueException
+   *           when <code>ids</code> is <code>null</code>
+   */
+  MessageCorrelationAsyncBuilder processInstanceIds(List<String> ids);
+
+  /**
+   * <p>
+   * Correlate the message such that the process instances found by the given
+   * query are selected.
+   * </p>
+   *
+   * @param processInstanceQuery
+   *          the query to select process instances to correlate to; at least
+   *          one of {@link #processInstanceIds(List)},
+   *          {@link #processInstanceQuery(ProcessInstanceQuery)}, or
+   *          {@link #historicProcessInstanceQuery(HistoricProcessInstanceQuery)}
+   *          has to be set.
+   * @return the builder
+   * @throws NullValueException
+   *           when <code>processInstanceQuery</code> is <code>null</code>
+   */
+  MessageCorrelationAsyncBuilder processInstanceQuery(ProcessInstanceQuery processInstanceQuery);
+
+  /**
+   * <p>
+   * Correlate the message such that the process instances found by the given
+   * query are selected.
+   * </p>
+   *
+   * @param historicProcessInstanceQuery
+   *          the query to select process instances to correlate to; at least
+   *          one of {@link #processInstanceIds(List)},
+   *          {@link #processInstanceQuery(ProcessInstanceQuery)}, or
+   *          {@link #historicProcessInstanceQuery(HistoricProcessInstanceQuery)}
+   *          has to be set.
+   * @return the builder
+   * @throws NullValueException
+   *           when <code>historicProcessInstanceQuery</code> is <code>null</code>
+   */
+  MessageCorrelationAsyncBuilder historicProcessInstanceQuery(HistoricProcessInstanceQuery historicProcessInstanceQuery);
+
+  /**
+   * <p>
+   * Pass a variable to the execution waiting on the message. Use this method
+   * for passing the message's payload.
+   * </p>
+   *
+   * <p>
+   * Invoking this method multiple times allows passing multiple variables.
+   * </p>
+   *
+   * @param variableName
+   *          the name of the variable to set
+   * @param variableValue
+   *          the value of the variable to set
+   * @return the builder
+   * @throws NullValueException
+   *           when <code>variableName</code> is <code>null</code>
+   */
+  MessageCorrelationAsyncBuilder setVariable(String variableName, Object variableValue);
+
+  /**
+   * <p>
+   * Pass a map of variables to the execution waiting on the message. Use this
+   * method for passing the message's payload
+   * </p>
+   *
+   * @param variables
+   *          the map of variables
+   * @return the builder
+   */
+  MessageCorrelationAsyncBuilder setVariables(Map<String, Object> variables);
+
+  /**
+   * Correlates a message asynchronously to executions that are waiting for this
+   * message based on the provided queries and list of process instance ids,
+   * whereby query results and list of ids will be merged.
+   *
+   * @return the batch which correlates the message asynchronously
+   *
+   * @throws NullValueException
+   *           when neither {@link #processInstanceIds(List)},
+   *           {@link #processInstanceQuery(ProcessInstanceQuery)}, nor
+   *           {@link #historicProcessInstanceQuery(HistoricProcessInstanceQuery)}}
+   *           have been set
+   * @throws BadUserRequestException
+   *           when no process instances are found with the given ids or queries
+   * @throws AuthorizationException
+   *           when the user has no {@link BatchPermissions#CREATE} or
+   *           {@link BatchPermissions#CREATE_BATCH_SET_VARIABLES} permission on
+   *           {@link Resources#BATCH}
+   */
+  Batch correlateAllAsync();
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/batch/creation/CorrelateAllMessageBatchAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/batch/creation/CorrelateAllMessageBatchAuthorizationTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.api.authorization.batch.creation;
+
+import org.camunda.bpm.engine.authorization.BatchPermissions;
+import org.camunda.bpm.engine.authorization.Permissions;
+import org.camunda.bpm.engine.authorization.ProcessDefinitionPermissions;
+import org.camunda.bpm.engine.authorization.Resources;
+import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
+import org.camunda.bpm.engine.test.api.authorization.util.AuthorizationScenario;
+import org.camunda.bpm.engine.test.api.authorization.util.AuthorizationTestRule;
+import org.camunda.bpm.engine.test.api.runtime.migration.models.ProcessModels;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+
+import static org.camunda.bpm.engine.test.api.authorization.util.AuthorizationScenario.scenario;
+import static org.camunda.bpm.engine.test.api.authorization.util.AuthorizationSpec.grant;
+
+public class CorrelateAllMessageBatchAuthorizationTest extends BatchCreationAuthorizationTest {
+
+  @Parameterized.Parameters(name = "Scenario {index}")
+  public static Collection<AuthorizationScenario[]> scenarios() {
+    return AuthorizationTestRule.asParameters(
+        scenario()
+            .withAuthorizations(
+              grant(Resources.PROCESS_DEFINITION, "processDefinitionKey", "userId",
+                  ProcessDefinitionPermissions.READ_INSTANCE)
+            )
+            .failsDueToRequired(
+                grant(Resources.BATCH, "batchId", "userId", Permissions.CREATE),
+                grant(Resources.BATCH, "batchId", "userId",
+                    BatchPermissions.CREATE_BATCH_CORRELATE_MESSAGE)
+            ),
+        scenario()
+            .withAuthorizations(
+                grant(Resources.PROCESS_DEFINITION, "processDefinitionKey", "userId",
+                    ProcessDefinitionPermissions.READ_INSTANCE),
+                grant(Resources.BATCH, "batchId", "userId", Permissions.CREATE)
+            ).succeeds(),
+        scenario()
+            .withAuthorizations(
+                grant(Resources.PROCESS_DEFINITION, "processDefinitionKey", "userId",
+                    ProcessDefinitionPermissions.READ_INSTANCE),
+                grant(Resources.BATCH, "batchId", "userId",
+                    BatchPermissions.CREATE_BATCH_CORRELATE_MESSAGE)
+            ).succeeds()
+    );
+  }
+
+  @Test
+  public void shouldAuthorizeSetVariablesBatch() {
+    // given
+    authRule
+        .init(scenario)
+        .withUser("userId")
+        .bindResource("batchId", "*")
+        .bindResource("processDefinitionKey", ProcessModels.PROCESS_KEY)
+        .start();
+
+    ProcessInstanceQuery processInstanceQuery = runtimeService.createProcessInstanceQuery();
+
+    // when
+    runtimeService.createMessageCorrelationAsync("test")
+      .processInstanceQuery(processInstanceQuery)
+      .setVariable("foo", "bar")
+      .correlateAllAsync();
+
+    // then
+    authRule.assertScenario(scenario);
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/CorrelateAllMessageBatchTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/CorrelateAllMessageBatchTest.java
@@ -1,0 +1,632 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.api.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+import static java.util.stream.Stream.of;
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.camunda.bpm.engine.BadUserRequestException;
+import org.camunda.bpm.engine.HistoryService;
+import org.camunda.bpm.engine.ManagementService;
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.batch.Batch;
+import org.camunda.bpm.engine.exception.NullValueException;
+import org.camunda.bpm.engine.history.HistoricProcessInstanceQuery;
+import org.camunda.bpm.engine.history.UserOperationLogEntry;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.repository.Deployment;
+import org.camunda.bpm.engine.runtime.ExecutionQuery;
+import org.camunda.bpm.engine.runtime.Job;
+import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
+import org.camunda.bpm.engine.runtime.VariableInstanceQuery;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.RequiredHistoryLevel;
+import org.camunda.bpm.engine.test.util.BatchRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class CorrelateAllMessageBatchTest {
+
+  protected static final String PROCESS_ONE_KEY = "process";
+  protected static final String PROCESS_TWO_KEY = "process-two";
+  protected static final String PROCESS_THREE_KEY = "process-three";
+  protected static final String MESSAGE_ONE_REF = "message";
+  protected static final String MESSAGE_TWO_REF = "message-two";
+
+  protected ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
+  protected ProcessEngineTestRule engineTestRule = new ProcessEngineTestRule(engineRule);
+  protected BatchRule rule = new BatchRule(engineRule, engineTestRule);
+
+  @Rule
+  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(engineTestRule).around(rule);
+
+  protected RuntimeService runtimeService;
+  protected HistoryService historyService;
+  protected ManagementService managementService;
+
+  @Before
+  public void assignServices() {
+    runtimeService = engineRule.getRuntimeService();
+    historyService = engineRule.getHistoryService();
+    managementService = engineRule.getManagementService();
+  }
+
+  @Before
+  public void deployProcessIntermediateMessageOne() {
+    BpmnModelInstance process = Bpmn.createExecutableProcess(PROCESS_ONE_KEY)
+      .startEvent()
+      .intermediateCatchEvent("messageCatch")
+      .message(MESSAGE_ONE_REF)
+      .userTask("task")
+      .endEvent()
+      .done();
+    engineTestRule.deploy(process);
+  }
+
+  @After
+  public void clearAuthentication() {
+    engineRule.getIdentityService().setAuthenticatedUserId(null);
+  }
+
+  @After
+  public void resetConfiguration() {
+    engineRule.getProcessEngineConfiguration()
+      .setInvocationsPerBatchJob(ProcessEngineConfigurationImpl.DEFAULT_INVOCATIONS_PER_BATCH_JOB);
+  }
+
+  @Test
+  public void shouldCorrelateAllWithInstanceIds() {
+    // given
+    deployProcessIntermediateMessageTwo();
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+    String processInstanceIdThree = runtimeService.startProcessInstanceByKey(PROCESS_TWO_KEY).getId();
+
+    List<String> processInstances = Arrays.asList(processInstanceIdOne, processInstanceIdThree);
+
+    Batch batch = runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+      .processInstanceIds(processInstances)
+      .correlateAllAsync();
+
+    ExecutionQuery taskExecutionQueryInstanceOne = runtimeService.createExecutionQuery()
+      .activityId("task")
+      .processInstanceId(processInstanceIdOne);
+    ExecutionQuery taskExecutionQueryInstanceTwo = runtimeService.createExecutionQuery()
+      .activityId("task")
+      .processInstanceId(processInstanceIdTwo);
+    ExecutionQuery taskExecutionQueryInstanceThree = runtimeService.createExecutionQuery()
+      .activityId("task")
+      .processInstanceId(processInstanceIdThree);
+
+    // assume
+    assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceTwo.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+
+    // when
+    rule.syncExec(batch);
+
+    // then
+    assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(1L);
+    assertThat(taskExecutionQueryInstanceTwo.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+  }
+
+  @Test
+  public void shouldCorrelateAllWithInstanceQuery() {
+    // given
+    deployProcessIntermediateMessageTwo();
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+    String processInstanceIdThree = runtimeService.startProcessInstanceByKey(PROCESS_TWO_KEY).getId();
+
+    ProcessInstanceQuery runtimeQuery = runtimeService.createProcessInstanceQuery()
+      .processInstanceIds(of(processInstanceIdOne, processInstanceIdThree).collect(toSet()));
+
+    Batch batch = runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+      .processInstanceQuery(runtimeQuery)
+      .correlateAllAsync();
+
+    ExecutionQuery taskExecutionQueryInstanceOne = runtimeService.createExecutionQuery()
+      .activityId("task")
+      .processInstanceId(processInstanceIdOne);
+    ExecutionQuery taskExecutionQueryInstanceTwo = runtimeService.createExecutionQuery()
+      .activityId("task")
+      .processInstanceId(processInstanceIdTwo);
+    ExecutionQuery taskExecutionQueryInstanceThree = runtimeService.createExecutionQuery()
+      .activityId("task")
+      .processInstanceId(processInstanceIdThree);
+
+    // assume
+    assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceTwo.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+
+    // when
+    rule.syncExec(batch);
+
+    // then
+    assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(1L);
+    assertThat(taskExecutionQueryInstanceTwo.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+  }
+
+  @Test
+  public void shouldCorrelateAllWithHistoricInstanceQuery() {
+    // given
+    deployProcessIntermediateMessageTwo();
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+    String processInstanceIdThree = runtimeService.startProcessInstanceByKey(PROCESS_TWO_KEY).getId();
+
+    HistoricProcessInstanceQuery historyQuery = historyService.createHistoricProcessInstanceQuery()
+      .processInstanceIds(of(processInstanceIdOne, processInstanceIdThree).collect(toSet()));
+
+    Batch batch = runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+      .historicProcessInstanceQuery(historyQuery)
+      .correlateAllAsync();
+
+    ExecutionQuery taskExecutionQueryInstanceOne = runtimeService.createExecutionQuery()
+      .activityId("task")
+      .processInstanceId(processInstanceIdOne);
+    ExecutionQuery taskExecutionQueryInstanceTwo = runtimeService.createExecutionQuery()
+      .activityId("task")
+      .processInstanceId(processInstanceIdTwo);
+    ExecutionQuery taskExecutionQueryInstanceThree = runtimeService.createExecutionQuery()
+      .activityId("task")
+      .processInstanceId(processInstanceIdThree);
+
+    // assume
+    assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceTwo.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+
+    // when
+    rule.syncExec(batch);
+
+    // then
+    assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(1L);
+    assertThat(taskExecutionQueryInstanceTwo.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+  }
+
+  @Test
+  public void shouldCorrelateAllWithoutMessage() {
+    // given
+    deployProcessIntermediateMessageTwo();
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+    String processInstanceIdThree = runtimeService.startProcessInstanceByKey(PROCESS_TWO_KEY).getId();
+
+    List<String> processInstances = Arrays.asList(processInstanceIdOne, processInstanceIdThree);
+
+    Batch batch = runtimeService.createMessageCorrelationAsync(null)
+      .processInstanceIds(processInstances)
+      .correlateAllAsync();
+
+    ExecutionQuery taskExecutionQueryInstanceOne = runtimeService.createExecutionQuery()
+      .activityId("task")
+      .processInstanceId(processInstanceIdOne);
+    ExecutionQuery taskExecutionQueryInstanceTwo = runtimeService.createExecutionQuery()
+      .activityId("task")
+      .processInstanceId(processInstanceIdTwo);
+    ExecutionQuery taskExecutionQueryInstanceThree = runtimeService.createExecutionQuery()
+      .activityId("task")
+      .processInstanceId(processInstanceIdThree);
+
+    // assume
+    assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceTwo.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+
+    // when
+    rule.syncExec(batch);
+
+    // then
+    assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(1L);
+    assertThat(taskExecutionQueryInstanceTwo.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(1L);
+  }
+
+  @Test
+  public void shouldNotCorrelateStartMessageEvent() {
+    // given
+    deployProcessStartMessageOne();
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+
+    List<String> processInstances = Arrays.asList(processInstanceIdOne);
+
+    Batch batch = runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+      .processInstanceIds(processInstances)
+      .correlateAllAsync();
+
+    ExecutionQuery taskExecutionQueryInstanceOne = runtimeService.createExecutionQuery()
+      .activityId("task")
+      .processInstanceId(processInstanceIdOne);
+    ExecutionQuery taskExecutionQueryInstanceThree = runtimeService.createExecutionQuery()
+      .activityId("task")
+      .processDefinitionKey(PROCESS_THREE_KEY);
+
+    // assume
+    assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+
+    // when
+    rule.syncExec(batch);
+
+    // then
+    assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(1L);
+    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+  }
+
+  @Test
+  public void shouldSetVariablesOnCorrelation() {
+    // given
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+
+    List<String> processInstances = Arrays.asList(processInstanceIdOne, processInstanceIdTwo);
+
+    Batch batch = runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+      .processInstanceIds(processInstances)
+      .setVariable("foo", "bar")
+      .correlateAllAsync();
+
+    VariableInstanceQuery query = runtimeService.createVariableInstanceQuery();
+
+    // assume
+    assertThat(query.list()).extracting("processInstanceId", "name", "value", "batchId")
+      .containsExactly(tuple(null, "foo", "bar", batch.getId()));
+
+    // when
+    rule.syncExec(batch);
+
+    // then
+    assertThat(query.list()).extracting("processInstanceId", "name", "value")
+      .containsExactlyInAnyOrder(tuple(processInstanceIdOne, "foo", "bar"), tuple(processInstanceIdTwo, "foo", "bar"));
+  }
+
+  @Test
+  public void shouldThrowException_NoProcessInstancesFound() {
+    // when/then
+    assertThatThrownBy(() ->
+      runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+        .processInstanceIds(Collections.emptyList())
+        .correlateAllAsync())
+      .isInstanceOf(BadUserRequestException.class)
+      .hasMessageContaining("process instance ids is empty");
+  }
+
+  @Test
+  public void shouldThrowException_QueriesAndIdsNull() {
+    // when/then
+    assertThatThrownBy(() -> runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF).correlateAllAsync())
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("No process instances found");
+
+  }
+
+  @Test
+  public void shouldThrowException_NullProcessInstanceIds() {
+    // when/then
+    assertThatThrownBy(() ->
+      runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+        .processInstanceIds(null)
+        .correlateAllAsync())
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("processInstanceIds");
+  }
+
+  @Test
+  public void shouldThrowException_NullProcessInstanceQuery() {
+    // when/then
+    assertThatThrownBy(() ->
+      runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+        .processInstanceQuery(null)
+        .correlateAllAsync())
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("processInstanceQuery");
+  }
+
+  @Test
+  public void shouldThrowException_NullHistoricProcessInstanceQuery() {
+    // when/then
+    assertThatThrownBy(() ->
+      runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+        .historicProcessInstanceQuery(null)
+        .correlateAllAsync())
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("historicProcessInstanceQuery");
+  }
+
+  @Test
+  public void shouldThrowException_NullVariableName() {
+    // when/then
+    assertThatThrownBy(() ->
+      runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+        .setVariable(null, "bar")
+        .correlateAllAsync())
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("variableName");
+  }
+
+  @Test
+  public void shouldThrowException_JavaSerializationForbidden() {
+    // given
+    runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY);
+    ProcessInstanceQuery runtimeQuery = runtimeService.createProcessInstanceQuery();
+
+    // when/then
+    assertThatThrownBy(() ->
+      runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+        .processInstanceQuery(runtimeQuery)
+        .setVariables(
+            Variables.putValue("foo",
+                Variables.serializedObjectValue()
+                 .serializedValue("foo")
+                 .serializationDataFormat(Variables.SerializationDataFormats.JAVA)
+                 .create()))
+        .correlateAllAsync())
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("ENGINE-17007 Cannot set variable with name foo. " +
+          "Java serialization format is prohibited");
+  }
+
+  @Test
+  public void shouldCreateDeploymentAwareBatchJobs_ByIds() {
+    // given
+    engineRule.getProcessEngineConfiguration().setInvocationsPerBatchJob(2);
+
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+    deployProcessIntermediateMessageOne();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+
+    List<Deployment> list = engineRule.getRepositoryService().createDeploymentQuery().list();
+    String deploymentIdOne = list.get(0).getId();
+    String deploymentIdTwo = list.get(1).getId();
+
+    List<String> processInstances = Arrays.asList(processInstanceIdOne, processInstanceIdTwo);
+
+    // when
+    Batch batch = runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+      .processInstanceIds(processInstances)
+      .correlateAllAsync();
+
+    rule.executeSeedJobs(batch);
+
+    // then
+    List<Job> executionJobs = rule.getExecutionJobs(batch);
+    assertThat(executionJobs)
+      .extracting("deploymentId")
+      .containsExactlyInAnyOrder(deploymentIdOne, deploymentIdTwo);
+
+    // clear
+    managementService.deleteBatch(batch.getId(), true);
+  }
+
+  @Test
+  public void shouldCreateDeploymentAwareBatchJobs_ByRuntimeQuery() {
+    // given
+    engineRule.getProcessEngineConfiguration().setInvocationsPerBatchJob(2);
+
+    runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY);
+    deployProcessIntermediateMessageOne();
+    runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY);
+
+    List<Deployment> list = engineRule.getRepositoryService().createDeploymentQuery().list();
+    String deploymentIdOne = list.get(0).getId();
+    String deploymentIdTwo = list.get(1).getId();
+
+    ProcessInstanceQuery runtimeQuery = runtimeService.createProcessInstanceQuery();
+
+    // when
+    Batch batch = runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+      .processInstanceQuery(runtimeQuery)
+      .correlateAllAsync();
+
+    rule.executeSeedJobs(batch);
+
+    // then
+    List<Job> executionJobs = rule.getExecutionJobs(batch);
+    assertThat(executionJobs)
+      .extracting("deploymentId")
+      .containsExactlyInAnyOrder(deploymentIdOne, deploymentIdTwo);
+
+    // clear
+    managementService.deleteBatch(batch.getId(), true);
+  }
+
+  @Test
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_ACTIVITY)
+  public void shouldCreateDeploymentAwareBatchJobs_ByHistoryQuery() {
+    // given
+    engineRule.getProcessEngineConfiguration().setInvocationsPerBatchJob(2);
+
+    runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY);
+    deployProcessIntermediateMessageOne();
+    runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY);
+
+    List<Deployment> list = engineRule.getRepositoryService().createDeploymentQuery().list();
+    String deploymentIdOne = list.get(0).getId();
+    String deploymentIdTwo = list.get(1).getId();
+
+    HistoricProcessInstanceQuery historyQuery = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    Batch batch = runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+      .historicProcessInstanceQuery(historyQuery)
+      .correlateAllAsync();
+
+    rule.executeSeedJobs(batch);
+
+    // then
+    List<Job> executionJobs = rule.getExecutionJobs(batch);
+    assertThat(executionJobs)
+      .extracting("deploymentId")
+      .containsExactlyInAnyOrder(deploymentIdOne, deploymentIdTwo);
+
+    // clear
+    managementService.deleteBatch(batch.getId(), true);
+  }
+
+  @Test
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+  public void shouldLogOperation() {
+    // given
+    runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY);
+
+    engineRule.getIdentityService().setAuthenticatedUserId("demo");
+
+    ProcessInstanceQuery runtimeQuery = runtimeService.createProcessInstanceQuery();
+
+    // when
+    Batch batch = runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+      .processInstanceQuery(runtimeQuery)
+      .setVariable("foo", "bar")
+      .correlateAllAsync();
+
+    // then
+    List<UserOperationLogEntry> logs = historyService.createUserOperationLogQuery().list();
+
+    assertThat(logs)
+      .extracting("property", "orgValue", "newValue", "operationType", "entityType", "category", "userId")
+      .containsExactlyInAnyOrder(
+          tuple("messageName", null, MESSAGE_ONE_REF, "CorrelateMessage", "ProcessInstance", "Operator", "demo"),
+          tuple("nrOfInstances", null, "1", "CorrelateMessage", "ProcessInstance", "Operator", "demo"),
+          tuple("nrOfVariables", null, "1", "CorrelateMessage", "ProcessInstance", "Operator", "demo"),
+          tuple("async", null, "true", "CorrelateMessage", "ProcessInstance", "Operator", "demo"));
+
+    // clear
+    managementService.deleteBatch(batch.getId(), true);
+  }
+
+  @Test
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+  public void shouldNotLogInstanceOperation() {
+    // given
+    runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY);
+
+    ProcessInstanceQuery runtimeQuery = runtimeService.createProcessInstanceQuery();
+
+    // when
+    Batch batch = runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+      .processInstanceQuery(runtimeQuery)
+      .setVariable("foo", "bar")
+      .correlateAllAsync();
+
+    // then
+    List<UserOperationLogEntry> logs = historyService.createUserOperationLogQuery()
+      .operationType(UserOperationLogEntry.OPERATION_TYPE_SET_VARIABLE)
+      .list();
+
+    assertThat(logs.size()).isEqualTo(0);
+
+    // clear
+    managementService.deleteBatch(batch.getId(), true);
+  }
+
+  @Test
+  public void shouldCreateProcessInstanceRelatedBatchJobsForSingleInvocations() {
+    // given
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+
+    List<String> processInstanceIds = Arrays.asList(processInstanceIdOne, processInstanceIdTwo);
+
+    // when
+    Batch batch = runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+      .processInstanceIds(processInstanceIds)
+      .correlateAllAsync();
+
+    rule.executeSeedJobs(batch);
+
+    // then
+    List<Job> executionJobs = rule.getExecutionJobs(batch);
+    assertThat(executionJobs)
+      .extracting("processInstanceId")
+      .containsExactlyInAnyOrder(processInstanceIdOne, processInstanceIdTwo);
+
+    // clear
+    managementService.deleteBatch(batch.getId(), true);
+  }
+
+  @Test
+  public void shouldNotCreateProcessInstanceRelatedBatchJobsForMultipleInvocations() {
+    // given
+    engineRule.getProcessEngineConfiguration().setInvocationsPerBatchJob(2);
+
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey(PROCESS_ONE_KEY).getId();
+
+    List<String> processInstanceIds = Arrays.asList(processInstanceIdOne, processInstanceIdTwo);
+
+    // when
+    Batch batch = runtimeService.createMessageCorrelationAsync(MESSAGE_ONE_REF)
+      .processInstanceIds(processInstanceIds)
+      .correlateAllAsync();
+
+    rule.executeSeedJobs(batch);
+
+    // then
+    List<Job> executionJobs = rule.getExecutionJobs(batch);
+    assertThat(executionJobs)
+      .extracting("processInstanceId")
+      .containsOnlyNulls();
+
+    // clear
+    managementService.deleteBatch(batch.getId(), true);
+  }
+
+  protected void deployProcessIntermediateMessageTwo() {
+    BpmnModelInstance process = Bpmn.createExecutableProcess(PROCESS_TWO_KEY)
+      .startEvent()
+      .intermediateCatchEvent()
+      .message(MESSAGE_TWO_REF)
+      .userTask("task")
+      .endEvent()
+      .done();
+    engineTestRule.deploy(process);
+  }
+
+  protected void deployProcessStartMessageOne() {
+    BpmnModelInstance process = Bpmn.createExecutableProcess(PROCESS_THREE_KEY)
+      .startEvent()
+      .message(MESSAGE_ONE_REF)
+      .userTask("task")
+      .endEvent()
+      .done();
+    engineTestRule.deploy(process);
+  }
+
+}


### PR DESCRIPTION
* adds RuntimeService method for asynchronous message correlation to multiple
  process instances
* adds asynchronous message correlation builder
* enables `executionsOnly` message correlation internally (no public API)
* adds message correlation batch resources (job handler, batch type,
  permissions, JSON converter)
* enables the batch jobs to be scheduled exclusively by the job executor
  by adding a process instance id to the jobs if they correlate to exactly
  one process instance each

related to CAM-13863, CAM-13819