### PR TITLE
CAMTEAM-235: test docker gha trigger

### DIFF
--- a/.ci/daily/Jenkinsfile
+++ b/.ci/daily/Jenkinsfile
@@ -88,7 +88,10 @@ pipeline {
         }
         stage('Trigger Docker CE GHA') {
           when {
-            branch cambpmDefaultBranch();
+            expression {
+              cambpmWithLabels('docker')
+            }
+//            branch cambpmDefaultBranch();
           }
           agent {
             kubernetes {
@@ -100,12 +103,16 @@ pipeline {
               ])
             }
           }
+          options {
+            timeout(time: 15, unit: 'MINUTES')
+          }
           environment {
             // define helper script input arguments
             INPUT_OWNER = 'camunda'
             INPUT_REPO = 'docker-camunda-bpm-platform'
             // ensure that the GHA trigger works for maintenance branches as well
-            INPUT_REF = cambpmGetDockerRepoBranch()
+//            INPUT_REF = cambpmGetDockerRepoBranch()
+            INPUT_REF = 'next'
             INPUT_WORKFLOW_FILE_NAME = 'build-test-and-publish-ce.yml'
             INPUT_WAIT_INPUT_WAIT_WORKFLOW = 'true'
           }


### PR DESCRIPTION
Related to [CAMTEAM-235](https://jira.camunda.com/browse/CAMTEAM-235)

:information_source: This PR is intended to test if GitHub resolved the issue with their API. This is currently blocking us from using the Docker GHA trigger stages.