### PR TITLE
[CAM-13954] Sending Message from External Task to Engine (via specific method)

### DIFF
--- a/clients/java/client/src/main/java/org/camunda/bpm/client/impl/EngineClient.java
+++ b/clients/java/client/src/main/java/org/camunda/bpm/client/impl/EngineClient.java
@@ -28,9 +28,11 @@ import org.camunda.bpm.client.task.impl.dto.ExtendLockRequestDto;
 import org.camunda.bpm.client.task.impl.dto.FailureRequestDto;
 import org.camunda.bpm.client.task.impl.dto.LockRequestDto;
 import org.camunda.bpm.client.topic.impl.dto.FetchAndLockRequestDto;
+import org.camunda.bpm.client.task.impl.dto.SendMessageRequestDto;
 import org.camunda.bpm.client.topic.impl.dto.TopicRequestDto;
 import org.camunda.bpm.client.variable.impl.TypedValueField;
 import org.camunda.bpm.client.variable.impl.TypedValues;
+import org.camunda.bpm.engine.variable.VariableMap;
 
 /**
  * @author Tassilo Weidner
@@ -52,7 +54,7 @@ public class EngineClient {
   public static final String EXECUTION_ID_RESOURCE_PATH = EXECUTION_RESOURCE_PATH + "/" + ID_PATH_PARAM;
   public static final String GET_LOCAL_VARIABLE =  EXECUTION_ID_RESOURCE_PATH + "/localVariables/" + NAME_PATH_PARAM;
   public static final String GET_LOCAL_BINARY_VARIABLE =  GET_LOCAL_VARIABLE + "/data";
-
+  public static final String SEND_MESSAGE =  "/message";
   protected String baseUrl;
   protected String workerId;
   protected int maxTasks;
@@ -111,6 +113,12 @@ public class EngineClient {
     FailureRequestDto payload = new FailureRequestDto(workerId, errorMessage, errorDetails, retries, retryTimeout, typedValueDtoMap, localTypedValueDtoMap);
     String resourcePath = FAILURE_RESOURCE_PATH.replace("{id}", taskId);
     String resourceUrl = baseUrl + resourcePath;
+    engineInteraction.postRequest(resourceUrl, payload, Void.class);
+  }
+
+  public void sendMessage(ExternalTask externalTask, String message, VariableMap correlationKeys, VariableMap processVariables, Boolean all) throws EngineClientException {
+    SendMessageRequestDto payload = new SendMessageRequestDto(workerId,externalTask, message, correlationKeys, processVariables, all);
+    String resourceUrl = baseUrl + SEND_MESSAGE;
     engineInteraction.postRequest(resourceUrl, payload, Void.class);
   }
 

--- a/clients/java/client/src/main/java/org/camunda/bpm/client/task/ExternalTaskService.java
+++ b/clients/java/client/src/main/java/org/camunda/bpm/client/task/ExternalTaskService.java
@@ -21,6 +21,7 @@ import org.camunda.bpm.client.exception.NotAcquiredException;
 import org.camunda.bpm.client.exception.NotFoundException;
 import org.camunda.bpm.client.exception.NotResumedException;
 import org.camunda.bpm.client.exception.ValueMapperException;
+import org.camunda.bpm.engine.variable.VariableMap;
 
 import java.util.Map;
 
@@ -301,5 +302,26 @@ public interface ExternalTaskService {
    * @throws ConnectionLostException if the connection could not be established
    */
   void extendLock(String externalTaskId, long newDuration);
+
+  /**
+   * Send Message
+   *
+   * @param message     which message string that you need to send to engine
+   * @param correlationKeys indicates the master keys for correlation.
+   * @param processVariables provides related variables to the process.
+   * @param all      specifies which params should be send (all or not).
+   *
+   * @throws NotFoundException if the task has been canceled and therefore does not exist anymore
+   * @throws NotAcquiredException if the task's most recent lock could not be acquired
+   * @throws ConnectionLostException if the connection could not be established
+   * @throws ValueMapperException
+   * <ul>
+   *   <li> if an object cannot be serialized
+   *   <li> if no 'objectTypeName' is provided for non-null value
+   *   <li> if value is of type abstract
+   *   <li> if no suitable serializer could be found
+   * </ul>
+   */
+  void sendMessage(ExternalTask externalTask, String message, VariableMap correlationKeys, VariableMap processVariables, Boolean all);
 
 }

