### PR TITLE
CAM-14141: fix(spin): add safe xml processing

### DIFF
--- a/engine-plugins/spin-plugin/src/main/java/org/camunda/spin/plugin/impl/SpinConfiguration.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/camunda/spin/plugin/impl/SpinConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.spin.plugin.impl;
+
+import org.camunda.bpm.engine.impl.cfg.AbstractProcessEnginePlugin;
+
+/**
+ * Java Bean holding Spin configuration properties.
+ */
+public class SpinConfiguration extends AbstractProcessEnginePlugin {
+
+  protected static final String XXE_PROPERTY = "xxe-processing";
+  protected static final String SP_PROPERTY = "secure-processing";
+
+  protected boolean enableXxeProcessing = false;
+  protected boolean enableSecureXmlProcessing = true;
+
+  public boolean isEnableXxeProcessing() {
+    return enableXxeProcessing;
+  }
+
+  public void setEnableXxeProcessing(boolean enableXxeProcessing) {
+    this.enableXxeProcessing = enableXxeProcessing;
+  }
+
+  public boolean isEnableSecureXmlProcessing() {
+    return enableSecureXmlProcessing;
+  }
+
+  public void setEnableSecureXmlProcessing(boolean enableSecureXmlProcessing) {
+    this.enableSecureXmlProcessing = enableSecureXmlProcessing;
+  }
+}

--- a/engine-plugins/spin-plugin/src/main/java/org/camunda/spin/plugin/impl/SpinProcessEnginePlugin.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/camunda/spin/plugin/impl/SpinProcessEnginePlugin.java
@@ -19,9 +19,10 @@ package org.camunda.spin.plugin.impl;
 import static org.camunda.spin.plugin.variable.type.SpinValueType.JSON;
 import static org.camunda.spin.plugin.variable.type.SpinValueType.XML;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import org.camunda.bpm.engine.impl.cfg.AbstractProcessEnginePlugin;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.util.ClassLoaderUtil;
 import org.camunda.bpm.engine.impl.variable.serializer.JavaObjectSerializer;
@@ -34,13 +35,19 @@ import org.camunda.spin.DataFormats;
  * @author Thorben Lindhauer
  *
  */
-public class SpinProcessEnginePlugin extends AbstractProcessEnginePlugin {
+public class SpinProcessEnginePlugin extends SpinConfiguration {
 
   @Override
   public void preInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
     // use classloader which loaded the plugin
     ClassLoader classloader = ClassLoaderUtil.getClassloader(SpinProcessEnginePlugin.class);
-    DataFormats.loadDataFormats(classloader);
+
+    // use Spin plugin configuration properties
+    Map<String, Object> configurationOptions = new HashMap<>();
+    configurationOptions.put(XXE_PROPERTY, isEnableXxeProcessing());
+    configurationOptions.put(SP_PROPERTY, isEnableSecureXmlProcessing());
+
+    DataFormats.loadDataFormats(classloader, configurationOptions);
   }
 
   @Override

--- a/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/impl/SpinProcessEnginePluginConfigurationTest.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/impl/SpinProcessEnginePluginConfigurationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.spin.plugin.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.camunda.bpm.engine.impl.cfg.ProcessEnginePlugin;
+import org.camunda.bpm.engine.test.util.ProcessEngineBootstrapRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SpinProcessEnginePluginConfigurationTest {
+
+  @Rule
+  public ProcessEngineBootstrapRule bootstrapRule
+      = new ProcessEngineBootstrapRule("custom.camunda.cfg.xml");
+
+  @Rule
+  public ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule(bootstrapRule);
+
+  @Test
+  public void shouldSetCustomSpinPluginProperties() {
+
+    // when
+    List<ProcessEnginePlugin> pluginList =
+        engineRule.getProcessEngineConfiguration().getProcessEnginePlugins();
+
+    // then
+    assertThat(pluginList).hasOnlyElementsOfType(SpinProcessEnginePlugin.class).hasSize(1);
+    SpinProcessEnginePlugin spinProcessEnginePlugin = (SpinProcessEnginePlugin) pluginList.get(0);
+    assertThat(spinProcessEnginePlugin.isEnableXxeProcessing()).isTrue();
+    assertThat(spinProcessEnginePlugin.isEnableSecureXmlProcessing()).isFalse();
+
+  }
+
+}

--- a/engine-plugins/spin-plugin/src/test/resources/custom.camunda.cfg.xml
+++ b/engine-plugins/spin-plugin/src/test/resources/custom.camunda.cfg.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans" 
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="processEngineConfiguration" class="org.camunda.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+  
+    <property name="jdbcUrl" value="jdbc:h2:mem:spin;DB_CLOSE_DELAY=1000" />
+    <property name="jdbcDriver" value="org.h2.Driver" />
+    <property name="jdbcUsername" value="sa" />
+    <property name="jdbcPassword" value="" />
+    
+    <!-- Database configurations -->
+    <property name="databaseSchemaUpdate" value="true" />
+    
+    <!-- job executor configurations -->
+    <property name="jobExecutorActivate" value="false" />
+    
+    <!-- mail server configurations -->
+    <property name="history" value="full" />
+
+    <!-- turn off metrics reporter -->
+    <property name="dbMetricsReporterActivate" value="false" />
+    <property name="telemetryReporterActivate" value="false" />
+    <property name="taskMetricsEnabled" value="false" />
+
+    <property name="processEnginePlugins">
+      <list>
+        <bean class="org.camunda.spin.plugin.impl.SpinProcessEnginePlugin">
+          <property name="enableXxeProcessing" value="true" />
+          <property name="enableSecureXmlProcessing" value="false" />
+        </bean>
+      </list>
+    </property>
+  </bean>
+  
+  <!--<bean id="uuidGenerator" class="org.camunda.bpm.engine.impl.persistence.StrongUuidGenerator" />-->
+
+</beans>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <version.uuid-generator>3.2.0</version.uuid-generator>
     <version.camunda.commons>1.10.0</version.camunda.commons>
     <version.camunda.connect>1.5.2</version.camunda.connect>
-    <version.camunda.spin>1.12.0</version.camunda.spin>
+    <version.camunda.spin>1.13.0-SNAPSHOT</version.camunda.spin>
     <version.camunda.template-engines>2.1.0</version.camunda.template-engines>
     <version.camunda.ee.xslt-plugin>1.1.0</version.camunda.ee.xslt-plugin>
     <version.feel-scala>1.13.3</version.feel-scala>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <version.uuid-generator>3.2.0</version.uuid-generator>
     <version.camunda.commons>1.10.0</version.camunda.commons>
     <version.camunda.connect>1.5.2</version.camunda.connect>
-    <version.camunda.spin>1.13.0-SNAPSHOT</version.camunda.spin>
+    <version.camunda.spin>1.13.0</version.camunda.spin>
     <version.camunda.template-engines>2.1.0</version.camunda.template-engines>
     <version.camunda.ee.xslt-plugin>1.1.0</version.camunda.ee.xslt-plugin>
     <version.feel-scala>1.13.3</version.feel-scala>


### PR DESCRIPTION
* Add configuration options to the Spin process engine plugin. With
  these options, users can enable/disable safe xml processing, if the
XML dataformat is used.

Related to CAM-14011, CAM-14141

:warning: The CI will fail until the related Spin PR is merged.