### PR TITLE
CAM-14497: fix(engine): add missing and sql operator

### DIFF
--- a/distro/run/modules/swaggerui/ui/package-lock.json
+++ b/distro/run/modules/swaggerui/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "7.18.0-SNAPSHOT",
+  "version": "7.17.0-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/distro/run/modules/swaggerui/ui/package-lock.json
+++ b/distro/run/modules/swaggerui/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "7.17.0-SNAPSHOT",
+  "version": "7.18.0-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricDetail.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricDetail.xml
@@ -423,7 +423,7 @@
       </if>
 
       <if test="userOperationId != null">
-        RES.OPERATION_ID_ = #{userOperationId}
+        and RES.OPERATION_ID_ = #{userOperationId}
       </if>
 
       <if test="sequenceCounter != null">

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricDetailQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricDetailQueryTest.java
@@ -120,6 +120,29 @@ public class HistoricDetailQueryTest {
 
   @Test
   @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  public void shouldQueryByUserOperationIdAndVariableUpdates() {
+    startProcessInstance(PROCESS_KEY);
+
+    identityService.setAuthenticatedUserId("demo");
+
+    String taskId = taskService.createTaskQuery().singleResult().getId();
+
+    // when
+    taskService.resolveTask(taskId, getVariables());
+
+    //then
+    String userOperationId = historyService.createHistoricDetailQuery().singleResult().getUserOperationId();
+
+    HistoricDetailQuery query = historyService.createHistoricDetailQuery()
+        .userOperationId(userOperationId)
+        .variableUpdates();
+
+    assertEquals(1, query.list().size());
+    assertEquals(1, query.count());
+  }
+
+  @Test
+  @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
   public void testQueryByInvalidUserOperationId() {
     startProcessInstance(PROCESS_KEY);
 


### PR DESCRIPTION
* Add missing SQL AND operator when filtering by userOperationId and another parameter in the HistoricDetail query.

Related to CAM-14497