### PR TITLE
CAM-11913: feat(run): add groovy lib to run distro

### DIFF
--- a/distro/run/assembly/assembly.xml
+++ b/distro/run/assembly/assembly.xml
@@ -44,6 +44,7 @@
       <outputDirectory>configuration/userlib/</outputDirectory>
       <includes>
         <include>com.h2database:h2</include>
+        <include>org.codehaus.groovy:groovy-all:jar:*</include>
       </includes>
     </dependencySet>
   </dependencySets>

--- a/distro/run/assembly/pom.xml
+++ b/distro/run/assembly/pom.xml
@@ -89,6 +89,12 @@
       <artifactId>h2</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-all</artifactId>
+      <version>${version.groovy}</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -40,6 +40,7 @@
         <artifactId>js</artifactId>
         <version>${version.graal.js}</version>
       </dependency>
+
       <dependency>
         <groupId>org.graalvm.js</groupId>
         <artifactId>js-scriptengine</artifactId>

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -25,6 +25,14 @@
       <version>${project.version}</version>
       <type>zip</type>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <!-- exclude Groovy 2.4.13 so that it doesn't conflict with the REST Assured version.
+               The groovy-all JAR will still be present in the ZIP archive. -->
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>groovy-all</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
* Make the Groovy scripting engine available by default in Camunda Run.

Related to CAM-11913