### PR TITLE
CAM-13447: feat(run): add admin authorization plugin

### DIFF
--- a/distro/run/assembly/resources/production.yml
+++ b/distro/run/assembly/resources/production.yml
@@ -41,6 +41,37 @@ camunda.bpm:
 # https://docs.camunda.org/manual/latest/user-guide/security/#authentication
 # https://docs.camunda.org/manual/latest/user-guide/camunda-bpm-run/#authentication
     auth.enabled: true
+# https://docs.camunda.org/manual/latest/user-guide/process-engine/identity-service/#configuration-properties-of-the-ldap-plugin
+# https://docs.camunda.org/manual/latest/user-guide/camunda-bpm-run/#ldap-identity-service
+# Uncomment this section in order to enable LDAP support for Camunda Run
+#    ldap:
+#      enabled: true
+#      server-url: ldaps://localhost:4334
+#      administrator-group-name: camunda-admin
+#      accept-untrusted-certificates: false
+#      manager-dn: uid=jonny,ou=office-berlin,o=camunda,c=org
+#      manager-password: s3cr3t
+#      base-dn: o=camunda,c=org
+#      user-search-base: ''
+#      user-search-filter: (objectclass=person)
+#      user-id-attribute: uid
+#      user-firstname-attribute: cn
+#      user-lastname-attribute: sn
+#      user-email-ttribute: mail
+#      user-password-attribute: userpassword
+#      group-search-base: ''
+#      group-search-filter: (objectclass=groupOfNames)
+#      group-id-attribute: cn
+#      group-name-attribute: cn
+#      group-member-attribute: member
+#      sort-control-supported: false
+# https://docs.camunda.org/manual/latest/user-guide/process-engine/authorization-service/#the-administrator-authorization-plugin
+# https://docs.camunda.org/manual/latest/user-guide/camunda-bpm-run/#ldap-administrator-authorization
+# Uncomment this section to grant administrator authorizations to an existing LDAP user or group
+#    admin-auth:
+#      enabled: true
+#      administrator-user-name: admin
+#      administrator-group-name: admins
 
 server:
 # https://docs.camunda.org/manual/latest/user-guide/camunda-bpm-run/#https

--- a/distro/run/assembly/resources/production.yml
+++ b/distro/run/assembly/resources/production.yml
@@ -43,7 +43,7 @@ camunda.bpm:
     auth.enabled: true
 # https://docs.camunda.org/manual/latest/user-guide/process-engine/identity-service/#configuration-properties-of-the-ldap-plugin
 # https://docs.camunda.org/manual/latest/user-guide/camunda-bpm-run/#ldap-identity-service
-# Uncomment this section in order to enable LDAP support for Camunda Run
+# Uncomment this section to enable LDAP support for Camunda Run
 #    ldap:
 #      enabled: true
 #      server-url: ldaps://localhost:4334

--- a/distro/run/core/src/main/java/org/camunda/bpm/run/CamundaBpmRunConfiguration.java
+++ b/distro/run/core/src/main/java/org/camunda/bpm/run/CamundaBpmRunConfiguration.java
@@ -21,8 +21,10 @@ import java.util.List;
 import org.camunda.bpm.engine.impl.cfg.CompositeProcessEnginePlugin;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.cfg.ProcessEnginePlugin;
+import org.camunda.bpm.engine.impl.plugin.AdministratorAuthorizationPlugin;
 import org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration;
 import org.camunda.bpm.identity.impl.ldap.plugin.LdapIdentityProviderPlugin;
+import org.camunda.bpm.run.property.CamundaBpmRunAdministratorAuthorizationProperties;
 import org.camunda.bpm.run.property.CamundaBpmRunLdapProperties;
 import org.camunda.bpm.run.property.CamundaBpmRunProperties;
 import org.camunda.bpm.spring.boot.starter.CamundaBpmAutoConfiguration;
