### PR TITLE
chore(feel): bump feel scala version

### DIFF
--- a/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/feel/BreakingScalaFeelBehaviorTest.java
+++ b/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/feel/BreakingScalaFeelBehaviorTest.java
@@ -109,8 +109,8 @@ public class BreakingScalaFeelBehaviorTest extends DmnEngineTest {
 
     // then
     thrown.expect(FeelException.class);
-    thrown.expectMessage("failed to parse expression ''Hello World'': " +
-      "Expected (\"not\" | positiveUnaryTests | unaryTests):1:1, found \"'Hello Wor\"");
+    thrown.expectMessage("FEEL/SCALA-01008 Error while evaluating expression: failed to parse expression ''Hello World'': "
+        + "Expected (acceptAnyInputValue | \"not\" | positiveUnaryTests):1:1, found \"'Hello Wor\"");
 
     // when
     engine.evaluateDecision(decision, Variables.createVariables().putValue("input", "Hello World"));

--- a/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/feel/BreakingScalaFeelBehaviorTest.java
+++ b/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/feel/BreakingScalaFeelBehaviorTest.java
@@ -58,7 +58,6 @@ public class BreakingScalaFeelBehaviorTest extends DmnEngineTest {
       .hasSingleEntry(true);
   }
 
-  @Ignore("CAM-11269")
   @Test
   @DecisionResource(resource = "breaking_unary_test_boolean.dmn")
   public void shouldEqualBoolean() {

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <version.camunda.spin>1.11.0</version.camunda.spin>
     <version.camunda.template-engines>2.1.0</version.camunda.template-engines>
     <version.camunda.ee.xslt-plugin>1.1.0</version.camunda.ee.xslt-plugin>
-    <version.feel-scala>1.13.1</version.feel-scala>
+    <version.feel-scala>1.13.3</version.feel-scala>
     <plugin.version.javadoc>3.0.1</plugin.version.javadoc>
   </properties>
 


### PR DESCRIPTION
this fixes an issue with unary-test comparison not being evaluated
without braces

Related to CAM-11269