### PR TITLE
CAMTEAM-235: chore(ci): disable docker gha trigger stage

### DIFF
--- a/.ci/daily/Jenkinsfile
+++ b/.ci/daily/Jenkinsfile
@@ -88,9 +88,7 @@ pipeline {
         }
         stage('Trigger Docker CE GHA') {
           when {
-            // temporarily disable stage due to GitHub API issues
-            expression { false }
-//            branch cambpmDefaultBranch();
+            branch cambpmDefaultBranch();
           }
           agent {
             kubernetes {

--- a/.ci/daily/Jenkinsfile
+++ b/.ci/daily/Jenkinsfile
@@ -88,11 +88,7 @@ pipeline {
         }
         stage('Trigger Docker CE GHA') {
           when {
-            allOf {
-              // only build snapshot docker images on master CE branch
-              expression { cambpmIsDevelopmentVersion }
-              branch cambpmDefaultBranch();
-            }
+            branch cambpmDefaultBranch();
           }
           agent {
             kubernetes {

--- a/.ci/daily/Jenkinsfile
+++ b/.ci/daily/Jenkinsfile
@@ -88,7 +88,11 @@ pipeline {
         }
         stage('Trigger Docker CE GHA') {
           when {
-            branch cambpmDefaultBranch();
+            allOf {
+              // only build snapshot docker images on master CE branch
+              expression { cambpmIsDevelopmentVersion }
+              branch cambpmDefaultBranch();
+            }
           }
           agent {
             kubernetes {


### PR DESCRIPTION
* Disable Docker GHA trigger stage due to GitHub API issues.
* Add a timeout option as an optimization so there are no infinite retried by the GHA invocation script.

Related to CAMTEAM-235

:information_source: The CI can't test the changes of this PR since the Docker GHA trigger stage should only execute on the `master` branch. You can find a successful execution on [this test PR](https://ci-pipeline.cambpm.camunda.cloud/blue/organizations/jenkins/7.18%2Fcambpm-ce%2Fcambpm-daily/detail/PR-1873/6/pipeline/).