### PR TITLE
CAM-14302: chore(engine): downgrade groovy to 2.4.21

### DIFF
--- a/distro/jboss/webapp-standalone/pom.xml
+++ b/distro/jboss/webapp-standalone/pom.xml
@@ -113,14 +113,6 @@
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-datetime</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-dateutil</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-templates</artifactId>
     </dependency>
     <dependency>

--- a/distro/run/assembly/assembly.xml
+++ b/distro/run/assembly/assembly.xml
@@ -48,8 +48,6 @@
         <include>org.codehaus.groovy:groovy-jsr223:jar:*</include>
         <include>org.codehaus.groovy:groovy-json:jar:*</include>
         <include>org.codehaus.groovy:groovy-xml:jar:*</include>
-        <include>org.codehaus.groovy:groovy-datetime:jar:*</include>
-        <include>org.codehaus.groovy:groovy-dateutil:jar:*</include>
         <include>org.codehaus.groovy:groovy-templates:jar:*</include>
       </includes>
     </dependencySet>

--- a/distro/run/assembly/pom.xml
+++ b/distro/run/assembly/pom.xml
@@ -116,14 +116,6 @@
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-datetime</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-dateutil</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-templates</artifactId>
     </dependency>
 

--- a/distro/tomcat/assembly/assembly.xml
+++ b/distro/tomcat/assembly/assembly.xml
@@ -46,8 +46,6 @@
         <include>org.codehaus.groovy:groovy-jsr223:jar:*</include>
         <include>org.codehaus.groovy:groovy-json:jar:*</include>
         <include>org.codehaus.groovy:groovy-xml:jar:*</include>
-        <include>org.codehaus.groovy:groovy-datetime:jar:*</include>
-        <include>org.codehaus.groovy:groovy-dateutil:jar:*</include>
         <include>org.codehaus.groovy:groovy-templates:jar:*</include>
         <include>org.graalvm.js:*</include>
         <include>org.graalvm.regex:regex:jar:*</include>
@@ -88,8 +86,6 @@
         <include>org.codehaus.groovy:groovy-jsr223:jar:*</include>
         <include>org.codehaus.groovy:groovy-json:jar:*</include>
         <include>org.codehaus.groovy:groovy-xml:jar:*</include>
-        <include>org.codehaus.groovy:groovy-datetime:jar:*</include>
-        <include>org.codehaus.groovy:groovy-dateutil:jar:*</include>
         <include>org.codehaus.groovy:groovy-templates:jar:*</include>
         <include>org.graalvm.js:*</include>
         <include>org.graalvm.regex:regex:jar:*</include>

--- a/distro/tomcat/assembly/pom.xml
+++ b/distro/tomcat/assembly/pom.xml
@@ -62,14 +62,6 @@
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-datetime</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-dateutil</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-templates</artifactId>
     </dependency>
 

--- a/distro/tomcat/webapp-standalone/pom.xml
+++ b/distro/tomcat/webapp-standalone/pom.xml
@@ -106,14 +106,6 @@
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-datetime</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-dateutil</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-templates</artifactId>
     </dependency>
     <dependency>

--- a/distro/wildfly/assembly/assembly.xml
+++ b/distro/wildfly/assembly/assembly.xml
@@ -49,8 +49,6 @@
         <include>org.codehaus.groovy:groovy-jsr223:jar:*</include>
         <include>org.codehaus.groovy:groovy-json:jar:*</include>
         <include>org.codehaus.groovy:groovy-xml:jar:*</include>
-        <include>org.codehaus.groovy:groovy-datetime:jar:*</include>
-        <include>org.codehaus.groovy:groovy-dateutil:jar:*</include>
         <include>org.codehaus.groovy:groovy-templates:jar:*</include>
         <include>org.graalvm.js:*</include>
         <include>org.graalvm.regex:regex:jar:*</include>

--- a/distro/wildfly/assembly/pom.xml
+++ b/distro/wildfly/assembly/pom.xml
@@ -94,14 +94,6 @@
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-datetime</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-dateutil</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-templates</artifactId>
     </dependency>
 

--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -96,14 +96,6 @@
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-datetime</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-dateutil</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-templates</artifactId>
     </dependency>
 

--- a/distro/wildfly/modules/src/main/modules/org/codehaus/groovy/groovy-all/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/codehaus/groovy/groovy-all/main/module.xml
@@ -4,8 +4,6 @@
     <resource-root path="groovy-jsr223-@version.groovy@.jar" />
     <resource-root path="groovy-json-@version.groovy@.jar" />
     <resource-root path="groovy-xml-@version.groovy@.jar" />
-    <resource-root path="groovy-datetime-@version.groovy@.jar" />
-    <resource-root path="groovy-dateutil-@version.groovy@.jar" />
     <resource-root path="groovy-templates-@version.groovy@.jar" />
   </resources>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -26,7 +26,7 @@
     <version.jersey2>2.34</version.jersey2>
     <!-- use minimum version of resteasy and jersey -->
     <version.jaxrs.api>2.0.1.Final</version.jaxrs.api>
-    <version.groovy>2.5.16</version.groovy>
+    <version.groovy>2.4.21</version.groovy>
     <version.graal.js>21.1.0</version.graal.js>
     <version.icu.icu4j>68.2</version.icu.icu4j>
     <version.gson>2.8.9</version.gson>


### PR DESCRIPTION
* Groovy 2.5.16 is incompatible with JDK 17. Downgrade to Groovy 2.4.21 until support for JDK 17 is added to Groovy 2.5.x.

Related to CAM-14302