### PR TITLE
fix(webapps): add SameSite attribute to session cookie

### DIFF
--- a/distro/jbossas7/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/distro/jbossas7/webapp/src/main/webapp/WEB-INF/web.xml
@@ -93,6 +93,20 @@
     <filter-name>CsrfPreventionFilter</filter-name>
     <url-pattern>/*</url-pattern>
   </filter-mapping>
+  
+  <!-- Session Cookie filter -->
+  <filter>
+    <filter-name>SessionCookieFilter</filter-name>
+    <filter-class>org.camunda.bpm.webapp.impl.security.filter.SessionCookieFilter</filter-class>
+    <!--<init-param>-->
+    <!--<param-name>enableSecureCookie</param-name>-->
+    <!--<param-value>true</param-value>-->
+    <!--</init-param>-->
+  </filter>
+  <filter-mapping>
+    <filter-name>SessionCookieFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
 
   <!-- HTTP Header Security Filter -->
   <filter>

--- a/distro/tomcat/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/distro/tomcat/webapp/src/main/webapp/WEB-INF/web.xml
@@ -94,6 +94,20 @@
     <url-pattern>/*</url-pattern>
   </filter-mapping>
 
+  <!-- Session Cookie filter -->
+  <filter>
+    <filter-name>SessionCookieFilter</filter-name>
+    <filter-class>org.camunda.bpm.webapp.impl.security.filter.SessionCookieFilter</filter-class>
+    <!--<init-param>-->
+    <!--<param-name>enableSecureCookie</param-name>-->
+    <!--<param-value>true</param-value>-->
+    <!--</init-param>-->
+  </filter>
+  <filter-mapping>
+    <filter-name>SessionCookieFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
   <!-- HTTP Header Security Filter -->
   <filter>
     <filter-name>HttpHeaderSecurity</filter-name>

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/camunda/bpm/SessionCookieSecurityIT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/camunda/bpm/SessionCookieSecurityIT.java
@@ -47,6 +47,7 @@ public class SessionCookieSecurityIT extends AbstractWebIntegrationTest {
     // then
     assertEquals(200, response.getStatus());
     assertTrue(isCookieHeaderValuePresent("HttpOnly", response));
+    assertTrue(isCookieHeaderValuePresent("SameSite=Lax", response));
     assertFalse(isCookieHeaderValuePresent("Secure", response));
 
     // cleanup

--- a/spring-boot-starter/starter-webapp-core/src/main/java/org/camunda/bpm/spring/boot/starter/webapp/CamundaBpmWebappInitializer.java
+++ b/spring-boot-starter/starter-webapp-core/src/main/java/org/camunda/bpm/spring/boot/starter/webapp/CamundaBpmWebappInitializer.java
@@ -31,6 +31,7 @@ import org.camunda.bpm.tasklist.impl.web.bootstrap.TasklistContainerBootstrap;
 import org.camunda.bpm.webapp.impl.engine.EngineRestApplication;
 import org.camunda.bpm.webapp.impl.security.auth.AuthenticationFilter;
 import org.camunda.bpm.webapp.impl.security.filter.CsrfPreventionFilter;
+import org.camunda.bpm.webapp.impl.security.filter.SessionCookieFilter;
 import org.camunda.bpm.webapp.impl.security.filter.headersec.HttpHeaderSecurityFilter;
 import org.camunda.bpm.webapp.impl.security.filter.util.HttpSessionMutexListener;
 import org.camunda.bpm.webapp.impl.util.ServletContextUtil;
@@ -45,7 +46,6 @@ import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import javax.servlet.FilterRegistration;
 import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
 import javax.servlet.ServletRegistration;
 import javax.servlet.SessionTrackingMode;
 import java.util.Collections;
@@ -98,6 +98,9 @@ public class CamundaBpmWebappInitializer implements ServletContextInitializer {
         applicationPath + "/api/*", applicationPath + "/app/*");
     registerFilter("CsrfPreventionFilter", CsrfPreventionFilter.class,
         webapp.getCsrf().getInitParams(),
+        applicationPath + "/api/*", applicationPath + "/app/*");
+    registerFilter("SessionCookieFilter", SessionCookieFilter.class,
+        webapp.getSessionCookie().getInitParams(),
         applicationPath + "/api/*", applicationPath + "/app/*");
 
     Map<String, String> headerSecurityProperties = webapp

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/SessionCookieIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/SessionCookieIT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.webapp.filter.session.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.HeaderRule;
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.TestApplication;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { TestApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {"server.error.include-message=always"})
+public class SessionCookieIT {
+
+  @Rule
+  public HeaderRule headerRule = new HeaderRule();
+
+  @LocalServerPort
+  public int port;
+
+  @Test
+  public void shouldSetCookieWebapp() {
+    headerRule.performRequest("http://localhost:" + port + "/camunda/app/tasklist/default");
+
+    String sessionCookieValue = headerRule.getSessionCookieValue();
+
+    assertThat(sessionCookieValue).matches(headerRule.getSessionCookieRegex("Lax"));
+  }
+
+  @Test
+  public void shouldSetCookieWebappRest() {
+    headerRule.performRequest("http://localhost:" + port + "/camunda/api/engine/engine/");
+
+    String sessionCookieValue = headerRule.getSessionCookieValue();
+
+    assertThat(sessionCookieValue).matches(headerRule.getSessionCookieRegex("Lax"));
+  }
+
+}

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/CookieNameIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/CookieNameIT.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.webapp.filter.session.it.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.HeaderRule;
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.TestApplication;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { TestApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+  "camunda.bpm.webapp.session-cookie.cookieName=myFancyCookieName",
+  "server.servlet.session.cookie.name=myFancyCookieName"
+})
+public class CookieNameIT {
+
+  @Rule
+  public HeaderRule headerRule = new HeaderRule();
+
+  @LocalServerPort
+  public int port;
+
+  @Test
+  public void shouldChangeCookieName() {
+    // given
+
+    // when
+    headerRule.performRequest("http://localhost:" + port + "/camunda/app/tasklist/default");
+
+    String sessionCookieValue = headerRule.getCookieValue("myFancyCookieName");
+
+    // then
+    assertThat(sessionCookieValue).matches(headerRule.getSessionCookieRegex("myFancyCookieName", "Lax"));
+  }
+
+}

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteCustomValueIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteCustomValueIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.webapp.filter.session.it.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.HeaderRule;
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.TestApplication;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { TestApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+  "camunda.bpm.webapp.session-cookie.sameSiteCookieValue=aCustomValue"
+})
+public class SameSiteCustomValueIT {
+
+  @Rule
+  public HeaderRule headerRule = new HeaderRule();
+
+  @LocalServerPort
+  public int port;
+
+  @Test
+  public void shouldSetSameSiteCookieCustomValue() {
+    headerRule.performRequest("http://localhost:" + port + "/camunda/app/tasklist/default");
+
+    String sessionCookieValue = headerRule.getSessionCookieValue();
+
+    assertThat(sessionCookieValue).matches(headerRule.getSessionCookieRegex("aCustomValue"));
+  }
+
+}

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteDisabledIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteDisabledIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.webapp.filter.session.it.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.HeaderRule;
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.TestApplication;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { TestApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+  "camunda.bpm.webapp.session-cookie.enableSameSiteCookie=false"
+})
+public class SameSiteDisabledIT {
+
+  @Rule
+  public HeaderRule headerRule = new HeaderRule();
+
+  @LocalServerPort
+  public int port;
+
+  @Test
+  public void shouldDisableSameSiteCookie() {
+    headerRule.performRequest("http://localhost:" + port + "/camunda/app/tasklist/default");
+
+    String sessionCookieValue = headerRule.getSessionCookieValue();
+
+    assertThat(sessionCookieValue).matches(headerRule.getSessionCookieRegex(null));
+  }
+
+}

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteEnabledIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteEnabledIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.webapp.filter.session.it.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.HeaderRule;
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.TestApplication;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { TestApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+  "camunda.bpm.webapp.session-cookie.enableSameSiteCookie=true"
+})
+public class SameSiteEnabledIT {
+
+  @Rule
+  public HeaderRule headerRule = new HeaderRule();
+
+  @LocalServerPort
+  public int port;
+
+  @Test
+  public void shouldEnableSameSiteCookie() {
+    headerRule.performRequest("http://localhost:" + port + "/camunda/app/tasklist/default");
+
+    String sessionCookieValue = headerRule.getSessionCookieValue();
+
+    assertThat(sessionCookieValue).matches(headerRule.getSessionCookieRegex("Lax"));
+  }
+
+}

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteOptionLaxIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteOptionLaxIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.webapp.filter.session.it.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.HeaderRule;
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.TestApplication;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { TestApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+  "camunda.bpm.webapp.session-cookie.sameSiteCookieOption=lax"
+})
+public class SameSiteOptionLaxIT {
+
+  @Rule
+  public HeaderRule headerRule = new HeaderRule();
+
+  @LocalServerPort
+  public int port;
+
+  @Test
+  public void shouldSetSameSiteCookieOptionLax() {
+    headerRule.performRequest("http://localhost:" + port + "/camunda/app/tasklist/default");
+
+    String sessionCookieValue = headerRule.getSessionCookieValue();
+
+    assertThat(sessionCookieValue).matches(headerRule.getSessionCookieRegex("Lax"));
+  }
+
+}

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteOptionStrictIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteOptionStrictIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.webapp.filter.session.it.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.HeaderRule;
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.TestApplication;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { TestApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+  "camunda.bpm.webapp.session-cookie.sameSiteCookieOption=strict"
+})
+public class SameSiteOptionStrictIT {
+
+  @Rule
+  public HeaderRule headerRule = new HeaderRule();
+
+  @LocalServerPort
+  public int port;
+
+  @Test
+  public void shouldSetSameSiteCookieOptionStrict() {
+    headerRule.performRequest("http://localhost:" + port + "/camunda/app/tasklist/default");
+
+    String sessionCookieValue = headerRule.getSessionCookieValue();
+
+    assertThat(sessionCookieValue).matches(headerRule.getSessionCookieRegex("Strict"));
+  }
+
+}

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SecureDisabledIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SecureDisabledIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.webapp.filter.session.it.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.HeaderRule;
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.TestApplication;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { TestApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+  "camunda.bpm.webapp.session-cookie.enableSecureCookie=false"
+})
+public class SecureDisabledIT {
+
+  @Rule
+  public HeaderRule headerRule = new HeaderRule();
+
+  @LocalServerPort
+  public int port;
+
+  @Test
+  public void shouldDisableSecureCookie() {
+    headerRule.performRequest("http://localhost:" + port + "/camunda/app/tasklist/default");
+
+    String sessionCookieValue = headerRule.getSessionCookieValue();
+
+    assertThat(sessionCookieValue).matches(headerRule.getSessionCookieRegex("Lax"));
+  }
+
+}

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SecureEnabledIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SecureEnabledIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.webapp.filter.session.it.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.HeaderRule;
+import org.camunda.bpm.spring.boot.starter.webapp.filter.util.TestApplication;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { TestApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+  "camunda.bpm.webapp.session-cookie.enableSecureCookie=true"
+})
+public class SecureEnabledIT {
+
+  @Rule
+  public HeaderRule headerRule = new HeaderRule();
+
+  @LocalServerPort
+  public int port;
+
+  @Test
+  public void shouldEnableSecureCookie() {
+    headerRule.performRequest("http://localhost:" + port + "/camunda/app/tasklist/default");
+
+    String sessionCookieValue = headerRule.getSessionCookieValue();
+
+    assertThat(sessionCookieValue).matches(headerRule.getSessionCookieRegex("Lax", true));
+  }
+
+}

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/util/HeaderRule.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/util/HeaderRule.java
@@ -17,6 +17,7 @@
 package org.camunda.bpm.spring.boot.starter.webapp.filter.util;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.rules.ExternalResource;
 
 import java.io.IOException;
@@ -121,6 +122,10 @@ public class HeaderRule extends ExternalResource {
   public String getXsrfCookieValue() {
     return getCookieValue("XSRF-TOKEN");
   }
+  
+  public String getSessionCookieValue() {
+    return getCookieValue("JSESSIONID");
+  }
 
   public String getErrorResponseContent() {
     try {
@@ -146,4 +151,31 @@ public class HeaderRule extends ExternalResource {
     return getHeaders(name) != null;
   }
 
+  public String getSessionCookieRegex(String sameSite) {
+    return getSessionCookieRegex(null, null, sameSite, false);
+  }
+  
+  public String getSessionCookieRegex(String cookieName, String sameSite) {
+    return getSessionCookieRegex(null, cookieName, sameSite, false);
+  }
+  
+  public String getSessionCookieRegex(String sameSite, boolean secure) {
+    return getSessionCookieRegex(null, null, sameSite, secure);
+  }
+  
+  public String getSessionCookieRegex(String path, String cookieNameInput, String sameSite, boolean secure) {
+    String cookieName = StringUtils.isBlank(cookieNameInput) ? "JSESSIONID" : cookieNameInput;
+    StringBuilder regex = new StringBuilder(cookieName + "=.*;\\W*Path=/");
+    if (path != null) {
+      regex.append(path);
+    }
+    regex.append(";\\W*HttpOnly");
+    if (sameSite != null) {
+      regex.append(";\\W*SameSite=").append(sameSite);
+    }
+    if (secure) {
+      regex.append(";\\W*Secure");
+    }
+    return regex.toString();
+  }
 }

--- a/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/SessionCookieProperties.java
+++ b/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/SessionCookieProperties.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.property;
+
+import static org.camunda.bpm.spring.boot.starter.property.CamundaBpmProperties.joinOn;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class SessionCookieProperties {
+
+  protected boolean enableSecureCookie = false;
+  protected boolean enableSameSiteCookie = true;
+  protected String sameSiteCookieOption;
+  protected String sameSiteCookieValue;
+  protected String cookieName;
+
+  public boolean isEnableSecureCookie() {
+    return enableSecureCookie;
+  }
+
+  public void setEnableSecureCookie(boolean enableSecureCookie) {
+    this.enableSecureCookie = enableSecureCookie;
+  }
+
+  public boolean isEnableSameSiteCookie() {
+    return enableSameSiteCookie;
+  }
+
+  public void setEnableSameSiteCookie(boolean enableSameSiteCookie) {
+    this.enableSameSiteCookie = enableSameSiteCookie;
+  }
+
+  public String getSameSiteCookieOption() {
+    return sameSiteCookieOption;
+  }
+
+  public void setSameSiteCookieOption(String sameSiteCookieOption) {
+    this.sameSiteCookieOption = sameSiteCookieOption;
+  }
+
+  public String getSameSiteCookieValue() {
+    return sameSiteCookieValue;
+  }
+
+  public void setSameSiteCookieValue(String sameSiteCookieValue) {
+    this.sameSiteCookieValue = sameSiteCookieValue;
+  }
+  
+  public String getCookieName() {
+    return cookieName;
+  }
+
+  public void setCookieName(String cookieName) {
+    this.cookieName = cookieName;
+  }
+
+  public Map<String, String> getInitParams() {
+    Map<String, String> initParams = new HashMap<>();
+
+    if (enableSecureCookie) { // only add param if it's true; default is false
+      initParams.put("enableSecureCookie", String.valueOf(enableSecureCookie));
+    }
+
+    if (!enableSameSiteCookie) { // only add param if it's false; default is true
+      initParams.put("enableSameSiteCookie", String.valueOf(enableSameSiteCookie));
+    }
+
+    if (StringUtils.isNotBlank(sameSiteCookieOption)) {
+      initParams.put("sameSiteCookieOption", sameSiteCookieOption);
+    }
+
+    if (StringUtils.isNotBlank(sameSiteCookieValue)) {
+      initParams.put("sameSiteCookieValue", sameSiteCookieValue);
+    }
+    
+    if (StringUtils.isNotBlank(cookieName)) {
+      initParams.put("cookieName", cookieName);
+    }
+
+    return initParams;
+  }
+
+  @Override
+  public String toString() {
+    return joinOn(this.getClass())
+      .add("enableSecureCookie='" + enableSecureCookie + '\'')
+      .add("enableSameSiteCookie='" + enableSameSiteCookie + '\'')
+      .add("sameSiteCookieOption='" + sameSiteCookieOption + '\'')
+      .add("sameSiteCookieValue='" + sameSiteCookieValue + '\'')
+      .add("cookieName='" + cookieName + '\'')
+      .toString();
+  }
+}

--- a/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/WebappProperty.java
+++ b/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/WebappProperty.java
@@ -36,6 +36,9 @@ public class WebappProperty {
 
   @NestedConfigurationProperty
   private CsrfProperties csrf = new CsrfProperties();
+  
+  @NestedConfigurationProperty
+  private SessionCookieProperties sessionCookie = new SessionCookieProperties();
 
   @NestedConfigurationProperty
   protected HeaderSecurityProperties headerSecurity = new HeaderSecurityProperties();
@@ -95,6 +98,14 @@ public class WebappProperty {
   public void setCsrf(CsrfProperties csrf) {
     this.csrf = csrf;
   }
+  
+  public SessionCookieProperties getSessionCookie() {
+    return sessionCookie;
+  }
+  
+  public void setSessionCookie(SessionCookieProperties sessionCookie) {
+    this.sessionCookie = sessionCookie;
+  }
 
   public HeaderSecurityProperties getHeaderSecurity() {
     return headerSecurity;
@@ -113,6 +124,7 @@ public class WebappProperty {
       .add("webappPath='" + applicationPath + '\'')
       .add("csrf='" + csrf + '\'')
       .add("headerSecurityProperties='" + headerSecurity + '\'')
+      .add("sessionCookie='" + sessionCookie + '\'')
       .toString();
   }
 }

--- a/webapps/src/main/java/org/camunda/bpm/webapp/impl/security/filter/CsrfPreventionFilter.java
+++ b/webapps/src/main/java/org/camunda/bpm/webapp/impl/security/filter/CsrfPreventionFilter.java
@@ -38,6 +38,7 @@ import javax.servlet.http.HttpSession;
 import javax.ws.rs.core.Response;
 
 import org.camunda.bpm.engine.rest.exception.InvalidRequestException;
+import org.camunda.bpm.webapp.impl.security.filter.util.CookieConstants;
 import org.camunda.bpm.webapp.impl.security.filter.util.CsrfConstants;
 import org.camunda.bpm.webapp.impl.util.ServletContextUtil;
 
@@ -101,11 +102,9 @@ public class CsrfPreventionFilter implements Filter {
 
   private int denyStatus = HttpServletResponse.SC_FORBIDDEN;
 
-  private final Set<String> entryPoints = new HashSet<String>();
+  private final Set<String> entryPoints = new HashSet<>();
 
-  protected String cookieName = CsrfConstants.CSRF_TOKEN_DEFAULT_COOKIE_NAME;
-
-  protected CsrfPreventionCookieConfigurator cookieConfigurator = new CsrfPreventionCookieConfigurator();
+  protected CookieConfigurator cookieConfigurator = new CookieConfigurator();
 
   @Override
   public void init(FilterConfig filterConfig) throws ServletException {
@@ -132,11 +131,6 @@ public class CsrfPreventionFilter implements Filter {
       String customEntryPoints = filterConfig.getInitParameter("entryPoints");
       if (!isBlank(customEntryPoints)) {
         setEntryPoints(customEntryPoints);
-      }
-
-      String cookieName = filterConfig.getInitParameter("cookieName");
-      if (!isBlank(cookieName)) {
-        setCookieName(cookieName);
       }
 
       cookieConfigurator.parseParams(filterConfig);
@@ -265,6 +259,7 @@ public class CsrfPreventionFilter implements Filter {
         if (session.getAttribute(CsrfConstants.CSRF_TOKEN_SESSION_ATTR_NAME) == null) {
           String token = generateCSRFToken();
 
+          String cookieName = cookieConfigurator.getCookieName(CsrfConstants.CSRF_TOKEN_DEFAULT_COOKIE_NAME);
           String csrfCookieValue = cookieName + "=" + token;
 
           String cookiePath = getCookiePath(request);
@@ -274,7 +269,7 @@ public class CsrfPreventionFilter implements Filter {
 
           csrfCookieValue += cookieConfigurator.getConfig();
 
-          response.addHeader(CsrfConstants.CSRF_SET_COOKIE_HEADER_NAME, csrfCookieValue);
+          response.addHeader(CookieConstants.SET_COOKIE_HEADER_NAME, csrfCookieValue);
 
           response.setHeader(CsrfConstants.CSRF_TOKEN_HEADER_NAME, token);
         }
@@ -328,10 +323,6 @@ public class CsrfPreventionFilter implements Filter {
    */
   public void setEntryPoints(String entryPoints) {
     this.entryPoints.addAll(parseURLs(entryPoints));
-  }
-
-  public void setCookieName(String cookieName) {
-    this.cookieName = cookieName;
   }
 
   /**
@@ -452,7 +443,7 @@ public class CsrfPreventionFilter implements Filter {
   }
 
   private Set<String> parseURLs(String urlString) {
-    Set<String> urlSet = new HashSet<String>();
+    Set<String> urlSet = new HashSet<>();
 
     if (urlString != null && !urlString.isEmpty()) {
       String values[] = urlString.split(",");

--- a/webapps/src/main/java/org/camunda/bpm/webapp/impl/security/filter/SessionCookieFilter.java
+++ b/webapps/src/main/java/org/camunda/bpm/webapp/impl/security/filter/SessionCookieFilter.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.webapp.impl.security.filter;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collection;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+import org.camunda.bpm.webapp.impl.security.filter.util.CookieConstants;
+
+public class SessionCookieFilter implements Filter {
+
+  protected CookieConfigurator cookieConfigurator = new CookieConfigurator();
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+    cookieConfigurator.parseParams(filterConfig);
+  }
+
+  @Override
+  public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+      throws IOException, ServletException {
+    if ((servletRequest instanceof HttpServletRequest) && (servletResponse instanceof HttpServletResponse)) {
+      // create a session if none exists yet
+      ((HttpServletRequest) servletRequest).getSession();
+      // execute filter chain with a response wrapper that handles sameSite attributes
+      filterChain.doFilter(servletRequest, new SameSiteResponseProxy((HttpServletResponse) servletResponse));
+    }
+  }
+
+  @Override
+  public void destroy() {
+  }
+
+  private class SameSiteResponseProxy extends HttpServletResponseWrapper {
+
+    private HttpServletResponse response;
+
+    public SameSiteResponseProxy(HttpServletResponse resp) {
+      super(resp);
+      response = resp;
+    }
+
+    @Override
+    public void sendError(int sc) throws IOException {
+      appendSameSiteIfMissing();
+      super.sendError(sc);
+    }
+
+    @Override
+    public void sendError(int sc, String msg) throws IOException {
+      appendSameSiteIfMissing();
+      super.sendError(sc, msg);
+    }
+
+    @Override
+    public void sendRedirect(String location) throws IOException {
+      appendSameSiteIfMissing();
+      super.sendRedirect(location);
+    }
+
+    @Override
+    public PrintWriter getWriter() throws IOException {
+      appendSameSiteIfMissing();
+      return super.getWriter();
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() throws IOException {
+      appendSameSiteIfMissing();
+      return super.getOutputStream();
+    }
+
+    private void appendSameSiteIfMissing() {
+      Collection<String> cookieHeaders = response.getHeaders(CookieConstants.SET_COOKIE_HEADER_NAME);
+      boolean firstHeader = true;
+      String cookieHeaderStart = cookieConfigurator.getCookieName("JSESSIONID") + "=";
+      for (String cookieHeader : cookieHeaders) {
+        if (cookieHeader.startsWith(cookieHeaderStart)) {
+          cookieHeader = cookieConfigurator.getConfig(cookieHeader);
+        } 
+        if (firstHeader) {
+          response.setHeader(CookieConstants.SET_COOKIE_HEADER_NAME, cookieHeader);
+          firstHeader = false;
+        } else {
+          response.addHeader(CookieConstants.SET_COOKIE_HEADER_NAME, cookieHeader);
+        }
+      }
+    }
+  }
+}

--- a/webapps/src/main/java/org/camunda/bpm/webapp/impl/security/filter/util/CookieConstants.java
+++ b/webapps/src/main/java/org/camunda/bpm/webapp/impl/security/filter/util/CookieConstants.java
@@ -21,20 +21,13 @@ import java.util.regex.Pattern;
 /**
  * @author Nikola Koevski
  */
