### PR TITLE
chore(engine): webapps jdk17 support

### DIFF
--- a/webapps/pom.xml
+++ b/webapps/pom.xml
@@ -150,42 +150,14 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.5.15</version>
+      <version>${version.mockito.new}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>3.5.15</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>2.0.2</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4-rule</artifactId>
-      <version>2.0.2</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>2.0.2</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-classloading-xstream</artifactId>
-      <version>2.0.2</version>
+      <version>${version.mockito.new}</version>
       <scope>test</scope>
     </dependency>
 
@@ -248,7 +220,7 @@
             <systemPropertyVariables>
               <myWorkingDir>${project.build.directory}</myWorkingDir>
             </systemPropertyVariables>
-            <argLine>-XX:MaxPermSize=128m</argLine>
+            <argLine>-XX:MaxMetaspaceSize=128m</argLine>
           </configuration>
         </plugin>
 

--- a/webapps/src/test/java/org/camunda/bpm/webapp/impl/security/filter/csrf/CsrfPreventionFilterTest.java
+++ b/webapps/src/test/java/org/camunda/bpm/webapp/impl/security/filter/csrf/CsrfPreventionFilterTest.java
@@ -19,12 +19,9 @@ package org.camunda.bpm.webapp.impl.security.filter.csrf;
 import org.camunda.bpm.webapp.impl.security.filter.CsrfPreventionFilter;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockFilterConfig;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -44,20 +41,17 @@ import java.util.Collection;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.webapp.impl.security.filter.util.CsrfConstants.CSRF_PATH_FIELD_NAME;
 import static org.camunda.bpm.webapp.impl.security.filter.util.CookieConstants.SET_COOKIE_HEADER_NAME;
+
 /**
  * @author Nikola Koevski
  */
 @RunWith(Parameterized.class)
-@PowerMockIgnore("javax.security.*")
 public class CsrfPreventionFilterTest {
 
   protected static final String SERVICE_PATH = "/camunda";
   protected static final String CSRF_COOKIE_NAME = "XSRF-TOKEN";
   protected static final String CSRF_HEADER_NAME = "X-XSRF-TOKEN";
   protected static final String CSRF_HEADER_REQUIRED = "Required";
-
-  @Rule
-  public PowerMockRule rule = new PowerMockRule();
 
   protected Filter csrfPreventionFilter;
 


### PR DESCRIPTION
- remove powermock
- update mockito to v4.3.1 & add mockito-inline for static tests
- fix deprecated mockito apis
- migrate tests from powermock to mockito

related to CAM-14389