@@ -46,6 +48,12 @@ public class CamundaBpmRunConfiguration {
   @ConditionalOnProperty(name = "enabled", havingValue = "true", prefix = CamundaBpmRunLdapProperties.PREFIX)
   public LdapIdentityProviderPlugin ldapIdentityProviderPlugin() {
     return camundaBpmRunProperties.getLdap();
+  }
+
+  @Bean
+  @ConditionalOnProperty(name = "enabled", havingValue = "true", prefix = CamundaBpmRunAdministratorAuthorizationProperties.PREFIX)
+  public AdministratorAuthorizationPlugin administratorAuthorizationPlugin() {
+    return camundaBpmRunProperties.getAdminAuth();
   }
 
   @Bean

--- a/distro/run/core/src/main/java/org/camunda/bpm/run/property/CamundaBpmRunAdministratorAuthorizationProperties.java
+++ b/distro/run/core/src/main/java/org/camunda/bpm/run/property/CamundaBpmRunAdministratorAuthorizationProperties.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.run.property;
+
+import org.camunda.bpm.engine.impl.plugin.AdministratorAuthorizationPlugin;
+
+public class CamundaBpmRunAdministratorAuthorizationProperties extends AdministratorAuthorizationPlugin {
+
+  public static final String PREFIX = CamundaBpmRunProperties.PREFIX + ".admin-auth";
+
+  boolean enabled = true;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  @Override
+  public String toString() {
+    return "CamundaBpmRunAdministratorAuthorizationProperty [enabled=" + enabled +
+        ", administratorGroupName=" + administratorGroupName +
+        ", administratorUserName=" + administratorUserName +
+        ']';
+  }
+}

--- a/distro/run/core/src/main/java/org/camunda/bpm/run/property/CamundaBpmRunCorsProperty.java
+++ b/distro/run/core/src/main/java/org/camunda/bpm/run/property/CamundaBpmRunCorsProperty.java
@@ -115,9 +115,9 @@ public class CamundaBpmRunCorsProperty {
         "enabled=" + enabled +
         ", decorateRequest=" + decorateRequest +
         ", allowCredentials=" + allowCredentials +
-        ", allowedOrigins='" + allowedOrigins +
-        ", allowedHeaders='" + allowedHeaders +
-        ", exposedHeaders='" + exposedHeaders +
+        ", allowedOrigins=" + allowedOrigins +
+        ", allowedHeaders=" + allowedHeaders +
+        ", exposedHeaders=" + exposedHeaders +
         ", preflightMaxAge=" + preflightMaxAge +
         ']';
   }

--- a/distro/run/core/src/main/java/org/camunda/bpm/run/property/CamundaBpmRunProperties.java
+++ b/distro/run/core/src/main/java/org/camunda/bpm/run/property/CamundaBpmRunProperties.java
@@ -34,6 +34,9 @@ public class CamundaBpmRunProperties {
   @NestedConfigurationProperty
   private CamundaBpmRunLdapProperties ldap = new CamundaBpmRunLdapProperties();
 
+  protected CamundaBpmRunAdministratorAuthorizationProperties adminAuth
+      = new CamundaBpmRunAdministratorAuthorizationProperties();
+
   public CamundaBpmRunAuthenticationProperties getAuth() {
     return auth;
   }
@@ -58,8 +61,21 @@ public class CamundaBpmRunProperties {
     this.ldap = ldap;
   }
 
+  public CamundaBpmRunAdministratorAuthorizationProperties getAdminAuth() {
+    return adminAuth;
+  }
+
+  public void setAdminAuth(CamundaBpmRunAdministratorAuthorizationProperties adminAuth) {
+    this.adminAuth = adminAuth;
+  }
+
   @Override
   public String toString() {
-    return "CamundaBpmRunProperties [auth=" + auth + ", cors=" + cors + ", ldap=" + ldap + "]";
+    return "CamundaBpmRunProperties [" +
+        "auth=" + auth +
+        ", cors=" + cors +
+        ", ldap=" + ldap +
+        ", adminAuth=" + adminAuth +
+        "]";
   }
 }

--- a/distro/run/core/src/test/java/org/camunda/bpm/run/test/config/identity/AdminAuthorizationConfigurationTest.java
+++ b/distro/run/core/src/test/java/org/camunda/bpm/run/test/config/identity/AdminAuthorizationConfigurationTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.run.test.config.identity;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.engine.impl.plugin.AdministratorAuthorizationPlugin;
+import org.camunda.bpm.run.CamundaBpmRun;
+import org.camunda.bpm.run.property.CamundaBpmRunAdministratorAuthorizationProperties;
+import org.camunda.bpm.run.property.CamundaBpmRunProperties;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { CamundaBpmRun.class })
+@ActiveProfiles(profiles = { "test-auth-enabled" , "test-admin-auth-enabled" })
+public class AdminAuthorizationConfigurationTest {
+
+  @Autowired
+  protected AdministratorAuthorizationPlugin authorizationPlugin;
+
+  @Autowired
+  protected CamundaBpmRunProperties properties;
+
+  @Test
+  public void shouldPickUpConfiguration() {
+    // given
+    CamundaBpmRunAdministratorAuthorizationProperties adminProps = properties.getAdminAuth();
+
+    // then
+    assertThat(adminProps.isEnabled()).isTrue();
+    assertThat(adminProps.getAdministratorGroupName()).isEqualTo(authorizationPlugin.getAdministratorGroupName());
+    assertThat(adminProps.getAdministratorUserName()).isEqualTo(authorizationPlugin.getAdministratorUserName());
+  }
+
+}

--- a/distro/run/core/src/test/resources/application-test-admin-auth-enabled.yml
+++ b/distro/run/core/src/test/resources/application-test-admin-auth-enabled.yml
@@ -1,0 +1,5 @@
+camunda.bpm.run.admin-auth:
+  enabled: true
+  authorization-enabled: true
+  administrator-group-name: admins
+  administrator-user-name: admin


### PR DESCRIPTION
* Add the Administrator Authorization Plugin to Camunda Run by default.
* Add a template LDAP configuration in the production.yml config file.

Related to CAM-13447