### PR TITLE
chore(distro/wildfly): Preparation for Wildfly-25 support

### DIFF
--- a/distro/wildfly/subsystem/src/main/java/org/camunda/bpm/container/impl/jboss/extension/SubsystemAttributeDefinitons.java
+++ b/distro/wildfly/subsystem/src/main/java/org/camunda/bpm/container/impl/jboss/extension/SubsystemAttributeDefinitons.java
@@ -139,14 +139,14 @@ public class SubsystemAttributeDefinitons {
             .setAttributeMarshaller(CustomMarshaller.OBJECT_AS_ELEMENT)
             .setAttributeParser(AttributeParser.OBJECT_LIST_PARSER)
             .setRequires(ModelConstants.PLUGIN_CLASS)
-            .setAllowNull(true)
+            .setRequired(false)
             .setRestartAllServices()
             .build();
 
     public static final ObjectListAttributeDefinition PLUGINS = ObjectListAttributeDefinition.Builder
             .of(ModelConstants.PLUGINS, PLUGIN)
             .setAttributeMarshaller(CustomMarshaller.OBJECT_LIST)
-            .setAllowNull(true)
+            .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();

--- a/distro/wildfly/subsystem/src/main/java/org/camunda/bpm/container/impl/jboss/util/FixedObjectTypeAttributeDefinition.java
+++ b/distro/wildfly/subsystem/src/main/java/org/camunda/bpm/container/impl/jboss/util/FixedObjectTypeAttributeDefinition.java
@@ -102,8 +102,7 @@ public class FixedObjectTypeAttributeDefinition extends ObjectTypeAttributeDefin
     }
 
     public FixedObjectTypeAttributeDefinition build() {
-      if (validator == null) { validator = new ObjectTypeValidator(allowNull, valueTypes); }
-//      attributeMarshaller = new Object
+      if (getValidator() == null) { setValidator(new ObjectTypeValidator(isAllowNull(), valueTypes)); }
       return new FixedObjectTypeAttributeDefinition(this, suffix, valueTypes);
     }
 
@@ -111,15 +110,5 @@ public class FixedObjectTypeAttributeDefinition extends ObjectTypeAttributeDefin
       this.suffix = suffix;
       return this;
     }
-
-    /*
-   --------------------------
-   added for binary compatibility for running compatibilty tests
-    */
-    @Override
-    public Builder setAllowNull(boolean allowNull) {
-      return super.setAllowNull(allowNull);
-    }
   }
-
 }


### PR DESCRIPTION
related to #cam-13942

Replace calls to setAllowNull(true/false) with setRequired(false/true).
Access fields validator and allowNull by getter method.

With these changes I can run current Camunda build on current WildFly-25.0.0.Beta1-SNAPSHOT.