### PR TITLE
fix(spring-boot-starter): avoid logging `Resource` objects

### DIFF
--- a/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/util/SpringBootProcessEngineLogger.java
+++ b/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/util/SpringBootProcessEngineLogger.java
@@ -22,6 +22,7 @@ import org.camunda.commons.logging.BaseLogger;
 import org.springframework.core.io.Resource;
 
 import java.net.URL;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
related to CAM-13833