### PR TITLE
chore(spring-boot-starter): disable cache for specific ITs

### DIFF
--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/csrf/it/properties/CookieNameIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/csrf/it/properties/CookieNameIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -34,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestPropertySource(properties = {
   "camunda.bpm.webapp.csrf.cookieName=myFancyCookieName"
 })
+@DirtiesContext
 public class CookieNameIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/csrf/it/properties/SameSiteCustomValueIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/csrf/it/properties/SameSiteCustomValueIT.java
@@ -24,10 +24,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import java.net.URLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestPropertySource(properties = {
   "camunda.bpm.webapp.csrf.sameSiteCookieValue=aCustomValue"
 })
+@DirtiesContext
 public class SameSiteCustomValueIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/csrf/it/properties/SameSiteDisabledIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/csrf/it/properties/SameSiteDisabledIT.java
@@ -24,10 +24,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import java.net.URLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestPropertySource(properties = {
   "camunda.bpm.webapp.csrf.enableSameSiteCookie=false"
 })
+@DirtiesContext
 public class SameSiteDisabledIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/csrf/it/properties/SameSiteEnabledIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/csrf/it/properties/SameSiteEnabledIT.java
@@ -24,10 +24,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import java.net.URLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestPropertySource(properties = {
   "camunda.bpm.webapp.csrf.enableSameSiteCookie=true"
 })
+@DirtiesContext
 public class SameSiteEnabledIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/csrf/it/properties/SameSiteOptionLaxIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/csrf/it/properties/SameSiteOptionLaxIT.java
@@ -24,10 +24,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import java.net.URLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestPropertySource(properties = {
   "camunda.bpm.webapp.csrf.sameSiteCookieOption=lax"
 })
+@DirtiesContext
 public class SameSiteOptionLaxIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/csrf/it/properties/SameSiteOptionStrictIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/csrf/it/properties/SameSiteOptionStrictIT.java
@@ -24,10 +24,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import java.net.URLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestPropertySource(properties = {
   "camunda.bpm.webapp.csrf.sameSiteCookieOption=strict"
 })
+@DirtiesContext
 public class SameSiteOptionStrictIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/csrf/it/properties/SecureDisabledIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/csrf/it/properties/SecureDisabledIT.java
@@ -24,10 +24,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import java.net.URLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestPropertySource(properties = {
   "camunda.bpm.webapp.csrf.enableSecureCookie=false"
 })
+@DirtiesContext
 public class SecureDisabledIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/csrf/it/properties/SecureEnabledIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/csrf/it/properties/SecureEnabledIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -36,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestPropertySource(properties = {
   "camunda.bpm.webapp.csrf.enableSecureCookie=true"
 })
+@DirtiesContext
 public class SecureEnabledIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/headersec/it/properties/HttpHeaderSecurityAbsenceIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/headersec/it/properties/HttpHeaderSecurityAbsenceIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -37,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
   "camunda.bpm.webapp.headerSecurity.contentTypeOptionsDisabled=true",
   "camunda.bpm.webapp.headerSecurity.hstsDisabled=true"
 })
+@DirtiesContext
 public class HttpHeaderSecurityAbsenceIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/headersec/it/properties/HttpHeaderSecurityPresenceIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/headersec/it/properties/HttpHeaderSecurityPresenceIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -37,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
   "camunda.bpm.webapp.headerSecurity.contentTypeOptionsDisabled=false",
   "camunda.bpm.webapp.headerSecurity.hstsDisabled=false"
 })
+@DirtiesContext
 public class HttpHeaderSecurityPresenceIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/headersec/it/properties/HttpHeaderSecurityValueIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/headersec/it/properties/HttpHeaderSecurityValueIT.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -38,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
   "camunda.bpm.webapp.headerSecurity.hstsDisabled=false",
   "camunda.bpm.webapp.headerSecurity.hstsValue=aValue"
 })
+@DirtiesContext
 public class HttpHeaderSecurityValueIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/CookieNameIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/CookieNameIT.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -34,6 +35,7 @@ import org.springframework.test.context.junit4.SpringRunner;
   "camunda.bpm.webapp.session-cookie.cookieName=myFancyCookieName",
   "server.servlet.session.cookie.name=myFancyCookieName"
 })
+@DirtiesContext
 public class CookieNameIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteCustomValueIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteCustomValueIT.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -33,6 +34,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @TestPropertySource(properties = {
   "camunda.bpm.webapp.session-cookie.sameSiteCookieValue=aCustomValue"
 })
+@DirtiesContext
 public class SameSiteCustomValueIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteDisabledIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteDisabledIT.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -33,6 +34,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @TestPropertySource(properties = {
   "camunda.bpm.webapp.session-cookie.enableSameSiteCookie=false"
 })
+@DirtiesContext
 public class SameSiteDisabledIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteEnabledIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteEnabledIT.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -33,6 +34,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @TestPropertySource(properties = {
   "camunda.bpm.webapp.session-cookie.enableSameSiteCookie=true"
 })
+@DirtiesContext
 public class SameSiteEnabledIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteOptionLaxIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteOptionLaxIT.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -33,6 +34,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @TestPropertySource(properties = {
   "camunda.bpm.webapp.session-cookie.sameSiteCookieOption=lax"
 })
+@DirtiesContext
 public class SameSiteOptionLaxIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteOptionStrictIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SameSiteOptionStrictIT.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -33,6 +34,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @TestPropertySource(properties = {
   "camunda.bpm.webapp.session-cookie.sameSiteCookieOption=strict"
 })
+@DirtiesContext
 public class SameSiteOptionStrictIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SecureDisabledIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SecureDisabledIT.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -33,6 +34,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @TestPropertySource(properties = {
   "camunda.bpm.webapp.session-cookie.enableSecureCookie=false"
 })
+@DirtiesContext
 public class SecureDisabledIT {
 
   @Rule

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SecureEnabledIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/camunda/bpm/spring/boot/starter/webapp/filter/session/it/properties/SecureEnabledIT.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -33,6 +34,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @TestPropertySource(properties = {
   "camunda.bpm.webapp.session-cookie.enableSecureCookie=true"
 })
+@DirtiesContext
 public class SecureEnabledIT {
 
   @Rule


### PR DESCRIPTION
* Uses `@DirtiesContext` for ITs that use a specific configuration
  that is never reused. This way, the cache and therefore also the
  memory footprint are kept smaller

related to CAM-14143