### PR TITLE
feat(selection): limit selection to elements on current plane

### DIFF
--- a/webapps/camunda-commons-ui/lib/widgets/bpmn-viewer/cam-widget-bpmn-viewer.js
+++ b/webapps/camunda-commons-ui/lib/widgets/bpmn-viewer/cam-widget-bpmn-viewer.js
@@ -43,6 +43,7 @@ module.exports = [
         disableNavigation: '&',
         onLoad: '&',
         onClick: '&',
+        onPlaneSet: '&',
         onMouseEnter: '&',
         onMouseLeave: '&',
         bpmnJsConf: '=?'
@@ -442,9 +443,10 @@ module.exports = [
           }
         }, 500);
 
-        var onPlaneChange = function(e, context) {
+        var onPlaneSet = function(e, context) {
           var newPlane = context.plane;
 
+          $scope.onPlaneSet();
           if (!newPlane) {
             return;
           }
@@ -467,7 +469,7 @@ module.exports = [
           eventBus.on('element.out', onOut);
           eventBus.on('element.mousedown', onMousedown);
           eventBus.on('canvas.viewbox.changed', onViewboxChange);
-          eventBus.on('plane.set', onPlaneChange);
+          eventBus.on('plane.set', onPlaneSet);
         }
 
         function clearEventListeners() {
@@ -477,7 +479,7 @@ module.exports = [
           eventBus.off('element.out', onOut);
           eventBus.off('element.mousedown', onMousedown);
           eventBus.off('canvas.viewbox.changed', onViewboxChange);
-          eventBus.off('plane.set', onPlaneChange);
+          eventBus.off('plane.set', onPlaneSet);
 
           search.updateSilently({
             plane: null

--- a/webapps/camunda-commons-ui/lib/widgets/bpmn-viewer/cam-widget-bpmn-viewer.less
+++ b/webapps/camunda-commons-ui/lib/widgets/bpmn-viewer/cam-widget-bpmn-viewer.less
@@ -1,7 +1,17 @@
 @import (less) "bpmn-js/dist/assets/bpmn-js.css";
-@import (less) "bpmn-js/dist/assets/diagram-js.css";
 
 @bpmn-nav-radius: 3px;
+
+// todo(marstamm): remove when bpmn-js supports viewer without diagram-js.css
+.djs-element-hidden {
+  display: none;
+}
+
+.djs-container {
+  --color-blue-205-100-50: hsl(205, 100%, 50%);
+  --color-white: hsl(0, 0%, 100%);
+  --color-black: hsl(0, 0%, 0%);
+}
 
 [cam-widget-bpmn-viewer] {
   border: 1px solid @gray-lighter;

--- a/webapps/ui/cockpit/client/scripts/directives/processDiagram.html
+++ b/webapps/ui/cockpit/client/scripts/directives/processDiagram.html
@@ -1,17 +1,18 @@
 <div ng-if="diagramEnabled" style="position: relative; height: 100%">
-  <div diagram-statistics-loader>
-  </div>
-  <div cam-widget-bpmn-viewer
-    diagram-data='diagramData'
-    key='{{key}}'
-    control='control'
-    on-load='onLoad()'
-    on-click='onClick(element, $event)'
-    on-mouse-enter='onMouseEnter(element, $event)'
-    on-mouse-leave='onMouseLeave(element, $event)'
+  <div diagram-statistics-loader></div>
+  <div
+    cam-widget-bpmn-viewer
+    diagram-data="diagramData"
+    key="{{key}}"
+    control="control"
+    on-load="onLoad()"
+    on-click="onClick(element, $event)"
+    on-plane-set="onPlaneSet()"
+    on-mouse-enter="onMouseEnter(element, $event)"
+    on-mouse-leave="onMouseLeave(element, $event)"
     bpmn-js-conf="bpmnJsConf"
-    style='height: 100%'>
-  </div>
+    style="height: 100%"
+  ></div>
 </div>
 <div ng-if="!diagramEnabled" class="placeholder-container">
   <div class="placeholder-content">

--- a/webapps/ui/cockpit/client/scripts/directives/processDiagram.js
+++ b/webapps/ui/cockpit/client/scripts/directives/processDiagram.js
@@ -123,7 +123,11 @@ var DirectiveController = [
 
     $scope.onClick = function(element, $event) {
       safeApply(function() {
+        // don't select invisible elements (process, collaboration, subprocess-plane)
+        var isRoot = !element.parent;
+
         if (
+          !isRoot &&
           bpmnElements[element.businessObject.id] &&
           isElementSelectable(bpmnElements[element.businessObject.id])
         ) {
@@ -269,6 +273,15 @@ var DirectiveController = [
       selection = newSelection;
     }
 
+    $scope.onPlaneSet = function() {
+      var canvas = $scope.control.getViewer().get('canvas');
+      var activePlane = canvas.getActivePlane();
+      var elementsOnPlane =
+        selection?.filter(el => canvas.findPlane(el) === activePlane) || [];
+
+      $scope.callbacks?.handlePlaneChange?.(elementsOnPlane, canvas);
+    };
+
     /*------------------- Handle scroll to bpmn element ---------------------*/
 
     $scope.$watch('selection.scrollToBpmnElement', function(newValue) {
@@ -304,6 +317,7 @@ var Directive = function() {
       processDiagramOverlay: '=',
       onElementClick: '&',
       selection: '=',
+      callbacks: '=',
       processData: '=',
       pageData: '=',
       overlayProviderComponent: '@',

--- a/webapps/ui/cockpit/client/scripts/pages/process-definition.html
+++ b/webapps/ui/cockpit/client/scripts/pages/process-definition.html
@@ -157,6 +157,7 @@
              key="{{processDefinition.id}}"
              on-element-click="handleBpmnElementSelection(id, $event)"
              selection="filter"
+             callbacks="callbacks"
              process-data="processData"
              page-data="pageData"
              collapsed="diagramCollapsed"

--- a/webapps/ui/cockpit/client/scripts/pages/process-instance.html
+++ b/webapps/ui/cockpit/client/scripts/pages/process-instance.html
@@ -183,6 +183,7 @@
         <div process-diagram="processDiagram"
              key="{{processInstance.definitionId}}"
              on-element-click="handleBpmnElementSelection(id, $event)"
+             callbacks="callbacks"
              selection="filter"
              process-data="processData"
              page-data="pageData"

--- a/webapps/ui/cockpit/client/scripts/pages/processDefinition.js
+++ b/webapps/ui/cockpit/client/scripts/pages/processDefinition.js
@@ -86,6 +86,16 @@ var Controller = [
       }
     };
 
+    $scope.callbacks = {
+      handlePlaneChange: function(selectionOnPlane) {
+        var newFilter = angular.copy($scope.filter);
+
+        newFilter.activityIds = selectionOnPlane || [];
+
+        processData.set('filter', newFilter);
+      }
+    };
+
     // utilities ///////////////////////
     $scope.hovered = null;
     $scope.hoverTitle = function(id) {

--- a/webapps/ui/cockpit/client/scripts/pages/processInstance.js
+++ b/webapps/ui/cockpit/client/scripts/pages/processInstance.js
@@ -675,6 +675,25 @@ var Controller = [
       component: 'cockpit.processInstance.runtime.action'
     });
 
+    $scope.callbacks = {
+      handlePlaneChange: function(selectionOnPlane, canvas) {
+        var newFilter = angular.copy($scope.filter);
+
+        newFilter.activityIds = selectionOnPlane || [];
+
+        newFilter.activityInstanceIds = $scope.filter.activityInstanceIds.filter(
+          instanceId => {
+            var instance = $scope.instanceIdToInstanceMap[instanceId];
+            return (
+              canvas.getActivePlane() === canvas.findPlane(instance.activityId)
+            );
+          }
+        );
+
+        processData.set('filter', newFilter);
+      }
+    };
+
     Data.instantiateProviders('cockpit.processInstance.data', {
       $scope: $scope,
       processData: processData


### PR DESCRIPTION
related to CAM-14099
based on https://github.com/camunda/camunda-bpm-platform/pull/1655

You might wonder "why are we wrapping the callbacks in an Object instead of passing it directly?" - and you would be right.
AngularJS defeated me and I could not figure it out. When passing the function directly, it was called, but the arguments were lost along the way. I have no Idea what AngularJS is doing and at this point, I just wrapped it to get a behavior I could understand