### PR TITLE
fix(cockpit): remove hidden blocking tooltips

### DIFF
--- a/webapps/ui/cockpit/client/scripts/components/callActivityOverlays/callActivityOverlay.js
+++ b/webapps/ui/cockpit/client/scripts/components/callActivityOverlays/callActivityOverlay.js
@@ -156,7 +156,6 @@ function addInteractions(
 
   if (redirectionTarget) {
     button.on('click', () => {
-      buttonOverlay.tooltip('hide');
       clickListener(redirectionTarget);
     });
   } else {
@@ -165,9 +164,11 @@ function addInteractions(
     buttonOverlay.css('cursor', 'not-allowed');
   }
 
-  // clear listeners
   $scope.$on('$destroy', function() {
+    // as these buttons happen outside of angular,
+    // we need to clean up listeners and tooltip once we leave to avoid memory leaks
     button.off('click');
+    buttonOverlay.tooltip('destroy');
     buttonOverlay.off('mouseenter mouseleave');
     diagramNode.off('mouseenter mouseleave');
   });


### PR DESCRIPTION
* remove tooltips when clicking on call activity navigation. These tooltips might otherwise block overlays if they are only hidden.
Related to CAM-13887