### PR TITLE
CAMTEAM-235: chore(ci): disable docker gha trigger stage

### DIFF
--- a/.ci/daily/Jenkinsfile
+++ b/.ci/daily/Jenkinsfile
@@ -88,7 +88,9 @@ pipeline {
         }
         stage('Trigger Docker CE GHA') {
           when {
-            branch cambpmDefaultBranch();
+            // temporarily disable stage due to GitHub API issues
+            expression { false }
+//            branch cambpmDefaultBranch();
           }
           agent {
             kubernetes {
@@ -99,6 +101,9 @@ pipeline {
                   useStableNodePool: false
               ])
             }
+          }
+          options {
+            timeout(time: 15, unit: 'MINUTES')
           }
           environment {
             // define helper script input arguments


### PR DESCRIPTION
* Disable Docker GHA trigger stage due to GitHub API issues.
* Add a timeout option as an optimization so there are no infinite retried by the GHA invocation script.

Related to CAMTEAM-235