### PR TITLE
CAM-13962: exclude Hikari's SLF4J from Jboss standalone webapp

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -304,7 +304,9 @@ pipeline {
         }
         stage('webapp-IT-standalone-tomcat-9') {
           when {
-            branch cambpmDefaultBranch();
+            expression {
+              cambpmWithLabels('tomcat', 'webapp-integration')
+            }
           }
           steps {
             cambpmConditionalRetry([
@@ -322,7 +324,7 @@ pipeline {
         stage('webapp-IT-standalone-wildfly') {
           when {
             expression {
-              cambpmWithLabels('wildfly')
+              cambpmWithLabels('wildfly', 'webapp-integration')
             }
           }
           steps {

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -37,6 +37,17 @@
         <groupId>com.zaxxer</groupId>
         <artifactId>HikariCP</artifactId>
         <version>${version.hikaricp}</version>
+        <exclusions>
+          <!-- When building with Java 8, hikari has a dependency to SLF4j 1.7.
+          When building with Java 11 or higher, Hikari has a dependency to SLF4j 
+          2.0.0-alpha1 instead. We are therefore excluding this dependency here
+          and assume that it comes from other dependencies where it is used 
+          (for example camunda-commons-logging). -->
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>


### PR DESCRIPTION
- this pulled in SLF4J 2.0.0-alpha if built with Java 11 (not with Java 8)
- Our libraries are built and tested with SLF4J 1.7 so we should use that

related to CAM-13962