### PR TITLE
CAM-11837: feat(run): include the connect plugin by default

### DIFF
--- a/distro/run/core/pom.xml
+++ b/distro/run/core/pom.xml
@@ -35,6 +35,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.camunda.bpm</groupId>
+      <artifactId>camunda-engine-plugin-connect</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-all</artifactId>
     </dependency>


### PR DESCRIPTION
* Include the Camunda Connect process engine plugin to Camunda Run by default.

Related to CAM-11837