--- a/clients/java/client/src/main/java/org/camunda/bpm/client/task/impl/ExternalTaskServiceImpl.java
+++ b/clients/java/client/src/main/java/org/camunda/bpm/client/task/impl/ExternalTaskServiceImpl.java
@@ -23,6 +23,7 @@ import org.camunda.bpm.client.impl.EngineClientException;
 import org.camunda.bpm.client.impl.ExternalTaskClientLogger;
 import org.camunda.bpm.client.task.ExternalTask;
 import org.camunda.bpm.client.task.ExternalTaskService;
+import org.camunda.bpm.engine.variable.VariableMap;
 
 /**
  * @author Tassilo Weidner
@@ -137,6 +138,15 @@ public class ExternalTaskServiceImpl implements ExternalTaskService {
       engineClient.extendLock(externalTaskId, newDuration);
     } catch (EngineClientException e) {
       throw LOG.externalTaskServiceException("extending lock", e);
+    }
+  }
+
+  @Override
+  public void sendMessage(ExternalTask externalTask, String message, VariableMap correlationKeys, VariableMap processVariables, Boolean all) {
+    try {
+      engineClient.sendMessage(externalTask, message, correlationKeys, processVariables, all);
+    } catch (EngineClientException e) {
+      throw LOG.externalTaskServiceException("sending message", e);
     }
   }
 }

--- a/clients/java/client/src/main/java/org/camunda/bpm/client/task/impl/dto/SendMessageRequestDto.java
+++ b/clients/java/client/src/main/java/org/camunda/bpm/client/task/impl/dto/SendMessageRequestDto.java
@@ -1,0 +1,56 @@
+package org.camunda.bpm.client.task.impl.dto;
+
+import org.camunda.bpm.client.impl.RequestDto;
+import org.camunda.bpm.engine.variable.VariableMap;
+import org.camunda.bpm.client.task.ExternalTask;
+
+public class SendMessageRequestDto extends RequestDto {
+    // no contain workerId
+
+    protected String messageName;
+    protected String businessKey;
+    protected String tenantId;
+    protected String processInstanceId;
+    protected VariableMap correlationKeys;
+    protected VariableMap processVariables;
+    protected Boolean all;
+
+    public SendMessageRequestDto(String workerId,ExternalTask externalTask, String messageName, VariableMap correlationKeys, VariableMap processVariables, Boolean all) {
+        super(workerId);
+        this.messageName = messageName;
+        this.businessKey = externalTask.getBusinessKey();
+        this.tenantId = externalTask.getTenantId();
+        this.processInstanceId = externalTask.getProcessInstanceId();
+        this.correlationKeys = correlationKeys;
+        this.processVariables = processVariables;
+        this.all = all;
+    }
+
+    public String getMessageName() {
+        return messageName;
+    }
+
+    public String getBusinessKey() {
+        return businessKey;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public String getProcessInstanceId() {
+        return processInstanceId;
+    }
+
+    public VariableMap getCorrelationKeys() {
+        return correlationKeys;
+    }
+
+    public VariableMap getProcessVariables() {
+        return processVariables;
+    }
+
+    public Boolean getAll() {
+        return all;
+    }
+}


### PR DESCRIPTION
Hello @tasso94 

I hope your are doing well.

According to our [negotiation ](https://jira.camunda.com/browse/CAM-13954)on `JIRA` and forum [link](https://forum.camunda.org/t/sending-message-from-external-task-to-engine-via-specific-method/30059), I have sent a pull request for the point.

I have attached related story as below 

**User Story (Required on creation):**

Following this [post](https://forum.camunda.org/t/sending-message-from-external-task-to-engine-via-specific-method/30059/5), sending a managed message will be important for the end-user client that needs to work with Rest API (between `External task` and `Engine`). Actually, we need a module for sending any kind of message to the `Engine` (from `External Task`) and it seems we could prepare it according to the [suggestion](https://forum.camunda.org/t/how-to-define-a-correlation-key-in-message-intermediate-catching-event/6041/4?u=tahaarian) ( use Rest API for `POST /message`).

**Functional Requirements (Required before implementation):**

The main goal is to send any kind of message (with related variables) between `External tasks` and the `Engine` which is used to communicate or notify some information. it should be done with an `External Task`.

As we describe the point, it will be like a specific method for sending proper messages to the `Engine`. So just we need a new API method.

Thank you so much for your support and great feedbacks.

I will appreciate if you could check the request and let me know if you have any points.

Best Regards,

Taha Arian



