### PR TITLE
Add the removal time for the subprocess of the invoice example

### DIFF
--- a/examples/invoice/src/main/resources/reviewInvoice.bpmn
+++ b/examples/invoice/src/main/resources/reviewInvoice.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1k1vca8" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.5.0">
-  <bpmn:process id="ReviewInvoice" name="Review Invoice" isExecutable="true" camunda:isStartableInTasklist="false">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1k1vca8" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+  <bpmn:process id="ReviewInvoice" name="Review Invoice" isExecutable="true" camunda:historyTimeToLive="45" camunda:isStartableInTasklist="false">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_1ggutts</bpmn:outgoing>
     </bpmn:startEvent>
@@ -21,24 +21,24 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ReviewInvoice">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="79" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1ggutts_di" bpmnElement="SequenceFlow_1ggutts">
-        <di:waypoint x="215" y="97" />
-        <di:waypoint x="270" y="97" />
+      <bpmndi:BPMNEdge id="SequenceFlow_0vvoxt0_di" bpmnElement="SequenceFlow_0vvoxt0">
+        <di:waypoint x="530" y="97" />
+        <di:waypoint x="592" y="97" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_144f11w_di" bpmnElement="SequenceFlow_144f11w">
         <di:waypoint x="370" y="97" />
         <di:waypoint x="430" y="97" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ggutts_di" bpmnElement="SequenceFlow_1ggutts">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="270" y="97" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_1og1zom_di" bpmnElement="EndEvent_1og1zom">
         <dc:Bounds x="592" y="79" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0vvoxt0_di" bpmnElement="SequenceFlow_0vvoxt0">
-        <di:waypoint x="530" y="97" />
-        <di:waypoint x="592" y="97" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="UserTask_01n44zw_di" bpmnElement="assignReviewer">
         <dc:Bounds x="270" y="57" width="100" height="80" />
       </bpmndi:BPMNShape>


### PR DESCRIPTION
Sometimes it is helpful to show the removal times in a chain of subprocesses.

This missing detail should be added to the codebase for further references.