### PR TITLE
CAM-14434: enable rolling-update and old-engine tests for h2

### DIFF
--- a/qa/test-db-rolling-update/create-new-engine/pom.xml
+++ b/qa/test-db-rolling-update/create-new-engine/pom.xml
@@ -221,31 +221,5 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-      <!-- For 7.16 to 7.17, we are not executing these tests against h2, because
-        the 7.16 engine works with H2 1.4 and the 7.17 engine works with H2 2.0. It
-        is therefore not possible to perform a rolling update when using H2. 
-        This profile should be removed with 7.18 development via https://jira.camunda.com/browse/CAM-14434.
-        -->
-      <id>h2</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>sql-maven-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 </project>

--- a/qa/test-db-rolling-update/create-old-engine/pom.xml
+++ b/qa/test-db-rolling-update/create-old-engine/pom.xml
@@ -82,24 +82,5 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-      <!-- For 7.16 to 7.17, we are not executing these tests against h2, because
-        the 7.16 engine works with H2 1.4 and the 7.17 engine works with H2 2.0. It
-        is therefore not possible to perform a rolling update when using H2. 
-        This profile should be removed with 7.18 development via https://jira.camunda.com/browse/CAM-14434.
-        -->
-      <id>h2</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 </project>

--- a/qa/test-db-rolling-update/test-old-engine/pom.xml
+++ b/qa/test-db-rolling-update/test-old-engine/pom.xml
@@ -141,31 +141,5 @@
         </plugins>
       </build>
     </profile>
-    
-    <profile>
-      <!-- For 7.16 to 7.17, we are not executing these tests against h2, because
-        the 7.16 engine works with H2 1.4 and the 7.17 engine works with H2 2.0. It
-        is therefore not possible to perform a rolling update when using H2. 
-        This profile should be removed with 7.18 development via https://jira.camunda.com/browse/CAM-14434.
-        -->
-      <id>h2</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <skipTests>true</skipTests>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>sql-maven-plugin</artifactId>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 </project>

--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -114,25 +114,6 @@
     </profile>
     
     <profile>
-      <!-- For 7.16 to 7.17, we are not executing these tests against h2, because
-        the 7.16 engine works with H2 1.4 and the 7.17 engine works with H2 2.0. It
-        is therefore not possible to perform a rolling update when using H2. 
-        This profile should be removed with 7.18 development via https://jira.camunda.com/browse/CAM-14434.
-        -->
-      <id>h2</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <skipTests>true</skipTests>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
       <id>old-engine</id>
 
       <dependencyManagement>


### PR DESCRIPTION
- were disabled during 7.17 development due to incompatibility
  of H2 1.4 and 2.0

related to CAM-14434