### PR TITLE
CAM-14308: make extension properties available for all external tasks

### DIFF
--- a/engine-plugins/connect-plugin/src/main/java/org/camunda/connect/plugin/impl/ConnectorParseListener.java
+++ b/engine-plugins/connect-plugin/src/main/java/org/camunda/connect/plugin/impl/ConnectorParseListener.java
@@ -21,6 +21,7 @@ import static org.camunda.bpm.engine.impl.bpmn.parser.BpmnParseUtil.parseInputOu
 
 import org.camunda.bpm.engine.BpmnParseException;
 import org.camunda.bpm.engine.impl.bpmn.parser.AbstractBpmnParseListener;
+import org.camunda.bpm.engine.impl.bpmn.parser.BpmnParse;
 import org.camunda.bpm.engine.impl.core.variable.mapping.IoMapping;
 import org.camunda.bpm.engine.impl.pvm.process.ActivityImpl;
 import org.camunda.bpm.engine.impl.pvm.process.ScopeImpl;
@@ -30,6 +31,38 @@ public class ConnectorParseListener extends AbstractBpmnParseListener {
 
   @Override
   public void parseServiceTask(Element serviceTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    parseConnectorElement(serviceTaskElement, scope, activity);
+  }
+
+  @Override
+  public void parseEndEvent(Element endEventElement, ScopeImpl scope, ActivityImpl activity) {
+    Element messageEventDefinitionElement = endEventElement.element(BpmnParse.MESSAGE_EVENT_DEFINITION);
+
+    if (messageEventDefinitionElement != null) {
+      parseConnectorElement(messageEventDefinitionElement, scope, activity);
+    }
+  }
+
+  @Override
+  public void parseIntermediateThrowEvent(Element intermediateEventElement, ScopeImpl scope, ActivityImpl activity) {
+    Element messageEventDefinitionElement = intermediateEventElement.element(BpmnParse.MESSAGE_EVENT_DEFINITION);
+
+    if (messageEventDefinitionElement != null) {
+      parseConnectorElement(messageEventDefinitionElement, scope, activity);
+    }
+  }
+
+  @Override
+  public void parseBusinessRuleTask(Element businessRuleTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    parseConnectorElement(businessRuleTaskElement, scope, activity);
+  }
+
+  @Override
+  public void parseSendTask(Element sendTaskElement, ScopeImpl scope, ActivityImpl activity) {
+    parseConnectorElement(sendTaskElement, scope, activity);
+  }
+
+  protected void parseConnectorElement(Element serviceTaskElement, ScopeImpl scope, ActivityImpl activity) {
     Element connectorDefinition = findCamundaExtensionElement(serviceTaskElement, "connector");
     if (connectorDefinition != null) {
       Element connectorIdElement = connectorDefinition.element("connectorId");

--- a/engine-plugins/connect-plugin/src/test/java/org/camunda/connect/plugin/ConnectProcessEnginePluginTest.java
+++ b/engine-plugins/connect-plugin/src/test/java/org/camunda/connect/plugin/ConnectProcessEnginePluginTest.java
@@ -254,7 +254,7 @@ public class ConnectProcessEnginePluginTest extends PluggableProcessEngineTestCa
       assertThat(re.getMessage(), containsString("Invalid format"));
     }
   }
-  
+
   @Deployment
   public void testSendTaskWithConnector() {
     String outputParamValue = "someSendTaskOutputValue";
@@ -276,7 +276,7 @@ public class ConnectProcessEnginePluginTest extends PluggableProcessEngineTestCa
     assertNotNull(variable);
     assertEquals(outputParamValue, variable.getValue());
   }
-  
+
   @Deployment
   public void testIntermediateMessageThrowEventWithConnector() {
     String outputParamValue = "someMessageThrowOutputValue";
@@ -297,7 +297,7 @@ public class ConnectProcessEnginePluginTest extends PluggableProcessEngineTestCa
     VariableInstance variable = runtimeService.createVariableInstanceQuery().variableName("out1").singleResult();
     assertNotNull(variable);
     assertEquals(outputParamValue, variable.getValue());
-}
+  }
 
   @Deployment
   public void testMessageEndEventWithConnector() {

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskSupportTest.businessRuleTask.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskSupportTest.businessRuleTask.bpmn20.xml
@@ -7,7 +7,14 @@
   <process id="oneExternalTaskProcess" isExecutable="true">
     <startEvent id="start" />
     <sequenceFlow id="flow1" sourceRef="start" targetRef="externalTask" />
-    <businessRuleTask id="externalTask" camunda:type="external" camunda:topic="externalTaskTopic" />
+    <businessRuleTask id="externalTask" camunda:type="external" camunda:topic="externalTaskTopic">
+      <extensionElements>
+        <camunda:properties>
+          <camunda:property name="key1" value="val1" />
+          <camunda:property name="key2" value="val2" />
+        </camunda:properties>
+      </extensionElements>
+    </businessRuleTask>
     <sequenceFlow id="flow2" sourceRef="externalTask" targetRef="end" />
     <endEvent id="end" />
   </process>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskSupportTest.messageEndEvent.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskSupportTest.messageEndEvent.bpmn20.xml
@@ -8,6 +8,12 @@
     <startEvent id="start" />
     <sequenceFlow id="flow1" sourceRef="start" targetRef="end" />
     <endEvent id="end" >
+      <extensionElements>
+        <camunda:properties>
+          <camunda:property name="key1" value="val1" />
+          <camunda:property name="key2" value="val2" />
+        </camunda:properties>
+      </extensionElements>
       <messageEventDefinition camunda:type="external" camunda:topic="externalTaskTopic" />
     </endEvent>
   </process>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskSupportTest.messageIntermediateEvent.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskSupportTest.messageIntermediateEvent.bpmn20.xml
@@ -8,6 +8,12 @@
     <startEvent id="start" />
     <sequenceFlow id="flow1" sourceRef="start" targetRef="externalTask" />
     <intermediateThrowEvent id="externalTask">
+      <extensionElements>
+        <camunda:properties>
+          <camunda:property name="key1" value="val1" />
+          <camunda:property name="key2" value="val2" />
+        </camunda:properties>
+      </extensionElements>
       <messageEventDefinition camunda:type="external" camunda:topic="externalTaskTopic" />
     </intermediateThrowEvent>
     <sequenceFlow id="flow2" sourceRef="externalTask" targetRef="end" />

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskSupportTest.sendTask.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskSupportTest.sendTask.bpmn20.xml
@@ -7,7 +7,14 @@
   <process id="oneExternalTaskProcess" isExecutable="true">
     <startEvent id="start" />
     <sequenceFlow id="flow1" sourceRef="start" targetRef="externalTask" />
-    <sendTask id="externalTask" camunda:type="external" camunda:topic="externalTaskTopic" />
+    <sendTask id="externalTask" camunda:type="external" camunda:topic="externalTaskTopic">
+      <extensionElements>
+        <camunda:properties>
+          <camunda:property name="key1" value="val1" />
+          <camunda:property name="key2" value="val2" />
+        </camunda:properties>
+      </extensionElements>
+    </sendTask>
     <sequenceFlow id="flow2" sourceRef="externalTask" targetRef="end" />
     <endEvent id="end" />
   </process>


### PR DESCRIPTION
- fixes the case for intermediate/end message events, business rule tasks,
  send tasks that are implemented as external tasks
- restructures the code how service-task-like activities are parsed
  and handed to parse listeners; avoids that we create a 'dummy' activity
  that also goes to parse listeners that remains unused; this comes at the cost
  of some duplicated code, but I think my solution has the better tradeoff
  than hackfixing this in the current solution

related to CAM-14308