-public final class CsrfConstants {
+public final class CookieConstants {
 
-  public static final String CSRF_SESSION_MUTEX = "CAMUNDA_SESSION_MUTEX";
+  public static final String SET_COOKIE_HEADER_NAME = "Set-Cookie";
 
-  public static final String CSRF_TOKEN_SESSION_ATTR_NAME = "CAMUNDA_CSRF_TOKEN";
+  public static final String SAME_SITE_FIELD_NAME = ";SameSite=";
+  public static final Pattern SAME_SITE_FIELD_NAME_REGEX = Pattern.compile(";\\w*SameSite\\w*=");
 
-  public static final String CSRF_TOKEN_HEADER_NAME = "X-XSRF-TOKEN";
-
-  public static final String CSRF_TOKEN_HEADER_REQUIRED = "Required";
-
-  public static final String CSRF_TOKEN_DEFAULT_COOKIE_NAME = "XSRF-TOKEN";
-
-  public static final Pattern CSRF_NON_MODIFYING_METHODS_PATTERN = Pattern.compile("GET|HEAD|OPTIONS");
-
-  public static final String CSRF_PATH_FIELD_NAME = ";Path=";
-
+  public static final String SECURE_FLAG_NAME = ";Secure";
+  public static final Pattern SECURE_FLAG_NAME_REGEX = Pattern.compile(";\\w*Secure");
 }

--- a/webapps/src/test/java/org/camunda/bpm/webapp/impl/security/filter/SessionCookieTest.java
+++ b/webapps/src/test/java/org/camunda/bpm/webapp/impl/security/filter/SessionCookieTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.webapp.impl.security.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.webapp.impl.util.HeaderRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SessionCookieTest {
+
+  @Rule
+  public HeaderRule headerRule = new HeaderRule();
+
+  @Test
+  public void shouldConfigureDefault() {
+    // given
+    headerRule.startServer("web.xml", "session");
+
+    // when
+    headerRule.performRequest();
+
+    // then
+    assertThat(headerRule.getCookieHeader()).matches(headerRule.getSessionCookieRegex("camunda", "Lax", false));
+  }
+
+  @Test
+  public void shouldConfigureRootContextPath() {
+    // given
+    headerRule.startServer("web.xml", "session", "/");
+
+    // when
+    headerRule.performRequest();
+
+    // then
+    assertThat(headerRule.getCookieHeader()).matches(headerRule.getSessionCookieRegex(null, "Lax", false));
+  }
+
+  @Test
+  public void shouldConfigureSecureEnabled() {
+    // given
+    headerRule.startServer("secure_enabled_web.xml", "session");
+
+    // when
+    headerRule.performRequest();
+
+    // then
+    assertThat(headerRule.getCookieHeader()).matches(headerRule.getSessionCookieRegex("camunda", "Lax", true));
+  }
+
+  @Test
+  public void shouldConfigureSameSiteDisabled() {
+    // given
+    headerRule.startServer("same_site_disabled_web.xml", "session");
+
+    // when
+    headerRule.performRequest();
+
+    // then
+    assertThat(headerRule.getCookieHeader()).matches(headerRule.getSessionCookieRegex("camunda", null, false));
+  }
+
+  @Test
+  public void shouldConfigureSameSiteOptionStrict() {
+    // given
+    headerRule.startServer("same_site_option_strict_web.xml", "session");
+
+    // when
+    headerRule.performRequest();
+
+    // then
+    assertThat(headerRule.getCookieHeader()).matches(headerRule.getSessionCookieRegex("camunda", "Strict", false));
+  }
+
+  @Test
+  public void shouldConfigureSameSiteOptionLax() {
+    // given
+    headerRule.startServer("same_site_option_lax_web.xml", "session");
+
+    // when
+    headerRule.performRequest();
+
+    // then
+    assertThat(headerRule.getCookieHeader()).matches(headerRule.getSessionCookieRegex("camunda", "Lax", false));
+  }
+
+  @Test
+  public void shouldConfigureSameSiteCustomValue() {
+    // given
+    headerRule.startServer("same_site_custom_value_web.xml", "session");
+
+    // when
+    headerRule.performRequest();
+
+    // then
+    assertThat(headerRule.getCookieHeader()).matches(headerRule.getSessionCookieRegex("camunda", "aCustomValue", false));
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenConfiguringBothSameSiteOptionAndValue() {
+    // given
+    headerRule.startServer("same_site_option_value_web.xml", "session");
+
+    // when
+    headerRule.performRequest();
+
+    Throwable expectedException = headerRule.getException();
+
+    // then
+    assertThat(expectedException)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Please either configure sameSiteCookieOption or sameSiteCookieValue.");
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenConfiguringUnknownSameSiteOption() {
+    // given
+    headerRule.startServer("same_site_option_unknown_web.xml", "session");
+
+    // when
+    headerRule.performRequest();
+
+    Throwable expectedException = headerRule.getException();
+
+    // then
+    assertThat(expectedException)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("For sameSiteCookieOption param, please configure one of the following options: [LAX, STRICT]");
+  }
+
+  @Test
+  public void shouldIgnoreCaseOfParamValues() {
+    // given
+    headerRule.startServer("ignore_case_web.xml", "session");
+
+    // when
+    headerRule.performRequest();
+
+    // then
+    assertThat(headerRule.getCookieHeader()).matches(headerRule.getSessionCookieRegex("camunda", "Lax", true));
+  }
+  
+  @Test
+  public void shouldConfigureCookieName() {
+    // given
+    headerRule.startServer("changed_cookie_name_web.xml", "session");
+
+    // when
+    headerRule.performRequest();
+
+    // then
+    assertThat(headerRule.getCookieHeader()).matches(headerRule.getSessionCookieRegex("camunda", "MYCOOKIENAME", "Lax", false));
+  }
+
+  @Test
+  public void shouldConfigureWhenCookieIsSent() {
+    // given
+    headerRule.startServer("web.xml", "session");
+
+    // when
+    headerRule.performRequestWithHeader("Cookie", "JSESSIONID=aToken");
+
+    // then
+    assertThat(headerRule.getCookieHeader()).matches(headerRule.getSessionCookieRegex("camunda", "Lax", false));
+  }
+  
+}

--- a/webapps/src/test/java/org/camunda/bpm/webapp/impl/security/filter/csrf/CsrfPreventionFilterAppPathTest.java
+++ b/webapps/src/test/java/org/camunda/bpm/webapp/impl/security/filter/csrf/CsrfPreventionFilterAppPathTest.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.webapp.impl.security.filter.util.CsrfConstants.CSRF_PATH_FIELD_NAME;
-import static org.camunda.bpm.webapp.impl.security.filter.util.CsrfConstants.CSRF_SET_COOKIE_HEADER_NAME;
+import static org.camunda.bpm.webapp.impl.security.filter.util.CookieConstants.SET_COOKIE_HEADER_NAME;
 
 public class CsrfPreventionFilterAppPathTest extends CsrfPreventionFilterTest {
 
@@ -71,7 +71,7 @@ public class CsrfPreventionFilterAppPathTest extends CsrfPreventionFilterTest {
     applyFilter(nonModifyingRequest, response);
 
     // then
-    String cookieToken = response.getHeader(CSRF_SET_COOKIE_HEADER_NAME);
+    String cookieToken = response.getHeader(SET_COOKIE_HEADER_NAME);
     String headerToken = response.getHeader(CSRF_HEADER_NAME);
 
     assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());

--- a/webapps/src/test/java/org/camunda/bpm/webapp/impl/security/filter/csrf/CsrfPreventionFilterTest.java
+++ b/webapps/src/test/java/org/camunda/bpm/webapp/impl/security/filter/csrf/CsrfPreventionFilterTest.java
@@ -43,7 +43,7 @@ import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.webapp.impl.security.filter.util.CsrfConstants.CSRF_PATH_FIELD_NAME;
-import static org.camunda.bpm.webapp.impl.security.filter.util.CsrfConstants.CSRF_SET_COOKIE_HEADER_NAME;
+import static org.camunda.bpm.webapp.impl.security.filter.util.CookieConstants.SET_COOKIE_HEADER_NAME;
 /**
  * @author Nikola Koevski
  */
@@ -119,7 +119,7 @@ public class CsrfPreventionFilterTest {
   public void testNonModifyingRequestTokenGeneration() throws IOException, ServletException {
     MockHttpServletResponse response = performNonModifyingRequest(nonModifyingRequestUrl, new MockHttpSession());
 
-    String cookieToken = (String) response.getHeader(CSRF_SET_COOKIE_HEADER_NAME);
+    String cookieToken = (String) response.getHeader(SET_COOKIE_HEADER_NAME);
     String headerToken = (String) response.getHeader(CSRF_HEADER_NAME);
 
     Assert.assertNotNull(cookieToken);
@@ -149,7 +149,7 @@ public class CsrfPreventionFilterTest {
     applyFilter(nonModifyingRequest, response);
 
     // then
-    String cookieToken = (String) response.getHeader(CSRF_SET_COOKIE_HEADER_NAME);
+    String cookieToken = (String) response.getHeader(SET_COOKIE_HEADER_NAME);
     String headerToken = (String) response.getHeader(CSRF_HEADER_NAME);
 
     Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());

--- a/webapps/src/test/java/org/camunda/bpm/webapp/impl/util/HeaderRule.java
+++ b/webapps/src/test/java/org/camunda/bpm/webapp/impl/util/HeaderRule.java
@@ -147,5 +147,23 @@ public class HeaderRule extends ExternalResource {
       throw new RuntimeException(e);
     }
   }
+  
+  public String getSessionCookieRegex(String path, String sameSite, boolean secure) {
+    return getSessionCookieRegex(path, "JSESSIONID", sameSite, secure);
+  }
+  
+  public String getSessionCookieRegex(String path, String cookieName, String sameSite, boolean secure) {
+    StringBuilder regex = new StringBuilder(cookieName + "=.*;\\W*Path=/");
+    if (path != null) {
+      regex.append(path);
+    }
+    if (sameSite != null) {
+      regex.append(";\\W*SameSite=").append(sameSite);
+    }
+    if (secure) {
+      regex.append(";\\W*Secure");
+    }
+    return regex.toString();
+  }
 
 }

--- a/webapps/src/test/resources/WEB-INF/session/changed_cookie_name_web.xml
+++ b/webapps/src/test/resources/WEB-INF/session/changed_cookie_name_web.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="2.5"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+  <display-name>Camunda Platform webapp</display-name>
+  
+  <context-param>
+    <param-name>org.eclipse.jetty.servlet.SessionCookie</param-name>
+    <param-value>MYCOOKIENAME</param-value>
+  </context-param>
+
+  <filter>
+    <filter-name>SessionCookieFilter</filter-name>
+    <filter-class>org.camunda.bpm.webapp.impl.security.filter.SessionCookieFilter</filter-class>
+    <init-param>
+      <param-name>cookieName</param-name>
+      <param-value>MYCOOKIENAME</param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>SessionCookieFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+</web-app>

--- a/webapps/src/test/resources/WEB-INF/session/ignore_case_web.xml
+++ b/webapps/src/test/resources/WEB-INF/session/ignore_case_web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="2.5"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+  <display-name>Camunda Platform webapp</display-name>
+
+  <filter>
+    <filter-name>SessionCookieFilter</filter-name>
+    <filter-class>org.camunda.bpm.webapp.impl.security.filter.SessionCookieFilter</filter-class>
+    <init-param>
+      <param-name>enableSecureCookie</param-name>
+      <param-value>trUe</param-value>
+    </init-param>
+    <init-param>
+      <param-name>sameSiteCookieOption</param-name>
+      <param-value>lAx</param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>SessionCookieFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+</web-app>

--- a/webapps/src/test/resources/WEB-INF/session/same_site_custom_value_web.xml
+++ b/webapps/src/test/resources/WEB-INF/session/same_site_custom_value_web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="2.5"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+  <display-name>Camunda Platform webapp</display-name>
+
+  <filter>
+    <filter-name>SessionCookieFilter</filter-name>
+    <filter-class>org.camunda.bpm.webapp.impl.security.filter.SessionCookieFilter</filter-class>
+    <init-param>
+      <param-name>sameSiteCookieValue</param-name>
+      <param-value>aCustomValue</param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>SessionCookieFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+</web-app>

--- a/webapps/src/test/resources/WEB-INF/session/same_site_disabled_web.xml
+++ b/webapps/src/test/resources/WEB-INF/session/same_site_disabled_web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="2.5"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+  <display-name>Camunda Platform webapp</display-name>
+
+  <filter>
+    <filter-name>SessionCookieFilter</filter-name>
+    <filter-class>org.camunda.bpm.webapp.impl.security.filter.SessionCookieFilter</filter-class>
+    <init-param>
+      <param-name>enableSameSiteCookie</param-name>
+      <param-value>false</param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>SessionCookieFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+</web-app>

--- a/webapps/src/test/resources/WEB-INF/session/same_site_option_lax_web.xml
+++ b/webapps/src/test/resources/WEB-INF/session/same_site_option_lax_web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="2.5"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+  <display-name>Camunda Platform webapp</display-name>
+
+  <filter>
+    <filter-name>SessionCookieFilter</filter-name>
+    <filter-class>org.camunda.bpm.webapp.impl.security.filter.SessionCookieFilter</filter-class>
+    <init-param>
+      <param-name>sameSiteCookieOption</param-name>
+      <param-value>lax</param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>SessionCookieFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+</web-app>

--- a/webapps/src/test/resources/WEB-INF/session/same_site_option_strict_web.xml
+++ b/webapps/src/test/resources/WEB-INF/session/same_site_option_strict_web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="2.5"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+  <display-name>Camunda Platform webapp</display-name>
+
+  <filter>
+    <filter-name>SessionCookieFilter</filter-name>
+    <filter-class>org.camunda.bpm.webapp.impl.security.filter.SessionCookieFilter</filter-class>
+    <init-param>
+      <param-name>sameSiteCookieOption</param-name>
+      <param-value>strict</param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>SessionCookieFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+</web-app>

--- a/webapps/src/test/resources/WEB-INF/session/same_site_option_unknown_web.xml
+++ b/webapps/src/test/resources/WEB-INF/session/same_site_option_unknown_web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="2.5"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+  <display-name>Camunda Platform webapp</display-name>
+
+  <filter>
+    <filter-name>SessionCookieFilter</filter-name>
+    <filter-class>org.camunda.bpm.webapp.impl.security.filter.SessionCookieFilter</filter-class>
+    <init-param>
+      <param-name>sameSiteCookieOption</param-name>
+      <param-value>anUnknownOption</param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>SessionCookieFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+</web-app>

--- a/webapps/src/test/resources/WEB-INF/session/same_site_option_value_web.xml
+++ b/webapps/src/test/resources/WEB-INF/session/same_site_option_value_web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="2.5"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+  <display-name>Camunda Platform webapp</display-name>
+
+  <filter>
+    <filter-name>SessionCookieFilter</filter-name>
+    <filter-class>org.camunda.bpm.webapp.impl.security.filter.SessionCookieFilter</filter-class>
+    <init-param>
+      <param-name>sameSiteCookieOption</param-name>
+      <param-value>strict</param-value>
+    </init-param>
+    <init-param>
+      <param-name>sameSiteCookieValue</param-name>
+      <param-value>aCustomValue</param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>SessionCookieFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+</web-app>

--- a/webapps/src/test/resources/WEB-INF/session/secure_enabled_web.xml
+++ b/webapps/src/test/resources/WEB-INF/session/secure_enabled_web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="2.5"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+  <display-name>Camunda Platform webapp</display-name>
+
+  <filter>
+    <filter-name>SessionCookieFilter</filter-name>
+    <filter-class>org.camunda.bpm.webapp.impl.security.filter.SessionCookieFilter</filter-class>
+    <init-param>
+      <param-name>enableSecureCookie</param-name>
+      <param-value>true</param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>SessionCookieFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+</web-app>

--- a/webapps/src/test/resources/WEB-INF/session/web.xml
+++ b/webapps/src/test/resources/WEB-INF/session/web.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="2.5"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+  <display-name>Camunda Platform webapp</display-name>
+
+  <filter>
+    <filter-name>SessionCookieFilter</filter-name>
+    <filter-class>org.camunda.bpm.webapp.impl.security.filter.SessionCookieFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>SessionCookieFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+</web-app>


### PR DESCRIPTION
* adds new SessionCookieFilter to handle session cookie fields;
  "SameSite=Lax" is added by default to the session cookie if no SameSite
  value is present yet
* generalizes CsrfPreventionCookieConfigurator as CookieConfigurator
* adds session cookie configuration options to Spring Boot Starter Webapps
* adds SessionCookieFilter to CE webapps (JBoss/WildFly and Tomcat)

related to CAM-13420