### PR TITLE
Closing ldap connection after password validation during checkPassword

### DIFF
--- a/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
+++ b/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
@@ -338,7 +338,7 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
 
       try {
         // bind authenticate for user + supplied password
-        openContext(user.getDn(), password);
+        initialContext = openContext(user.getDn(), password);
         return true;
 
       } catch(LdapAuthenticationException e) {

--- a/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
+++ b/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.naming.AuthenticationException;
@@ -85,9 +84,13 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
   }
 
   public void close() {
-    if (initialContext != null) {
+    closeLdapCtx(initialContext);
+  }
+
+  protected void closeLdapCtx(LdapContext context) {
+    if (context != null) {
       try {
-        initialContext.close();
+        context.close();
       } catch (Exception e) {
         // ignore
         LdapPluginLogger.INSTANCE.exceptionWhenClosingLdapCOntext(e);
@@ -336,13 +339,18 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
       return false;
     } else {
 
+      LdapContext context = null;
+
       try {
         // bind authenticate for user + supplied password
-        initialContext = openContext(user.getDn(), password);
+        context = openContext(user.getDn(), password);
         return true;
 
       } catch(LdapAuthenticationException e) {
         return false;
+
+      } finally {
+        closeLdapCtx(context);
 
       }
 


### PR DESCRIPTION
The [`LdapIdentityProviderSession.checkPassword`](https://github.com/camunda/camunda-bpm-platform/blob/master/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java#L310) opens two LDAP-Connections: 
* One for [finding the user](https://github.com/camunda/camunda-bpm-platform/blob/master/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java#L332) and
* one for [validating its password](https://github.com/camunda/camunda-bpm-platform/blob/master/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java#L341).

The first one gets closed after the user is fetched. The second one, validating the user's password, does not get close.

With this scenario high frequent usages of the `checkPassword` will result in too many LDAP connections which itself could result in too many open file-handles.
 
