### PR TITLE
fix(engine): end joined executions synchronously

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/BpmnActivityBehavior.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/behavior/BpmnActivityBehavior.java
@@ -52,7 +52,7 @@ public class BpmnActivityBehavior {
    * parallel paths of executions are created.
    */
   public void performDefaultOutgoingBehavior(ActivityExecution activityExecution) {
-    performOutgoingBehavior(activityExecution, true, null);
+    performOutgoingBehavior(activityExecution, true);
   }
 
   /**
@@ -66,7 +66,7 @@ public class BpmnActivityBehavior {
    * be created.
    */
   public void performIgnoreConditionsOutgoingBehavior(ActivityExecution activityExecution) {
-    performOutgoingBehavior(activityExecution, false, null);
+    performOutgoingBehavior(activityExecution, false);
   }
 
   /**
@@ -79,7 +79,7 @@ public class BpmnActivityBehavior {
    *          not to take a transition.
    */
   protected void performOutgoingBehavior(ActivityExecution execution,
-          boolean checkConditions, List<ActivityExecution> reusableExecutions) {
+          boolean checkConditions) {
 
     LOG.leavingActivity(execution.getActivity().getId());
 
@@ -101,13 +101,7 @@ public class BpmnActivityBehavior {
       execution.leaveActivityViaTransition(transitionsToTake.get(0));
 
     } else if (transitionsToTake.size() >= 1) {
-
-      if (reusableExecutions == null || reusableExecutions.isEmpty()) {
-        execution.leaveActivityViaTransitions(transitionsToTake, Arrays.asList(execution));
-      } else {
-        execution.leaveActivityViaTransitions(transitionsToTake, reusableExecutions);
-      }
-
+      execution.leaveActivityViaTransitions(transitionsToTake, Arrays.asList(execution));
     } else {
 
       if (defaultSequenceFlow != null) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/delegate/ActivityExecution.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/delegate/ActivityExecution.java
@@ -263,5 +263,7 @@ public interface ActivityExecution extends DelegateExecution {
   public Map<ScopeImpl, PvmExecutionImpl> createActivityExecutionMapping();
 
   void setEnded(boolean b);
+  
+  void setIgnoreAsync(boolean ignoreAsync);
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/PvmExecutionImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/PvmExecutionImpl.java
@@ -1042,7 +1042,18 @@ public abstract class PvmExecutionImpl extends CoreExecution implements
     // and the activity is left with the scope
     // execution)
     recyclableExecutions.remove(this);
+    
+    // End all other executions synchronously.
+    // This ensures a proper execution tree in case
+    // the activity is marked as 'async-after'.
+    // Otherwise, ending the other executions as well
+    // as the next logical operation are executed
+    // asynchronously. The order of those operations can 
+    // not be guaranteed anymore. This can lead to executions 
+    // getting stuck in case they rely on ending the other 
+    // executions first. 
     for (ActivityExecution execution : recyclableExecutions) {
+      execution.setIgnoreAsync(true);
       execution.end(_transitions.isEmpty());
     }
 
@@ -1872,6 +1883,7 @@ public abstract class PvmExecutionImpl extends CoreExecution implements
     this.scopeInstantiationContext = startContext;
   }
 
+  @Override
   public void setIgnoreAsync(boolean ignoreAsync) {
     this.ignoreAsync = ignoreAsync;
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/gateway/InclusiveGatewayTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/gateway/InclusiveGatewayTest.java
@@ -28,12 +28,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.assertj.core.api.Assertions;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
-import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
 import org.camunda.bpm.engine.impl.util.CollectionUtil;
 import org.camunda.bpm.engine.runtime.ActivityInstance;
 import org.camunda.bpm.engine.runtime.Execution;
@@ -44,7 +42,6 @@ import org.camunda.bpm.engine.task.TaskQuery;
 import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.camunda.bpm.model.bpmn.Bpmn;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -73,7 +70,7 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
     for (int i = 1; i <= 3; i++) {
       ProcessInstance pi = runtimeService.startProcessInstanceByKey("inclusiveGwDiverging", CollectionUtil.singletonMap("input", i));
       List<Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
-      List<String> expectedNames = new ArrayList<String>();
+      List<String> expectedNames = new ArrayList<>();
       if (i == 1) {
         expectedNames.add(TASK1_NAME);
       }
@@ -218,7 +215,7 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
     runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnBeanProperty", CollectionUtil.singletonMap("order", new InclusiveGatewayTestOrder(150)));
     List<Task> tasks = taskService.createTaskQuery().list();
     assertEquals(2, tasks.size());
-    Map<String, String> expectedNames = new HashMap<String, String>();
+    Map<String, String> expectedNames = new HashMap<>();
     expectedNames.put(BEAN_TASK2_NAME, BEAN_TASK2_NAME);
     expectedNames.put(BEAN_TASK3_NAME, BEAN_TASK3_NAME);
     for (Task task : tasks) {
@@ -230,7 +227,7 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
   @Deployment
   @Test
   public void testDecideBasedOnListOrArrayOfBeans() {
-    List<InclusiveGatewayTestOrder> orders = new ArrayList<InclusiveGatewayTestOrder>();
+    List<InclusiveGatewayTestOrder> orders = new ArrayList<>();
     orders.add(new InclusiveGatewayTestOrder(50));
     orders.add(new InclusiveGatewayTestOrder(300));
     orders.add(new InclusiveGatewayTestOrder(175));
@@ -254,7 +251,7 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
     List<Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
     assertNotNull(tasks);
     assertEquals(2, tasks.size());
-    List<String> expectedNames = new ArrayList<String>();
+    List<String> expectedNames = new ArrayList<>();
     expectedNames.add(BEAN_TASK2_NAME);
     expectedNames.add(BEAN_TASK3_NAME);
     for (Task t : tasks) {
@@ -292,7 +289,7 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
             CollectionUtil.singletonMap("order", new InclusiveGatewayTestOrder(125)));
     List<Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
     assertEquals(2, tasks.size());
-    List<String> expectedNames = new ArrayList<String>();
+    List<String> expectedNames = new ArrayList<>();
     expectedNames.add(BEAN_TASK2_NAME);
     expectedNames.add(BEAN_TASK3_NAME);
     for (Task t : tasks) {
@@ -327,7 +324,7 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
     ProcessInstance pi = runtimeService.startProcessInstanceByKey("inclusiveGwDefaultSequenceFlow", CollectionUtil.singletonMap("input", 1));
     List<Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
     assertEquals(2, tasks.size());
-    Map<String, String> expectedNames = new HashMap<String, String>();
+    Map<String, String> expectedNames = new HashMap<>();
     expectedNames.put("Input is one", "Input is one");
     expectedNames.put("Input is three or one", "Input is three or one");
     for (Task t : tasks) {
@@ -397,7 +394,7 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
     pi = runtimeService.startProcessInstanceByKey("inclusiveNoIdOnSequenceFlow", CollectionUtil.singletonMap("input", 1));
     List<Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
     assertEquals(2, tasks.size());
-    Map<String, String> expectedNames = new HashMap<String, String>();
+    Map<String, String> expectedNames = new HashMap<>();
     expectedNames.put("Input is one", "Input is one");
     expectedNames.put("Input is more than one", "Input is more than one");
     for (Task t : tasks) {
@@ -437,7 +434,7 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
   @Test
   public void testJoinAfterSubprocesses() {
     // Test case to test act-1204
-    Map<String, Object> variableMap = new HashMap<String, Object>();
+    Map<String, Object> variableMap = new HashMap<>();
     variableMap.put("a", 1);
     variableMap.put("b", 1);
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("InclusiveGateway", variableMap);
@@ -458,7 +455,7 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
     processInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
     assertNull(processInstance);
 
-    variableMap = new HashMap<String, Object>();
+    variableMap = new HashMap<>();
     variableMap.put("a", 1);
     variableMap.put("b", 2);
     processInstance = runtimeService.startProcessInstanceByKey("InclusiveGateway", variableMap);
@@ -478,7 +475,7 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
     processInstance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult();
     assertNull(processInstance);
 
-    variableMap = new HashMap<String, Object>();
+    variableMap = new HashMap<>();
     variableMap.put("a", 2);
     variableMap.put("b", 2);
     try {
@@ -536,14 +533,14 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
   @Test
   public void testDecisionFunctionality() {
 
-    Map<String, Object> variables = new HashMap<String, Object>();
+    Map<String, Object> variables = new HashMap<>();
 
     // Test with input == 1
     variables.put("input", 1);
     ProcessInstance pi = runtimeService.startProcessInstanceByKey("inclusiveGateway", variables);
     List<Task> tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
     assertEquals(3, tasks.size());
-    Map<String, String> expectedMessages = new HashMap<String, String>();
+    Map<String, String> expectedMessages = new HashMap<>();
     expectedMessages.put(TASK1_NAME, TASK1_NAME);
     expectedMessages.put(TASK2_NAME, TASK2_NAME);
     expectedMessages.put(TASK3_NAME, TASK3_NAME);
@@ -557,7 +554,7 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
     pi = runtimeService.startProcessInstanceByKey("inclusiveGateway", variables);
     tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
     assertEquals(2, tasks.size());
-    expectedMessages = new HashMap<String, String>();
+    expectedMessages = new HashMap<>();
     expectedMessages.put(TASK2_NAME, TASK2_NAME);
     expectedMessages.put(TASK3_NAME, TASK3_NAME);
     for (Task task : tasks) {
@@ -570,7 +567,7 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
     pi = runtimeService.startProcessInstanceByKey("inclusiveGateway", variables);
     tasks = taskService.createTaskQuery().processInstanceId(pi.getId()).list();
     assertEquals(1, tasks.size());
-    expectedMessages = new HashMap<String, String>();
+    expectedMessages = new HashMap<>();
     expectedMessages.put(TASK3_NAME, TASK3_NAME);
     for (Task task : tasks) {
       expectedMessages.remove(task.getName());
@@ -787,77 +784,16 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
     assertEquals("taskAfterJoin", task.getTaskDefinitionKey());
   }
 
-  @Ignore("https://jira.camunda.com/browse/CAM-14116")
   @Deployment(resources = ASYNC_CONCURRENT_PARALLEL_GATEWAY)
   @Test
-  public void shouldCompleteWithConcurrentExecution_ParallelGateway_1() {
-    runtimeService.startProcessInstanceByKey("Process_Model11842");
+  public void shouldCompleteWithConcurrentExecution_ParallelGateway() {
+    // given
+    runtimeService.startProcessInstanceByKey("process");
 
-    AtomicReference<String> jobIdNotifyListener = new AtomicReference<>();
-    AtomicReference<String> jobIdActivityEnd = new AtomicReference<>();
-    managementService.createJobQuery().list().forEach(job -> {
-      if ("transition-notify-listener-take$Flow_0wno03o".equals(((JobEntity)job).getJobHandlerConfigurationRaw())) {
-        jobIdNotifyListener.set(job.getId());
+    // when
+    testRule.executeAvailableJobs(1);
 
-      } else if ("activity-end".equals(((JobEntity)job).getJobHandlerConfigurationRaw())) {
-        jobIdActivityEnd.set(job.getId());
-
-      }
-    });
-
-    managementService.executeJob(jobIdNotifyListener.get());
-    managementService.executeJob(jobIdActivityEnd.get());
-
-    Assertions.assertThat(managementService.createJobQuery().count()).isEqualTo(0);
-    Assertions.assertThat(historyService.createHistoricProcessInstanceQuery().singleResult().getState())
-        .isEqualTo("COMPLETED");
-  }
-
-  @Deployment(resources = ASYNC_CONCURRENT_PARALLEL_GATEWAY)
-  @Test
-  public void shouldCompleteWithConcurrentExecution_ParallelGateway_2() {
-    runtimeService.startProcessInstanceByKey("Process_Model11842");
-
-    AtomicReference<String> jobIdNotifyListener = new AtomicReference<>();
-    AtomicReference<String> jobIdActivityEnd = new AtomicReference<>();
-    managementService.createJobQuery().list().forEach(job -> {
-      if ("transition-notify-listener-take$Flow_0wno03o".equals(((JobEntity)job).getJobHandlerConfigurationRaw())) {
-        jobIdNotifyListener.set(job.getId());
-      } else if ("activity-end".equals(((JobEntity)job).getJobHandlerConfigurationRaw())) {
-        jobIdActivityEnd.set(job.getId());
-      }
-    });
-
-    managementService.executeJob(jobIdActivityEnd.get());
-    managementService.executeJob(jobIdNotifyListener.get());
-
-    Assertions.assertThat(managementService.createJobQuery().count()).isEqualTo(0);
-    Assertions.assertThat(historyService.createHistoricProcessInstanceQuery().singleResult().getState())
-        .isEqualTo("COMPLETED");
-  }
-
-
-  @Ignore("https://jira.camunda.com/browse/CAM-14116")
-  @Deployment(resources = ASYNC_CONCURRENT_PARALLEL_INCLUSIVE_GATEWAY)
-  @Test
-  public void shouldCompleteWithConcurrentExecution_InclusiveGateway_1() {
-    runtimeService.startProcessInstanceByKey("Process_Model11842");
-
-    AtomicReference<String> jobIdNotifyListener = new AtomicReference<>();
-    AtomicReference<String> jobIdActivityEnd = new AtomicReference<>();
-    managementService.createJobQuery().list().forEach(job -> {
-      if ("transition-notify-listener-take$Flow_0wno03o".equals(((JobEntity)job).getJobHandlerConfigurationRaw())) {
-        jobIdNotifyListener.set(job.getId());
-
-      } else if ("activity-end".equals(((JobEntity)job).getJobHandlerConfigurationRaw())) {
-        jobIdActivityEnd.set(job.getId());
-
-      }
-    });
-
-    managementService.executeJob(jobIdNotifyListener.get());
-    managementService.executeJob(jobIdActivityEnd.get());
-
+    // then
     Assertions.assertThat(managementService.createJobQuery().count()).isEqualTo(0);
     Assertions.assertThat(historyService.createHistoricProcessInstanceQuery().singleResult().getState())
         .isEqualTo("COMPLETED");
@@ -865,25 +801,17 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
 
   @Deployment(resources = ASYNC_CONCURRENT_PARALLEL_INCLUSIVE_GATEWAY)
   @Test
-  public void shouldCompleteWithConcurrentExecution_InclusiveGateway_2() {
-    runtimeService.startProcessInstanceByKey("Process_Model11842");
+  public void shouldCompleteWithConcurrentExecution_InclusiveGateway() {
+    // given
+    runtimeService.startProcessInstanceByKey("process");
 
-    AtomicReference<String> jobIdNotifyListener = new AtomicReference<>();
-    AtomicReference<String> jobIdActivityEnd = new AtomicReference<>();
-    managementService.createJobQuery().list().forEach(job -> {
-      if ("transition-notify-listener-take$Flow_0wno03o".equals(((JobEntity)job).getJobHandlerConfigurationRaw())) {
-        jobIdNotifyListener.set(job.getId());
-      } else if ("activity-end".equals(((JobEntity)job).getJobHandlerConfigurationRaw())) {
-        jobIdActivityEnd.set(job.getId());
-      }
-    });
+    // when
+    testRule.executeAvailableJobs(1);
 
-    managementService.executeJob(jobIdActivityEnd.get());
-    managementService.executeJob(jobIdNotifyListener.get());
-
+    // then
     Assertions.assertThat(managementService.createJobQuery().count()).isEqualTo(0);
     Assertions.assertThat(historyService.createHistoricProcessInstanceQuery().singleResult().getState())
         .isEqualTo("COMPLETED");
   }
-
+  
 }

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/gateway/InclusiveGatewayTest.AsyncConcurrentExecutions.ParallelInclusiveGateway.bpmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/gateway/InclusiveGatewayTest.AsyncConcurrentExecutions.ParallelInclusiveGateway.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0muexi8" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.14.0">
-  <bpmn:process id="Process_Model11842" isExecutable="true">
+  <bpmn:process id="process" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Start">
       <bpmn:outgoing>Flow_0rqk3uh</bpmn:outgoing>
     </bpmn:startEvent>

--- a/qa/test-db-instance-migration/test-fixture-716/src/main/java/org/camunda/bpm/qa/upgrade/TestFixture.java
+++ b/qa/test-db-instance-migration/test-fixture-716/src/main/java/org/camunda/bpm/qa/upgrade/TestFixture.java
@@ -21,6 +21,7 @@ import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.qa.upgrade.externaltask.ExternalTaskFailureLogScenario;
 import org.camunda.bpm.qa.upgrade.job.JobFailureLogScenario;
+import org.camunda.bpm.qa.upgrade.pvm.AsyncJoinScenario;
 
 public class TestFixture {
 
@@ -39,6 +40,7 @@ public class TestFixture {
 
     runner.setupScenarios(ExternalTaskFailureLogScenario.class);
     runner.setupScenarios(JobFailureLogScenario.class);
+    runner.setupScenarios(AsyncJoinScenario.class);
 
     processEngine.close();
   }

--- a/qa/test-db-instance-migration/test-fixture-716/src/main/java/org/camunda/bpm/qa/upgrade/pvm/AsyncJoinScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-716/src/main/java/org/camunda/bpm/qa/upgrade/pvm/AsyncJoinScenario.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.qa.upgrade.pvm;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.qa.upgrade.DescribesScenario;
+import org.camunda.bpm.qa.upgrade.ScenarioSetup;
+
+public class AsyncJoinScenario {
+
+  @Deployment
+  public static String modelParallelDeployment() {
+    return "org/camunda/bpm/qa/upgrade/pvm/asyncParallelGateway.bpmn20.xml";
+  }
+  
+  @Deployment
+  public static String modelInclusiveDeployment() {
+    return "org/camunda/bpm/qa/upgrade/pvm/asyncInclusiveGateway.bpmn20.xml";
+  }
+
+  @DescribesScenario("asyncJoinParallel")
+  public static ScenarioSetup createJobsForParallelJoin() {
+    return (engine, scenarioName) -> {
+      engine.getRuntimeService().startProcessInstanceByKey("async-join-parallel-716", scenarioName);
+
+      // result: two jobs have been created, one for each concurrent execution
+      // reaching the parallel join gateway
+    };
+  }
+  
+  @DescribesScenario("asyncJoinInclusive")
+  public static ScenarioSetup createJobsForInclusiveJoin() {
+    return (engine, scenarioName) -> {
+      engine.getRuntimeService().startProcessInstanceByKey("async-join-inclusive-716", scenarioName);
+
+      // result: two jobs have been created, one for each concurrent execution
+      // reaching the inclusive join gateway
+    };
+  }
+}

--- a/qa/test-db-instance-migration/test-fixture-716/src/main/resources/org/camunda/bpm/qa/upgrade/pvm/asyncInclusiveGateway.bpmn20.xml
+++ b/qa/test-db-instance-migration/test-fixture-716/src/main/resources/org/camunda/bpm/qa/upgrade/pvm/asyncInclusiveGateway.bpmn20.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0muexi8" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.14.0">
-  <bpmn:process id="process" isExecutable="true">
+  <bpmn:process id="async-join-inclusive-716" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Start">
       <bpmn:outgoing>Flow_0rqk3uh</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:sequenceFlow id="Flow_0rqk3uh" sourceRef="StartEvent_1" targetRef="Gateway_1" />
-    <bpmn:sequenceFlow id="Flow_1a" sourceRef="Gateway_1" targetRef="GatewayJoin_1" />
+    <bpmn:sequenceFlow id="Flow_1a" name="${true}" sourceRef="Gateway_1" targetRef="GatewayJoin_1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${true}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
     <bpmn:endEvent id="EndEvent_1" name="End">
       <bpmn:incoming>Flow_1vxbfya</bpmn:incoming>
     </bpmn:endEvent>
@@ -14,17 +16,9 @@
     <bpmn:sequenceFlow id="Flow_3b" name="${false}" sourceRef="Gateway_2" targetRef="GatewayJoin_2">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:parallelGateway id="Gateway_1">
-      <bpmn:incoming>Flow_0rqk3uh</bpmn:incoming>
-      <bpmn:outgoing>Flow_1a</bpmn:outgoing>
-      <bpmn:outgoing>Flow_1b</bpmn:outgoing>
-    </bpmn:parallelGateway>
-    <bpmn:parallelGateway id="GatewayJoin_1" camunda:asyncAfter="true">
-      <bpmn:incoming>Flow_1a</bpmn:incoming>
-      <bpmn:incoming>Flow_1b</bpmn:incoming>
-      <bpmn:outgoing>Flow_0wno03o</bpmn:outgoing>
-    </bpmn:parallelGateway>
-    <bpmn:sequenceFlow id="Flow_1b" sourceRef="Gateway_1" targetRef="GatewayJoin_1" />
+    <bpmn:sequenceFlow id="Flow_1b" name="${true}" sourceRef="Gateway_1" targetRef="GatewayJoin_1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${true}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_3a" name="${true}" sourceRef="Gateway_2" targetRef="GatewayJoin_2">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -38,12 +32,36 @@
       <bpmn:incoming>Flow_3b</bpmn:incoming>
       <bpmn:outgoing>Flow_1vxbfya</bpmn:outgoing>
     </bpmn:inclusiveGateway>
+    <bpmn:inclusiveGateway id="Gateway_1">
+      <bpmn:incoming>Flow_0rqk3uh</bpmn:incoming>
+      <bpmn:outgoing>Flow_1a</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1b</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:inclusiveGateway id="GatewayJoin_1" camunda:asyncAfter="true">
+      <bpmn:incoming>Flow_1a</bpmn:incoming>
+      <bpmn:incoming>Flow_1b</bpmn:incoming>
+      <bpmn:outgoing>Flow_0wno03o</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_Model11842">
-      <bpmndi:BPMNEdge id="Flow_1vxbfya_di" bpmnElement="Flow_1vxbfya">
-        <di:waypoint x="725" y="170" />
-        <di:waypoint x="782" y="170" />
+      <bpmndi:BPMNEdge id="Flow_1mbqv6t_di" bpmnElement="Flow_3a">
+        <di:waypoint x="560" y="195" />
+        <di:waypoint x="560" y="230" />
+        <di:waypoint x="700" y="230" />
+        <di:waypoint x="700" y="195" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="614" y="212" width="33" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0edbe2p_di" bpmnElement="Flow_1b">
+        <di:waypoint x="270" y="195" />
+        <di:waypoint x="270" y="230" />
+        <di:waypoint x="430" y="230" />
+        <di:waypoint x="430" y="195" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="334" y="212" width="33" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1gyp8gi_di" bpmnElement="Flow_3b">
         <di:waypoint x="560" y="145" />
@@ -54,30 +72,22 @@
           <dc:Bounds x="612" y="92" width="37" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1mbqv6t_di" bpmnElement="Flow_3a">
-        <di:waypoint x="560" y="195" />
-        <di:waypoint x="560" y="230" />
-        <di:waypoint x="700" y="230" />
-        <di:waypoint x="700" y="195" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="614" y="212" width="33" height="14" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNEdge id="Flow_1vxbfya_di" bpmnElement="Flow_1vxbfya">
+        <di:waypoint x="725" y="170" />
+        <di:waypoint x="782" y="170" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0wno03o_di" bpmnElement="Flow_0wno03o">
         <di:waypoint x="455" y="170" />
         <di:waypoint x="535" y="170" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0edbe2p_di" bpmnElement="Flow_1b">
-        <di:waypoint x="270" y="195" />
-        <di:waypoint x="270" y="230" />
-        <di:waypoint x="430" y="230" />
-        <di:waypoint x="430" y="195" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0kyb26z_di" bpmnElement="Flow_1a">
         <di:waypoint x="270" y="145" />
         <di:waypoint x="270" y="110" />
         <di:waypoint x="430" y="110" />
         <di:waypoint x="430" y="145" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="334" y="92" width="33" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0rqk3uh_di" bpmnElement="Flow_0rqk3uh">
         <di:waypoint x="188" y="170" />
@@ -89,22 +99,22 @@
           <dc:Bounds x="159" y="195" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_19pft0p_di" bpmnElement="Gateway_2">
-        <dc:Bounds x="535" y="145" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0wpxx6f_di" bpmnElement="GatewayJoin_2">
-        <dc:Bounds x="675" y="145" width="50" height="50" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1ha3mlr_di" bpmnElement="EndEvent_1">
         <dc:Bounds x="782" y="152" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="790" y="195" width="20" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1v7gfv2_di" bpmnElement="Gateway_1">
+      <bpmndi:BPMNShape id="Gateway_19pft0p_di" bpmnElement="Gateway_2">
+        <dc:Bounds x="535" y="145" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0wpxx6f_di" bpmnElement="GatewayJoin_2">
+        <dc:Bounds x="675" y="145" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1a00uph_di" bpmnElement="Gateway_1">
         <dc:Bounds x="245" y="145" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1d4ekhc_di" bpmnElement="GatewayJoin_1">
+      <bpmndi:BPMNShape id="Gateway_1ls9mqu_di" bpmnElement="GatewayJoin_1">
         <dc:Bounds x="405" y="145" width="50" height="50" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/qa/test-db-instance-migration/test-fixture-716/src/main/resources/org/camunda/bpm/qa/upgrade/pvm/asyncParallelGateway.bpmn20.xml
+++ b/qa/test-db-instance-migration/test-fixture-716/src/main/resources/org/camunda/bpm/qa/upgrade/pvm/asyncParallelGateway.bpmn20.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0muexi8" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.14.0">
-  <bpmn:process id="process" isExecutable="true">
+  <bpmn:process id="async-join-parallel-716" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Start">
       <bpmn:outgoing>Flow_0rqk3uh</bpmn:outgoing>
     </bpmn:startEvent>

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7130/restart/RestartProcessIntanceWithInitialVariablesTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7130/restart/RestartProcessIntanceWithInitialVariablesTest.java
@@ -17,7 +17,6 @@
 package org.camunda.bpm.qa.upgrade.scenarios7130.restart;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7160/externaltask/ExternalTaskFailureLogTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7160/externaltask/ExternalTaskFailureLogTest.java
@@ -19,11 +19,9 @@ package org.camunda.bpm.qa.upgrade.scenarios7160.externaltask;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.camunda.bpm.engine.ExternalTaskService;
-import org.camunda.bpm.engine.ManagementService;
 import org.camunda.bpm.engine.externaltask.ExternalTask;
 import org.camunda.bpm.engine.history.HistoricIncident;
 import org.camunda.bpm.engine.runtime.Incident;
-import org.camunda.bpm.engine.runtime.Job;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.qa.upgrade.Origin;
 import org.camunda.bpm.qa.upgrade.ScenarioUnderTest;

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7170/pvm/AsyncJoinTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7170/pvm/AsyncJoinTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.qa.upgrade.scenarios7170.pvm;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.assertj.core.api.Assertions;
+import org.camunda.bpm.engine.ManagementService;
+import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.runtime.JobQuery;
+import org.camunda.bpm.qa.upgrade.Origin;
+import org.camunda.bpm.qa.upgrade.ScenarioUnderTest;
+import org.camunda.bpm.qa.upgrade.UpgradeTestRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+@ScenarioUnderTest("AsyncJoinScenario")
+@Origin("7.16.0")
+public class AsyncJoinTest {
+
+  @Rule
+  public UpgradeTestRule engineRule = new UpgradeTestRule();
+
+  ManagementService managementService;
+
+  @Before
+  public void assignServices() {
+    managementService = engineRule.getManagementService();
+  }
+
+  @Test
+  @ScenarioUnderTest("asyncJoinParallel.1")
+  public void shouldCompleteWithConcurrentExecution_ParallelGateway() {
+    // given
+    JobQuery jobQuery = engineRule.jobQuery();
+    AtomicReference<String> jobIdNotifyListener = new AtomicReference<>();
+    AtomicReference<String> jobIdActivityEnd = new AtomicReference<>();
+    jobQuery.list().forEach(job -> {
+      if ("transition-notify-listener-take$Flow_0wno03o".equals(((JobEntity)job).getJobHandlerConfigurationRaw())) {
+        jobIdNotifyListener.set(job.getId());
+      } else if ("activity-end".equals(((JobEntity)job).getJobHandlerConfigurationRaw())) {
+        jobIdActivityEnd.set(job.getId());
+      }
+    });
+
+    managementService.executeJob(jobIdActivityEnd.get());
+    
+    // when
+    managementService.executeJob(jobIdNotifyListener.get());
+
+    // then
+    Assertions.assertThat(jobQuery.count()).isEqualTo(0);
+    Assertions.assertThat(engineRule.historicProcessInstance().getState())
+        .isEqualTo("COMPLETED");
+  }
+
+  @Test
+  @ScenarioUnderTest("asyncJoinInclusive.1")
+  public void shouldCompleteWithConcurrentExecution_InclusiveGateway() {
+    // given
+    JobQuery jobQuery = engineRule.jobQuery();
+    AtomicReference<String> jobIdNotifyListener = new AtomicReference<>();
+    AtomicReference<String> jobIdActivityEnd = new AtomicReference<>();
+    jobQuery.list().forEach(job -> {
+      if ("transition-notify-listener-take$Flow_0wno03o".equals(((JobEntity)job).getJobHandlerConfigurationRaw())) {
+        jobIdNotifyListener.set(job.getId());
+      } else if ("activity-end".equals(((JobEntity)job).getJobHandlerConfigurationRaw())) {
+        jobIdActivityEnd.set(job.getId());
+      }
+    });
+
+    managementService.executeJob(jobIdActivityEnd.get());
+    
+    // when
+    managementService.executeJob(jobIdNotifyListener.get());
+
+    // then
+    Assertions.assertThat(jobQuery.count()).isEqualTo(0);
+    Assertions.assertThat(engineRule.historicProcessInstance().getState())
+        .isEqualTo("COMPLETED");
+  }
+}

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios730/boundary/NonInterruptingBoundaryEventScenarioTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios730/boundary/NonInterruptingBoundaryEventScenarioTest.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import org.camunda.bpm.engine.management.ActivityStatistics;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
-import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.qa.upgrade.Origin;
 import org.camunda.bpm.qa.upgrade.ScenarioUnderTest;
 import org.camunda.bpm.qa.upgrade.UpgradeTestRule;

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios780/CreateProcessInstanceWithJsonVariablesTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios780/CreateProcessInstanceWithJsonVariablesTest.java
@@ -18,28 +18,21 @@ package org.camunda.bpm.qa.upgrade.scenarios780;
 
 import java.util.HashMap;
 import java.util.List;
-import org.camunda.bpm.engine.history.HistoricVariableInstance;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.runtime.VariableInstance;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
-import org.camunda.bpm.engine.variable.value.ObjectValue;
 import org.camunda.bpm.engine.variable.value.TypedValue;
 import org.camunda.bpm.qa.upgrade.Origin;
 
 import org.camunda.bpm.qa.upgrade.ScenarioUnderTest;
-import org.camunda.bpm.qa.upgrade.json.beans.Customer;
 import org.camunda.bpm.qa.upgrade.json.beans.ObjectList;
 import org.camunda.bpm.qa.upgrade.json.beans.Order;
 
-import org.camunda.bpm.qa.upgrade.json.beans.OrderDetails;
 import org.camunda.bpm.qa.upgrade.json.beans.RegularCustomer;
-import org.camunda.bpm.qa.upgrade.json.beans.SpecialCustomer;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @ScenarioUnderTest("CreateProcessInstanceWithJsonVariablesScenario")
@@ -100,7 +93,7 @@ public class CreateProcessInstanceWithJsonVariablesTest {
   }
 
   public void assertSerializedMap(TypedValue typedValue) {
-    HashMap<String, String> expected = new HashMap<String, String>();
+    HashMap<String, String> expected = new HashMap<>();
     expected.put("foo", "bar");
     Assert.assertEquals(expected, typedValue.getValue());
   }

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios790/CreateProcessInstanceWithJsonVariablesTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios790/CreateProcessInstanceWithJsonVariablesTest.java
@@ -18,7 +18,6 @@ package org.camunda.bpm.qa.upgrade.scenarios790;
 
 import java.util.HashMap;
 import java.util.List;
-import org.camunda.bpm.engine.history.HistoricVariableInstance;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.runtime.VariableInstance;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
@@ -26,19 +25,14 @@ import org.camunda.bpm.engine.variable.value.TypedValue;
 import org.camunda.bpm.qa.upgrade.Origin;
 
 import org.camunda.bpm.qa.upgrade.ScenarioUnderTest;
-import org.camunda.bpm.qa.upgrade.json.beans.Customer;
 import org.camunda.bpm.qa.upgrade.json.beans.ObjectList;
 import org.camunda.bpm.qa.upgrade.json.beans.Order;
 
-import org.camunda.bpm.qa.upgrade.json.beans.OrderDetails;
 import org.camunda.bpm.qa.upgrade.json.beans.RegularCustomer;
-import org.camunda.bpm.qa.upgrade.json.beans.SpecialCustomer;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @ScenarioUnderTest("CreateProcessInstanceWithJsonVariablesScenario")
@@ -99,7 +93,7 @@ public class CreateProcessInstanceWithJsonVariablesTest {
   }
 
   public void assertSerializedMap(TypedValue typedValue) {
-    HashMap<String, String> expected = new HashMap<String, String>();
+    HashMap<String, String> expected = new HashMap<>();
     expected.put("foo", "bar");
     Assert.assertEquals(expected, typedValue.getValue());
   }

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/util/ActivityInstanceAssert.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/util/ActivityInstanceAssert.java
@@ -17,7 +17,6 @@
 package org.camunda.bpm.qa.upgrade.util;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Stack;
@@ -63,10 +62,10 @@ public class ActivityInstanceAssert {
           return false;
         } else {
 
-          List<ExpectedActivityInstance> unmatchedInstances = new ArrayList<ExpectedActivityInstance>(expectedInstance.getChildActivityInstances());
+          List<ExpectedActivityInstance> unmatchedInstances = new ArrayList<>(expectedInstance.getChildActivityInstances());
           for (ActivityInstance child1 : actualInstance.getChildActivityInstances()) {
             boolean matchFound = false;
-            for (ExpectedActivityInstance child2 : new ArrayList<ExpectedActivityInstance>(unmatchedInstances)) {
+            for (ExpectedActivityInstance child2 : new ArrayList<>(unmatchedInstances)) {
               if (isTreeMatched(child2, child1)) {
                 unmatchedInstances.remove(child2);
                 matchFound = true;
@@ -79,7 +78,7 @@ public class ActivityInstanceAssert {
           }
 
           List<ExpectedTransitionInstance> unmatchedTransitionInstances =
-              new ArrayList<ExpectedTransitionInstance>(expectedInstance.getChildTransitionInstances());
+              new ArrayList<>(expectedInstance.getChildTransitionInstances());
           for (TransitionInstance child : actualInstance.getChildTransitionInstances()) {
             Iterator<ExpectedTransitionInstance> expectedTransitionInstanceIt = unmatchedTransitionInstances.iterator();
 
@@ -108,7 +107,7 @@ public class ActivityInstanceAssert {
   public static class ActivityInstanceTreeBuilder {
 
     protected ExpectedActivityInstance rootInstance = null;
-    protected Stack<ExpectedActivityInstance> activityInstanceStack = new Stack<ExpectedActivityInstance>();
+    protected Stack<ExpectedActivityInstance> activityInstanceStack = new Stack<>();
 
     public ActivityInstanceTreeBuilder() {
       this(null);
@@ -125,7 +124,7 @@ public class ActivityInstanceAssert {
       newInstance.setActivityIds(activityIds);
 
       ExpectedActivityInstance parentInstance = activityInstanceStack.peek();
-      List<ExpectedActivityInstance> childInstances = new ArrayList<ExpectedActivityInstance>(parentInstance.getChildActivityInstances());
+      List<ExpectedActivityInstance> childInstances = new ArrayList<>(parentInstance.getChildActivityInstances());
       childInstances.add(newInstance);
       parentInstance.setChildActivityInstances(childInstances);
 
@@ -152,7 +151,7 @@ public class ActivityInstanceAssert {
       newInstance.setActivityId(activityId);
       ExpectedActivityInstance parentInstance = activityInstanceStack.peek();
 
-      List<ExpectedTransitionInstance> childInstances = new ArrayList<ExpectedTransitionInstance>(
+      List<ExpectedTransitionInstance> childInstances = new ArrayList<>(
           parentInstance.getChildTransitionInstances());
       childInstances.add(newInstance);
       parentInstance.setChildTransitionInstances(childInstances);


### PR DESCRIPTION
Ensures that executions that are joined in a parallel or inclusive gateway
are ended synchronously before executing the next logical operation,
e.g. taking the next transition. This ensures the order of operations at
join gateways, even if a gateway is marked as `async-after`. Otherwise,
executions can get stuck unnecessarily at another inclusive join.

related to CAM-14116