### PR TITLE
fix(engine): never skip I/O for EventBasedGateway

### DIFF
--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/gateway/EventBasedGatewayInputOutputTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/gateway/EventBasedGatewayInputOutputTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.bpmn.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.camunda.bpm.engine.history.HistoricVariableInstance;
+import org.camunda.bpm.engine.test.bpmn.iomapping.VariableLogDelegate;
+import org.camunda.bpm.engine.test.util.PluggableProcessEngineTest;
+import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EventBasedGatewayInputOutputTest extends PluggableProcessEngineTest {
+
+  protected static final BpmnModelInstance EVENT_GATEWAY_PROCESS =
+    Bpmn.createExecutableProcess("process")
+      .startEvent()
+      .eventBasedGateway()
+      .intermediateCatchEvent("conditionalEvent")
+        .camundaOutputParameter("eventOutput", "foo")
+        .conditionalEventDefinition()
+        .condition("${moveOn}")
+        .conditionalEventDefinitionDone()
+      .serviceTask("inputParameterTask")
+        .camundaInputParameter("variable1", "testValue")
+        .camundaClass(VariableLogDelegate.class)
+      .endEvent()
+      .done();
+
+  protected boolean skipOutputMappingVal;
+
+  @Before
+  public void setUp() {
+    skipOutputMappingVal = processEngineConfiguration.isSkipOutputMappingOnCanceledActivities();
+    processEngineConfiguration.setSkipOutputMappingOnCanceledActivities(true);
+    VariableLogDelegate.reset();
+  }
+
+  @After
+  public void tearDown() {
+    processEngineConfiguration.setSkipOutputMappingOnCanceledActivities(skipOutputMappingVal);
+    VariableLogDelegate.reset();
+  }
+
+  @Test
+  public void shouldProcessInputOutputParametersAfterEventGateway() {
+    // given
+    testRule.deploy(EVENT_GATEWAY_PROCESS);
+
+    // when
+    runtimeService.startProcessInstanceByKey("process", Variables.putValue("moveOn", true));
+
+    // then
+    List<HistoricVariableInstance> vars = historyService.createHistoricVariableInstanceQuery()
+        .variableName("eventOutput")
+        .list();
+    assertThat(vars).hasSize(1);
+    assertThat(vars.get(0).getValue()).isEqualTo("foo");
+
+    assertThat(VariableLogDelegate.LOCAL_VARIABLES).hasSize(1);
+    vars = historyService.createHistoricVariableInstanceQuery()
+        .variableName("variable1")
+        .list();
+    assertThat(vars).hasSize(1);
+    assertThat(vars.get(0).getValue()).isEqualTo("testValue");
+  }
+
+  @Test
+  public void shouldNotProcessInputOutputParametersAfterEventGatewayDeletion() {
+    // given
+    testRule.deploy(EVENT_GATEWAY_PROCESS);
+    String instanceId = runtimeService.startProcessInstanceByKey("process", Variables.putValue("moveOn", false)).getId();
+
+    // when
+    runtimeService.deleteProcessInstance(instanceId, "manual cancelation");
+
+    // then
+    assertThat(VariableLogDelegate.LOCAL_VARIABLES).isEmpty();
+    assertThat(historyService.createHistoricVariableInstanceQuery()
+        .variableName("eventOutput")
+        .count()).isEqualTo(0L);
+    assertThat(historyService.createHistoricVariableInstanceQuery()
+        .variableName("variable1")
+        .count()).isEqualTo(0L);
+  }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/iomapping/VariableLogDelegate.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/iomapping/VariableLogDelegate.java
@@ -29,16 +29,18 @@ import org.camunda.bpm.engine.delegate.JavaDelegate;
  */
 public class VariableLogDelegate implements JavaDelegate, ExecutionListener {
 
-  public static Map<String, Object> LOCAL_VARIABLES= new HashMap<String, Object>();
+  public static Map<String, Object> LOCAL_VARIABLES= new HashMap<>();
 
+  @Override
   public void execute(DelegateExecution execution) throws Exception {
     LOCAL_VARIABLES = execution.getVariablesLocal();
   }
 
   public static void reset() {
-    LOCAL_VARIABLES = new HashMap<String, Object>();
+    LOCAL_VARIABLES = new HashMap<>();
   }
 
+  @Override
   public void notify(DelegateExecution execution) throws Exception {
     LOCAL_VARIABLES = execution.getVariablesLocal();
   }


### PR DESCRIPTION
* Never skips I/O for EventBasedGateway when canceled since this gateway
  is always canceled, even when finished "normally". Follow-up activities
  would always skip I/O as well otherwise. The gateway cannot have I/O
  itself, so not skipping I/O is fine here even when canceled, e.g. by delete.

related to CAM-14456