### PR TITLE
chore(run): remove META-INF folder from artifact

### DIFF
--- a/distro/run/distro/assembly.xml
+++ b/distro/run/distro/assembly.xml
@@ -24,6 +24,11 @@
 
     <dependencySet>
       <unpack>true</unpack>
+      <unpackOptions>
+        <excludes>
+          <exclude>**/META-INF/**</exclude>
+        </excludes>
+      </unpackOptions>
       <includes>
         <include>org.camunda.bpm.distro:camunda-sql-scripts:jar:*</include>
       </includes>

--- a/distro/tomcat/distro/assembly.xml
+++ b/distro/tomcat/distro/assembly.xml
@@ -22,6 +22,11 @@
 
     <dependencySet>
       <unpack>true</unpack>
+      <unpackOptions>
+        <excludes>
+          <exclude>**/META-INF/**</exclude>
+        </excludes>
+      </unpackOptions>
       <includes>
         <include>org.camunda.bpm.distro:camunda-sql-scripts:jar:*</include>
       </includes>

--- a/distro/wildfly/distro/assembly.xml
+++ b/distro/wildfly/distro/assembly.xml
@@ -24,6 +24,11 @@
     <dependencySet>
       <outputDirectory />
       <unpack>true</unpack>
+      <unpackOptions>
+        <excludes>
+          <exclude>**/META-INF/**</exclude>
+        </excludes>
+      </unpackOptions>
       <includes>
         <include>org.camunda.bpm.distro:camunda-sql-scripts:jar:*</include>
       </includes>


### PR DESCRIPTION
* removes the `META-INF` folder from the `configuration` folder in the
  final distribution artifacts

related to CAM-13961