### PR TITLE
[CAM-14536] Allow querying for last deployment when name for deployment not provided

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/CommandLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/CommandLogger.java
@@ -317,4 +317,8 @@ public class CommandLogger extends ProcessEngineLogger {
       cause.getMessage());
   }
 
+  public void warnFilteringDuplicatesEnabledWithNullDeploymentName() {
+    logWarn("047", "Deployment name set to null. Filtering duplicates will not work properly.");
+  }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeployCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeployCmd.java
@@ -210,6 +210,10 @@ public class DeployCmd implements Command<DeploymentWithDefinitions>, Serializab
 
     if (deploymentBuilder.isDuplicateFilterEnabled()) {
 
+      if (candidateDeployment.getName() == null) {
+        LOG.warnFilteringDuplicatesEnabledWithNullDeploymentName();
+      }
+
       String source = candidateDeployment.getSource();
       if (source == null || source.isEmpty()) {
         source = ProcessApplicationDeployment.PROCESS_APPLICATION_DEPLOYMENT_SOURCE;


### PR DESCRIPTION
bugfix: Fix query used for resolving duplicates for deployments when name is not provided

related to CAM-14536