### PR TITLE
chore(engine): camunda-engine-plugin-spin jdk17 support

### DIFF
--- a/engine-plugins/pom.xml
+++ b/engine-plugins/pom.xml
@@ -28,6 +28,17 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${version.mockito.new}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>2.3.6</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/HistoricVariableJsonSerializationWithValidationTest.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/HistoricVariableJsonSerializationWithValidationTest.java
@@ -16,7 +16,7 @@
  */
 package org.camunda.spin.plugin.variables;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/JsonSerializationWithValidationOnMultipleEnginesTest.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/camunda/spin/plugin/variables/JsonSerializationWithValidationOnMultipleEnginesTest.java
@@ -19,13 +19,11 @@ package org.camunda.spin.plugin.variables;
 import static org.camunda.bpm.engine.variable.Variables.objectValue;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.ProcessEngineException;
-import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.runtime.DeserializationTypeValidator;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.test.ProcessEngineRule;

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <version.uuid-generator>3.2.0</version.uuid-generator>
     <version.camunda.commons>1.10.0</version.camunda.commons>
     <version.camunda.connect>1.5.2</version.camunda.connect>
-    <version.camunda.spin>1.13.1</version.camunda.spin>
+    <version.camunda.spin>1.14.0</version.camunda.spin>
     <version.camunda.template-engines>2.1.0</version.camunda.template-engines>
     <version.camunda.ee.xslt-plugin>1.1.0</version.camunda.ee.xslt-plugin>
     <version.feel-scala>1.13.3</version.feel-scala>


### PR DESCRIPTION
- update mockito to v4.3.1
- fix deprecated mockito apis
- update jaxb-impl to v2.3.6
- use latest camunda-spin

related to CAM-14365