### PR TITLE
fix(engine): make Liquibase work from JAR

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -470,6 +470,32 @@
           <shadeTestJar>true</shadeTestJar>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-upgrade-scripts-liquibase</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+
+                <!-- copy all upgrade scripts after 7.15 -->
+                <mkdir dir="target/classes/org/camunda/bpm/engine/db/liquibase/upgrade" />
+                <copy todir="target/classes/org/camunda/bpm/engine/db/liquibase/upgrade">
+                  <fileset dir="target/classes/org/camunda/bpm/engine/db/upgrade" 
+                           excludes="*_6.*_*,*_7.0_*,*_7.1_*,*_7.2_*,*_7.3_*,*_7.4_*,*_7.5_*,*_7.6_*,*_7.7_*,
+                           *_7.8_*,*_7.9_*,*_7.10_*,*_7.11_*,*_7.12_*,*_7.13_*,*_7.14_*,*_7.15_*" />
+                </copy>
+
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>

--- a/engine/src/main/resources/org/camunda/bpm/engine/db/liquibase/camunda-changelog.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/db/liquibase/camunda-changelog.xml
@@ -74,7 +74,7 @@
   </changeSet>
 
   <changeSet author="Camunda" id="7.16-to-7.17">
-    <sqlFile path="../upgrade/${db.name}_engine_7.16_to_7.17.sql"
+    <sqlFile path="upgrade/${db.name}_engine_7.16_to_7.17.sql"
              encoding="UTF-8"
              relativeToChangelogFile="true"
              splitStatements="true"
@@ -86,7 +86,7 @@
   </changeSet>
 
   <changeSet author="Camunda" id="7.17-to-7.18">
-    <sqlFile path="../upgrade/${db.name}_engine_7.17_to_7.18.sql"
+    <sqlFile path="upgrade/${db.name}_engine_7.17_to_7.18.sql"
              encoding="UTF-8"
              relativeToChangelogFile="true"
              splitStatements="true"

--- a/spring-boot-starter/starter-qa/integration-test-liquibase/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-liquibase/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.camunda.bpm.springboot.project</groupId>
+    <artifactId>camunda-bpm-spring-boot-starter-qa</artifactId>
+    <version>7.18.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>qa-liquibase</artifactId>
+  <name>Camunda Platform - Spring Boot Starter - QA - Liquibase</name>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.camunda.bpm.springboot</groupId>
+      <artifactId>camunda-bpm-spring-boot-starter</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.camunda.bpm.springboot</groupId>
+      <artifactId>camunda-bpm-spring-boot-starter-test</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.liquibase</groupId>
+      <artifactId>liquibase-core</artifactId>
+    </dependency>
+
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>integration-test-spring-boot-starter</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+            <executions>
+              <execution>
+                <id>pre-integration-test</id>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>post-integration-test</id>
+                <goals>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/spring-boot-starter/starter-qa/integration-test-liquibase/src/test/java/org/camunda/bpm/springboot/project/qa/liquibase/Application.java
+++ b/spring-boot-starter/starter-qa/integration-test-liquibase/src/test/java/org/camunda/bpm/springboot/project/qa/liquibase/Application.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.springboot.project.qa.liquibase;
+
+import org.camunda.bpm.spring.boot.starter.annotation.EnableProcessApplication;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+@EnableProcessApplication("myProcessApplication")
+public class Application {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+
+}

--- a/spring-boot-starter/starter-qa/integration-test-liquibase/src/test/java/org/camunda/bpm/springboot/project/qa/liquibase/LiquibaseApplicationIT.java
+++ b/spring-boot-starter/starter-qa/integration-test-liquibase/src/test/java/org/camunda/bpm/springboot/project/qa/liquibase/LiquibaseApplicationIT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.springboot.project.qa.liquibase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.RuntimeService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { Application.class },
+                webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class LiquibaseApplicationIT {
+
+  @Autowired
+  RuntimeService runtimeService;
+
+  @Autowired
+  ProcessEngine processEngine;
+
+  @Test
+  public void shouldStartApplicationSuccessfully() {
+    // then no exception due to Liquibase changelog not being installable
+    assertThat(runtimeService).isNotNull();
+  }
+
+}

--- a/spring-boot-starter/starter-qa/integration-test-liquibase/src/test/resources/application.properties
+++ b/spring-boot-starter/starter-qa/integration-test-liquibase/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+camunda.bpm.generic-properties.properties.telemetry-reporter-activate=false
+spring.liquibase.change-log=classpath:org/camunda/bpm/engine/db/liquibase/camunda-changelog.xml

--- a/spring-boot-starter/starter-qa/integration-test-liquibase/src/test/resources/logback-test.xml
+++ b/spring-boot-starter/starter-qa/integration-test-liquibase/src/test/resources/logback-test.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/base.xml"/>
+  <logger name="org.springframework" level="info"/>
+  <logger name="org.hibernate" level="info"/>
+  <logger name="org.camunda" level="info"/>
+  <logger name="org.camunda.bpm.engine.persistence" level="warn"/>
+</configuration>

--- a/spring-boot-starter/starter-qa/pom.xml
+++ b/spring-boot-starter/starter-qa/pom.xml
@@ -23,6 +23,7 @@
       <modules>
         <module>integration-test-simple</module>
         <module>integration-test-plugins</module>
+        <module>integration-test-liquibase</module>
       </modules>
       <build>
         <pluginManagement>
@@ -69,6 +70,7 @@
         <module>integration-test-simple</module>
         <module>integration-test-plugins</module>
         <module>integration-test-webapp</module>
+        <module>integration-test-liquibase</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
* Copies upgrade scripts relevant to Liquibase into liquibase directory
  on engine core compile.
* Adjusts changesets to the new location of the upgrade scripts.
* Adds a Spring Boot Starter IT that installs the DB using our Liquibase
  changelog from a JAR.

related to [CAM-14629](https://jira.camunda.com/browse/CAM-14629)