### PR TITLE
fix(engine): replace IN by OR for MySQL authorization joins

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -1806,6 +1806,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       properties.put("dayComparator", DbSqlSessionFactory.databaseSpecificDaysComparator.get(databaseType));
 
       properties.put("collationForCaseSensitivity", DbSqlSessionFactory.databaseSpecificCollationForCaseSensitivity.get(databaseType));
+      
+      properties.put("authJoinStart", DbSqlSessionFactory.databaseSpecificAuthJoinStart.get(databaseType));
+      properties.put("authJoinEnd", DbSqlSessionFactory.databaseSpecificAuthJoinEnd.get(databaseType));
+      properties.put("authJoinSeparator", DbSqlSessionFactory.databaseSpecificAuthJoinSeparator.get(databaseType));
+      
+      properties.put("authJoin1Start", DbSqlSessionFactory.databaseSpecificAuth1JoinStart.get(databaseType));
+      properties.put("authJoin1End", DbSqlSessionFactory.databaseSpecificAuth1JoinEnd.get(databaseType));
+      properties.put("authJoin1Separator", DbSqlSessionFactory.databaseSpecificAuth1JoinSeparator.get(databaseType));
 
       Map<String, String> constants = DbSqlSessionFactory.dbSpecificConstants.get(databaseType);
       for (Entry<String, String> entry : constants.entrySet()) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
