### PR TITLE
CAM-14153: let parse listeners modify form key via task definition

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/GetFormKeyCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/GetFormKeyCmd.java
@@ -21,6 +21,7 @@ import org.camunda.bpm.engine.delegate.Expression;
 import org.camunda.bpm.engine.impl.cfg.CommandChecker;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.context.Context;
+import org.camunda.bpm.engine.impl.form.FormDefinition;
 import org.camunda.bpm.engine.impl.form.handler.DefaultStartFormHandler;
 import org.camunda.bpm.engine.impl.form.handler.DelegateStartFormHandler;
 import org.camunda.bpm.engine.impl.form.handler.FormHandler;
@@ -79,21 +80,8 @@ public class GetFormKeyCmd implements Command<String> {
 
     if (taskDefinitionKey == null) {
 
-      // TODO: Maybe add getFormKey() to FormHandler interface to avoid the following cast
-      FormHandler formHandler = processDefinition.getStartFormHandler();
-
-      if (formHandler instanceof DelegateStartFormHandler) {
-        DelegateStartFormHandler delegateFormHandler = (DelegateStartFormHandler) formHandler;
-        formHandler = delegateFormHandler.getFormHandler();
-      }
-
-      // Sorry!!! In case of a custom start form handler (which does not extend
-      // the DefaultFormHandler) a formKey would never be returned. So a custom
-      // form handler (for a startForm) has always to extend the DefaultStartFormHandler!
-      if (formHandler instanceof DefaultStartFormHandler) {
-        DefaultStartFormHandler startFormHandler = (DefaultStartFormHandler) formHandler;
-        formKeyExpression = startFormHandler.getFormKey();
-      }
+      FormDefinition formDefinition = processDefinition.getStartFormDefinition();
+      formKeyExpression = formDefinition.getFormKey();
 
     } else {
       TaskDefinition taskDefinition = processDefinition.getTaskDefinitions().get(taskDefinitionKey);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/form/FormDefinition.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/form/FormDefinition.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.form;
+
+import org.camunda.bpm.engine.delegate.Expression;
+
+public class FormDefinition {
+
+  protected Expression formKey;
+  // camunda form definition
+  protected Expression camundaFormDefinitionKey;
+  protected String camundaFormDefinitionBinding;
+  protected Expression camundaFormDefinitionVersion;
+
+  public Expression getFormKey() {
+    return formKey;
+  }
+  public void setFormKey(Expression formKey) {
+    this.formKey = formKey;
+  }
+  public Expression getCamundaFormDefinitionKey() {
+    return camundaFormDefinitionKey;
+  }
+  public void setCamundaFormDefinitionKey(Expression camundaFormDefinitionKey) {
+    this.camundaFormDefinitionKey = camundaFormDefinitionKey;
+  }
+  public String getCamundaFormDefinitionBinding() {
+    return camundaFormDefinitionBinding;
+  }
+  public void setCamundaFormDefinitionBinding(String camundaFormDefinitionBinding) {
+    this.camundaFormDefinitionBinding = camundaFormDefinitionBinding;
+  }
+  public Expression getCamundaFormDefinitionVersion() {
+    return camundaFormDefinitionVersion;
+  }
+  public void setCamundaFormDefinitionVersion(Expression camundaFormDefinitionVersion) {
+    this.camundaFormDefinitionVersion = camundaFormDefinitionVersion;
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/form/handler/DefaultFormHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/form/handler/DefaultFormHandler.java
@@ -31,6 +31,7 @@ import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.el.ExpressionManager;
 import org.camunda.bpm.engine.impl.form.FormDataImpl;
+import org.camunda.bpm.engine.impl.form.FormDefinition;
 import org.camunda.bpm.engine.impl.form.type.AbstractFormFieldType;
 import org.camunda.bpm.engine.impl.form.type.FormTypes;
 import org.camunda.bpm.engine.impl.form.validator.FormFieldValidator;
@@ -68,13 +69,6 @@ public class DefaultFormHandler implements FormHandler {
   protected String deploymentId;
   protected String businessKeyFieldId;
 
-  protected Expression formKey;
-
-  // Camunda Form Definition
-  protected Expression camundaFormDefinitionKey;
-  protected String camundaFormDefinitionBinding;
-  protected Expression camundaFormDefinitionVersion;
-
   protected List<FormPropertyHandler> formPropertyHandlers = new ArrayList<>();
 
   protected List<FormFieldHandler> formFieldHandlers = new ArrayList<>();
@@ -94,35 +88,6 @@ public class DefaultFormHandler implements FormHandler {
 
       // provide support for new form field metadata
       parseFormData(bpmnParse, expressionManager, extensionElement);
-    }
-
-    String formKeyAttribute = activityElement.attributeNS(BpmnParse.CAMUNDA_BPMN_EXTENSIONS_NS, "formKey");
-    String formRefAttribute = activityElement.attributeNS(BpmnParse.CAMUNDA_BPMN_EXTENSIONS_NS, "formRef");
-
-    if(formKeyAttribute != null && formRefAttribute != null) {
-      bpmnParse.addError("Invalid element definition: only one of the attributes formKey and formRef is allowed.", activityElement);
-    }
-
-    if (formKeyAttribute != null) {
-      this.formKey = expressionManager.createExpression(formKeyAttribute);
-    } else if(formRefAttribute != null) {
-      // formRef
-      this.camundaFormDefinitionKey = expressionManager.createExpression(formRefAttribute);
-      // formRefBinding
-      String formRefBindingAttribute = activityElement.attributeNS(BpmnParse.CAMUNDA_BPMN_EXTENSIONS_NS,
-          "formRefBinding");
-      if (formRefBindingAttribute == null || !ALLOWED_FORM_REF_BINDINGS.contains(formRefBindingAttribute)) {
-        bpmnParse.addError("Invalid element definition: value for formRefBinding attribute has to be one of "
-            + ALLOWED_FORM_REF_BINDINGS + " but was " + formRefBindingAttribute, activityElement);
-      }
-      this.camundaFormDefinitionBinding = formRefBindingAttribute;
-
-      // formRefVersion
-      if (FORM_REF_BINDING_VERSION.equals(formRefBindingAttribute)) {
-        String formRefVersionAttribute = activityElement.attributeNS(BpmnParse.CAMUNDA_BPMN_EXTENSIONS_NS,
-            "formRefVersion");
-        this.camundaFormDefinitionVersion = expressionManager.createExpression(formRefVersionAttribute);
-      }
     }
   }
 
@@ -422,19 +387,4 @@ public class DefaultFormHandler implements FormHandler {
     this.businessKeyFieldId = businessKeyFieldId;
   }
 
-  public Expression getFormKey() {
-    return formKey;
-  }
-
-  public Expression getCamundaFormDefinitionKey() {
-    return camundaFormDefinitionKey;
-  }
-
-  public String getCamundaFormDefinitionBinding() {
-    return camundaFormDefinitionBinding;
-  }
-
-  public Expression getCamundaFormDefinitionVersion() {
-    return camundaFormDefinitionVersion;
-  }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/form/handler/DefaultStartFormHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/form/handler/DefaultStartFormHandler.java
@@ -16,14 +16,13 @@
  */
 package org.camunda.bpm.engine.impl.form.handler;
 
+import org.camunda.bpm.engine.delegate.Expression;
 import org.camunda.bpm.engine.form.StartFormData;
-import org.camunda.bpm.engine.impl.bpmn.parser.BpmnParse;
 import org.camunda.bpm.engine.impl.form.CamundaFormRefImpl;
+import org.camunda.bpm.engine.impl.form.FormDefinition;
 import org.camunda.bpm.engine.impl.form.StartFormDataImpl;
-import org.camunda.bpm.engine.impl.persistence.entity.DeploymentEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
-import org.camunda.bpm.engine.impl.util.xml.Element;
 import org.camunda.bpm.engine.variable.VariableMap;
 
 
@@ -32,17 +31,14 @@ import org.camunda.bpm.engine.variable.VariableMap;
  */
 public class DefaultStartFormHandler extends DefaultFormHandler implements StartFormHandler {
 
-  @Override
-  public void parseConfiguration(Element activityElement, DeploymentEntity deployment, ProcessDefinitionEntity processDefinition, BpmnParse bpmnParse) {
-    super.parseConfiguration(activityElement, deployment, processDefinition, bpmnParse);
-
-    if (formKey != null) {
-      processDefinition.setStartFormKey(true);
-    }
-  }
-
   public StartFormData createStartFormData(ProcessDefinitionEntity processDefinition) {
     StartFormDataImpl startFormData = new StartFormDataImpl();
+
+    FormDefinition startFormDefinition = processDefinition.getStartFormDefinition();
+    Expression formKey = startFormDefinition.getFormKey();
+    Expression camundaFormDefinitionKey = startFormDefinition.getCamundaFormDefinitionKey();
+    String camundaFormDefinitionBinding = startFormDefinition.getCamundaFormDefinitionBinding();
+    Expression camundaFormDefinitionVersion = startFormDefinition.getCamundaFormDefinitionVersion();
 
     if (formKey != null) {
       startFormData.setFormKey(formKey.getExpressionText());

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/form/handler/DefaultTaskFormHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/form/handler/DefaultTaskFormHandler.java
@@ -16,10 +16,13 @@
  */
 package org.camunda.bpm.engine.impl.form.handler;
 
+import org.camunda.bpm.engine.delegate.Expression;
 import org.camunda.bpm.engine.form.TaskFormData;
 import org.camunda.bpm.engine.impl.form.CamundaFormRefImpl;
+import org.camunda.bpm.engine.impl.form.FormDefinition;
 import org.camunda.bpm.engine.impl.form.TaskFormDataImpl;
 import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
+import org.camunda.bpm.engine.impl.task.TaskDefinition;
 
 
 /**
@@ -30,11 +33,13 @@ public class DefaultTaskFormHandler extends DefaultFormHandler implements TaskFo
   public TaskFormData createTaskForm(TaskEntity task) {
     TaskFormDataImpl taskFormData = new TaskFormDataImpl();
 
-    // for CMMN task the form key has to be set here
-    // for BPMN, the parser will already take care of it
-    if(task.getCaseDefinitionId() != null) {
-      formKey = task.getTaskDefinition().getFormKey();
-    }
+    TaskDefinition taskDefinition = task.getTaskDefinition();
+
+    FormDefinition formDefinition = taskDefinition.getFormDefinition();
+    Expression formKey = formDefinition.getFormKey();
+    Expression camundaFormDefinitionKey = formDefinition.getCamundaFormDefinitionKey();
+    String camundaFormDefinitionBinding = formDefinition.getCamundaFormDefinitionBinding();
+    Expression camundaFormDefinitionVersion = formDefinition.getCamundaFormDefinitionVersion();
 
     if (formKey != null) {
       Object formValue = formKey.getValue(task);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ProcessDefinitionEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ProcessDefinitionEntity.java
@@ -31,6 +31,7 @@ import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.db.DbEntity;
 import org.camunda.bpm.engine.impl.db.EnginePersistenceLogger;
 import org.camunda.bpm.engine.impl.db.HasDbRevision;
+import org.camunda.bpm.engine.impl.form.FormDefinition;
 import org.camunda.bpm.engine.impl.form.handler.StartFormHandler;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.persistence.deploy.cache.DeploymentCache;
@@ -60,6 +61,7 @@ public class ProcessDefinitionEntity extends ProcessDefinitionImpl implements Pr
   protected String resourceName;
   protected Integer historyLevel;
   protected StartFormHandler startFormHandler;
+  protected FormDefinition startFormDefinition;
   protected String diagramResourceName;
   protected boolean isGraphicalNotationDefined;
   protected Map<String, TaskDefinition> taskDefinitions;
@@ -350,6 +352,14 @@ public class ProcessDefinitionEntity extends ProcessDefinitionImpl implements Pr
 
   public void setStartFormHandler(StartFormHandler startFormHandler) {
     this.startFormHandler = startFormHandler;
+  }
+
+  public FormDefinition getStartFormDefinition() {
+    return startFormDefinition;
+  }
+
+  public void setStartFormDefinition(FormDefinition startFormDefinition) {
+    this.startFormDefinition = startFormDefinition;
   }
 
   public Map<String, TaskDefinition> getTaskDefinitions() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/task/TaskDefinition.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/task/TaskDefinition.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.camunda.bpm.engine.delegate.Expression;
 import org.camunda.bpm.engine.delegate.TaskListener;
+import org.camunda.bpm.engine.impl.form.FormDefinition;
 import org.camunda.bpm.engine.impl.form.handler.TaskFormHandler;
 import org.camunda.bpm.engine.impl.util.CollectionUtil;
 
@@ -49,11 +50,7 @@ public class TaskDefinition {
 
   // form fields
   protected TaskFormHandler taskFormHandler;
-  protected Expression formKey;
-  // camunda form definition
-  protected Expression camundaFormDefinitionKey;
-  protected String camundaFormDefinitionBinding;
-  protected Expression camundaFormDefinitionVersion;
+  protected FormDefinition formDefinition = new FormDefinition();
 
   // task listeners
   protected Map<String, List<TaskListener>> taskListeners = new HashMap<>();
@@ -190,35 +187,32 @@ public class TaskDefinition {
     timeoutTaskListeners.put(timeoutId, taskListener);
   }
 
+  public FormDefinition getFormDefinition() {
+    return formDefinition;
+  }
+
+  public void setFormDefinition(FormDefinition formDefinition) {
+    this.formDefinition = formDefinition;
+  }
+
   public Expression getFormKey() {
-    return formKey;
+    return formDefinition.getFormKey();
   }
 
   public void setFormKey(Expression formKey) {
-    this.formKey = formKey;
+    this.formDefinition.setFormKey(formKey);
   }
 
   public Expression getCamundaFormDefinitionKey() {
-    return camundaFormDefinitionKey;
-  }
-
-  public void setCamundaFormDefinitionKey(Expression camundaFormDefinitionKey) {
-    this.camundaFormDefinitionKey = camundaFormDefinitionKey;
+    return formDefinition.getCamundaFormDefinitionKey();
   }
 
   public String getCamundaFormDefinitionBinding() {
-    return camundaFormDefinitionBinding;
-  }
-
-  public void setCamundaFormDefinitionBinding(String camundaFormDefinitionBinding) {
-    this.camundaFormDefinitionBinding = camundaFormDefinitionBinding;
+    return formDefinition.getCamundaFormDefinitionBinding();
   }
 
   public Expression getCamundaFormDefinitionVersion() {
-    return camundaFormDefinitionVersion;
+    return formDefinition.getCamundaFormDefinitionVersion();
   }
 
-  public void setCamundaFormDefinitionVersion(Expression camundaFormDefinitionVersion) {
-    this.camundaFormDefinitionVersion = camundaFormDefinitionVersion;
-  }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/start/StartEventCamundaFormDefinitionParseTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/start/StartEventCamundaFormDefinitionParseTest.java
@@ -22,8 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.camunda.bpm.engine.ParseException;
 import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.camunda.bpm.engine.impl.form.handler.DefaultStartFormHandler;
-import org.camunda.bpm.engine.impl.form.handler.DelegateFormHandler;
+import org.camunda.bpm.engine.impl.form.FormDefinition;
 import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.camunda.bpm.engine.impl.test.TestHelper;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
@@ -61,8 +60,8 @@ public class StartEventCamundaFormDefinitionParseTest {
     }
   }
 
-  protected DefaultStartFormHandler getStartFormHandler() {
-    return (DefaultStartFormHandler) ((DelegateFormHandler)getProcessDefinition().getStartFormHandler()).getFormHandler();
+  protected FormDefinition getStartFormDefinition() {
+    return getProcessDefinition().getStartFormDefinition();
   }
 
 private ProcessDefinitionEntity getProcessDefinition() {
@@ -77,11 +76,11 @@ private ProcessDefinitionEntity getProcessDefinition() {
   public void shouldParseCamundaFormDefinitionVersionBinding() {
     // given a deployed process with a StartEvent containing a Camunda Form definition with version binding
     // then
-    DefaultStartFormHandler startFormHandler = getStartFormHandler();
+    FormDefinition startFormDefinition = getStartFormDefinition();
 
-    assertThat(startFormHandler.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
-    assertThat(startFormHandler.getCamundaFormDefinitionBinding()).isEqualTo("version");
-    assertThat(startFormHandler.getCamundaFormDefinitionVersion().getExpressionText()).isEqualTo("1");
+    assertThat(startFormDefinition.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
+    assertThat(startFormDefinition.getCamundaFormDefinitionBinding()).isEqualTo("version");
+    assertThat(startFormDefinition.getCamundaFormDefinitionVersion().getExpressionText()).isEqualTo("1");
   }
 
   @Test
@@ -89,10 +88,10 @@ private ProcessDefinitionEntity getProcessDefinition() {
   public void shouldParseCamundaFormDefinitionLatestBinding() {
     // given a deployed process with a StartEvent containing a Camunda Form definition with latest binding
     // then
-    DefaultStartFormHandler startFormHandler = getStartFormHandler();
+    FormDefinition startFormDefinition = getStartFormDefinition();
 
-    assertThat(startFormHandler.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
-    assertThat(startFormHandler.getCamundaFormDefinitionBinding()).isEqualTo("latest");
+    assertThat(startFormDefinition.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
+    assertThat(startFormDefinition.getCamundaFormDefinitionBinding()).isEqualTo("latest");
   }
 
   @Test
@@ -100,10 +99,10 @@ private ProcessDefinitionEntity getProcessDefinition() {
   public void shouldParseCamundaFormDefinitionMultipleStartEvents() {
     // given a deployed process with a StartEvent containing a Camunda Form definition with latest binding and another StartEvent inside a subprocess
     // then
-    DefaultStartFormHandler startFormHandler = getStartFormHandler();
+    FormDefinition startFormDefinition = getStartFormDefinition();
 
-    assertThat(startFormHandler.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
-    assertThat(startFormHandler.getCamundaFormDefinitionBinding()).isEqualTo("latest");
+    assertThat(startFormDefinition.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
+    assertThat(startFormDefinition.getCamundaFormDefinitionBinding()).isEqualTo("latest");
   }
 
   @Test
@@ -111,10 +110,10 @@ private ProcessDefinitionEntity getProcessDefinition() {
   public void shouldParseCamundaFormDefinitionDeploymentBinding() {
     // given a deployed process with a StartEvent containing a Camunda Form definition with deployment binding
     // then
-    DefaultStartFormHandler startFormHandler = getStartFormHandler();
+    FormDefinition startFormDefinition = getStartFormDefinition();
 
-    assertThat(startFormHandler.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
-    assertThat(startFormHandler.getCamundaFormDefinitionBinding()).isEqualTo("deployment");
+    assertThat(startFormDefinition.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
+    assertThat(startFormDefinition.getCamundaFormDefinitionBinding()).isEqualTo("deployment");
   }
 
   @Test

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/usertask/UserTaskCamundaFormDefinitionParseTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/usertask/UserTaskCamundaFormDefinitionParseTest.java
@@ -24,8 +24,7 @@ import org.camunda.bpm.engine.ParseException;
 import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.impl.bpmn.behavior.UserTaskActivityBehavior;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.camunda.bpm.engine.impl.form.handler.DefaultTaskFormHandler;
-import org.camunda.bpm.engine.impl.form.handler.DelegateFormHandler;
+import org.camunda.bpm.engine.impl.form.FormDefinition;
 import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
 import org.camunda.bpm.engine.impl.task.TaskDefinition;
@@ -74,26 +73,22 @@ public class UserTaskCamundaFormDefinitionParseTest {
     return cachedProcessDefinition.findActivity(activityId);
   }
 
-  protected DefaultTaskFormHandler getTaskFormHandler(TaskDefinition taskDefinition) {
-    return (DefaultTaskFormHandler) ((DelegateFormHandler)taskDefinition.getTaskFormHandler()).getFormHandler();
-  }
-
   @Test
   @Deployment
   public void shouldParseCamundaFormDefinitionVersionBinding() {
     // given a deployed process with a UserTask containing a Camunda Form definition with version binding
     // then
     TaskDefinition taskDefinition = findUserTaskDefinition("UserTask");
-    DefaultTaskFormHandler taskFormHandler = getTaskFormHandler(taskDefinition);
+    FormDefinition formDefinition = taskDefinition.getFormDefinition();
 
     assertThat(taskDefinition.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
-    assertThat(taskFormHandler.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
+    assertThat(formDefinition.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
 
     assertThat(taskDefinition.getCamundaFormDefinitionBinding()).isEqualTo("version");
-    assertThat(taskFormHandler.getCamundaFormDefinitionBinding()).isEqualTo("version");
+    assertThat(formDefinition.getCamundaFormDefinitionBinding()).isEqualTo("version");
 
     assertThat(taskDefinition.getCamundaFormDefinitionVersion().getExpressionText()).isEqualTo("1");
-    assertThat(taskFormHandler.getCamundaFormDefinitionVersion().getExpressionText()).isEqualTo("1");
+    assertThat(formDefinition.getCamundaFormDefinitionVersion().getExpressionText()).isEqualTo("1");
   }
 
   @Test
@@ -102,13 +97,13 @@ public class UserTaskCamundaFormDefinitionParseTest {
     // given a deployed process with a UserTask containing a Camunda Form definition with latest binding
     // then
     TaskDefinition taskDefinition = findUserTaskDefinition("UserTask");
-    DefaultTaskFormHandler taskFormHandler = getTaskFormHandler(taskDefinition);
+    FormDefinition formDefinition = taskDefinition.getFormDefinition();
 
     assertThat(taskDefinition.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
-    assertThat(taskFormHandler.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
+    assertThat(formDefinition.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
 
     assertThat(taskDefinition.getCamundaFormDefinitionBinding()).isEqualTo("latest");
-    assertThat(taskFormHandler.getCamundaFormDefinitionBinding()).isEqualTo("latest");
+    assertThat(formDefinition.getCamundaFormDefinitionBinding()).isEqualTo("latest");
   }
 
   @Test
@@ -117,13 +112,13 @@ public class UserTaskCamundaFormDefinitionParseTest {
     // given a deployed process with a UserTask containing a Camunda Form definition with deployment binding
     // then
     TaskDefinition taskDefinition = findUserTaskDefinition("UserTask");
-    DefaultTaskFormHandler taskFormHandler = getTaskFormHandler(taskDefinition);
+    FormDefinition formDefinition = taskDefinition.getFormDefinition();
 
     assertThat(taskDefinition.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
-    assertThat(taskFormHandler.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
+    assertThat(formDefinition.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId");
 
     assertThat(taskDefinition.getCamundaFormDefinitionBinding()).isEqualTo("deployment");
-    assertThat(taskFormHandler.getCamundaFormDefinitionBinding()).isEqualTo("deployment");
+    assertThat(formDefinition.getCamundaFormDefinitionBinding()).isEqualTo("deployment");
   }
 
   @Test
@@ -132,24 +127,24 @@ public class UserTaskCamundaFormDefinitionParseTest {
     // given a deployed process with two UserTask containing a Camunda Form definition with deployment binding
     // then
     TaskDefinition taskDefinition1 = findUserTaskDefinition("UserTask_1");
-    DefaultTaskFormHandler taskFormHandler1 = getTaskFormHandler(taskDefinition1);
+    FormDefinition formDefinition1 = taskDefinition1.getFormDefinition();
 
     assertThat(taskDefinition1.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId_1");
-    assertThat(taskFormHandler1.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId_1");
+    assertThat(formDefinition1.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId_1");
 
     assertThat(taskDefinition1.getCamundaFormDefinitionBinding()).isEqualTo("deployment");
-    assertThat(taskFormHandler1.getCamundaFormDefinitionBinding()).isEqualTo("deployment");
+    assertThat(formDefinition1.getCamundaFormDefinitionBinding()).isEqualTo("deployment");
 
     TaskDefinition taskDefinition2 = findUserTaskDefinition("UserTask_2");
-    DefaultTaskFormHandler taskFormHandler2 = getTaskFormHandler(taskDefinition2);
+    FormDefinition formDefinition2 = taskDefinition2.getFormDefinition();
     assertThat(taskDefinition2.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId_2");
-    assertThat(taskFormHandler2.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId_2");
+    assertThat(formDefinition2.getCamundaFormDefinitionKey().getExpressionText()).isEqualTo("formId_2");
 
     assertThat(taskDefinition2.getCamundaFormDefinitionBinding()).isEqualTo("version");
-    assertThat(taskFormHandler2.getCamundaFormDefinitionBinding()).isEqualTo("version");
+    assertThat(formDefinition2.getCamundaFormDefinitionBinding()).isEqualTo("version");
 
     assertThat(taskDefinition2.getCamundaFormDefinitionVersion().getExpressionText()).isEqualTo("2");
-    assertThat(taskFormHandler2.getCamundaFormDefinitionVersion().getExpressionText()).isEqualTo("2");
+    assertThat(formDefinition2.getCamundaFormDefinitionVersion().getExpressionText()).isEqualTo("2");
   }
 
   @Test

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/deploy/BPMNParseListenerTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/deploy/BPMNParseListenerTest.java
@@ -16,22 +16,42 @@
  */
 package org.camunda.bpm.engine.test.standalone.deploy;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.camunda.bpm.engine.FormService;
 import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.form.CamundaFormRef;
+import org.camunda.bpm.engine.form.TaskFormData;
+import org.camunda.bpm.engine.impl.bpmn.behavior.UserTaskActivityBehavior;
+import org.camunda.bpm.engine.impl.bpmn.parser.AbstractBpmnParseListener;
+import org.camunda.bpm.engine.impl.el.Expression;
+import org.camunda.bpm.engine.impl.el.ExpressionManager;
+import org.camunda.bpm.engine.impl.form.FormDefinition;
 import org.camunda.bpm.engine.impl.persistence.entity.ProcessInstanceWithVariablesImpl;
 import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
 import org.camunda.bpm.engine.impl.pvm.process.ProcessDefinitionImpl;
+import org.camunda.bpm.engine.impl.pvm.process.ScopeImpl;
+import org.camunda.bpm.engine.impl.task.TaskDefinition;
+import org.camunda.bpm.engine.impl.util.xml.Element;
+import org.camunda.bpm.engine.repository.DeploymentWithDefinitions;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
-import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.task.Task;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.util.ProcessEngineBootstrapRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
 import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 /**
  * @author Frederik Heremans
@@ -42,8 +62,11 @@ public class BPMNParseListenerTest {
   public static ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule(
       "org/camunda/bpm/engine/test/standalone/deploy/bpmn.parse.listener.camunda.cfg.xml");
 
+  protected ProcessEngineRule engineRule = new ProvidedProcessEngineRule(bootstrapRule);
+  protected ProcessEngineTestRule engineTestRule = new ProcessEngineTestRule(engineRule);
+
   @Rule
-  public ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule(bootstrapRule);
+  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(engineTestRule);
 
   protected RuntimeService runtimeService;
   protected RepositoryService repositoryService;
@@ -54,18 +77,37 @@ public class BPMNParseListenerTest {
     repositoryService = engineRule.getRepositoryService();
   }
 
-  @Deployment
+  @After
+  public void tearDown() {
+    DelegatingBpmnParseListener.DELEGATE = null;
+  }
+
   @Test
   public void testAlterProcessDefinitionKeyWhenDeploying() throws Exception {
+    // given
+    DelegatingBpmnParseListener.DELEGATE = new TestBPMNParseListener();
+
+    // when
+    engineTestRule.deploy("org/camunda/bpm/engine/test/standalone/deploy/"
+        + "BPMNParseListenerTest.testAlterProcessDefinitionKeyWhenDeploying.bpmn20.xml");
+
+    // then
     // Check if process-definition has different key
     assertEquals(0, repositoryService.createProcessDefinitionQuery().processDefinitionKey("oneTaskProcess").count());
     assertEquals(1, repositoryService.createProcessDefinitionQuery().processDefinitionKey("oneTaskProcess-modified").count());
   }
 
-  @Deployment
   @Test
   public void testAlterActivityBehaviors() throws Exception {
 
+    // given
+    DelegatingBpmnParseListener.DELEGATE = new TestBPMNParseListener();
+
+    // when
+    engineTestRule.deploy("org/camunda/bpm/engine/test/standalone/deploy/"
+        + "BPMNParseListenerTest.testAlterActivityBehaviors.bpmn20.xml");
+
+    // then
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskWithIntermediateThrowEvent-modified");
     ProcessDefinitionImpl processDefinition = ((ProcessInstanceWithVariablesImpl) processInstance).getExecutionEntity().getProcessDefinition();
 
@@ -78,4 +120,99 @@ public class BPMNParseListenerTest {
     ActivityImpl endEvent = processDefinition.findActivity("theEnd");
     assertTrue(endEvent.getActivityBehavior() instanceof TestBPMNParseListener.TestNoneEndEventActivityBehavior);
   }
+
+  @Test
+  public void shouldModifyFormKeyViaTaskDefinition() {
+    // given
+    String originalFormKey = "some-form-key";
+    String modifiedFormKey = "another-form-key";
+
+    BpmnModelInstance model = Bpmn.createExecutableProcess("process")
+      .startEvent()
+      .userTask("task").camundaFormKey(originalFormKey)
+      .endEvent()
+      .done();
+
+    DelegatingBpmnParseListener.DELEGATE = new AbstractBpmnParseListener() {
+      @Override
+      public void parseUserTask(Element userTaskElement, ScopeImpl scope, ActivityImpl activity) {
+        UserTaskActivityBehavior activityBehavior = (UserTaskActivityBehavior) activity.getActivityBehavior();
+        TaskDefinition taskDefinition = activityBehavior.getTaskDefinition();
+
+        ExpressionManager expressionManager = new ExpressionManager();
+        Expression formKeyExpression = expressionManager.createExpression(modifiedFormKey);
+
+        taskDefinition.setFormKey(formKeyExpression);
+      }
+    };
+
+    // when
+    DeploymentWithDefinitions deployment = engineTestRule.deploy(model);
+
+    // then
+    ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
+
+    FormService formService = engineRule.getFormService();
+    String formKey = formService.getTaskFormKey(processDefinition.getId(), "task");
+    assertThat(formKey).isEqualTo(modifiedFormKey);
+
+    runtimeService.startProcessInstanceByKey("process");
+    Task task = engineRule.getTaskService().createTaskQuery().singleResult();
+    TaskFormData formData = formService.getTaskFormData(task.getId());
+    assertThat(formData.getFormKey()).isEqualTo(modifiedFormKey);
+  }
+
+
+  @Test
+  public void shouldModifyFormRefViaTaskDefinition() {
+    // given
+    String originalFormRef = "some-form-ref";
+    String originalFormRefBinding = "deployment";
+
+    String modifiedFormRef = "another-form-ref";
+    String modifiedFormRefBinding = "version";
+    Integer modifiedFormRefVersion = 20;
+
+    BpmnModelInstance model = Bpmn.createExecutableProcess("process")
+      .startEvent()
+      .userTask("task")
+        .camundaFormRef(originalFormRef)
+        .camundaFormRefBinding(originalFormRefBinding)
+      .endEvent()
+      .done();
+
+    DelegatingBpmnParseListener.DELEGATE = new AbstractBpmnParseListener() {
+      @Override
+      public void parseUserTask(Element userTaskElement, ScopeImpl scope, ActivityImpl activity) {
+        UserTaskActivityBehavior activityBehavior = (UserTaskActivityBehavior) activity.getActivityBehavior();
+        TaskDefinition taskDefinition = activityBehavior.getTaskDefinition();
+        FormDefinition formDefinition = taskDefinition.getFormDefinition();
+
+        ExpressionManager expressionManager = new ExpressionManager();
+
+        Expression formRefExpression = expressionManager.createExpression(modifiedFormRef);
+        formDefinition.setCamundaFormDefinitionKey(formRefExpression);
+
+        formDefinition.setCamundaFormDefinitionBinding(modifiedFormRefBinding);
+
+        Expression formVersionExpression = expressionManager.createExpression(modifiedFormRefVersion.toString());
+        formDefinition.setCamundaFormDefinitionVersion(formVersionExpression);
+      }
+    };
+
+    // when
+    engineTestRule.deploy(model);
+
+    // then
+    runtimeService.startProcessInstanceByKey("process");
+    Task task = engineRule.getTaskService().createTaskQuery().singleResult();
+
+    FormService formService = engineRule.getFormService();
+    TaskFormData formData = formService.getTaskFormData(task.getId());
+    CamundaFormRef formRef = formData.getCamundaFormRef();
+    assertThat(formRef.getKey()).isEqualTo(modifiedFormRef);
+    assertThat(formRef.getBinding()).isEqualTo(modifiedFormRefBinding);
+    assertThat(formRef.getVersion()).isEqualTo(modifiedFormRefVersion);
+  }
+
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/standalone/deploy/DelegatingBpmnParseListener.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/standalone/deploy/DelegatingBpmnParseListener.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.standalone.deploy;
+
+import java.util.List;
+
+import org.camunda.bpm.engine.impl.bpmn.parser.BpmnParseListener;
+import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
+import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
+import org.camunda.bpm.engine.impl.pvm.process.ScopeImpl;
+import org.camunda.bpm.engine.impl.pvm.process.TransitionImpl;
+import org.camunda.bpm.engine.impl.util.xml.Element;
+import org.camunda.bpm.engine.impl.variable.VariableDeclaration;
+
+public class DelegatingBpmnParseListener implements BpmnParseListener {
+
+  public static BpmnParseListener DELEGATE;
+
+  @Override
+  public void parseProcess(Element processElement, ProcessDefinitionEntity processDefinition) {
+    DELEGATE.parseProcess(processElement, processDefinition);
+  }
+
+  @Override
+  public void parseStartEvent(Element startEventElement, ScopeImpl scope,
+      ActivityImpl startEventActivity) {
+    DELEGATE.parseStartEvent(startEventElement, scope, startEventActivity);
+  }
+
+  @Override
+  public void parseExclusiveGateway(Element exclusiveGwElement, ScopeImpl scope,
+      ActivityImpl activity) {
+    DELEGATE.parseExclusiveGateway(exclusiveGwElement, scope, activity);
+  }
+
+  @Override
+  public void parseInclusiveGateway(Element inclusiveGwElement, ScopeImpl scope,
+      ActivityImpl activity) {
+    DELEGATE.parseInclusiveGateway(inclusiveGwElement, scope, activity);
+  }
+
+  @Override
+  public void parseParallelGateway(Element parallelGwElement, ScopeImpl scope,
+      ActivityImpl activity) {
+    DELEGATE.parseParallelGateway(parallelGwElement, scope, activity);
+  }
+
+  @Override
+  public void parseScriptTask(Element scriptTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    DELEGATE.parseScriptTask(scriptTaskElement, scope, activity);
+  }
+
+  @Override
+  public void parseServiceTask(Element serviceTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    DELEGATE.parseServiceTask(serviceTaskElement, scope, activity);
+  }
+
+  @Override
+  public void parseBusinessRuleTask(Element businessRuleTaskElement, ScopeImpl scope,
+      ActivityImpl activity) {
+    DELEGATE.parseBusinessRuleTask(businessRuleTaskElement, scope, activity);
+  }
+
+  @Override
+  public void parseTask(Element taskElement, ScopeImpl scope, ActivityImpl activity) {
+    DELEGATE.parseTask(taskElement, scope, activity);
+  }
+
+  @Override
+  public void parseManualTask(Element manualTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    DELEGATE.parseManualTask(manualTaskElement, scope, activity);
+  }
+
+  @Override
+  public void parseUserTask(Element userTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    DELEGATE.parseUserTask(userTaskElement, scope, activity);
+  }
+
+  @Override
+  public void parseEndEvent(Element endEventElement, ScopeImpl scope, ActivityImpl activity) {
+    DELEGATE.parseEndEvent(endEventElement, scope, activity);
+  }
+
+  @Override
+  public void parseBoundaryTimerEventDefinition(Element timerEventDefinition, boolean interrupting,
+      ActivityImpl timerActivity) {
+    DELEGATE.parseBoundaryTimerEventDefinition(timerEventDefinition, interrupting, timerActivity);
+  }
+
+  @Override
+  public void parseBoundaryErrorEventDefinition(Element errorEventDefinition, boolean interrupting,
+      ActivityImpl activity, ActivityImpl nestedErrorEventActivity) {
+    DELEGATE.parseBoundaryErrorEventDefinition(errorEventDefinition, interrupting, activity, nestedErrorEventActivity);
+  }
+
+  @Override
+  public void parseSubProcess(Element subProcessElement, ScopeImpl scope, ActivityImpl activity) {
+    DELEGATE.parseSubProcess(subProcessElement, scope, activity);
+  }
+
+  @Override
+  public void parseCallActivity(Element callActivityElement, ScopeImpl scope,
+      ActivityImpl activity) {
+    DELEGATE.parseCallActivity(callActivityElement, scope, activity);
+  }
+
+  @Override
+  public void parseProperty(Element propertyElement, VariableDeclaration variableDeclaration,
+      ActivityImpl activity) {
+    DELEGATE.parseProperty(propertyElement, variableDeclaration, activity);
+  }
+
+  @Override
+  public void parseSequenceFlow(Element sequenceFlowElement, ScopeImpl scopeElement,
+      TransitionImpl transition) {
+    DELEGATE.parseSequenceFlow(sequenceFlowElement, scopeElement, transition);
+  }
+
+  @Override
+  public void parseSendTask(Element sendTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    DELEGATE.parseSendTask(sendTaskElement, scope, activity);
+  }
+
+  @Override
+  public void parseMultiInstanceLoopCharacteristics(Element activityElement,
+      Element multiInstanceLoopCharacteristicsElement, ActivityImpl activity) {
+    DELEGATE.parseMultiInstanceLoopCharacteristics(activityElement, multiInstanceLoopCharacteristicsElement, activity);
+  }
+
+  @Override
+  public void parseIntermediateTimerEventDefinition(Element timerEventDefinition,
+      ActivityImpl timerActivity) {
+    DELEGATE.parseIntermediateTimerEventDefinition(timerEventDefinition, timerActivity);
+  }
+
+  @Override
+  public void parseRootElement(Element rootElement,
+      List<ProcessDefinitionEntity> processDefinitions) {
+    DELEGATE.parseRootElement(rootElement, processDefinitions);
+  }
+
+  @Override
+  public void parseReceiveTask(Element receiveTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    DELEGATE.parseReceiveTask(receiveTaskElement, scope, activity);
+  }
+
+  @Override
+  public void parseIntermediateSignalCatchEventDefinition(Element signalEventDefinition,
+      ActivityImpl signalActivity) {
+    DELEGATE.parseIntermediateSignalCatchEventDefinition(signalEventDefinition, signalActivity);
+  }
+
+  @Override
+  public void parseIntermediateMessageCatchEventDefinition(Element messageEventDefinition,
+      ActivityImpl nestedActivity) {
+    DELEGATE.parseIntermediateMessageCatchEventDefinition(messageEventDefinition, nestedActivity);
+  }
+
+  @Override
+  public void parseBoundarySignalEventDefinition(Element signalEventDefinition,
+      boolean interrupting, ActivityImpl signalActivity) {
+    DELEGATE.parseBoundarySignalEventDefinition(signalEventDefinition, interrupting, signalActivity);
+  }
+
+  @Override
+  public void parseEventBasedGateway(Element eventBasedGwElement, ScopeImpl scope,
+      ActivityImpl activity) {
+    DELEGATE.parseEventBasedGateway(eventBasedGwElement, scope, activity);
+  }
+
+  @Override
+  public void parseTransaction(Element transactionElement, ScopeImpl scope, ActivityImpl activity) {
+    DELEGATE.parseTransaction(transactionElement, scope, activity);
+  }
+
+  @Override
+  public void parseCompensateEventDefinition(Element compensateEventDefinition,
+      ActivityImpl compensationActivity) {
+    DELEGATE.parseCompensateEventDefinition(compensateEventDefinition, compensationActivity);
+  }
+
+  @Override
+  public void parseIntermediateThrowEvent(Element intermediateEventElement, ScopeImpl scope,
+      ActivityImpl activity) {
+    DELEGATE.parseIntermediateThrowEvent(intermediateEventElement, scope, activity);
+  }
+
+  @Override
+  public void parseIntermediateCatchEvent(Element intermediateEventElement, ScopeImpl scope,
+      ActivityImpl activity) {
+    DELEGATE.parseIntermediateCatchEvent(intermediateEventElement, scope, activity);
+  }
+
+  @Override
+  public void parseBoundaryEvent(Element boundaryEventElement, ScopeImpl scopeElement,
+      ActivityImpl nestedActivity) {
+    DELEGATE.parseBoundaryEvent(boundaryEventElement, scopeElement, nestedActivity);
+  }
+
+  @Override
+  public void parseBoundaryMessageEventDefinition(Element element, boolean interrupting,
+      ActivityImpl messageActivity) {
+    DELEGATE.parseBoundaryMessageEventDefinition(element, interrupting, messageActivity);
+  }
+
+  @Override
+  public void parseBoundaryEscalationEventDefinition(Element escalationEventDefinition,
+      boolean interrupting, ActivityImpl boundaryEventActivity) {
+    DELEGATE.parseBoundaryEscalationEventDefinition(escalationEventDefinition, interrupting, boundaryEventActivity);
+  }
+
+  @Override
+  public void parseBoundaryConditionalEventDefinition(Element element, boolean interrupting,
+      ActivityImpl conditionalActivity) {
+    DELEGATE.parseBoundaryConditionalEventDefinition(element, interrupting, conditionalActivity);
+  }
+
+  @Override
+  public void parseIntermediateConditionalEventDefinition(Element conditionalEventDefinition,
+      ActivityImpl conditionalActivity) {
+    DELEGATE.parseIntermediateConditionalEventDefinition(conditionalEventDefinition, conditionalActivity);
+  }
+
+  @Override
+  public void parseConditionalStartEventForEventSubprocess(Element element,
+      ActivityImpl conditionalActivity, boolean interrupting) {
+    DELEGATE.parseConditionalStartEventForEventSubprocess(element, conditionalActivity, interrupting);
+  }
+}

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/standalone/deploy/bpmn.parse.listener.camunda.cfg.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/standalone/deploy/bpmn.parse.listener.camunda.cfg.xml
@@ -29,7 +29,7 @@
     
     <property name="customPreBPMNParseListeners">
       <list>
-        <bean class="org.camunda.bpm.engine.test.standalone.deploy.TestBPMNParseListener" />
+        <bean class="org.camunda.bpm.engine.test.standalone.deploy.DelegatingBpmnParseListener" />
       </list>
     </property>
     


### PR DESCRIPTION
- introduces a new FormDefinition pojo that contains the form
  related configuration of a task or start event
- removes the duplicated parsing logic in BpmnParse and the task form
  handler

related to CAM-14153