### PR TITLE
feat(engine): add businessKeyIn criterion to hist proc inst query 

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/history-process-instance.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/history-process-instance.ftl
@@ -86,6 +86,11 @@
     "type": "string",
     "desc": "Filter by process instance business key."
   },
+  "processInstanceBusinessKeyIn": {
+    "type": "array",
+    "itemType": "string",
+    "desc": "Filter by a list of business keys. A process instance must have one of the given business keys. Must be a JSON array of Strings."
+  },
 
   "processInstanceBusinessKeyLike": {
     "type": "string",

--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/history-process-instance.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/history-process-instance.ftl
@@ -89,7 +89,7 @@
   "processInstanceBusinessKeyIn": {
     "type": "array",
     "itemType": "string",
-    "desc": "Filter by a list of business keys. A process instance must have one of the given business keys. Must be a JSON array of Strings."
+    "desc": "Filter by a list of business keys. A process instance must have one of the given business keys. ${listTypeDescription}"
   },
 
   "processInstanceBusinessKeyLike": {

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/history/process-instance/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/history/process-instance/get.ftl
@@ -20,7 +20,7 @@
 
     <@lib.parameters
         object = params
-        skip = ["orQueries"] <#-- OR Queries not avaialble in GET -->
+        skip = ["orQueries"] <#-- OR Queries not available in GET -->
         last = true />
 
   ],

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricProcessInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricProcessInstanceQueryDto.java
@@ -58,7 +58,7 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
 
   private static final List<String> VALID_SORT_BY_VALUES;
   static {
-    VALID_SORT_BY_VALUES = new ArrayList<String>();
+    VALID_SORT_BY_VALUES = new ArrayList<>();
     VALID_SORT_BY_VALUES.add(SORT_BY_PROCESS_INSTANCE_ID_VALUE);
     VALID_SORT_BY_VALUES.add(SORT_BY_PROCESS_DEFINITION_ID_VALUE);
     VALID_SORT_BY_VALUES.add(SORT_BY_PROCESS_INSTANCE_BUSINESS_KEY_VALUE);
@@ -80,6 +80,7 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
   private String processDefinitionNameLike;
   private List<String> processDefinitionKeyNotIn;
   private String processInstanceBusinessKey;
+  private List<String> processInstanceBusinessKeyIn;
   private String processInstanceBusinessKeyLike;
   private Boolean rootProcessInstances;
   private Boolean finished;
@@ -179,6 +180,11 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
   @CamundaQueryParam("processInstanceBusinessKey")
   public void setProcessInstanceBusinessKey(String processInstanceBusinessKey) {
     this.processInstanceBusinessKey = processInstanceBusinessKey;
+  }
+
+  @CamundaQueryParam(value = "processInstanceBusinessKeyIn", converter = StringListConverter.class)
+  public void setProcessInstanceBusinessKeyIn(List<String> processInstanceBusinessKeyIn) {
+    this.processInstanceBusinessKeyIn = processInstanceBusinessKeyIn;
   }
 
   @CamundaQueryParam("processInstanceBusinessKeyLike")
@@ -402,7 +408,7 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
       query.processDefinitionKey(processDefinitionKey);
     }
     if (processDefinitionKeys != null && !processDefinitionKeys.isEmpty()) {
-      query.processDefinitionKeyIn(processDefinitionKeys.toArray(new String[processDefinitionKeys.size()]));
+      query.processDefinitionKeyIn(processDefinitionKeys.toArray(new String[0]));
     }
     if (processDefinitionName != null) {
       query.processDefinitionName(processDefinitionName);
@@ -415,6 +421,9 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
     }
     if (processInstanceBusinessKey != null) {
       query.processInstanceBusinessKey(processInstanceBusinessKey);
+    }
+    if (processInstanceBusinessKeyIn != null && !processInstanceBusinessKeyIn.isEmpty()) {
+      query.processInstanceBusinessKeyIn(processInstanceBusinessKeyIn.toArray(new String[0]));
     }
     if (processInstanceBusinessKeyLike != null) {
       query.processInstanceBusinessKeyLike(processInstanceBusinessKeyLike);
@@ -477,7 +486,7 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
       query.caseInstanceId(caseInstanceId);
     }
     if (tenantIds != null && !tenantIds.isEmpty()) {
-      query.tenantIdIn(tenantIds.toArray(new String[tenantIds.size()]));
+      query.tenantIdIn(tenantIds.toArray(new String[0]));
     }
     if (TRUE.equals(withoutTenantId)) {
       query.withoutTenantId();
@@ -523,11 +532,11 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
     }
 
     if (executedActivityIdIn != null && !executedActivityIdIn.isEmpty()) {
-      query.executedActivityIdIn(executedActivityIdIn.toArray(new String[executedActivityIdIn.size()]));
+      query.executedActivityIdIn(executedActivityIdIn.toArray(new String[0]));
     }
 
     if (activeActivityIdIn != null && !activeActivityIdIn.isEmpty()) {
-      query.activeActivityIdIn(activeActivityIdIn.toArray(new String[activeActivityIdIn.size()]));
+      query.activeActivityIdIn(activeActivityIdIn.toArray(new String[0]));
     }
 
     if (executedJobAfter != null) {

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricProcessInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricProcessInstanceRestServiceQueryTest.java
@@ -1123,6 +1123,55 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
   }
 
   @Test
+  public void shouldQueryByBusinessKeyIn() {
+    given()
+        .queryParam("processInstanceBusinessKeyIn", "business-key-one,business-key-two")
+        .then()
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .get(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
+
+    verifyBusinessKeyInListInvocation();
+  }
+
+  @Test
+  public void shouldQueryByBusinessKeyInAsPost() {
+    Map<String, List<String>> parameters = getCompleteBusinessKeyInListQueryParameters();
+
+    given()
+        .contentType(POST_JSON_CONTENT_TYPE)
+        .body(parameters)
+        .then()
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .post(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
+
+    verifyBusinessKeyInListInvocation();
+  }
+
+  protected Map<String, List<String>> getCompleteBusinessKeyInListQueryParameters() {
+    Map<String, List<String>> parameters = new HashMap<>();
+
+    List<String> processInstanceBusinessKeys = new ArrayList<>();
+    processInstanceBusinessKeys.add("business-key-one");
+    processInstanceBusinessKeys.add("business-key-two");
+
+    parameters.put("processInstanceBusinessKeyIn", processInstanceBusinessKeys);
+
+    return parameters;
+  }
+
+  protected void verifyBusinessKeyInListInvocation() {
+    Map<String, List<String>> parameters = getCompleteBusinessKeyInListQueryParameters();
+    List<String> value = parameters.get("processInstanceBusinessKeyIn");
+
+    verify(mockedQuery).processInstanceBusinessKeyIn(value.toArray(new String[0]));
+    verify(mockedQuery).list();
+  }
+
+  @Test
   public void testQueryByProcessDefinitionKeyIn() {
     given()
       .queryParam("processDefinitionKeyIn", "firstProcessDefinitionKey,secondProcessDefinitionKey")

--- a/engine/src/main/java/org/camunda/bpm/engine/history/HistoricProcessInstanceQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/history/HistoricProcessInstanceQuery.java
@@ -73,6 +73,9 @@ public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInsta
   /** Only select historic process instances with the given business key */
   HistoricProcessInstanceQuery processInstanceBusinessKey(String processInstanceBusinessKey);
 
+  /** Only select historic process instances whose business key is in the given set. */
+  HistoricProcessInstanceQuery processInstanceBusinessKeyIn(String... processInstanceBusinessKeyIn);
+
   /**
    * Only select historic process instances which had a business key like the given value.
    *

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessInstanceQueryImpl.java
@@ -357,7 +357,7 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
       String dbType = processEngineConfiguration.getDatabaseType();
 
       for (ProcessInstanceQueryImpl orQuery: queries) {
-        for (QueryVariableValue var : orQuery.queryVariableValues) {
+        for (QueryVariableValue var : orQuery.getQueryVariableValues()) {
           var.initialize(variableSerializers, dbType);
         }
       }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/QueryVariableValue.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/QueryVariableValue.java
@@ -18,6 +18,7 @@ package org.camunda.bpm.engine.impl;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 
 import org.camunda.bpm.engine.impl.variable.serializer.VariableSerializers;
 import org.camunda.bpm.engine.variable.Variables;
@@ -111,4 +112,22 @@ public class QueryVariableValue implements Serializable {
   public void setVariableValueIgnoreCase(boolean variableValueIgnoreCase) {
     this.variableValueIgnoreCase = variableValueIgnoreCase;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    QueryVariableValue that = (QueryVariableValue) o;
+    return local == that.local && variableNameIgnoreCase == that.variableNameIgnoreCase
+        && variableValueIgnoreCase == that.variableValueIgnoreCase && name.equals(that.name) && value.equals(that.value)
+        && operator == that.operator && Objects.equals(valueCondition, that.valueCondition);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, value, operator, local, valueCondition, variableNameIgnoreCase, variableValueIgnoreCase);
+  }
+
 }

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
@@ -329,7 +329,7 @@
        names for the respective conditions (i.e. VI0, VI1, VI2, ...) -->
     <bind name="variableConditionCounter" value="0" />
     <foreach collection="queries" item="query">
-      <foreach collection="query.queryVariableValues" item="value">
+      <foreach collection="query.queryVariableNameToValuesMap">
         LEFT JOIN ${prefix}ACT_HI_VARINST VI${variableConditionCounter}
         ON SELF.PROC_INST_ID_ = VI${variableConditionCounter}.PROC_INST_ID_
         <bind name="variableConditionCounter" value="variableConditionCounter + 1" />
@@ -384,6 +384,13 @@
             </if>
             <if test="query.businessKey != null">
               ${queryType} SELF.BUSINESS_KEY_ = #{query.businessKey}
+            </if>
+            <if test="query.businessKeyIn != null">
+              ${queryType} SELF.BUSINESS_KEY_ in
+              <foreach item="item" index="index" collection="query.businessKeyIn"
+                       open="(" separator="," close=")">
+                #{item}
+              </foreach>
             </if>
             <if test="query.businessKeyLike != null">
               ${queryType} SELF.BUSINESS_KEY_ like #{query.businessKeyLike} ESCAPE ${escapeChar}
@@ -483,18 +490,20 @@
               ${queryType} SELF.PROC_INST_ID_ = (select SUPER_PROCESS_INSTANCE_ID_ from ${prefix}ACT_HI_CASEINST where
               CASE_INST_ID_ = #{query.subCaseInstanceId})
             </if>
-            <foreach collection="query.queryVariableValues" index="index" item="queryVariableValue">
+            <foreach collection="query.queryVariableNameToValuesMap" item="queryVariableValues">
               <bind name="varPrefix" value="'VI' + variableConditionCounter + '.'"/>
-              ${queryType} (${varPrefix}ID_ IS NOT NULL
-              AND 
-              
-              <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.variableNameEqualsCaseInsensitive" />
-              
-              <bind name="varTypeField" value="'VAR_TYPE_'"/>
-              <if test="queryVariableValue.valueConditions != null">
-                and <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.variableValueConditions"/>
-              </if>
-              )
+              <foreach collection="queryVariableValues" item="queryVariableValue">
+                ${queryType} (${varPrefix}ID_ IS NOT NULL
+                AND
+
+                <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.variableNameEqualsCaseInsensitive" />
+
+                <bind name="varTypeField" value="'VAR_TYPE_'"/>
+                <if test="queryVariableValue.valueConditions != null">
+                  and <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.variableValueConditions"/>
+                </if>
+                )
+              </foreach>
               <bind name="variableConditionCounter" value="variableConditionCounter + 1" />
             </foreach>
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricProcessInstanceQueryOrTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricProcessInstanceQueryOrTest.java
@@ -38,6 +38,7 @@ import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.RequiredHistoryLevel;
 import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.engine.variable.Variables;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.junit.After;
@@ -250,6 +251,144 @@ public class HistoricProcessInstanceQueryOrTest {
 
     // then
     assertEquals(2, processInstances.size());
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_1() {
+    // GIVEN
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar")).getProcessInstanceId();
+
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("bar", "foo")).getProcessInstanceId();
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .or()
+          .variableValueEquals("foo", "bar")
+          .variableValueEquals("bar", "foo")
+        .endOr()
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder(processInstanceIdOne, processInstanceIdTwo);
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_2() {
+    // GIVEN
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar").putValue("bar", "foo")).getProcessInstanceId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar").putValue("bar", "foo")).getProcessInstanceId();
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .or()
+          .variableValueEquals("foo", "bar")
+          .variableValueEquals("bar", "foo")
+        .endOr()
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder(processInstanceIdOne, processInstanceIdTwo);
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_3() {
+    // GIVEN
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar")).getProcessInstanceId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar")).getProcessInstanceId();
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .or()
+          .variableValueEquals("foo", "bar")
+        .endOr()
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder(processInstanceIdOne, processInstanceIdTwo);
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_4() {
+    // GIVEN
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar")).getProcessInstanceId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar")).getProcessInstanceId();
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .or()
+          .variableValueEquals("foo", "bar")
+          .variableValueEquals("foo", "bar")
+        .endOr()
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder(processInstanceIdOne, processInstanceIdTwo);
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_5() {
+    // GIVEN
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar")).getProcessInstanceId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar").putValue("bar", 5)).getProcessInstanceId();
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .or()
+          .variableValueEquals("foo", "bar")
+          .variableValueEquals("foo", "baz")
+          .variableValueEquals("bar", 5)
+        .endOr()
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder(processInstanceIdOne, processInstanceIdTwo);
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_6() {
+    // GIVEN
+    runtimeService.startProcessInstanceByKey("oneTaskProcess", Variables.putValue("foo", "bar"));
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar").putValue("bar", 5)).getProcessInstanceId();
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .or()
+          .variableValueEquals("foo", "baz")
+          .variableValueEquals("bar", 5)
+        .endOr()
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder(processInstanceIdTwo);
   }
 
   @Test

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricProcessInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricProcessInstanceTest.java
@@ -1746,6 +1746,248 @@ public class HistoricProcessInstanceTest {
     assertEquals("car", historicVariable.getValue());
   }
 
+  @Test
+  @Deployment(resources = {"org/camunda/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_1() {
+    // GIVEN
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar").putValue("bar", "foo"))
+        .getProcessInstanceId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar").putValue("bar", "foo"))
+        .getProcessInstanceId();
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .variableValueEquals("foo", "bar")
+        .variableValueEquals("bar", "foo")
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder(processInstanceIdOne, processInstanceIdTwo);
+  }
+
+  @Test
+  @Deployment(resources = {"org/camunda/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_2() {
+    // GIVEN
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar").putValue("bar", "foo"))
+        .getProcessInstanceId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar").putValue("bar", "foo"))
+        .getProcessInstanceId();
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .variableValueEquals("foo", "bar")
+        .variableValueEquals("foo", "bar")
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder(processInstanceIdOne, processInstanceIdTwo);
+  }
+
+  @Test
+  @Deployment(resources = {"org/camunda/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_3() {
+    // GIVEN
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar").putValue("bar", "foo"))
+        .getProcessInstanceId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar").putValue("bar", "foo"))
+        .getProcessInstanceId();
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .variableValueEquals("foo", "bar")
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder(processInstanceIdOne, processInstanceIdTwo);
+  }
+
+  @Test
+  @Deployment(resources = {"org/camunda/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_4() {
+    // GIVEN
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar"))
+        .getProcessInstanceId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("bar", "foo"))
+        .getProcessInstanceId();
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .variableValueEquals("foo", "bar")
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder(processInstanceIdOne);
+  }
+
+  @Test
+  @Deployment(resources = {"org/camunda/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_5() {
+    // GIVEN
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("foo", "bar"))
+        .getProcessInstanceId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+        Variables.putValue("bar", "foo"))
+        .getProcessInstanceId();
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .variableValueEquals("foo", "bar")
+        .variableValueEquals("foo", "bar")
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder(processInstanceIdOne);
+  }
+
+  @Test
+  @Deployment(resources = {"org/camunda/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_6() {
+    // GIVEN
+    runtimeService.startProcessInstanceByKey("oneTaskProcess", Variables.putValue("foo", "bar"));
+    runtimeService.startProcessInstanceByKey("oneTaskProcess", Variables.putValue("bar", "foo"));
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .variableValueEquals("foo", "bar")
+        .variableValueEquals("bar", "foo")
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder();
+  }
+
+  @Test
+  @Deployment(resources = {"org/camunda/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_7() {
+    // GIVEN
+    runtimeService.startProcessInstanceByKey("oneTaskProcess", Variables.putValue("foo", "foo"));
+    runtimeService.startProcessInstanceByKey("oneTaskProcess", Variables.putValue("bar", "foo"));
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .variableValueEquals("foo", "bar")
+        .variableValueEquals("foo", "foo")
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder();
+  }
+
+  @Test
+  @Deployment(resources = {"org/camunda/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_8() {
+    // GIVEN
+    runtimeService.startProcessInstanceByKey("oneTaskProcess", Variables.putValue("foo", "foo"));
+    runtimeService.startProcessInstanceByKey("oneTaskProcess", Variables.putValue("foo", "bar"));
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .variableValueEquals("foo", "bar")
+        .variableValueEquals("foo", "foo")
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder();
+  }
+
+  @Test
+  @Deployment(resources = {"org/camunda/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_9() {
+    // GIVEN
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey("oneTaskProcess", "a-business-key").getProcessInstanceId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey("oneTaskProcess", "another-business-key").getProcessInstanceId();
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .processInstanceBusinessKeyIn("a-business-key", "another-business-key")
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder(processInstanceIdOne, processInstanceIdTwo);
+  }
+
+  @Test
+  @Deployment(resources = {"org/camunda/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_10() {
+    // GIVEN
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey("oneTaskProcess", "a-business-key").getProcessInstanceId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey("oneTaskProcess").getProcessInstanceId();
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .processInstanceBusinessKeyIn("a-business-key", "another-business-key")
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder(processInstanceIdOne);
+  }
+
+  @Test
+  @Deployment(resources = {"org/camunda/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_11() {
+    // GIVEN
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey("oneTaskProcess", "a-business-key").getProcessInstanceId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey("oneTaskProcess", "a-business-key").getProcessInstanceId();
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .processInstanceBusinessKeyIn("a-business-key")
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder(processInstanceIdOne, processInstanceIdTwo);
+  }
+
+  @Test
+  @Deployment(resources = {"org/camunda/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByVariableValue_12() {
+    // GIVEN
+    String processInstanceIdOne = runtimeService.startProcessInstanceByKey("oneTaskProcess", "a-business-key").getProcessInstanceId();
+    String processInstanceIdTwo = runtimeService.startProcessInstanceByKey("oneTaskProcess", "a-business-key").getProcessInstanceId();
+
+    // WHEN
+    List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
+        .processInstanceBusinessKeyIn("a-business-key", "another-business-key")
+        .list();
+
+    // THEN
+    assertThat(processInstances)
+        .extracting("processInstanceId")
+        .containsExactlyInAnyOrder(processInstanceIdOne, processInstanceIdTwo);
+  }
+
   protected void deployment(String... resources) {
     testHelper.deploy(resources);
   }


### PR DESCRIPTION
* Adds `processInstanceBusinessKeyIn` criterion to `HistoricProcessInstanceQuery` to select historic process instances whose business key is in the given set.
* Reduces SQL complexity for variable value criteria by... 
   * `LEFT JOIN` only for distinct variable names
   * removing condition duplicates

related to CAM-14107