### PR TITLE
test(qa/migration): fix assertions of hist details `#isInitial` flags

### DIFF
--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7130/restart/RestartProcessIntanceWithInitialVariablesTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7130/restart/RestartProcessIntanceWithInitialVariablesTest.java
@@ -97,7 +97,7 @@ public class RestartProcessIntanceWithInitialVariablesTest {
         .processInstanceId(restartedProcessInstance.getId())
         .singleResult();
     assertNotNull(detail);
-    assertFalse(detail.isInitial());
+    assertTrue(detail.isInitial());
     assertEquals("initial1", detail.getVariableName());
     assertEquals("value1", detail.getTextValue());
   }
@@ -162,7 +162,7 @@ public class RestartProcessIntanceWithInitialVariablesTest {
 
     for (HistoricDetail historicDetail : details) {
       HistoricVariableUpdateEventEntity detail = (HistoricVariableUpdateEventEntity) historicDetail;
-      assertFalse(detail.isInitial());
+      assertTrue(detail.isInitial());
     }
   }
 
@@ -228,6 +228,6 @@ public class RestartProcessIntanceWithInitialVariablesTest {
         .processInstanceId(restartedProcessInstance.getId())
         .singleResult();
 
-    assertFalse(detail.isInitial());
+    assertTrue(detail.isInitial());
   }
 }


### PR DESCRIPTION
The `isInitial` flag for historical details of set variables is always set to `true` during the start phase.

related to CAM-14007