@@ -94,6 +94,14 @@ public class DbSqlSessionFactory implements SessionFactory {
   public static final Map<String, String> databaseSpecificDaysComparator = new HashMap<>();
 
   public static final Map<String, String> databaseSpecificCollationForCaseSensitivity = new HashMap<>();
+  
+  public static final Map<String, String> databaseSpecificAuthJoinStart = new HashMap<>();
+  public static final Map<String, String> databaseSpecificAuthJoinEnd = new HashMap<>();
+  public static final Map<String, String> databaseSpecificAuthJoinSeparator = new HashMap<>();
+  
+  public static final Map<String, String> databaseSpecificAuth1JoinStart = new HashMap<>();
+  public static final Map<String, String> databaseSpecificAuth1JoinEnd = new HashMap<>();
+  public static final Map<String, String> databaseSpecificAuth1JoinSeparator = new HashMap<>();
 
   /*
    * On SQL server, the overall maximum number of parameters in a prepared statement
@@ -110,6 +118,10 @@ public class DbSqlSessionFactory implements SessionFactory {
     String defaultDistinctCountBeforeStart = "select count(distinct";
     String defaultDistinctCountBeforeEnd = ")";
     String defaultDistinctCountAfterEnd = "";
+    
+    String defaultAuthOnStart = "IN (";
+    String defaultAuthOnEnd = ")";
+    String defaultAuthOnSeparator = ",";
 
     // h2
     databaseSpecificLimitBeforeStatements.put(H2, "");
@@ -148,6 +160,14 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificDaysComparator.put(H2, "DATEDIFF(DAY, ${date}, #{currentTimestamp}) >= ${days}");
 
     databaseSpecificCollationForCaseSensitivity.put(H2, "");
+    
+    databaseSpecificAuthJoinStart.put(H2, defaultAuthOnStart);
+    databaseSpecificAuthJoinEnd.put(H2, defaultAuthOnEnd);
+    databaseSpecificAuthJoinSeparator.put(H2, defaultAuthOnSeparator);
+    
+    databaseSpecificAuth1JoinStart.put(H2, defaultAuthOnStart);
+    databaseSpecificAuth1JoinEnd.put(H2, defaultAuthOnEnd);
+    databaseSpecificAuth1JoinSeparator.put(H2, defaultAuthOnSeparator);
 
     HashMap<String, String> constants = new HashMap<>();
     constants.put("constant.event", "'event'");
@@ -202,6 +222,14 @@ public class DbSqlSessionFactory implements SessionFactory {
       databaseSpecificDaysComparator.put(mysqlLikeDatabase, "DATEDIFF(#{currentTimestamp}, ${date}) >= ${days}");
 
       databaseSpecificCollationForCaseSensitivity.put(mysqlLikeDatabase, "");
+      
+      databaseSpecificAuthJoinStart.put(mysqlLikeDatabase, "=");
+      databaseSpecificAuthJoinEnd.put(mysqlLikeDatabase, "");
+      databaseSpecificAuthJoinSeparator.put(mysqlLikeDatabase, "OR AUTH.RESOURCE_ID_ =");
+      
+      databaseSpecificAuth1JoinStart.put(mysqlLikeDatabase, "=");
+      databaseSpecificAuth1JoinEnd.put(mysqlLikeDatabase, "");
+      databaseSpecificAuth1JoinSeparator.put(mysqlLikeDatabase, "OR AUTH1.RESOURCE_ID_ =");
 
       addDatabaseSpecificStatement(mysqlLikeDatabase, "toggleForeignKey", "toggleForeignKey_mysql");
       addDatabaseSpecificStatement(mysqlLikeDatabase, "selectDeploymentsByQueryCriteria", "selectDeploymentsByQueryCriteria_mysql");
@@ -293,6 +321,14 @@ public class DbSqlSessionFactory implements SessionFactory {
       databaseSpecificIfNull.put(postgresLikeDatabase, "COALESCE");
 
       databaseSpecificCollationForCaseSensitivity.put(postgresLikeDatabase, "");
+      
+      databaseSpecificAuthJoinStart.put(postgresLikeDatabase, defaultAuthOnStart);
+      databaseSpecificAuthJoinEnd.put(postgresLikeDatabase, defaultAuthOnEnd);
+      databaseSpecificAuthJoinSeparator.put(postgresLikeDatabase, defaultAuthOnSeparator);
+      
+      databaseSpecificAuth1JoinStart.put(postgresLikeDatabase, defaultAuthOnStart);
+      databaseSpecificAuth1JoinEnd.put(postgresLikeDatabase, defaultAuthOnEnd);
+      databaseSpecificAuth1JoinSeparator.put(postgresLikeDatabase, defaultAuthOnSeparator);
 
       addDatabaseSpecificStatement(postgresLikeDatabase, "insertByteArray", "insertByteArray_postgres");
       addDatabaseSpecificStatement(postgresLikeDatabase, "updateByteArray", "updateByteArray_postgres");
@@ -397,6 +433,14 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificDaysComparator.put(ORACLE, "${date} <= #{currentTimestamp} - ${days}");
 
     databaseSpecificCollationForCaseSensitivity.put(ORACLE, "");
+    
+    databaseSpecificAuthJoinStart.put(ORACLE, defaultAuthOnStart);
+    databaseSpecificAuthJoinEnd.put(ORACLE, defaultAuthOnEnd);
+    databaseSpecificAuthJoinSeparator.put(ORACLE, defaultAuthOnSeparator);
+    
+    databaseSpecificAuth1JoinStart.put(ORACLE, defaultAuthOnStart);
+    databaseSpecificAuth1JoinEnd.put(ORACLE, defaultAuthOnEnd);
+    databaseSpecificAuth1JoinSeparator.put(ORACLE, defaultAuthOnSeparator);
 
     addDatabaseSpecificStatement(ORACLE, "selectHistoricProcessInstanceDurationReport", "selectHistoricProcessInstanceDurationReport_oracle");
     addDatabaseSpecificStatement(ORACLE, "selectHistoricTaskInstanceDurationReport", "selectHistoricTaskInstanceDurationReport_oracle");
@@ -480,6 +524,14 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificDaysComparator.put(DB2, "${date} + ${days} DAYS <= #{currentTimestamp}");
 
     databaseSpecificCollationForCaseSensitivity.put(DB2, "");
+    
+    databaseSpecificAuthJoinStart.put(DB2, defaultAuthOnStart);
+    databaseSpecificAuthJoinEnd.put(DB2, defaultAuthOnEnd);
+    databaseSpecificAuthJoinSeparator.put(DB2, defaultAuthOnSeparator);
+    
+    databaseSpecificAuth1JoinStart.put(DB2, defaultAuthOnStart);
+    databaseSpecificAuth1JoinEnd.put(DB2, defaultAuthOnEnd);
+    databaseSpecificAuth1JoinSeparator.put(DB2, defaultAuthOnSeparator);
 
     addDatabaseSpecificStatement(DB2, "selectMeterLogAggregatedByTimeInterval", "selectMeterLogAggregatedByTimeInterval_db2_or_mssql");
     addDatabaseSpecificStatement(DB2, "selectExecutionByNativeQuery", "selectExecutionByNativeQuery_mssql_or_db2");
@@ -566,6 +618,14 @@ public class DbSqlSessionFactory implements SessionFactory {
     databaseSpecificDaysComparator.put(MSSQL, "DATEDIFF(DAY, ${date}, #{currentTimestamp}) >= ${days}");
 
     databaseSpecificCollationForCaseSensitivity.put(MSSQL, "COLLATE Latin1_General_CS_AS");
+    
+    databaseSpecificAuthJoinStart.put(MSSQL, defaultAuthOnStart);
+    databaseSpecificAuthJoinEnd.put(MSSQL, defaultAuthOnEnd);
+    databaseSpecificAuthJoinSeparator.put(MSSQL, defaultAuthOnSeparator);
+    
+    databaseSpecificAuth1JoinStart.put(MSSQL, defaultAuthOnStart);
+    databaseSpecificAuth1JoinEnd.put(MSSQL, defaultAuthOnEnd);
+    databaseSpecificAuth1JoinSeparator.put(MSSQL, defaultAuthOnSeparator);
 
     addDatabaseSpecificStatement(MSSQL, "selectMeterLogAggregatedByTimeInterval", "selectMeterLogAggregatedByTimeInterval_db2_or_mssql");
     addDatabaseSpecificStatement(MSSQL, "selectExecutionByNativeQuery", "selectExecutionByNativeQuery_mssql_or_db2");

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Authorization.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Authorization.xml
@@ -699,8 +699,8 @@
   
   <sql id="authCheckJoin">
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">      
-      <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />      
-      AUTH ON (AUTH.RESOURCE_ID_ in (RES.ID_, '*'))      
+      <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
+      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.ID_ ${authJoinSeparator} '*' ${authJoinEnd})
     </if>    
   </sql>
   

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/DecisionDefinition.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/DecisionDefinition.xml
@@ -242,7 +242,7 @@
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
-      AUTH ON (AUTH.RESOURCE_ID_ in (RES.ID_, RES.KEY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.ID_ ${authJoinSeparator} RES.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
     </if>
 
     <where>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/DecisionRequirementsDefinition.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/DecisionRequirementsDefinition.xml
@@ -205,7 +205,7 @@
     
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" /> 
-      AUTH ON (AUTH.RESOURCE_ID_ in (RES.ID_, RES.KEY_, '*'))      
+      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.ID_ ${authJoinSeparator} RES.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
     </if>
     
     <where>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/EventSubscription.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/EventSubscription.xml
@@ -82,7 +82,14 @@
 
       <if test="!authCheck.revokeAuthorizationCheckEnabled">
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
-        AUTH ON (AUTH.RESOURCE_ID_ in (RES.ID_, EXECUTION.ID_, PROCDEF.KEY_, PROC_EXECUTION.ID_, PROCDEF.KEY_, '*'))
+        AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.ID_ 
+          ${authJoinSeparator} EXECUTION.ID_
+          ${authJoinSeparator} PROCDEF.KEY_
+          ${authJoinSeparator} PROC_EXECUTION.ID_
+          ${authJoinSeparator} PROCDEF.KEY_
+          ${authJoinSeparator} '*'
+          ${authJoinEnd}
+        )
       </if>
     </if>
 
@@ -291,7 +298,7 @@
       inner join ${prefix}ACT_RE_PROCDEF P on RES.CONFIGURATION_ = P.ID_
       <if test="!authCheck.revokeAuthorizationCheckEnabled">
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
-        AUTH ON (AUTH.RESOURCE_ID_ in (P.KEY_, '*'))
+        AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} P.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
       </if>
     </if>
     <where>
@@ -310,7 +317,7 @@
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       inner join ${prefix}ACT_RE_PROCDEF P on RES.CONFIGURATION_ = P.ID_
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
-      AUTH ON (AUTH.RESOURCE_ID_ in (P.KEY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} P.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
     </if>
     <where>
       (EVENT_TYPE_ = 'conditional')

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Execution.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Execution.xml
@@ -259,7 +259,7 @@
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" /> 
-      AUTH ON (AUTH.RESOURCE_ID_ in (RES.ID_, P.KEY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.ID_ ${authJoinSeparator} P.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
     </if>
 
     <where>
@@ -431,7 +431,7 @@
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
-      AUTH ON (AUTH.RESOURCE_ID_ in (RES.PROC_INST_ID_, P.KEY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.PROC_INST_ID_ ${authJoinSeparator} P.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
     </if>
 
     <where>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ExternalTask.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ExternalTask.xml
@@ -195,21 +195,21 @@
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" /> 
       AUTH ON (
        (AUTH.RESOURCE_TYPE_ = 8 
-        AND AUTH.RESOURCE_ID_ in (RES.PROC_INST_ID_, '*') 
+        AND (AUTH.RESOURCE_ID_ ${authJoinStart} RES.PROC_INST_ID_ ${authJoinSeparator} '*' ${authJoinEnd})   
         AND ${bitand1}AUTH.PERMS_${bitand2}2${bitand3} = 2)
       OR
        (AUTH.RESOURCE_TYPE_ = 6 
-        AND AUTH.RESOURCE_ID_ in (RES.PROC_DEF_KEY_, '*') 
+        AND (AUTH.RESOURCE_ID_ ${authJoinStart} RES.PROC_DEF_KEY_ ${authJoinSeparator} '*' ${authJoinEnd}) 
         AND ${bitand1}AUTH.PERMS_${bitand2}512${bitand3} = 512) 
       )
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
       AUTH1 ON (
          (AUTH1.RESOURCE_TYPE_ = 8 
-          AND AUTH1.RESOURCE_ID_ in (RES.PROC_INST_ID_, '*') 
+          AND (AUTH1.RESOURCE_ID_ ${authJoin1Start} RES.PROC_INST_ID_ ${authJoin1Separator} '*' ${authJoin1End})
           AND ${bitand1}AUTH1.PERMS_${bitand2}4${bitand3} = 4)         
       OR
          (AUTH1.RESOURCE_TYPE_ = 6 
-          AND AUTH1.RESOURCE_ID_ in (RES.PROC_DEF_KEY_, '*') 
+          AND (AUTH1.RESOURCE_ID_ ${authJoin1Start} RES.PROC_DEF_KEY_ ${authJoin1Separator} '*' ${authJoin1End}) 
           AND ${bitand1}AUTH1.PERMS_${bitand2}1024${bitand3} = 1024)
       )    
     </if>
@@ -338,11 +338,11 @@
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" /> 
       AUTH ON (
        (AUTH.RESOURCE_TYPE_ = 8 
-        AND AUTH.RESOURCE_ID_ in (RES.PROC_INST_ID_, '*') 
+        AND AUTH.RESOURCE_ID_ ${authJoinStart} RES.PROC_INST_ID_ ${authJoinSeparator} '*' ${authJoinEnd} 
         AND ${bitand1}AUTH.PERMS_${bitand2}2${bitand3} = 2)
       OR
-       (AUTH.RESOURCE_TYPE_ = 6 
-        AND AUTH.RESOURCE_ID_ in (RES.PROC_DEF_KEY_, '*')
+       (AUTH.RESOURCE_TYPE_ = 6
+        AND AUTH.RESOURCE_ID_ ${authJoinStart} RES.PROC_DEF_KEY_ ${authJoinSeparator} '*' ${authJoinEnd} 
         AND ${bitand1}AUTH.PERMS_${bitand2}512${bitand3} = 512) 
       )
     </if>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricActivityInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricActivityInstance.xml
@@ -260,11 +260,13 @@
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause"/>
-      AUTH ON (AUTH.RESOURCE_ID_ in (
-      <if test="authCheck.isHistoricInstancePermissionsEnabled">
-        RES.PROC_INST_ID_,
-      </if>
-      RES.PROC_DEF_KEY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart}
+        RES.PROC_DEF_KEY_ ${authJoinSeparator} '*'
+        <if test="authCheck.isHistoricInstancePermissionsEnabled">
+          ${authJoinSeparator} RES.PROC_INST_ID_
+        </if>
+        ${authJoinEnd}
+      )
     </if>
 
     <where>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricDecisionInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricDecisionInstance.xml
@@ -301,7 +301,7 @@
         test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include
           refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause"/>
-      AUTH ON (AUTH.RESOURCE_ID_ in (RES.DEC_DEF_KEY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.DEC_DEF_KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
     </if>
 
     <where>
@@ -515,7 +515,7 @@
           FROM ${prefix}ACT_RE_DECISION_DEF RES
           <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
             <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
-            AUTH ON (AUTH.RESOURCE_ID_ in (RES.KEY_, '*'))
+            AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
           </if>
           <where>
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricDetail.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricDetail.xml
@@ -339,13 +339,14 @@
       </if>
       <if test="!authCheck.revokeAuthorizationCheckEnabled">
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
-        AUTH ON (AUTH.RESOURCE_ID_ in (
-        <if test="authCheck.isHistoricInstancePermissionsEnabled">
-          RES.PROC_INST_ID_,
-          TI.ID_,
-        </if>
-        RES.PROC_DEF_KEY_, '*'
-        ))
+        AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart}
+          RES.PROC_DEF_KEY_ ${authJoinSeparator} '*'
+          <if test="authCheck.isHistoricInstancePermissionsEnabled">
+            ${authJoinSeparator} RES.PROC_INST_ID_
+            ${authJoinSeparator} TI.ID_
+          </if>
+          ${authJoinEnd}
+        )
       </if>
     </if>
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricExternalTaskLog.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricExternalTaskLog.xml
@@ -285,11 +285,13 @@
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause"/>
-      AUTH ON (AUTH.RESOURCE_ID_ in (
-      <if test="authCheck.isHistoricInstancePermissionsEnabled">
-        RES.PROC_INST_ID_,
-      </if>
-      RES.PROC_DEF_KEY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart}
+        RES.PROC_DEF_KEY_ ${authJoinSeparator} '*'
+        <if test="authCheck.isHistoricInstancePermissionsEnabled">
+          ${authJoinSeparator} RES.PROC_INST_ID_
+        </if>
+        ${authJoinEnd}
+      )
     </if>
 
     <where>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricIdentityLinkLog.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricIdentityLinkLog.xml
@@ -261,12 +261,14 @@
       </if>
       <if test="!authCheck.revokeAuthorizationCheckEnabled">
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause"/>
-        AUTH ON (AUTH.RESOURCE_ID_ in (
-        <if test="authCheck.isHistoricInstancePermissionsEnabled">
-          TI.PROC_INST_ID_,
-          RES.TASK_ID_,
-        </if>
-        RES.PROC_DEF_KEY_, '*'))
+        AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart}
+          RES.PROC_DEF_KEY_ ${authJoinSeparator} '*'
+          <if test="authCheck.isHistoricInstancePermissionsEnabled">
+            ${authJoinSeparator} TI.PROC_INST_ID_
+            ${authJoinSeparator} RES.TASK_ID_
+          </if>
+          ${authJoinEnd}
+        )
       </if>
     </if>
     

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricIncident.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricIncident.xml
@@ -333,11 +333,13 @@
         See camunda-bpm-platform-ee/webapps/camunda-webapp/plugins/src/main/resources/org/camunda/bpm/cockpit/impl/plugin/history/historicIncident.xml
       -->
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause"/>
-      AUTH ON (AUTH.RESOURCE_ID_ in (
-      <if test="authCheck.isHistoricInstancePermissionsEnabled">
-      RES.PROC_INST_ID_,
-      </if>
-      RES.PROC_DEF_KEY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart}
+        RES.PROC_DEF_KEY_ ${authJoinSeparator} '*'
+        <if test="authCheck.isHistoricInstancePermissionsEnabled">
+          ${authJoinSeparator} RES.PROC_INST_ID_
+        </if>
+        ${authJoinEnd}
+      )
     </if>
 
     <where>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricJobLog.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricJobLog.xml
@@ -338,11 +338,13 @@
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause"/>
-      AUTH ON (AUTH.RESOURCE_ID_ in (
-      <if test="authCheck.isHistoricInstancePermissionsEnabled">
-        RES.PROCESS_INSTANCE_ID_,
-      </if>
-      RES.PROCESS_DEF_KEY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart}
+        RES.PROCESS_DEF_KEY_ ${authJoinSeparator} '*'
+        <if test="authCheck.isHistoricInstancePermissionsEnabled">
+          ${authJoinSeparator} RES.PROCESS_INSTANCE_ID_
+        </if>
+        ${authJoinEnd}
+      )
     </if>
 
     <where>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
@@ -290,11 +290,13 @@
           See camunda-bpm-platform-ee/webapps/camunda-webapp/plugins/src/main/resources/org/camunda/bpm/cockpit/impl/plugin/history/historicProcessInstance.xml
         -->
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause"/>
-        AUTH ON (AUTH.RESOURCE_ID_ in (
-        <if test="authCheck.isHistoricInstancePermissionsEnabled">
-            SELF.ID_,
-        </if>
-        SELF.PROC_DEF_KEY_, '*'))
+        AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart}
+          SELF.PROC_DEF_KEY_ ${authJoinSeparator} '*'
+          <if test="authCheck.isHistoricInstancePermissionsEnabled">
+            ${authJoinSeparator} SELF.ID_
+          </if>
+          ${authJoinEnd}
+        )
     </if>
 
     <bind name="INC_JOIN" value="false" />
@@ -709,7 +711,7 @@
           FROM ${prefix}ACT_RE_PROCDEF RES
           <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
             <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
-            AUTH ON (AUTH.RESOURCE_ID_ in (RES.KEY_, '*'))
+            AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
           </if>
           <where>
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
@@ -275,12 +275,14 @@
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
-      AUTH ON (AUTH.RESOURCE_ID_ in (
+      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart}
+        RES.PROC_DEF_KEY_ ${authJoinSeparator} '*'
         <if test="authCheck.isHistoricInstancePermissionsEnabled">
-          RES.PROC_INST_ID_,
-          RES.ID_,
+          ${authJoinSeparator} RES.PROC_INST_ID_
+          ${authJoinSeparator} RES.ID_
         </if>
-        RES.PROC_DEF_KEY_, '*'))
+        ${authJoinEnd}
+      )
     </if>
 
     <bind name="HPI_JOIN" value="false" />

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricVariableInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricVariableInstance.xml
@@ -314,14 +314,14 @@
       </if>
       <if test="!authCheck.revokeAuthorizationCheckEnabled">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause"/>
-          AUTH ON (AUTH.RESOURCE_ID_ in (
-            <if test="authCheck.isHistoricInstancePermissionsEnabled">
-              RES.PROC_INST_ID_,
-              TI.ID_,
-            </if>
-            RES.PROC_DEF_KEY_
-            , '*'
-          ))
+        AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart}
+          RES.PROC_DEF_KEY_ ${authJoinSeparator} '*'
+          <if test="authCheck.isHistoricInstancePermissionsEnabled">
+            ${authJoinSeparator} RES.PROC_INST_ID_
+            ${authJoinSeparator} TI.ID_
+          </if>
+          ${authJoinEnd}
+        )
       </if>
     </if>
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/JobDefinition.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/JobDefinition.xml
@@ -169,7 +169,7 @@
       on RES.PROC_DEF_ID_ = PROCDEF.ID_           
       <if test="!authCheck.revokeAuthorizationCheckEnabled">    
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" /> 
-        AUTH ON (AUTH.RESOURCE_ID_ in (RES.ID_, PROCDEF.KEY_, '*'))      
+        AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.ID_ ${authJoinSeparator} PROCDEF.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})      
       </if>
     </if>
     

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ProcessDefinition.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ProcessDefinition.xml
@@ -241,12 +241,12 @@
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
-      AUTH ON (AUTH.RESOURCE_ID_ in (RES.ID_, RES.KEY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.ID_ ${authJoinSeparator} RES.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
 
       <if test="startablePermissionCheck">
         <bind name="atomicChecks" value="processDefinitionCreatePermissionChecks" />
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClauseWithBinding" />
-        AUTH1 ON (AUTH1.RESOURCE_ID_ in (RES.KEY_, '*'))
+        AUTH1 ON (AUTH1.RESOURCE_ID_ ${authJoin1Start} RES.KEY_ ${authJoin1Separator} '*' ${authJoin1End})
       </if>
     </if>
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Statistics.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Statistics.xml
@@ -205,7 +205,7 @@
 
       <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" /> 
-        AUTH ON (AUTH.RESOURCE_ID_ in (RES.ID_, RES.KEY_, '*'))      
+        AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.ID_ ${authJoinSeparator} RES.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})      
       </if>
       <where>
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.queryAuthorizationCheck" />
@@ -434,7 +434,7 @@
           <if test="!revokeAuthorizationCheckEnabled">
             <bind name="atomicChecks" value="processInstancePermissionChecks" />
             <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClauseWithBinding" />
-            AUTH ON (AUTH.RESOURCE_ID_ in (E.PROC_INST_ID_, P.KEY_, '*'))
+            AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} E.PROC_INST_ID_ ${authJoinSeparator} P.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
           </if>
         </if>
 
@@ -494,7 +494,7 @@
                     <if test="!revokeAuthorizationCheckEnabled">
                       <bind name="atomicChecks" value="processInstancePermissionChecks" />
                       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClauseWithBinding" />
-                      AUTH ON (AUTH.RESOURCE_ID_ in (E.PROC_INST_ID_, P.KEY_, '*'))
+                      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} E.PROC_INST_ID_ ${authJoinSeparator} P.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
                     </if>
                   </if>
 
@@ -525,7 +525,7 @@
                       <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !revokeAuthorizationCheckEnabled &amp;&amp; authUserId != null">
                         <bind name="atomicChecks" value="jobPermissionChecks" />
                         <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClauseWithBinding" />
-                        AUTH ON (AUTH.RESOURCE_ID_ in (JOB.PROCESS_INSTANCE_ID_, JOB.PROCESS_DEF_KEY_, '*'))
+                        AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} JOB.PROCESS_INSTANCE_ID_ ${authJoinSeparator} JOB.PROCESS_DEF_KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
                       </if>
 
                       where
@@ -552,7 +552,7 @@
                         <if test="!revokeAuthorizationCheckEnabled">
                           <bind name="atomicChecks" value="incidentPermissionChecks" />
                           <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClauseWithBinding" />
-                          AUTH ON (AUTH.RESOURCE_ID_ in (I.PROC_INST_ID_, PROCDEF.KEY_, '*'))
+                          AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} I.PROC_INST_ID_ ${authJoinSeparator} PROCDEF.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
                         </if>
                       </if>
 
@@ -590,7 +590,7 @@
                     <if test="!revokeAuthorizationCheckEnabled">
                       <bind name="atomicChecks" value="processInstancePermissionChecks" />
                       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClauseWithBinding" />
-                      AUTH ON (AUTH.RESOURCE_ID_ in (E.PROC_INST_ID_, P.KEY_, '*'))
+                      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} E.PROC_INST_ID_ ${authJoinSeparator} P.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
                     </if>
                   </if>
 
@@ -626,7 +626,7 @@
                 <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !revokeAuthorizationCheckEnabled &amp;&amp; authUserId != null">
                   <bind name="atomicChecks" value="jobPermissionChecks" />
                   <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClauseWithBinding" />
-                  AUTH ON (AUTH.RESOURCE_ID_ in (JOB.PROCESS_INSTANCE_ID_, JOB.PROCESS_DEF_KEY_, '*'))
+                  AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} JOB.PROCESS_INSTANCE_ID_ ${authJoinSeparator} JOB.PROCESS_DEF_KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
                 </if>
 
                 where
@@ -663,7 +663,7 @@
                 <if test="!revokeAuthorizationCheckEnabled">
                   <bind name="atomicChecks" value="incidentPermissionChecks" />
                   <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClauseWithBinding" />
-                  AUTH ON (AUTH.RESOURCE_ID_ in (I.PROC_INST_ID_, PROCDEF.KEY_, '*'))
+                  AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} I.PROC_INST_ID_ ${authJoinSeparator} PROCDEF.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
                 </if>
               </if>
               where

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
@@ -308,7 +308,7 @@
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; authCheck.authUserId != null">
       <if test="!authCheck.revokeAuthorizationCheckEnabled">    
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" /> 
-        AUTH ON (AUTH.RESOURCE_ID_ in (RES.ID_, D.KEY_, '*'))      
+        AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.ID_ ${authJoinSeparator} D.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
       </if>
     </if>
     

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/UserOperationLogEntry.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/UserOperationLogEntry.xml
@@ -260,12 +260,14 @@
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause"/>
-      AUTH ON (AUTH.RESOURCE_ID_ in (
-      <if test="authCheck.isHistoricInstancePermissionsEnabled">
-        RES.PROC_INST_ID_,
-        RES.TASK_ID_,
-      </if>
-      RES.PROC_DEF_KEY_, RES.CATEGORY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart}
+        RES.PROC_DEF_KEY_ ${authJoinSeparator} RES.CATEGORY_ ${authJoinSeparator} '*'
+        <if test="authCheck.isHistoricInstancePermissionsEnabled">
+          ${authJoinSeparator} RES.PROC_INST_ID_
+          ${authJoinSeparator} RES.TASK_ID_
+        </if>
+        ${authJoinEnd}
+      )
     </if>
 
     <where>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/VariableInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/VariableInstance.xml
@@ -327,13 +327,13 @@
             on PROCDEF.ID_ = PROC_EXECUTION.PROC_DEF_ID_   
             <if test="!authCheck.revokeAuthorizationCheckEnabled">      
               <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" /> 
-              AUTH ON (
-              AUTH.RESOURCE_ID_ in (
-                                    RES.PROC_INST_ID_,
-                                    PROC_EXECUTION.ID_,
-                                    PROCDEF.KEY_,
-                                    RES.TASK_ID_,
-                                    '*')
+              AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart}
+                RES.PROC_INST_ID_ 
+                ${authJoinSeparator} PROC_EXECUTION.ID_
+                ${authJoinSeparator} PROCDEF.KEY_
+                ${authJoinSeparator} RES.TASK_ID_
+                ${authJoinSeparator} '*'
+                ${authJoinEnd}
               )
             </if>
           </if>

--- a/webapps/src/main/resources/org/camunda/bpm/cockpit/plugin/base/queries/incident.xml
+++ b/webapps/src/main/resources/org/camunda/bpm/cockpit/plugin/base/queries/incident.xml
@@ -83,7 +83,7 @@
 
           <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
             <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
-            AUTH ON (AUTH.RESOURCE_ID_ in (RES.PROC_INST_ID_, PROCDEF.KEY_, '*'))
+            AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.PROC_INST_ID_ ${authJoinSeparator} PROCDEF.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
           </if>
 
           <where>

--- a/webapps/src/main/resources/org/camunda/bpm/cockpit/plugin/base/queries/processDefinition.xml
+++ b/webapps/src/main/resources/org/camunda/bpm/cockpit/plugin/base/queries/processDefinition.xml
@@ -60,7 +60,7 @@
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
-      AUTH ON (AUTH.RESOURCE_ID_ in (EXEC2.PROC_INST_ID_, PROCDEF.KEY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} EXEC2.PROC_INST_ID_ ${authJoinSeparator} PROCDEF.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
     </if>
 
     <where>

--- a/webapps/src/main/resources/org/camunda/bpm/cockpit/plugin/base/queries/processInstance.xml
+++ b/webapps/src/main/resources/org/camunda/bpm/cockpit/plugin/base/queries/processInstance.xml
@@ -118,7 +118,10 @@
 
       <if test="!authCheck.revokeAuthorizationCheckEnabled">
         <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
-        AUTH ON (AUTH.RESOURCE_ID_ in (RES.PROC_INST_ID_, P.KEY_, '*'))
+        AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.PROC_INST_ID_ 
+          ${authJoinSeparator} P.KEY_ 
+          ${authJoinSeparator} '*' 
+        ${authJoinEnd})
       </if>
 
     </if>
@@ -292,7 +295,11 @@
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
       <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" />
-      AUTH ON (AUTH.RESOURCE_ID_ in (RES.PROC_INST_ID_, EXEC1.PROC_INST_ID_, PROCDEF.KEY_, '*'))
+      AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.PROC_INST_ID_
+        ${authJoinSeparator} EXEC1.PROC_INST_ID_ 
+        ${authJoinSeparator} PROCDEF.KEY_ 
+        ${authJoinSeparator} '*' 
+      ${authJoinEnd})
     </if>
 
     <where>


### PR DESCRIPTION
* replaces the IN construct on MySQL by OR used in the queries
  when including authorization checks

related to CAM-14092