### PR TITLE
fix(webapp/wildfly): exclude system modules for export feature

### DIFF
--- a/distro/jboss/webapp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/distro/jboss/webapp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -2,6 +2,8 @@
 <jboss-deployment-structure>
   <deployment>
     <exclusions>
+      <module name="com.fasterxml.jackson.datatype.jackson-datatype-jsr310" />
+      <module name="org.jboss.resteasy.resteasy-jackson2-provider" />
       <module name="org.jboss.resteasy.resteasy-jackson-provider" />
       <module name="org.jboss.resteasy.resteasy-jettison-provider" />
     </exclusions>


### PR DESCRIPTION
Excludes `resteasy-jackson2-provider` and `jackson-datatype-jsr310` system modules to ensure that the libraries local to the deployment are used.

related to CAM-14419