### PR TITLE
feat(engine/rest/openapi): provide exception error codes

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/ExceptionDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/ExceptionDto.ftl
@@ -10,8 +10,15 @@
     <@lib.property
         name = "message"
         type = "string"
-        last = true
         desc = "A detailed message of the error." />
+
+    <@lib.property
+        name = "code"
+        type = "number"
+        last = true
+        desc = "The code allows your client application to identify the error in an automated fashion.
+                You can look up the meaning of all built-in codes and learn how to add custom codes
+                in the [User Guide](${docsUrl}/user-guide/process-engine/error-handling/#exception-codes)." />
 
 </@lib.dto>
 </#macro>

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/ExceptionDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/ExceptionDto.java
@@ -25,6 +25,7 @@ public class ExceptionDto {
 
   protected String type;
   protected String message;
+  protected Integer code;
 
   public ExceptionDto() {
 
@@ -65,6 +66,13 @@ public class ExceptionDto {
   public void setMessage(String message) {
     this.message = message;
   }
-  
-  
+
+  public Integer getCode() {
+    return code;
+  }
+
+  public void setCode(Integer code) {
+    this.code = code;
+  }
+
 }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/ExceptionHandlerHelper.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/ExceptionHandlerHelper.java
@@ -52,11 +52,36 @@ public class ExceptionHandlerHelper {
     Response.Status responseStatus = getStatus(throwable);
     ExceptionDto exceptionDto = fromException(throwable);
 
+    provideExceptionCode(throwable, exceptionDto);
+
     return Response
         .status(responseStatus)
         .entity(exceptionDto)
         .type(MediaType.APPLICATION_JSON_TYPE)
         .build();
+  }
+
+  protected void provideExceptionCode(Throwable throwable, ExceptionDto exceptionDto) {
+    Integer code = null;
+    if (throwable instanceof ProcessEngineException) {
+      code = getCode(throwable);
+
+    } else if (throwable instanceof RestException) {
+      Throwable cause = throwable.getCause();
+      if (cause instanceof ProcessEngineException) {
+        code = getCode(cause);
+
+      }
+    }
+
+    if (code != null) {
+      exceptionDto.setCode(code);
+    }
+  }
+
+  protected Integer getCode(Throwable throwable) {
+    ProcessEngineException pex = (ProcessEngineException) throwable;
+    return pex.getCode();
   }
 
   public ExceptionDto fromException(Throwable e) {

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/DecisionDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/DecisionDefinitionRestServiceInteractionTest.java
@@ -562,6 +562,24 @@ public class DecisionDefinitionRestServiceInteractionTest extends AbstractRestSe
   }
 
   @Test
+  public void shouldReturnErrorCode() {
+    when(decisionEvaluationBuilderMock.evaluate())
+        .thenThrow(new ProcessEngineException("foo", 123));
+
+    Map<String, Object> json = new HashMap<>();
+    json.put("variables", Collections.emptyMap());
+
+    given().pathParam("key", MockProvider.EXAMPLE_DECISION_DEFINITION_KEY)
+        .contentType(POST_JSON_CONTENT_TYPE).body(json)
+        .then().expect()
+          .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode()).contentType(ContentType.JSON)
+          .body("type", is(RestException.class.getSimpleName()))
+          .body("message", containsString("foo"))
+          .body("code", equalTo(123))
+    .when().post(EVALUATE_DECISION_BY_KEY_URL);
+  }
+
+  @Test
   public void testEvaluateDecision_NotValid() {
     String message = "expected message";
     when(decisionEvaluationBuilderMock.evaluate()).thenThrow(new NotValidException(message));

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ExceptionHandlerTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ExceptionHandlerTest.java
@@ -19,6 +19,7 @@ package org.camunda.bpm.engine.rest;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.nullValue;
 
 import javax.ws.rs.core.Response.Status;
 
@@ -53,6 +54,7 @@ public class ExceptionHandlerTest extends AbstractRestServiceTest {
       .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode())
       .body("type", equalTo(Exception.class.getSimpleName()))
       .body("message", equalTo("expected exception"))
+      .body("code", nullValue())
     .when().get(GENERAL_EXCEPTION_URL);
   }
 
@@ -63,6 +65,7 @@ public class ExceptionHandlerTest extends AbstractRestServiceTest {
       .statusCode(Status.BAD_REQUEST.getStatusCode())
       .body("type", equalTo(RestException.class.getSimpleName()))
       .body("message", equalTo("expected exception"))
+      .body("code", nullValue())
     .when().get(REST_EXCEPTION_URL);
   }
 
@@ -73,6 +76,7 @@ public class ExceptionHandlerTest extends AbstractRestServiceTest {
       .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode())
       .body("type", equalTo(ProcessEngineException.class.getSimpleName()))
       .body("message", equalTo("expected exception"))
+      .body("code", equalTo(0))
     .when().get(PROCESS_ENGINE_EXCEPTION_URL);
   }
 
@@ -84,6 +88,7 @@ public class ExceptionHandlerTest extends AbstractRestServiceTest {
       .statusCode(Status.FORBIDDEN.getStatusCode())
       .body("type", equalTo(AuthorizationException.class.getSimpleName()))
       .body("message", equalTo("The user with id 'someUser' does not have 'somePermission' permission on resource 'someResourceId' of type 'someResourceName'."))
+      .body("code", equalTo(0))
       .body("userId", equalTo("someUser"))
       .body("resourceName", equalTo("someResourceName"))
       .body("resourceId", equalTo("someResourceId"))
@@ -101,6 +106,7 @@ public class ExceptionHandlerTest extends AbstractRestServiceTest {
     .expect().contentType(ContentType.JSON)
       .statusCode(Status.FORBIDDEN.getStatusCode())
       .body("type", equalTo(AuthorizationException.class.getSimpleName()))
+      .body("code", equalTo(0))
       .body("message", equalTo("The user with id 'someUser' does not have one of the following permissions: 'somePermission1' permission on resource "
           + "'someResourceId1' of type 'someResourceName1' or 'somePermission2' permission on resource "
           + "'someResourceId2' of type 'someResourceName2'"))
@@ -121,6 +127,7 @@ public class ExceptionHandlerTest extends AbstractRestServiceTest {
       .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode())
         .body("type", equalTo(StackOverflowError.class.getSimpleName()))
         .body("message", equalTo("Stack overflow"))
+        .body("code", nullValue())
       .when().get(STACK_OVERFLOW_ERROR_URL);
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/MessageRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/MessageRestServiceTest.java
@@ -1246,6 +1246,27 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     .when().post(MESSAGE_URL);
   }
 
+  @Test
+  public void shouldReturnErrorOnMessageCorrelation() {
+    // given
+    doThrow(new ProcessEngineException("foo", 123))
+        .when(messageCorrelationBuilderMock).correlateWithResult();
+
+    String messageName = "aMessageName";
+    Map<String, Object> messageParameters = new HashMap<>();
+    messageParameters.put("messageName", messageName);
+
+    // when/
+    given().contentType(POST_JSON_CONTENT_TYPE)
+           .body(messageParameters)
+    .then().expect()
+           .contentType(ContentType.JSON)
+           .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode())
+           .body("type", equalTo(ProcessEngineException.class.getSimpleName()))
+           .body("message", equalTo("foo"))
+           .body("code", equalTo(123))
+    .when().post(MESSAGE_URL);
+  }
 
   protected void checkVariablesInResult(String content, int idx) {
     List<String> variableNames = java.util.Arrays.asList(MockProvider.EXAMPLE_VARIABLE_INSTANCE_NAME, MockProvider.EXAMPLE_DESERIALIZED_VARIABLE_INSTANCE_NAME);

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
@@ -4079,4 +4079,40 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
       .get(PROCESS_DEFINITION_CALL_ACTIVITY_MAPPINGS);
   }
 
+  @Test
+  public void shouldReturnErrorCodeWhenStartingProcessInstance() {
+    when(mockInstantiationBuilder.executeWithVariablesInReturn(anyBoolean(), anyBoolean()))
+      .thenThrow(new ProcessEngineException("foo", 123));
+
+    given()
+      .pathParam("key", MockProvider.EXAMPLE_PROCESS_DEFINITION_KEY)
+      .contentType(POST_JSON_CONTENT_TYPE)
+      .body(EMPTY_JSON_OBJECT)
+    .then().expect()
+      .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode()).contentType(ContentType.JSON)
+      .body("type", equalTo(RestException.class.getSimpleName()))
+      .body("message", equalTo("Cannot instantiate process definition aProcDefId: foo"))
+      .body("code", equalTo(123))
+    .when()
+      .post(START_PROCESS_INSTANCE_BY_KEY_URL);
+  }
+
+  @Test
+  public void shouldReturnErrorCodeWhenSubmittingForm() {
+    doThrow(new ProcessEngineException("foo", 123))
+        .when(formServiceMock).submitStartForm(any(String.class), Mockito.any());
+
+    given()
+      .pathParam("id", MockProvider.EXAMPLE_PROCESS_DEFINITION_ID)
+      .contentType(POST_JSON_CONTENT_TYPE)
+      .body(EMPTY_JSON_OBJECT)
+    .then().expect()
+      .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode()).contentType(ContentType.JSON)
+      .body("type", equalTo(RestException.class.getSimpleName()))
+      .body("message", equalTo("Cannot instantiate process definition aProcDefId: foo"))
+      .body("code", equalTo(123))
+    .when()
+      .post(SUBMIT_FORM_URL);
+  }
+
 }

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ProcessInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ProcessInstanceRestServiceInteractionTest.java
@@ -1903,6 +1903,26 @@ public class ProcessInstanceRestServiceInteractionTest extends
   }
 
   @Test
+  public void shouldReturnErrorOnSettingVariable() {
+    String variableKey = "aVariableKey";
+    String variableValue = "aVariableValue";
+
+    Map<String, Object> variableJson = VariablesBuilder.getVariableValueMap(variableValue);
+
+    doThrow(new ProcessEngineException("foo", 123))
+        .when(runtimeServiceMock)
+        .setVariable(eq(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID), eq(variableKey), any());
+
+    given().pathParam("id", MockProvider.EXAMPLE_PROCESS_INSTANCE_ID).pathParam("varId", variableKey)
+      .contentType(ContentType.JSON).body(variableJson)
+    .then().expect().statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode())
+      .body("type", Matchers.is(RestException.class.getSimpleName()))
+      .body("message", Matchers.is("Cannot put process instance variable aVariableKey: foo"))
+      .body("code", Matchers.is(123))
+    .when().put(SINGLE_PROCESS_INSTANCE_VARIABLE_URL);
+  }
+
+  @Test
   public void testPostSingleFileVariableWithEncodingAndMimeType() throws Exception {
 
     byte[] value = "some text".getBytes();
@@ -3779,8 +3799,8 @@ public class ProcessInstanceRestServiceInteractionTest extends
           .body(body)
         .then().expect()
           .statusCode(Status.BAD_REQUEST.getStatusCode())
-          .body(Matchers.containsString("{\"type\":\"InvalidRequestException\"," +
-              "\"message\":\"Cannot set variables: Unsupported value type 'unknown'\"}"))
+          .body("type", equalTo(InvalidRequestException.class.getSimpleName()))
+          .body("message", equalTo("Cannot set variables: Unsupported value type 'unknown'"))
         .when()
           .post(PROCESS_INSTANCE_SET_VARIABLES_ASYNC_URL);
   }
@@ -3801,8 +3821,8 @@ public class ProcessInstanceRestServiceInteractionTest extends
           .body("{}")
         .then().expect()
           .statusCode(Status.BAD_REQUEST.getStatusCode())
-          .body(Matchers.containsString("{\"type\":\"InvalidRequestException\"," +
-              "\"message\":\"message\"}"))
+          .body("type", equalTo(InvalidRequestException.class.getSimpleName()))
+          .body("message", equalTo("message"))
         .when()
           .post(PROCESS_INSTANCE_SET_VARIABLES_ASYNC_URL);
   }
@@ -3836,7 +3856,8 @@ public class ProcessInstanceRestServiceInteractionTest extends
           .body("{}")
         .then().expect()
           .statusCode(Status.BAD_REQUEST.getStatusCode())
-          .body(Matchers.containsString("{\"type\":\"InvalidRequestException\",\"message\":\"message\"}"))
+          .body("type", equalTo(InvalidRequestException.class.getSimpleName()))
+          .body("message", equalTo("message"))
         .when()
           .post(PROCESS_INSTANCE_SET_VARIABLES_ASYNC_URL);
   }
@@ -3853,7 +3874,8 @@ public class ProcessInstanceRestServiceInteractionTest extends
           .body("{}")
         .then().expect()
           .statusCode(Status.BAD_REQUEST.getStatusCode())
-          .body(Matchers.containsString("{\"type\":\"BadUserRequestException\",\"message\":\"message\"}"))
+          .body("type", equalTo(BadUserRequestException.class.getSimpleName()))
+          .body("message", equalTo("message"))
         .when()
           .post(PROCESS_INSTANCE_SET_VARIABLES_ASYNC_URL);
   }
@@ -4010,8 +4032,8 @@ public class ProcessInstanceRestServiceInteractionTest extends
       .body("{}")
     .then().expect()
       .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode())
-      .body(Matchers.containsString("{\"type\":\"ProcessEngineException\"," +
-          "\"message\":\"message\"}"))
+      .body("type", equalTo(ProcessEngineException.class.getSimpleName()))
+      .body("message", equalTo("message"))
     .when()
       .post(PROCESS_INSTANCE_CORRELATE_MESSAGE_ASYNC_URL);
   }
@@ -4043,7 +4065,8 @@ public class ProcessInstanceRestServiceInteractionTest extends
       .body("{}")
     .then().expect()
       .statusCode(Status.BAD_REQUEST.getStatusCode())
-      .body(Matchers.containsString("{\"type\":\"InvalidRequestException\",\"message\":\"message\"}"))
+      .body("type", equalTo(InvalidRequestException.class.getSimpleName()))
+      .body("message", equalTo("message"))
     .when()
       .post(PROCESS_INSTANCE_CORRELATE_MESSAGE_ASYNC_URL);
   }
@@ -4059,7 +4082,8 @@ public class ProcessInstanceRestServiceInteractionTest extends
       .body("{}")
     .then().expect()
       .statusCode(Status.BAD_REQUEST.getStatusCode())
-      .body(Matchers.containsString("{\"type\":\"BadUserRequestException\",\"message\":\"message\"}"))
+      .body("type", equalTo(BadUserRequestException.class.getSimpleName()))
+      .body("message", equalTo("message"))
     .when()
       .post(PROCESS_INSTANCE_CORRELATE_MESSAGE_ASYNC_URL);
   }

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/SignalRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/SignalRestServiceTest.java
@@ -477,4 +477,25 @@ public class SignalRestServiceTest extends AbstractRestServiceTest {
       .post(SIGNAL_URL);
   }
 
+  @Test
+  public void shouldReturnError() {
+    doThrow(new ProcessEngineException("foo", 123))
+        .when(signalBuilderMock).send();
+
+    Map<String, Object> requestBody = new HashMap<>();
+    requestBody.put("name", "aSignalName");
+
+    given()
+      .contentType(POST_JSON_CONTENT_TYPE)
+      .body(requestBody)
+    .then()
+      .expect()
+        .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode())
+        .body("type", equalTo(ProcessEngineException.class.getSimpleName()))
+        .body("message", equalTo("foo"))
+        .body("code", equalTo(123))
+    .when()
+      .post(SIGNAL_URL);
+  }
+
 }

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/TaskRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/TaskRestServiceInteractionTest.java
@@ -953,6 +953,22 @@ public class TaskRestServiceInteractionTest extends
   }
 
   @Test
+  public void shouldReturnErrorOnSubmitTaskForm() {
+    doThrow(new ProcessEngineException("foo", 123))
+        .when(formServiceMock).submitTaskForm(anyString(), Mockito.any());
+
+    given().pathParam("id", EXAMPLE_TASK_ID)
+      .header("accept", MediaType.APPLICATION_JSON)
+      .contentType(POST_JSON_CONTENT_TYPE).body("{}")
+    .then().expect()
+      .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode()).contentType(ContentType.JSON)
+      .body("type", equalTo(RestException.class.getSimpleName()))
+      .body("message", equalTo("Cannot submit task form anId: foo"))
+      .body("code", equalTo(123))
+    .when().post(SUBMIT_FORM_URL);
+  }
+
+  @Test
   public void testSubmitFormWithNotSupportedVariableType() {
     String variableKey = "aVariableKey";
     String variableValue = "1abc";
@@ -1793,6 +1809,22 @@ public class TaskRestServiceInteractionTest extends
         .body("type", equalTo(RestException.class.getSimpleName()))
         .body("message", equalTo("Cannot complete task " + EXAMPLE_TASK_ID + ": expected exception"))
       .when().post(COMPLETE_TASK_URL);
+  }
+
+  @Test
+  public void shouldReturnErrorOnCompletingTask() {
+    doThrow(new ProcessEngineException("foo", 123))
+        .when(taskServiceMock).complete(any(String.class), Mockito.any());
+
+    given().pathParam("id", EXAMPLE_TASK_ID)
+      .header("accept", MediaType.APPLICATION_JSON)
+      .contentType(POST_JSON_CONTENT_TYPE).body(EMPTY_JSON_OBJECT)
+    .then().expect()
+      .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode()).contentType(ContentType.JSON)
+      .body("type", equalTo(RestException.class.getSimpleName()))
+      .body("message", equalTo("Cannot complete task anId: foo"))
+      .body("code", equalTo(123))
+    .when().post(COMPLETE_TASK_URL);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/TaskVariableRestResourceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/TaskVariableRestResourceInteractionTest.java
@@ -305,6 +305,31 @@ public class TaskVariableRestResourceInteractionTest extends
   }
 
   @Test
+  public void shouldReturnErrorOnModification() {
+    String variableKey = "aKey";
+    int variableValue = 123;
+    Map<String, Object> messageBodyJson = new HashMap<>();
+    Map<String, Object> modifications = VariablesBuilder.create().variable(variableKey, variableValue).getVariables();
+    messageBodyJson.put("modifications", modifications);
+
+    TaskServiceImpl taskServiceMock = mockTaskServiceImpl();
+    doThrow(new ProcessEngineException("foo", 123))
+        .when(taskServiceMock).updateVariables(any(), any(), any());
+
+    given()
+      .pathParam("id", EXAMPLE_TASK_ID)
+      .contentType(ContentType.JSON)
+      .body(messageBodyJson)
+    .then().expect()
+      .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode())
+      .body("type", is(RestException.class.getSimpleName()))
+      .body("message", is("Cannot modify variables for task anId: foo"))
+      .body("code", is(123))
+    .when()
+      .post(SINGLE_TASK_MODIFY_VARIABLES_URL);
+  }
+
+  @Test
   public void testGetSingleVariable() {
     String variableKey = "aVariableKey";
     int variableValue = 123;

--- a/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringTransactionsProcessEngineConfiguration.java
+++ b/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringTransactionsProcessEngineConfiguration.java
@@ -80,6 +80,9 @@ public class SpringTransactionsProcessEngineConfiguration extends ProcessEngineC
     if (DbSqlSessionFactory.CRDB.equals(databaseType)) {
       defaultCommandInterceptorsTxRequired.add(getCrdbRetryInterceptor());
     }
+    if (!isDisableExceptionCode()) {
+      defaultCommandInterceptorsTxRequired.add(getExceptionCodeInterceptor());
+    }
     defaultCommandInterceptorsTxRequired.add(new LogInterceptor());
     defaultCommandInterceptorsTxRequired.add(new CommandCounterInterceptor(this));
     defaultCommandInterceptorsTxRequired.add(new ProcessApplicationContextInterceptor(this));
@@ -95,6 +98,9 @@ public class SpringTransactionsProcessEngineConfiguration extends ProcessEngineC
     // so that a Spring TX may be rolled back before retrying.
     if (DbSqlSessionFactory.CRDB.equals(databaseType)) {
       defaultCommandInterceptorsTxRequiresNew.add(getCrdbRetryInterceptor());
+    }
+    if (!isDisableExceptionCode()) {
+      defaultCommandInterceptorsTxRequiresNew.add(getExceptionCodeInterceptor());
     }
     defaultCommandInterceptorsTxRequiresNew.add(new LogInterceptor());
     defaultCommandInterceptorsTxRequiresNew.add(new CommandCounterInterceptor(this));

--- a/engine/src/main/java/org/camunda/bpm/engine/ProcessEngineException.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/ProcessEngineException.java
@@ -16,6 +16,9 @@
  */
 package org.camunda.bpm.engine;
 
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.errorcode.BuiltinExceptionCode;
+import org.camunda.bpm.engine.impl.errorcode.ExceptionCodeProvider;
 
 /**
  * Runtime exception that is the superclass of all exceptions in the process engine.
@@ -25,6 +28,8 @@ package org.camunda.bpm.engine;
 public class ProcessEngineException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
+
+  protected int code = BuiltinExceptionCode.FALLBACK.getCode();
 
   public ProcessEngineException() {
     super();
@@ -38,7 +43,41 @@ public class ProcessEngineException extends RuntimeException {
     super(message);
   }
 
+  public ProcessEngineException(String message, int code) {
+    super(message);
+    this.code = code;
+  }
+
   public ProcessEngineException(Throwable cause) {
     super(cause);
   }
+
+  /**
+   * <p>The exception code can be set via delegation code.
+   *
+   * <p>Setting an error code on the exception in delegation code always overrides
+   * the exception code from a custom {@link ExceptionCodeProvider}.
+   *
+   * <p>Your business logic can react to the exception code exposed
+   * via {@link #getCode} when calling Camunda Java API and is
+   * even exposed to the REST API when an error occurs.
+   */
+  public void setCode(int code) {
+    this.code = code;
+  }
+
+  /**
+   * <p>Accessor of the exception error code.
+   *
+   * <p>If not changed via {@link #setCode}, default code is {@link BuiltinExceptionCode#FALLBACK}
+   * which is always overridden by a custom or built-in error code provider.
+   *
+   * <p>You can implement a custom {@link ExceptionCodeProvider}
+   * and register it in the {@link ProcessEngineConfigurationImpl}
+   * via the {@code customExceptionCodeProvider} property.
+   */
+  public int getCode() {
+    return code;
+  }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/JtaProcessEngineConfiguration.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/JtaProcessEngineConfiguration.java
@@ -70,6 +70,9 @@ public class JtaProcessEngineConfiguration extends ProcessEngineConfigurationImp
     if (DbSqlSessionFactory.CRDB.equals(databaseType)) {
       defaultCommandInterceptorsTxRequired.add(getCrdbRetryInterceptor());
     }
+    if (!isDisableExceptionCode()) {
+      defaultCommandInterceptorsTxRequired.add(getExceptionCodeInterceptor());
+    }
     defaultCommandInterceptorsTxRequired.add(new LogInterceptor());
     defaultCommandInterceptorsTxRequired.add(new CommandCounterInterceptor(this));
     defaultCommandInterceptorsTxRequired.add(new ProcessApplicationContextInterceptor(this));
@@ -85,6 +88,9 @@ public class JtaProcessEngineConfiguration extends ProcessEngineConfigurationImp
     // so that a Java EE managed TX may be rolled back before retrying.
     if (DbSqlSessionFactory.CRDB.equals(databaseType)) {
       defaultCommandInterceptorsTxRequiresNew.add(getCrdbRetryInterceptor());
+    }
+    if (!isDisableExceptionCode()) {
+      defaultCommandInterceptorsTxRequiresNew.add(getExceptionCodeInterceptor());
     }
     defaultCommandInterceptorsTxRequiresNew.add(new LogInterceptor());
     defaultCommandInterceptorsTxRequiresNew.add(new CommandCounterInterceptor(this));

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/StandaloneProcessEngineConfiguration.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/StandaloneProcessEngineConfiguration.java
@@ -39,6 +39,9 @@ public class StandaloneProcessEngineConfiguration extends ProcessEngineConfigura
     if (DbSqlSessionFactory.CRDB.equals(databaseType)) {
       defaultCommandInterceptorsTxRequired.add(getCrdbRetryInterceptor());
     }
+    if (!isDisableExceptionCode()) {
+      defaultCommandInterceptorsTxRequired.add(getExceptionCodeInterceptor());
+    }
     defaultCommandInterceptorsTxRequired.add(new LogInterceptor());
     defaultCommandInterceptorsTxRequired.add(new CommandCounterInterceptor(this));
     defaultCommandInterceptorsTxRequired.add(new ProcessApplicationContextInterceptor(this));
@@ -50,6 +53,9 @@ public class StandaloneProcessEngineConfiguration extends ProcessEngineConfigura
     List<CommandInterceptor> defaultCommandInterceptorsTxRequired = new ArrayList<CommandInterceptor>();
     if (DbSqlSessionFactory.CRDB.equals(databaseType)) {
       defaultCommandInterceptorsTxRequired.add(getCrdbRetryInterceptor());
+    }
+    if (!isDisableExceptionCode()) {
+      defaultCommandInterceptorsTxRequired.add(getExceptionCodeInterceptor());
     }
     defaultCommandInterceptorsTxRequired.add(new LogInterceptor());
     defaultCommandInterceptorsTxRequired.add(new CommandCounterInterceptor(this));

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/CommandLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/CommandLogger.java
@@ -321,4 +321,15 @@ public class CommandLogger extends ProcessEngineLogger {
     logWarn("047", "Deployment name set to null. Filtering duplicates will not work properly.");
   }
 
+  public void warnReservedErrorCode(int initialCode) {
+    logWarn("048", "With error code {} you are using a reserved error code. Falling back to default error code 0. "
+        + "If you want to override built-in error codes, please disable the built-in error code provider.", initialCode);
+  }
+
+  public void warnResetToBuiltinCode(Integer builtinCode, int initialCode) {
+    logWarn("049", "You are trying to override the built-in code {} with {}. "
+        + "Falling back to built-in code. If you want to override built-in error codes, "
+        + "please disable the built-in error code provider.", builtinCode, initialCode);
+  }
+
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/BatchDbSqlSession.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/BatchDbSqlSession.java
@@ -25,12 +25,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.executor.BatchExecutorException;
 import org.apache.ibatis.executor.BatchResult;
 import org.apache.ibatis.session.ExecutorType;
-import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.db.DbEntity;
-import org.camunda.bpm.engine.impl.db.EnginePersistenceLogger;
 import org.camunda.bpm.engine.impl.db.FlushResult;
 import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbBulkOperation;
 import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbEntityOperation;
@@ -72,7 +71,7 @@ public class BatchDbSqlSession extends DbSqlSession {
     try {
       // applies all operations
       batchResults = flushBatchOperations();
-    } catch (RuntimeException e) {
+    } catch (PersistenceException e) {
       return postProcessBatchFailure(operations, e);
     }
 
@@ -96,7 +95,7 @@ public class BatchDbSqlSession extends DbSqlSession {
     return FlushResult.withFailures(failedOperations);
   }
 
-  protected FlushResult postProcessBatchFailure(List<DbOperation> operations, RuntimeException exception) {
+  protected FlushResult postProcessBatchFailure(List<DbOperation> operations, PersistenceException exception) {
     BatchExecutorException batchExecutorException =
         ExceptionUtil.findBatchExecutorException(exception);
 
@@ -144,7 +143,7 @@ public class BatchDbSqlSession extends DbSqlSession {
   protected void postProcessJdbcBatchResult(
       Iterator<DbOperation> operationsIt,
       int[] statementResults,
-      Exception failure,
+      PersistenceException failure,
       List<DbOperation> failedOperations) {
     boolean failureHandled = false;
 
@@ -218,7 +217,7 @@ public class BatchDbSqlSession extends DbSqlSession {
 
   protected void postProcessOperationPerformed(DbOperation operation,
                                                int rowsAffected,
-                                               Exception failure) {
+                                               PersistenceException failure) {
 
     switch(operation.getOperationType()) {
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/SimpleDbSqlSession.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/SimpleDbSqlSession.java
@@ -22,8 +22,8 @@ import java.sql.Connection;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.session.ExecutorType;
-import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.db.DbEntity;
 import org.camunda.bpm.engine.impl.db.FlushResult;
 import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbBulkOperation;
@@ -84,7 +84,7 @@ public class SimpleDbSqlSession extends DbSqlSession {
     try {
       executeInsertEntity(insertStatement, dbEntity);
       entityInsertPerformed(operation, 1, null);
-    } catch (Exception e) {
+    } catch (PersistenceException e) {
       entityInsertPerformed(operation, 0, e);
     }
   }
@@ -105,7 +105,7 @@ public class SimpleDbSqlSession extends DbSqlSession {
     try {
       int nrOfRowsDeleted = executeDelete(deleteStatement, dbEntity);
       entityDeletePerformed(operation, nrOfRowsDeleted, null);
-    } catch (Exception e) {
+    } catch (PersistenceException e) {
       entityDeletePerformed(operation, 0, e);
     }
   }
@@ -120,7 +120,7 @@ public class SimpleDbSqlSession extends DbSqlSession {
     try {
       int rowsAffected = executeDelete(statement, parameter);
       bulkDeletePerformed(operation, rowsAffected, null);
-    } catch (Exception e) {
+    } catch (PersistenceException e) {
       bulkDeletePerformed(operation, 0, e);
     }
   }
@@ -140,7 +140,7 @@ public class SimpleDbSqlSession extends DbSqlSession {
     try {
       int rowsAffected = executeUpdate(updateStatement, dbEntity);
       entityUpdatePerformed(operation, rowsAffected, null);
-    } catch (Exception e) {
+    } catch (PersistenceException e) {
       entityUpdatePerformed(operation, 0, e);
     }
   }
@@ -155,7 +155,7 @@ public class SimpleDbSqlSession extends DbSqlSession {
     try {
       int rowsAffected = executeUpdate(statement, parameter);
       bulkUpdatePerformed(operation, rowsAffected, null);
-    } catch (Exception e) {
+    } catch (PersistenceException e) {
       bulkUpdatePerformed(operation, 0, e);
     }
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/el/UelExpressionCondition.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/el/UelExpressionCondition.java
@@ -58,9 +58,9 @@ public class UelExpressionCondition implements Condition {
     boolean result = false;
     try {
       result = evaluate(scope, execution);
-    } catch (ProcessEngineException pee) {
-      if (!(pee.getCause() instanceof PropertyNotFoundException)) {
-        throw pee;
+    } catch (ProcessEngineException pex) {
+      if (!(pex.getCause() instanceof PropertyNotFoundException)) {
+        throw pex;
       }
     }
     return result;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/errorcode/BuiltinExceptionCode.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/errorcode/BuiltinExceptionCode.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.errorcode;
+
+import org.camunda.bpm.engine.CrdbTransactionRetryException;
+import org.camunda.bpm.engine.OptimisticLockingException;
+import org.camunda.bpm.engine.ProcessEngineException;
+
+/**
+ * The set of built-in exception codes the built-in {@link ExceptionCodeProvider}
+ * uses to assign a code to a {@link ProcessEngineException}.
+ */
+public enum BuiltinExceptionCode {
+
+  /**
+   * The code assigned to a {@link ProcessEngineException} when no other code is assigned.
+   */
+  FALLBACK(0),
+
+  /**
+   * This code is assigned when an {@link OptimisticLockingException} or {@link CrdbTransactionRetryException} occurs.
+   */
+  OPTIMISTIC_LOCKING(1),
+
+  /**
+   * This code is assigned when a "deadlock" persistence exception is detected.
+   */
+  DEADLOCK(10_000),
+
+  /**
+   * This code is assigned when a "foreign key constraint violation" persistence exception is detected.
+   */
+  FOREIGN_KEY_CONSTRAINT_VIOLATION(10_001),
+
+  /**
+   * This code is assigned when a "column size too small" persistence exception is detected.
+   */
+  COLUMN_SIZE_TOO_SMALL(10_002);
+
+  protected final int code;
+
+  BuiltinExceptionCode(int code) {
+    this.code = code;
+  }
+
+  public int getCode() {
+    return code;
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/errorcode/ExceptionCodeProvider.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/errorcode/ExceptionCodeProvider.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.errorcode;
+
+import org.camunda.bpm.engine.OptimisticLockingException;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.util.ExceptionUtil;
+
+import java.sql.SQLException;
+
+import static org.camunda.bpm.engine.impl.errorcode.BuiltinExceptionCode.COLUMN_SIZE_TOO_SMALL;
+import static org.camunda.bpm.engine.impl.errorcode.BuiltinExceptionCode.DEADLOCK;
+import static org.camunda.bpm.engine.impl.errorcode.BuiltinExceptionCode.FOREIGN_KEY_CONSTRAINT_VIOLATION;
+import static org.camunda.bpm.engine.impl.errorcode.BuiltinExceptionCode.OPTIMISTIC_LOCKING;
+
+/**
+ * <p>One of the provider methods are called when a {@link ProcessEngineException} occurs.
+ * The default implementation provides the built-in exception codes.
+ *
+ * <p>You can disable the built-in or/and additionally register a custom provider via
+ * the {@link ProcessEngineConfigurationImpl} using the following properties:
+ * <ul>
+ *   <li>{@code disableExceptionCode} - disables the whole feature
+ *   <li>{@code disableBuiltinExceptionCodeProvider} - only disables the built-in provider
+ *   and allows overriding reserved exception codes
+ *   <li>{@code customExceptionCodeProvider} - provide custom exception codes
+ */
+public interface ExceptionCodeProvider {
+
+  /**
+   * <p>Called when a {@link ProcessEngineException} occurs.
+   *
+   * <p>Provides the exception code that can be determined based on the passed {@link ProcessEngineException}.
+   * Only called when no other provider method is called.
+   *
+   * @param processEngineException that occurred.
+   * @return an integer value representing the error code. When returning {@code null},
+   * the {@link BuiltinExceptionCode#FALLBACK} gets assigned to the exception.
+   */
+  default Integer provideCode(ProcessEngineException processEngineException) {
+    if (processEngineException instanceof OptimisticLockingException) {
+      return OPTIMISTIC_LOCKING.getCode();
+
+    }
+
+    return null;
+  }
+
+  /**
+   * <p>Called when a {@link SQLException} occurs.
+   *
+   * <p>Provides the exception code that can be determined based on the passed {@link SQLException}.
+   * The error code is assigned to the top level {@link ProcessEngineException}.
+   * Only called when no other provider method is called.
+   *
+   * @param sqlException that occurred.
+   * @return an integer value representing the error code. When returning {@code null},
+   * the {@link BuiltinExceptionCode#FALLBACK} gets assigned to the exception.
+   */
+  default Integer provideCode(SQLException sqlException) {
+    boolean deadlockDetected = ExceptionUtil.checkDeadlockException(sqlException);
+    if (deadlockDetected) {
+      return DEADLOCK.getCode();
+    }
+
+    boolean foreignKeyConstraintViolated = ExceptionUtil.checkForeignKeyConstraintViolation(sqlException, false);
+    if (foreignKeyConstraintViolated) {
+      return FOREIGN_KEY_CONSTRAINT_VIOLATION.getCode();
+    }
+
+    boolean columnSizeTooSmall = ExceptionUtil.checkValueTooLongException(sqlException);
+    if (columnSizeTooSmall) {
+      return COLUMN_SIZE_TOO_SMALL.getCode();
+    }
+
+    return null;
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandInvocationContext.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/CommandInvocationContext.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-import org.apache.ibatis.exceptions.PersistenceException;
 import org.camunda.bpm.application.InvocationContext;
 import org.camunda.bpm.application.ProcessApplicationReference;
 import org.camunda.bpm.engine.ProcessEngineException;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/ExceptionCodeInterceptor.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/interceptor/ExceptionCodeInterceptor.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.interceptor;
+
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.impl.ProcessEngineLogger;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.cmd.CommandLogger;
+import org.camunda.bpm.engine.impl.errorcode.BuiltinExceptionCode;
+import org.camunda.bpm.engine.impl.errorcode.ExceptionCodeProvider;
+import org.camunda.bpm.engine.impl.util.ExceptionUtil;
+
+import java.sql.SQLException;
+import java.util.function.Supplier;
+
+/**
+ * <p>A command interceptor to catch {@link ProcessEngineException} errors and assign error codes.
+ *
+ * <p>The interceptor assigns an error code to the {@link ProcessEngineException}
+ * based on the built-in or custom {@link ExceptionCodeProvider}.
+ */
+public class ExceptionCodeInterceptor extends CommandInterceptor {
+
+  protected static final CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
+
+  public static final int MIN_CUSTOM_CODE = 20_000;
+  public static final int MAX_CUSTOM_CODE = 39_999;
+
+  protected ExceptionCodeProvider builtinExceptionCodeProvider;
+  protected ExceptionCodeProvider customExceptionCodeProvider;
+
+  public ExceptionCodeInterceptor(ExceptionCodeProvider builtinExceptionCodeProvider,
+                                  ExceptionCodeProvider customExceptionCodeProvider) {
+    this.builtinExceptionCodeProvider = builtinExceptionCodeProvider;
+    this.customExceptionCodeProvider = customExceptionCodeProvider;
+  }
+
+  @Override
+  public <T> T execute(Command<T> command) {
+    try {
+      return next.execute(command);
+
+    } catch (ProcessEngineException pex) {
+      assignCodeToException(pex);
+      throw pex;
+
+    }
+  }
+
+  /**
+   * <p>Built-in code provider has precedence over custom code provider and initial code (assigned via delegation code).
+   * Custom and initial code is tried to be reset in case it violates the reserved code range.
+   *
+   * <p>When {@code disableBuiltInExceptionCodeProvider} flag
+   * in {@link ProcessEngineConfigurationImpl} is configured to {@code true},
+   * custom provider can override reserved codes.
+   */
+  protected Integer provideCodeBySupplier(Supplier<Integer> builtinSupplier,
+                                          Supplier<Integer> customSupplier,
+                                          int initialCode) {
+    boolean assignedByDelegationCode = initialCode != BuiltinExceptionCode.FALLBACK.getCode();
+    boolean builtinProviderConfigured = builtinExceptionCodeProvider != null;
+
+    if (builtinProviderConfigured) {
+      Integer providedCode = builtinSupplier.get();
+      if (providedCode != null) {
+        if (assignedByDelegationCode) {
+          LOG.warnResetToBuiltinCode(providedCode, initialCode);
+        }
+        return providedCode;
+      }
+
+    }
+
+    boolean customProviderConfigured = customExceptionCodeProvider != null;
+    if (customProviderConfigured && !assignedByDelegationCode) {
+      Integer providedCode = customSupplier.get();
+      if (providedCode != null && builtinProviderConfigured) {
+        return tryResetReservedCode(providedCode);
+
+      } else {
+        return providedCode;
+
+      }
+
+    } else if (builtinProviderConfigured) {
+      return tryResetReservedCode(initialCode);
+
+    }
+
+    return null;
+  }
+
+  protected Integer provideCode(ProcessEngineException pex, int initialCode) {
+    SQLException sqlException = ExceptionUtil.unwrapException(pex);
+
+    Supplier<Integer> builtinSupplier = null;
+    Supplier<Integer> customSupplier = null;
+    if (sqlException != null) {
+      builtinSupplier = () -> builtinExceptionCodeProvider.provideCode(sqlException);
+      customSupplier = () -> customExceptionCodeProvider.provideCode(sqlException);
+
+    } else {
+      builtinSupplier = () -> builtinExceptionCodeProvider.provideCode(pex);
+      customSupplier = () -> customExceptionCodeProvider.provideCode(pex);
+
+    }
+
+    return provideCodeBySupplier(builtinSupplier, customSupplier, initialCode);
+  }
+
+  /**
+   * Resets codes to the {@link BuiltinExceptionCode#FALLBACK}
+   * in case they are < {@link #MIN_CUSTOM_CODE} or > {@link #MAX_CUSTOM_CODE}.
+   */
+  protected Integer tryResetReservedCode(Integer code) {
+    if (codeReserved(code)) {
+      LOG.warnReservedErrorCode(code);
+      return BuiltinExceptionCode.FALLBACK.getCode();
+
+    } else {
+      return code;
+
+    }
+  }
+
+  protected boolean codeReserved(Integer code) {
+    return code != null && (code < MIN_CUSTOM_CODE || code > MAX_CUSTOM_CODE);
+  }
+
+  protected void assignCodeToException(ProcessEngineException pex) {
+    int initialCode = pex.getCode();
+    Integer providedCode = provideCode(pex, initialCode);
+
+    if (providedCode != null) {
+      pex.setCode(providedCode);
+
+    }
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/ScriptCondition.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/ScriptCondition.java
@@ -74,10 +74,10 @@ public class ScriptCondition implements Condition {
 
     try {
       result = evaluate(scope, execution);
-    } catch (ProcessEngineException pee) {
-      if (! (pee.getMessage().contains("No such property") ||
-             pee.getCause() instanceof ScriptEvaluationException) ) {
-        throw pee;
+    } catch (ProcessEngineException pex) {
+      if (! (pex.getMessage().contains("No such property") ||
+             pex.getCause() instanceof ScriptEvaluationException) ) {
+        throw pex;
       }
     }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/ExceptionUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/ExceptionUtil.java
@@ -19,13 +19,14 @@ package org.camunda.bpm.engine.impl.util;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.executor.BatchExecutorException;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.context.Context;
+import org.camunda.bpm.engine.impl.db.sql.DbSqlSessionFactory;
 import org.camunda.bpm.engine.impl.persistence.entity.ByteArrayEntity;
 import org.camunda.bpm.engine.repository.ResourceType;
 
@@ -47,7 +48,7 @@ public class ExceptionUtil {
 
   public static String getExceptionStacktrace(ByteArrayEntity byteArray) {
     String result = null;
-    if(byteArray != null) {
+    if (byteArray != null) {
       result = StringUtil.fromBytes(byteArray.getBytes());
     }
     return result;
@@ -81,130 +82,190 @@ public class ExceptionUtil {
     return result;
   }
 
-  public static boolean checkValueTooLongException(ProcessEngineException exception) {
-    List<SQLException> sqlExceptionList = findRelatedSqlExceptions(exception);
-    for (SQLException ex: sqlExceptionList) {
-      if (ex.getMessage().contains("too long")
-        || ex.getMessage().contains("too large")
-        || ex.getMessage().contains("TOO LARGE")
-        || ex.getMessage().contains("ORA-01461")
-        || ex.getMessage().contains("ORA-01401")
-        || ex.getMessage().contains("data would be truncated")
-        || ex.getMessage().contains("SQLCODE=-302, SQLSTATE=22001")) {
-        return true;
-      }
+  protected static Throwable getPersistenceCauseException(PersistenceException persistenceException) {
+    Throwable cause = persistenceException.getCause();
+    if (cause instanceof BatchExecutorException) {
+      return cause.getCause();
+
+    } else {
+      return persistenceException.getCause();
+
     }
-    return false;
   }
 
-  public static boolean checkConstraintViolationException(ProcessEngineException exception) {
-    List<SQLException> sqlExceptionList = findRelatedSqlExceptions(exception);
-    for (SQLException ex: sqlExceptionList) {
-      if (ex.getMessage().contains("constraint")
-        || ex.getMessage().contains("violat")
-        || ex.getMessage().toLowerCase().contains("duplicate")
-        || ex.getMessage().contains("ORA-00001")
-        || ex.getMessage().contains("SQLCODE=-803, SQLSTATE=23505")) {
-        return true;
+  public static SQLException unwrapException(PersistenceException persistenceException) {
+    Throwable cause = getPersistenceCauseException(persistenceException);
+    if (cause instanceof SQLException) {
+      SQLException sqlException = (SQLException) cause;
+      SQLException nextException = sqlException.getNextException();
+      if (nextException != null) {
+        return nextException;
+
+      } else {
+        return sqlException;
+
       }
+
+    } else {
+      return null;
     }
-    return false;
   }
 
-  public static List<SQLException> findRelatedSqlExceptions(Throwable exception) {
-    List<SQLException> sqlExceptionList = new ArrayList<SQLException>();
-    Throwable cause = exception;
-    do {
-      if (cause instanceof SQLException) {
-        SQLException sqlEx = (SQLException) cause;
-        sqlExceptionList.add(sqlEx);
-        while (sqlEx.getNextException() != null) {
-          sqlExceptionList.add(sqlEx.getNextException());
-          sqlEx = sqlEx.getNextException();
-        }
+  public static SQLException unwrapException(ProcessEngineException genericPersistenceException) {
+    Throwable cause = genericPersistenceException.getCause();
+
+    if (cause instanceof ProcessEngineException) {
+      ProcessEngineException processEngineException = (ProcessEngineException) cause;
+
+      Throwable processEngineExceptionCause = processEngineException.getCause();
+      if (processEngineExceptionCause instanceof PersistenceException) {
+        return unwrapException((PersistenceException) processEngineExceptionCause);
+
+      } else {
+        return null;
+
       }
-      cause = cause.getCause();
-    } while (cause != null);
-    return sqlExceptionList;
+    } else if (cause instanceof PersistenceException) {
+      return unwrapException((PersistenceException) cause);
+
+    } else {
+      return null;
+
+    }
   }
 
-  public static boolean checkForeignKeyConstraintViolation(Throwable cause) {
+  public static boolean checkValueTooLongException(SQLException sqlException) {
+    String message = sqlException.getMessage();
+    return message.contains("too long") ||
+        message.contains("too large") ||
+        message.contains("TOO LARGE") ||
+        message.contains("ORA-01461") ||
+        message.contains("ORA-01401") ||
+        message.contains("data would be truncated") ||
+        message.contains("SQLCODE=-302, SQLSTATE=22001");
+  }
 
-    List<SQLException> relatedSqlExceptions = findRelatedSqlExceptions(cause);
-    for (SQLException exception : relatedSqlExceptions) {
+  public static boolean checkValueTooLongException(ProcessEngineException genericPersistenceException) {
+    SQLException sqlException = unwrapException(genericPersistenceException);
 
-      // PostgreSQL doesn't allow for a proper check
-      if ("23503".equals(exception.getSQLState()) && exception.getErrorCode() == 0) {
-        return false;
-      } else if (
-        // SqlServer
-        (exception.getMessage().toLowerCase().contains("foreign key constraint")
-          || ("23000".equals(exception.getSQLState()) && exception.getErrorCode() == 547))
-        // MySql, MariaDB & PostgreSQL
-        || (exception.getMessage().toLowerCase().contains("foreign key constraint")
-          // MySql & MariaDB
-          || ("23000".equals(exception.getSQLState()) && exception.getErrorCode() == 1452))
-        // Oracle & H2
-        || (exception.getMessage().toLowerCase().contains("integrity constraint")
+    if (sqlException == null) {
+      return false;
+    }
+
+    return ExceptionUtil.checkValueTooLongException(sqlException);
+  }
+
+  public static boolean checkConstraintViolationException(ProcessEngineException genericPersistenceException) {
+    SQLException sqlException = unwrapException(genericPersistenceException);
+
+    if (sqlException == null) {
+      return false;
+    }
+
+    String message = sqlException.getMessage();
+    return message.contains("constraint") ||
+        message.contains("violat") ||
+        message.toLowerCase().contains("duplicate") ||
+        message.contains("ORA-00001") ||
+        message.contains("SQLCODE=-803, SQLSTATE=23505");
+  }
+
+  public static boolean checkForeignKeyConstraintViolation(PersistenceException persistenceException) {
+    SQLException sqlException = unwrapException(persistenceException);
+
+    if (sqlException == null) {
+      return false;
+    }
+
+    return checkForeignKeyConstraintViolation(sqlException);
+  }
+
+  public static boolean checkForeignKeyConstraintViolation(SQLException sqlException) {
+    String message = sqlException.getMessage().toLowerCase();
+    String sqlState = sqlException.getSQLState();
+    int errorCode = sqlException.getErrorCode();
+
+    // PostgreSQL doesn't allow for a proper check
+    if ("23503".equals(sqlState) && errorCode == 0) {
+      return false;
+    } else {
+      // SqlServer
+      return message.contains("foreign key constraint") ||
+          "23000".equals(sqlState) && errorCode == 547 ||
+          // MySql & MariaDB & PostgreSQL
+          "23000".equals(sqlState) && errorCode == 1452 ||
+          // Oracle & H2
+          message.contains("integrity constraint") ||
           // Oracle
-          || ("23000".equals(exception.getSQLState()) && exception.getErrorCode() == 2291)
+          "23000".equals(sqlState) && errorCode == 2291 ||
           // H2
-          || ("23506".equals(exception.getSQLState()) && exception.getErrorCode() == 23506))
-        // DB2
-        || (exception.getMessage().toLowerCase().contains("sqlstate=23503") && exception.getMessage().toLowerCase().contains("sqlcode=-530"))
-        // DB2 zOS
-        || ("23503".equals(exception.getSQLState()) && exception.getErrorCode() == -530)
-        ) {
-
-        return true;
-      }
+          "23506".equals(sqlState) && errorCode == 23506 ||
+          // DB2
+          message.contains("sqlstate=23503") && message.toLowerCase().contains("sqlcode=-530") ||
+          // DB2 zOS
+          "23503".equals(sqlState) && errorCode == -530;
     }
-
-    return false;
   }
 
-  public static boolean checkVariableIntegrityViolation(Throwable cause) {
+  public static boolean checkVariableIntegrityViolation(PersistenceException persistenceException) {
+    SQLException sqlException = unwrapException(persistenceException);
 
-    List<SQLException> relatedSqlExceptions = findRelatedSqlExceptions(cause);
-    for (SQLException exception : relatedSqlExceptions) {
-      if (
-        // MySQL & MariaDB
-        (exception.getMessage().toLowerCase().contains("act_uniq_variable") && "23000".equals(exception.getSQLState()) && exception.getErrorCode() == 1062)
+    if (sqlException == null) {
+      return false;
+    }
+
+    String message = sqlException.getMessage().toLowerCase();
+    String sqlState = sqlException.getSQLState().toUpperCase();
+    int errorCode = sqlException.getErrorCode();
+
+    // MySQL & MariaDB
+    return (message.contains("act_uniq_variable") && "23000".equals(sqlState) && errorCode == 1062)
         // PostgreSQL
-        || (exception.getMessage().toLowerCase().contains("act_uniq_variable") && "23505".equals(exception.getSQLState()) && exception.getErrorCode() == 0)
+        || (message.contains("act_uniq_variable") && "23505".equals(sqlState) && errorCode == 0)
         // SqlServer
-        || (exception.getMessage().toLowerCase().contains("act_uniq_variable") && "23000".equals(exception.getSQLState()) && exception.getErrorCode() == 2601)
+        || (message.contains("act_uniq_variable") && "23000".equals(sqlState) && errorCode == 2601)
         // Oracle
-        || (exception.getMessage().toLowerCase().contains("act_uniq_variable") && "23000".equals(exception.getSQLState()) && exception.getErrorCode() == 1)
+        || (message.contains("act_uniq_variable") && "23000".equals(sqlState) && errorCode == 1)
         // H2
-        || (exception.getMessage().toLowerCase().contains("act_uniq_variable") && "23505".equals(exception.getSQLState()) && exception.getErrorCode() == 23505)
-        ) {
-        return true;
-      }
-    }
-
-    return false;
+        || (message.contains("act_uniq_variable") && "23505".equals(sqlState) && errorCode == 23505);
   }
 
-  public static Boolean checkCrdbTransactionRetryException(Throwable cause) {
-    List<SQLException> relatedSqlExceptions = findRelatedSqlExceptions(cause);
-    for (SQLException exception : relatedSqlExceptions) {
-      String errorMessage = exception.getMessage().toLowerCase();
-      int errorCode = exception.getErrorCode();
-      if ((errorCode == 40001 || errorMessage != null)
-          && (errorMessage.contains("restart transaction") || errorMessage.contains("retry txn"))
+  public static boolean checkCrdbTransactionRetryException(Throwable exception) {
+    SQLException sqlException = null;
+
+    if (exception instanceof PersistenceException) {
+      sqlException = unwrapException((PersistenceException) exception);
+
+    } else if (exception instanceof ProcessEngineException) {
+      sqlException = unwrapException((ProcessEngineException) exception);
+
+    } else {
+      return false;
+
+    }
+
+    if (sqlException == null) {
+      return false;
+    }
+
+    return checkCrdbTransactionRetryException(sqlException);
+  }
+
+  public static boolean checkCrdbTransactionRetryException(SQLException sqlException) {
+    String errorMessage = sqlException.getMessage();
+    int errorCode = sqlException.getErrorCode();
+    if ((errorCode == 40001 || errorMessage != null)) {
+      errorMessage = errorMessage.toLowerCase();
+      return (errorMessage.contains("restart transaction") || errorMessage.contains("retry txn"))
           // TX retry errors with RETRY_COMMIT_DEADLINE_EXCEEDED are handled
           // as a ProcessEngineException (cause: Process engine persistence exception)
           // due to a long-running transaction
-          && !errorMessage.contains("retry_commit_deadline_exceeded")) {
-        return true;
-      }
+          && !errorMessage.contains("retry_commit_deadline_exceeded");
     }
-
     return false;
   }
 
-  public static BatchExecutorException findBatchExecutorException(Throwable exception) {
+  public static BatchExecutorException findBatchExecutorException(PersistenceException exception) {
     Throwable cause = exception;
     do {
       if (cause instanceof BatchExecutorException) {
@@ -214,26 +275,6 @@ public class ExceptionUtil {
     } while (cause != null);
 
     return null;
-  }
-
-  public static String collectExceptionMessages(Throwable cause) {
-    String message = cause.getMessage();
-
-    //collect real SQL exception messages in case of batch processing
-    Throwable exCause = cause;
-    do {
-      if (exCause instanceof BatchExecutorException) {
-        final List<SQLException> relatedSqlExceptions = ExceptionUtil.findRelatedSqlExceptions(exCause);
-        StringBuilder sb = new StringBuilder();
-        for (SQLException sqlException : relatedSqlExceptions) {
-          sb.append(sqlException).append("\n");
-        }
-        message = message + "\n" + sb.toString();
-      }
-      exCause = exCause.getCause();
-    } while (exCause != null);
-
-    return message;
   }
 
   /**

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/DeleteProcessDefinitionTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/DeleteProcessDefinitionTest.java
@@ -145,10 +145,10 @@ public class DeleteProcessDefinitionTest {
     try {
       repositoryService.deleteProcessDefinition(processDefinition.getId());
       fail("Should fail, since there exists a process instance");
-    } catch (ProcessEngineException pee) {
+    } catch (ProcessEngineException pex) {
       // then Exception is expected, the deletion should fail since there exist a process instance
       // and the cascade flag is per default false
-      assertTrue(pee.getMessage().contains("Deletion of process definition without cascading failed."));
+      assertTrue(pex.getMessage().contains("Deletion of process definition without cascading failed."));
     }
     assertEquals(1, repositoryService.createProcessDefinitionQuery().count());
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/RepositoryServiceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/RepositoryServiceTest.java
@@ -203,9 +203,9 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
     try {
       repositoryService.deleteDeployment(processDefinition.getDeploymentId());
       fail("Exception expected");
-    } catch (ProcessEngineException pee) {
+    } catch (ProcessEngineException pex) {
       // Exception expected when deleting deployment with running process
-      assert(pee.getMessage().contains("Deletion of process definition without cascading failed."));
+      assert(pex.getMessage().contains("Deletion of process definition without cascading failed."));
     }
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/callactivity/CallActivityDelegateMappingTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/callactivity/CallActivityDelegateMappingTest.java
@@ -133,10 +133,10 @@ public class CallActivityDelegateMappingTest {
     try {
       engineRule.getRuntimeService().startProcessInstanceByKey("callSimpleSubProcess");
       fail("Exception expected!");
-    } catch (ProcessEngineException pee) {
+    } catch (ProcessEngineException pex) {
       assertEquals(
               "Unknown property used in expression: ${notFound}. Cause: Cannot resolve identifier 'notFound'",
-              pee.getMessage());
+              pex.getMessage());
     }
   }
 
@@ -152,9 +152,9 @@ public class CallActivityDelegateMappingTest {
     try {
       engineRule.getTaskService().complete(taskBeforeSubProcess.getId());
       fail("Exeption expected!");
-    } catch (ProcessEngineException pee) { //then
-      Assert.assertTrue(pee.getMessage().equalsIgnoreCase("org.camunda.bpm.engine.ProcessEngineException: New process engine exception.")
-              || pee.getMessage().contains("1234"));
+    } catch (ProcessEngineException pex) { //then
+      Assert.assertTrue(pex.getMessage().equalsIgnoreCase("org.camunda.bpm.engine.ProcessEngineException: New process engine exception.")
+              || pex.getMessage().contains("1234"));
     }
 
     //then process rollback to user task which is before sub process
@@ -221,9 +221,9 @@ public class CallActivityDelegateMappingTest {
     try {
       engineRule.getTaskService().complete(taskInSubProcess.getId());
       fail("Exeption expected!");
-    } catch (ProcessEngineException pee) { //then
-      Assert.assertTrue(pee.getMessage().equalsIgnoreCase("org.camunda.bpm.engine.ProcessEngineException: New process engine exception.")
-              || pee.getMessage().contains("1234"));
+    } catch (ProcessEngineException pex) { //then
+      Assert.assertTrue(pex.getMessage().equalsIgnoreCase("org.camunda.bpm.engine.ProcessEngineException: New process engine exception.")
+              || pex.getMessage().contains("1234"));
     }
 
     //then process rollback to user task which is in sub process

--- a/engine/src/test/java/org/camunda/bpm/engine/test/cockroachdb/CockroachDbExclusiveLockDisabledTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/cockroachdb/CockroachDbExclusiveLockDisabledTest.java
@@ -470,7 +470,7 @@ public class CockroachDbExclusiveLockDisabledTest extends ConcurrencyTestHelper 
 
     public Void execute(CommandContext commandContext) {
 
-      monitor.sync();  // thread will block here until makeContinue() is called form main thread
+      monitor.sync();  // thread will block here until makeContinue() is called from main thread
 
       tries++;
       historyLevelSetupCommand.execute(commandContext);
@@ -601,7 +601,7 @@ public class CockroachDbExclusiveLockDisabledTest extends ConcurrencyTestHelper 
     @Override
     public void initializeInstallationId(CommandContext commandContext) {
 
-      monitor.sync(); // thread will block here until makeContinue() is called form main thread
+      monitor.sync(); // thread will block here until makeContinue() is called from main thread
 
       tries++;
       super.initializeInstallationId(commandContext);
@@ -620,7 +620,7 @@ public class CockroachDbExclusiveLockDisabledTest extends ConcurrencyTestHelper 
     @Override
     public void initializeTelemetryProperty(CommandContext commandContext) {
 
-      monitor.sync(); // thread will block here until makeContinue() is called form main thread
+      monitor.sync(); // thread will block here until makeContinue() is called from main thread
 
       tries++;
       super.initializeTelemetryProperty(commandContext);
@@ -641,7 +641,7 @@ public class CockroachDbExclusiveLockDisabledTest extends ConcurrencyTestHelper 
     }
 
     public Void execute(CommandContext commandContext) {
-      monitor.sync();  // thread will block here until makeContinue() is called form main thread
+      monitor.sync();  // thread will block here until makeContinue() is called from main thread
 
       historyCleanupCmd.execute(commandContext);
 
@@ -676,7 +676,7 @@ public class CockroachDbExclusiveLockDisabledTest extends ConcurrencyTestHelper 
     }
 
     public Void execute(CommandContext commandContext) {
-      monitor.sync();  // thread will block here until makeContinue() is called form main thread
+      monitor.sync();  // thread will block here until makeContinue() is called from main thread
 
       tries++;
       deployCmd.execute(commandContext);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/BuiltinExceptionCodeForeignKeyConstraintViolationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/BuiltinExceptionCodeForeignKeyConstraintViolationTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.concurrency;
+
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.impl.db.sql.DbSqlSessionFactory;
+import org.camunda.bpm.engine.impl.errorcode.BuiltinExceptionCode;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.test.RequiredDatabase;
+import org.camunda.bpm.engine.test.Deployment;
+import org.junit.Test;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class BuiltinExceptionCodeForeignKeyConstraintViolationTest extends ConcurrencyTestCase {
+
+  protected static class ControllableDeleteProcessDefinitionCommand extends ControllableCommand<Void> {
+
+    protected String processDefinitionId;
+
+    protected Exception exception;
+
+    public ControllableDeleteProcessDefinitionCommand(String processDefinitionId) {
+      this.processDefinitionId = processDefinitionId;
+    }
+
+    public Void execute(CommandContext commandContext) {
+      monitor.sync();  // thread will block here until makeContinue() is called from main thread
+
+      commandContext.getProcessEngineConfiguration()
+          .getRepositoryService()
+          .deleteProcessDefinition(processDefinitionId);
+
+      monitor.sync();  // thread will block here until waitUntilDone() is called form main thread
+
+      return null;
+    }
+
+  }
+
+  public static class ControllableStartProcessInstanceCommand extends ControllableCommand<Void> {
+
+    protected String processDefinitionKey;
+
+    public ControllableStartProcessInstanceCommand(String processDefinitionKey) {
+      this.processDefinitionKey = processDefinitionKey;
+    }
+
+    public Void execute(CommandContext commandContext) {
+      monitor.sync();  // thread will block here until makeContinue() is called from main thread
+
+      commandContext.getProcessEngineConfiguration()
+          .getRuntimeService()
+          .startProcessInstanceByKey(processDefinitionKey);
+
+      monitor.sync();  // thread will block here until waitUntilDone() is called form main thread
+
+      return null;
+    }
+  }
+
+  /**
+   * This test case doesn't lead to a foreign key constraint violation on DB2.
+   * Instead, the following error is thrown: https://www.sqlerror.de/db2_sql_error_-532_sqlstate_23504.html
+   *
+   * This test case doesn't lead to a foreign key constraint violation on CRDB.
+   * Instead, a deadlock error is detected.
+   */
+  @Deployment(resources = "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
+  @RequiredDatabase(excludes = {DbSqlSessionFactory.DB2, DbSqlSessionFactory.CRDB})
+  @Test
+  public void shouldReturnForeignKeyConstraintErrorCode() {
+    // given
+    ThreadControl thread1 = executeControllableCommand(new ControllableStartProcessInstanceCommand("oneTaskProcess"));
+    thread1.reportInterrupts();
+    thread1.waitForSync();
+
+    String processDefinitionKey = repositoryService.createProcessDefinitionQuery()
+        .processDefinitionKey("oneTaskProcess")
+        .singleResult()
+        .getId();
+
+    ThreadControl thread2 = executeControllableCommand(new ControllableDeleteProcessDefinitionCommand(processDefinitionKey));
+    thread2.reportInterrupts();
+    thread2.waitForSync();
+
+    //start process instance, but not commit transaction
+    thread1.makeContinue();
+    thread1.waitForSync();
+
+    //delete process definition, but not commit transaction
+    thread2.makeContinue();
+    thread2.waitForSync();
+
+    //commit transaction that starts a process instance
+    thread1.makeContinue();
+    thread1.waitUntilDone();
+
+    // when: try to commit the transaction that deletes a process definition
+    thread2.makeContinue();
+    thread2.waitUntilDone();
+
+    // then
+    assertThat(thread2.exception)
+        .isInstanceOf(ProcessEngineException.class)
+        .extracting("code")
+        .contains(BuiltinExceptionCode.FOREIGN_KEY_CONSTRAINT_VIOLATION.getCode());
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/CompetingCompleteTaskSetVariableTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/CompetingCompleteTaskSetVariableTest.java
@@ -45,7 +45,7 @@ public class CompetingCompleteTaskSetVariableTest extends ConcurrencyTestCase {
     }
 
     public Void execute(CommandContext commandContext) {
-      monitor.sync();  // thread will block here until makeContinue() is called form main thread
+      monitor.sync();  // thread will block here until makeContinue() is called from main thread
 
       new CompleteTaskCmd(taskId, null).execute(commandContext);
 
@@ -70,7 +70,7 @@ public class CompetingCompleteTaskSetVariableTest extends ConcurrencyTestCase {
     }
 
     public Void execute(CommandContext commandContext) {
-      monitor.sync();  // thread will block here until makeContinue() is called form main thread
+      monitor.sync();  // thread will block here until makeContinue() is called from main thread
 
       new SetTaskVariablesCmd(taskId, variables, true).execute(commandContext);
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/CompetingMessageCorrelationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/CompetingMessageCorrelationTest.java
@@ -608,7 +608,7 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
     @Override
     public Void execute(CommandContext commandContext) {
 
-      monitor.sync();  // thread will block here until makeContinue() is called form main thread
+      monitor.sync();  // thread will block here until makeContinue() is called from main thread
 
       MessageCorrelationBuilderImpl correlationBuilder = new MessageCorrelationBuilderImpl(commandContext, messageName);
       if (processInstanceId != null) {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentDeploymentTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentDeploymentTest.java
@@ -180,7 +180,7 @@ public class ConcurrentDeploymentTest extends ConcurrencyTestCase {
     }
 
     public Void execute(CommandContext commandContext) {
-      monitor.sync();  // thread will block here until makeContinue() is called form main thread
+      monitor.sync();  // thread will block here until makeContinue() is called from main thread
 
       new DeployCmd((DeploymentBuilderImpl) deploymentBuilder).execute(commandContext);
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentHistoryCleanupTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentHistoryCleanupTest.java
@@ -105,7 +105,7 @@ public class ConcurrentHistoryCleanupTest extends ConcurrencyTestCase {
   protected static class ControllableHistoryCleanupCommand extends ControllableCommand<Void> {
 
     public Void execute(CommandContext commandContext) {
-      monitor.sync();  // thread will block here until makeContinue() is called form main thread
+      monitor.sync();  // thread will block here until makeContinue() is called from main thread
 
       new HistoryCleanupCmd(true).execute(commandContext);
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentHistoryLevelTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentHistoryLevelTest.java
@@ -92,7 +92,7 @@ public class ConcurrentHistoryLevelTest extends ConcurrencyTestCase {
 
     public Void execute(CommandContext commandContext) {
 
-      monitor.sync(); // thread will block here until makeContinue() is called form main thread
+      monitor.sync(); // thread will block here until makeContinue() is called from main thread
 
       new HistoryLevelSetupCommand().execute(commandContext);
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentInstallationIdInitializationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentInstallationIdInitializationTest.java
@@ -91,7 +91,7 @@ public class ConcurrentInstallationIdInitializationTest extends ConcurrencyTestC
 
     public Void execute(CommandContext commandContext) {
 
-      monitor.sync(); // thread will block here until makeContinue() is called form main thread
+      monitor.sync(); // thread will block here until makeContinue() is called from main thread
 
       new BootstrapEngineCommand().initializeInstallationId(commandContext);
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentTelemetryConfigurationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/ConcurrentTelemetryConfigurationTest.java
@@ -96,7 +96,7 @@ public class ConcurrentTelemetryConfigurationTest extends ConcurrencyTestCase {
 
     public Void execute(CommandContext commandContext) {
 
-      monitor.sync(); // thread will block here until makeContinue() is called form main thread
+      monitor.sync(); // thread will block here until makeContinue() is called from main thread
 
       new BootstrapEngineCommand().initializeTelemetryProperty(commandContext);
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/DeadlockTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/DeadlockTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.errorcode;
+
+import org.camunda.bpm.engine.impl.db.sql.DbSqlSessionFactory;
+import org.camunda.bpm.engine.impl.test.RequiredDatabase;
+import org.camunda.bpm.engine.impl.util.ExceptionUtil;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.camunda.bpm.engine.impl.util.ExceptionUtil.DEADLOCK_CODES.CRDB;
+import static org.camunda.bpm.engine.impl.util.ExceptionUtil.DEADLOCK_CODES.DB2;
+import static org.camunda.bpm.engine.impl.util.ExceptionUtil.DEADLOCK_CODES.H2;
+import static org.camunda.bpm.engine.impl.util.ExceptionUtil.DEADLOCK_CODES.MARIADB_MYSQL;
+import static org.camunda.bpm.engine.impl.util.ExceptionUtil.DEADLOCK_CODES.MSSQL;
+import static org.camunda.bpm.engine.impl.util.ExceptionUtil.DEADLOCK_CODES.ORACLE;
+import static org.camunda.bpm.engine.impl.util.ExceptionUtil.DEADLOCK_CODES.POSTGRES;
+
+/**
+ * HEADS-UP: If a test fails, please make sure to adjust the error code / sql state for the respective
+ * database in {@link ExceptionUtil.DEADLOCK_CODES}.
+ */
+@RequiredDatabase(
+    excludes = DbSqlSessionFactory.MSSQL
+) // This test is flaky on SQL Server. Flakyness will be investigated with CAM-14749.
+public class DeadlockTest {
+
+  public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
+  public ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
+
+  @Rule
+  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+
+  protected SQLException sqlException;
+
+  @Before
+  public void createTestTables() throws SQLException {
+    Connection conn = engineRule.getProcessEngineConfiguration().getDataSource().getConnection();
+    Statement statement = conn.createStatement();
+    statement.execute("CREATE TABLE deadlock_test1 (FOO INTEGER)");
+    statement.execute("CREATE TABLE deadlock_test2 (FOO INTEGER)");
+    statement.executeUpdate("INSERT INTO deadlock_test1 VALUES (0)");
+    statement.executeUpdate("INSERT INTO deadlock_test2 VALUES (0)");
+
+    sqlException = null;
+  }
+
+  @After
+  public void cleanTables() throws SQLException {
+    Connection conn = engineRule.getProcessEngineConfiguration().getDataSource().getConnection();
+    Statement statement = conn.createStatement();
+    statement.execute("DROP TABLE deadlock_test1");
+    statement.execute("DROP TABLE deadlock_test2");
+  }
+
+  @Test
+  public void shouldProvokeDeadlock() throws InterruptedException {
+    String databaseType = engineRule.getProcessEngineConfiguration().getDatabaseType();
+    switch (databaseType) {
+    case DbSqlSessionFactory.MARIADB:
+    case DbSqlSessionFactory.MYSQL:
+      provokeDeadlock();
+      assertThat(sqlException.getSQLState()).isEqualTo(MARIADB_MYSQL.getSqlState());
+      assertThat(sqlException.getErrorCode()).isEqualTo(MARIADB_MYSQL.getErrorCode());
+      break;
+    case DbSqlSessionFactory.MSSQL:
+      provokeDeadlock();
+      assertThat(sqlException.getSQLState()).isEqualTo(MSSQL.getSqlState());
+      assertThat(sqlException.getErrorCode()).isEqualTo(MSSQL.getErrorCode());
+      break;
+    case DbSqlSessionFactory.DB2:
+      provokeDeadlock();
+      assertThat(sqlException.getSQLState()).isEqualTo(DB2.getSqlState());
+      assertThat(sqlException.getErrorCode()).isEqualTo(DB2.getErrorCode());
+      break;
+    case DbSqlSessionFactory.ORACLE:
+      provokeDeadlock();
+      assertThat(sqlException.getSQLState()).isEqualTo(ORACLE.getSqlState());
+      assertThat(sqlException.getErrorCode()).isEqualTo(ORACLE.getErrorCode());
+      break;
+    case DbSqlSessionFactory.POSTGRES:
+      provokeDeadlock();
+      assertThat(sqlException.getSQLState()).isEqualTo(POSTGRES.getSqlState());
+      assertThat(sqlException.getErrorCode()).isEqualTo(POSTGRES.getErrorCode());
+      break;
+    case DbSqlSessionFactory.CRDB:
+      provokeDeadlock();
+      assertThat(sqlException.getSQLState()).isEqualTo(CRDB.getSqlState());
+      assertThat(sqlException.getErrorCode()).isEqualTo(CRDB.getErrorCode());
+      break;
+    case DbSqlSessionFactory.H2:
+      provokeDeadlock();
+      assertThat(sqlException.getSQLState()).isEqualTo(H2.getSqlState());
+      assertThat(sqlException.getErrorCode()).isEqualTo(H2.getErrorCode());
+      break;
+    default:
+      fail("database unknown");
+    }
+  }
+
+  public void provokeDeadlock() throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(2);
+
+    DataSource dataSource = engineRule.getProcessEngineConfiguration().getDataSource();
+
+    Thread t1 = new Thread(() -> {
+      try (Connection conn = dataSource.getConnection()) {
+        try {
+          conn.setAutoCommit(false);
+
+          Statement statement = conn.createStatement();
+          statement.executeUpdate("UPDATE deadlock_test1 SET FOO=1");
+
+          latch.countDown();
+          try {
+            latch.await();
+          } catch (InterruptedException e) {
+          }
+
+          statement.executeUpdate("UPDATE deadlock_test2 SET FOO=1");
+          conn.commit();
+
+        } catch (SQLException e) {
+          sqlException = e;
+          try {
+            conn.rollback();
+          } catch (SQLException ex) {
+          }
+        }
+      } catch (SQLException e) {
+      }
+    });
+
+    Thread t2 = new Thread(() -> {
+      try (Connection conn = dataSource.getConnection()) {
+        try {
+          conn.setAutoCommit(false);
+
+          Statement statement = conn.createStatement();
+          statement.executeUpdate("UPDATE deadlock_test2 SET FOO=1");
+
+          latch.countDown();
+          try {
+            latch.await();
+          } catch (InterruptedException e) {
+          }
+
+          statement.executeUpdate("UPDATE deadlock_test1 SET FOO=1");
+          conn.commit();
+
+        } catch (SQLException e) {
+          sqlException = e;
+          try {
+            conn.rollback();
+          } catch (SQLException ex) {
+          }
+        }
+      } catch (SQLException e) {
+      }
+    });
+    t1.start();
+    t2.start();
+    t1.join();
+    t2.join();
+  }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/ExceptionBuiltinCodesTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/ExceptionBuiltinCodesTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.errorcode;
+
+import org.camunda.bpm.engine.AuthorizationService;
+import org.camunda.bpm.engine.IdentityService;
+import org.camunda.bpm.engine.OptimisticLockingException;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.authorization.Authorization;
+import org.camunda.bpm.engine.authorization.Permission;
+import org.camunda.bpm.engine.authorization.Resources;
+import org.camunda.bpm.engine.authorization.TaskPermissions;
+import org.camunda.bpm.engine.identity.User;
+import org.camunda.bpm.engine.impl.db.sql.DbSqlSessionFactory;
+import org.camunda.bpm.engine.impl.errorcode.BuiltinExceptionCode;
+import org.camunda.bpm.engine.impl.interceptor.Command;
+import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.camunda.bpm.engine.impl.test.RequiredDatabase;
+import org.camunda.bpm.engine.runtime.Execution;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.camunda.bpm.engine.authorization.Authorization.AUTH_TYPE_GRANT;
+
+public class ExceptionBuiltinCodesTest {
+
+  protected ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
+  protected ProcessEngineTestRule engineTestRule = new ProcessEngineTestRule(engineRule);
+
+  @Rule
+  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(engineTestRule);
+
+  protected RuntimeService runtimeService;
+  protected IdentityService identityService;
+  protected AuthorizationService authorizationService;
+
+  @Before
+  public void assignServices() {
+    runtimeService = engineRule.getRuntimeService();
+    identityService = engineRule.getIdentityService();
+    authorizationService = engineRule.getAuthorizationService();
+  }
+
+  @After
+  public void clear() {
+    engineRule.getIdentityService().deleteUser("kermit");
+    engineRule.getAuthorizationService().createAuthorizationQuery().list()
+        .forEach(authorization -> authorizationService.deleteAuthorization(authorization.getId()));
+    engineRule.getRuntimeService().createProcessInstanceQuery().processInstanceBusinessKey("sub-process").list()
+        .forEach(pi -> runtimeService.deleteProcessInstance(pi.getProcessInstanceId(), ""));
+  }
+
+  @Test
+  public void shouldHaveColumnSizeTooSmallErrorCode() {
+    // given
+    BpmnModelInstance modelInstance = Bpmn.createExecutableProcess("process")
+        .startEvent()
+        .endEvent()
+        .done();
+
+    engineTestRule.deploy(modelInstance);
+
+    String businessKey = generateString(1_000);
+
+    // when/then
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("process", businessKey))
+        .extracting("code")
+          .contains(BuiltinExceptionCode.COLUMN_SIZE_TOO_SMALL.getCode());
+  }
+
+  @Test
+  public void shouldHaveDefaultErrorCodeUniqueKeyConstraintPersistenceExceptionNotCovered() {
+    // given
+    Authorization authorizationOne = authorizationService.createNewAuthorization(AUTH_TYPE_GRANT);
+    authorizationOne.setGroupId("aUserId");
+    authorizationOne.setPermissions(new Permission[] { TaskPermissions.READ });
+    authorizationOne.setResourceId("foo");
+    authorizationOne.setResource(Resources.TASK);
+
+    authorizationService.saveAuthorization(authorizationOne);
+
+    Authorization authorizationTwo = authorizationService.createNewAuthorization(AUTH_TYPE_GRANT);
+    authorizationTwo.setGroupId("aUserId");
+    authorizationTwo.setPermissions(new Permission[]{TaskPermissions.READ});
+    authorizationTwo.setResourceId("foo");
+    authorizationTwo.setResource(Resources.TASK);
+
+    // when/then
+    assertThatThrownBy(() -> authorizationService.saveAuthorization(authorizationTwo))
+        .extracting("code")
+        .contains(BuiltinExceptionCode.FALLBACK.getCode());
+  }
+
+  @Test
+  public void shouldHaveOleErrorCode() {
+    // given
+    User user = identityService.newUser("kermit");
+    identityService.saveUser(user);
+
+    User user1 = identityService.createUserQuery().singleResult();
+    User user2 = identityService.createUserQuery().singleResult();
+
+    user1.setFirstName("name one");
+    identityService.saveUser(user1);
+
+    user2.setFirstName("name two");
+
+    // when/then
+    assertThatThrownBy(() -> identityService.saveUser(user2))
+        .isInstanceOf(OptimisticLockingException.class)
+        .extracting("code")
+        .contains(BuiltinExceptionCode.OPTIMISTIC_LOCKING.getCode());
+  }
+
+  /**
+   * This test case doesn't lead to a foreign key constraint violation on DB2.
+   * Instead, the following error is thrown: https://www.sqlerror.de/db2_sql_error_-532_sqlstate_23504.html
+   */
+  @Test
+  @RequiredDatabase(excludes = DbSqlSessionFactory.DB2)
+  public void shouldHaveForeignKeyConstraintViolationCode() {
+    BpmnModelInstance modelInstance = Bpmn.createExecutableProcess("calling")
+        .startEvent()
+        .callActivity()
+          .calledElement("called")
+          .camundaInBusinessKey("sub-process")
+        .endEvent()
+        .done();
+
+    engineTestRule.deploy(modelInstance);
+
+    modelInstance = Bpmn.createExecutableProcess("called")
+        .startEvent()
+        .userTask()
+        .endEvent()
+        .done();
+
+    engineTestRule.deploy(modelInstance);
+
+    String processInstanceId = runtimeService.startProcessInstanceByKey("calling").getId();
+
+    List<Execution> executions = runtimeService.createExecutionQuery().list();
+    executions.forEach((execution -> {
+      ((ExecutionEntity) execution).setCachedEntityState(0);
+
+      engineRule.getProcessEngineConfiguration()
+          .getCommandExecutorTxRequired()
+          .execute((Command<Void>) commandContext -> {
+            commandContext.getDbEntityManager().merge(((ExecutionEntity) execution));
+            return null;
+          });
+    }));
+
+    assertThatThrownBy(() -> runtimeService.deleteProcessInstance(processInstanceId, ""))
+        .isInstanceOf(ProcessEngineException.class)
+        .extracting("code")
+        .contains(BuiltinExceptionCode.FOREIGN_KEY_CONSTRAINT_VIOLATION.getCode());
+  }
+
+  // helper ////////////////////////////////////////////////////////////////////////////////////////
+
+  protected String generateString(int size) {
+    return new String(new char[size]).replace('\0', 'a');
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/FailingJavaDelegateWithCustomException.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/FailingJavaDelegateWithCustomException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.errorcode;
+
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+
+public class FailingJavaDelegateWithCustomException implements JavaDelegate {
+
+  @Override
+  public void execute(DelegateExecution execution) throws Exception {
+    throw new MyCustomException("foo", (int) execution.getVariable("code"));
+  }
+
+  public static class MyCustomException extends ProcessEngineException {
+
+    public MyCustomException(String message, int code) {
+      super(message, code);
+    }
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/FailingJavaDelegateWithErrorCode.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/FailingJavaDelegateWithErrorCode.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.errorcode;
+
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+
+public class FailingJavaDelegateWithErrorCode implements JavaDelegate {
+
+  @Override
+  public void execute(DelegateExecution execution) throws Exception {
+    throw new ProcessEngineException("foo", (int) execution.getVariable("code"));
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/FailingJavaDelegateWithOleAndErrorCode.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/FailingJavaDelegateWithOleAndErrorCode.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.errorcode;
+
+import org.camunda.bpm.engine.OptimisticLockingException;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.JavaDelegate;
+
+public class FailingJavaDelegateWithOleAndErrorCode implements JavaDelegate {
+
+  @Override
+  public void execute(DelegateExecution execution) throws Exception {
+    OptimisticLockingException ole = new OptimisticLockingException("foo");
+    ole.setCode((int) execution.getVariable("code"));
+    throw ole;
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/conf/BuiltinExceptionCodeProviderDisabledWithCustomProviderTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/conf/BuiltinExceptionCodeProviderDisabledWithCustomProviderTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.errorcode.conf;
+
+import org.camunda.bpm.engine.IdentityService;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.identity.User;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.errorcode.ExceptionCodeProvider;
+import org.camunda.bpm.engine.test.errorcode.FailingJavaDelegateWithErrorCode;
+import org.camunda.bpm.engine.test.util.ProcessEngineBootstrapRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+
+public class BuiltinExceptionCodeProviderDisabledWithCustomProviderTest {
+
+  protected static int PROVIDED_CUSTOM_CODE = 888_888;
+
+  @ClassRule
+  public static ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule(c -> {
+    c.setDisableBuiltinExceptionCodeProvider(true);
+    c.setCustomExceptionCodeProvider(new ExceptionCodeProvider() {
+
+      @Override
+      public Integer provideCode(SQLException sqlException) {
+        return PROVIDED_CUSTOM_CODE;
+      }
+
+      @Override
+      public Integer provideCode(ProcessEngineException processEngineException) {
+        return PROVIDED_CUSTOM_CODE;
+      }
+
+    });
+  });
+
+  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule(bootstrapRule);
+  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
+
+  @Rule
+  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+
+  protected RuntimeService runtimeService;
+  protected IdentityService identityService;
+
+  protected ProcessEngineConfigurationImpl engineConfig;
+
+  @Before
+  public void assignServices() {
+    runtimeService = engineRule.getRuntimeService();
+    identityService = engineRule.getIdentityService();
+
+    engineConfig = engineRule.getProcessEngineConfiguration();
+  }
+
+  @After
+  public void clear() {
+    engineRule.getIdentityService().deleteUser("kermit");
+  }
+
+  @Test
+  public void shouldOverrideBuiltinCodeColumnSizeTooSmall() {
+    // given
+    BpmnModelInstance modelInstance = Bpmn.createExecutableProcess("process")
+        .startEvent()
+        .endEvent()
+        .done();
+
+    testRule.deploy(modelInstance);
+
+    String businessKey = generateString(1_000);
+
+    // when/then
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("process", businessKey))
+        .extracting("code")
+        .contains(PROVIDED_CUSTOM_CODE);
+  }
+
+  @Test
+  public void shouldOverrideBuiltinCodeOptimisticLockingException() {
+    // given
+    User user = identityService.newUser("kermit");
+    identityService.saveUser(user);
+
+    User user1 = identityService.createUserQuery().singleResult();
+    User user2 = identityService.createUserQuery().singleResult();
+
+    user1.setFirstName("name one");
+    identityService.saveUser(user1);
+
+    user2.setFirstName("name two");
+
+    // when/then
+    assertThatThrownBy(() -> identityService.saveUser(user2))
+        .extracting("code")
+        .contains(PROVIDED_CUSTOM_CODE);
+  }
+
+  @Test
+  public void shouldOverrideProvidedExceptionCodeFromDelegationCode() {
+    // given
+    BpmnModelInstance myProcess = Bpmn.createExecutableProcess("foo")
+        .startEvent()
+        .serviceTask()
+          .camundaClass(FailingJavaDelegateWithErrorCode.class)
+        .endEvent()
+        .done();
+
+    testRule.deploy(myProcess);
+
+    // when
+    ThrowingCallable callable =
+        () -> runtimeService.startProcessInstanceByKey("foo",
+            Variables.putValue("code", 999_999));
+
+    // then
+    assertThatThrownBy(callable)
+        .extracting("code")
+        .contains(999_999);
+  }
+
+  @Test
+  public void shouldOverrideProvidedExceptionCodeFromDelegationCodeAndAllowOverridingReservedCode() {
+    // given
+    BpmnModelInstance myProcess = Bpmn.createExecutableProcess("foo")
+        .startEvent()
+        .serviceTask()
+          .camundaClass(FailingJavaDelegateWithErrorCode.class)
+        .endEvent()
+        .done();
+
+    testRule.deploy(myProcess);
+
+    // when
+    ThrowingCallable callable =
+        () -> runtimeService.startProcessInstanceByKey("foo",
+            Variables.putValue("code", 1000));
+
+    // then
+    assertThatThrownBy(callable)
+        .extracting("code")
+        .contains(1000);
+  }
+
+  // helper ////////////////////////////////////////////////////////////////////////////////////////
+
+  protected String generateString(int size) {
+    return new String(new char[size]).replace('\0', 'a');
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/conf/CustomErrorCodeProviderTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/conf/CustomErrorCodeProviderTest.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.errorcode.conf;
+
+import ch.qos.logback.classic.Level;
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.camunda.bpm.engine.IdentityService;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.impl.errorcode.BuiltinExceptionCode;
+import org.camunda.bpm.engine.impl.errorcode.ExceptionCodeProvider;
+import org.camunda.bpm.engine.test.errorcode.FailingJavaDelegateWithCustomException;
+import org.camunda.bpm.engine.test.errorcode.FailingJavaDelegateWithErrorCode;
+import org.camunda.bpm.engine.test.errorcode.FailingJavaDelegateWithOleAndErrorCode;
+import org.camunda.bpm.engine.test.util.ProcessEngineBootstrapRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.camunda.commons.testing.ProcessEngineLoggingRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.Assert.fail;
+
+public class CustomErrorCodeProviderTest {
+
+  protected static int PROVIDED_CUSTOM_CODE = 33_333;
+
+  @ClassRule
+  public static ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule(c -> {
+    c.setCustomExceptionCodeProvider(new ExceptionCodeProvider() {
+
+      @Override
+      public Integer provideCode(SQLException sqlException) {
+        return PROVIDED_CUSTOM_CODE;
+      }
+
+      @Override
+      public Integer provideCode(ProcessEngineException processEngineException) {
+        return PROVIDED_CUSTOM_CODE;
+      }
+
+    });
+  });
+
+  @Rule
+  public ProcessEngineLoggingRule loggingRule = new ProcessEngineLoggingRule()
+      .watch("org.camunda.bpm.engine.cmd")
+      .level(Level.WARN);
+
+  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule(bootstrapRule);
+  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
+
+  @Rule
+  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+
+  protected RuntimeService runtimeService;
+  protected IdentityService identityService;
+
+  @Before
+  public void assignServices() {
+    runtimeService = engineRule.getRuntimeService();
+    identityService = engineRule.getIdentityService();
+  }
+
+  @After
+  public void clear() {
+    engineRule.getIdentityService().deleteUser("kermit");
+  }
+
+  @Test
+  public void shouldOverrideProvidedExceptionCode1() {
+    // given
+    BpmnModelInstance myProcess = Bpmn.createExecutableProcess("foo")
+        .startEvent()
+        .serviceTask()
+          .camundaClass(FailingJavaDelegateWithErrorCode.class)
+        .endEvent()
+        .done();
+
+    testRule.deploy(myProcess);
+
+    // when
+    Throwable exception = catchThrowable(() -> runtimeService.startProcessInstanceByKey("foo",
+        Variables.putValue("code", 22_222)));
+
+    // then
+    assertThat(((ProcessEngineException) exception).getCode()).isEqualTo(22_222);
+  }
+
+  @Test
+  public void shouldOverrideProvidedExceptionCode2() {
+    // given
+    BpmnModelInstance myProcess = Bpmn.createExecutableProcess("foo")
+        .startEvent()
+        .serviceTask()
+          .camundaClass(FailingJavaDelegateWithErrorCode.class)
+        .endEvent()
+        .done();
+
+    testRule.deploy(myProcess);
+
+    // when
+    Throwable exception = catchThrowable(() -> runtimeService.startProcessInstanceByKey("foo",
+        Variables.putValue("code", 20_000)));
+
+    // then
+    assertThat(((ProcessEngineException) exception).getCode()).isEqualTo(20_000);
+  }
+
+  @Test
+  public void shouldOverrideProvidedExceptionCode3() {
+    // given
+    BpmnModelInstance myProcess = Bpmn.createExecutableProcess("foo")
+        .startEvent()
+        .serviceTask()
+          .camundaClass(FailingJavaDelegateWithErrorCode.class)
+        .endEvent()
+        .done();
+
+    testRule.deploy(myProcess);
+
+    // when
+    Throwable exception = catchThrowable(() -> runtimeService.startProcessInstanceByKey("foo",
+        Variables.putValue("code", 39_999)));
+
+    // then
+    assertThat(((ProcessEngineException) exception).getCode()).isEqualTo(39_999);
+  }
+
+  /**
+   * This situation cannot happen right now since OLE are not thrown within delegation code
+   * but when the process transaction is flushed. However, with this test case we ensure
+   * that the built-in code provider has precedence over a code that was assigned via delegation
+   * code. This ensures consistent behavior when we add non-SQL exception related built-in codes in the future.
+   */
+  @Test
+  public void shouldOverrideCodeFromDelegationCodeWithBuiltinCode() {
+    // given
+    BpmnModelInstance myProcess = Bpmn.createExecutableProcess("foo")
+        .startEvent()
+        .serviceTask()
+          .camundaClass(FailingJavaDelegateWithOleAndErrorCode.class)
+        .endEvent()
+        .done();
+
+    testRule.deploy(myProcess);
+
+    // when
+    ThrowingCallable callable =
+        () -> runtimeService.startProcessInstanceByKey("foo",
+            Variables.putValue("code", 40_000));
+
+    // then
+    assertThatThrownBy(callable)
+        .extracting("code")
+        .contains(BuiltinExceptionCode.OPTIMISTIC_LOCKING.getCode());
+    assertThat(loggingRule.getLog().get(0).getMessage())
+        .contains("Falling back to built-in code");
+  }
+
+  @Test
+  public void shouldOverrideCodeZeroWithCustomCode() {
+    // given
+    BpmnModelInstance myProcess = Bpmn.createExecutableProcess("foo")
+        .startEvent()
+        .serviceTask()
+          .camundaClass(FailingJavaDelegateWithErrorCode.class)
+        .endEvent()
+        .done();
+
+    testRule.deploy(myProcess);
+
+    // when
+    ThrowingCallable callable =
+        () -> runtimeService.startProcessInstanceByKey("foo",
+            Variables.putValue("code", 0));
+
+    // then
+    assertThatThrownBy(callable)
+        .extracting("code")
+        .contains(PROVIDED_CUSTOM_CODE);
+  }
+
+  @Test
+  public void shouldResetReservedCodeFromDelegationCode1() {
+    // given
+    BpmnModelInstance myProcess = Bpmn.createExecutableProcess("foo")
+        .startEvent()
+        .serviceTask()
+          .camundaClass(FailingJavaDelegateWithErrorCode.class)
+        .endEvent()
+        .done();
+
+    testRule.deploy(myProcess);
+
+    // when
+    ThrowingCallable callable =
+        () -> runtimeService.startProcessInstanceByKey("foo",
+            Variables.putValue("code", 1));
+
+    // then
+    assertThatThrownBy(callable)
+        .extracting("code")
+        .contains(BuiltinExceptionCode.FALLBACK.getCode());
+    assertThat(loggingRule.getLog().get(0).getMessage())
+        .contains("Falling back to default error code 0.");
+  }
+
+  @Test
+  public void shouldResetReservedCodeFromDelegationCode2() {
+    // given
+    BpmnModelInstance myProcess = Bpmn.createExecutableProcess("foo")
+        .startEvent()
+        .serviceTask()
+          .camundaClass(FailingJavaDelegateWithErrorCode.class)
+        .endEvent()
+        .done();
+
+    testRule.deploy(myProcess);
+
+    // when
+    ThrowingCallable callable =
+        () -> runtimeService.startProcessInstanceByKey("foo",
+            Variables.putValue("code", 19_999));
+
+    // then
+    assertThatThrownBy(callable)
+        .extracting("code")
+        .contains(BuiltinExceptionCode.FALLBACK.getCode());
+    assertThat(loggingRule.getLog().get(0).getMessage())
+        .contains("Falling back to default error code 0.");
+  }
+
+  @Test
+  public void shouldResetReservedCodeFromDelegationCode3() {
+    // given
+    BpmnModelInstance myProcess = Bpmn.createExecutableProcess("foo")
+        .startEvent()
+        .serviceTask()
+          .camundaClass(FailingJavaDelegateWithErrorCode.class)
+        .endEvent()
+        .done();
+
+    testRule.deploy(myProcess);
+
+    // when
+    ThrowingCallable callable =
+        () -> runtimeService.startProcessInstanceByKey("foo",
+            Variables.putValue("code", 40_000));
+
+    // then
+    assertThatThrownBy(callable)
+        .extracting("code")
+        .contains(BuiltinExceptionCode.FALLBACK.getCode());
+    assertThat(loggingRule.getLog().get(0).getMessage())
+        .contains("Falling back to default error code 0.");
+  }
+
+  @Test
+  public void shouldProvideCustomCodeFromDelegationCodeWithCustomException() {
+    // given
+    BpmnModelInstance myProcess = Bpmn.createExecutableProcess("foo")
+        .startEvent()
+        .serviceTask()
+          .camundaClass(FailingJavaDelegateWithCustomException.class)
+        .endEvent()
+        .done();
+
+    testRule.deploy(myProcess);
+
+    // when
+    ThrowingCallable callable =
+        () -> runtimeService.startProcessInstanceByKey("foo",
+            Variables.putValue("code", 22_222));
+
+    // then
+    assertThatThrownBy(callable)
+        .extracting("code")
+        .contains(22_222);
+  }
+
+  @Test
+  public void shouldHaveSubordinationToBuiltinCode() {
+    // given
+    BpmnModelInstance modelInstance = Bpmn.createExecutableProcess("process")
+        .startEvent()
+        .endEvent()
+        .done();
+
+    testRule.deploy(modelInstance);
+
+    String businessKey = generateString(1_000);
+
+    // when/then
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("process", businessKey))
+        .isInstanceOf(ProcessEngineException.class)
+        .extracting("code")
+        .contains(BuiltinExceptionCode.COLUMN_SIZE_TOO_SMALL.getCode());
+  }
+
+  // helper ////////////////////////////////////////////////////////////////////////////////////////
+
+  protected String generateString(int size) {
+    return new String(new char[size]).replace('\0', 'a');
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/conf/ExceptionCodeDisabledTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/conf/ExceptionCodeDisabledTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.errorcode.conf;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.camunda.bpm.engine.IdentityService;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.identity.User;
+import org.camunda.bpm.engine.impl.errorcode.BuiltinExceptionCode;
+import org.camunda.bpm.engine.test.errorcode.FailingJavaDelegateWithErrorCode;
+import org.camunda.bpm.engine.test.util.ProcessEngineBootstrapRule;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+public class ExceptionCodeDisabledTest {
+
+  @ClassRule
+  public static ProcessEngineBootstrapRule bootstrapRule =
+      new ProcessEngineBootstrapRule(c -> c.setDisableExceptionCode(true));
+
+  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule(bootstrapRule);
+  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
+
+  @Rule
+  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+
+  protected RuntimeService runtimeService;
+  protected IdentityService identityService;
+
+  @Before
+  public void assignServices() {
+    runtimeService = engineRule.getRuntimeService();
+    identityService = engineRule.getIdentityService();
+  }
+
+  @After
+  public void clear() {
+    engineRule.getIdentityService().deleteUser("kermit");
+  }
+
+  @Test
+  public void shouldReturnDefaultErrorCodeWhenColumnSizeTooSmall() {
+    // given
+    BpmnModelInstance modelInstance = Bpmn.createExecutableProcess("process")
+        .startEvent()
+        .endEvent()
+        .done();
+
+    testRule.deploy(modelInstance);
+
+    String businessKey = generateString(1_000);
+
+    // when/then
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("process", businessKey))
+        .extracting("code")
+        .contains(BuiltinExceptionCode.FALLBACK.getCode());
+  }
+
+  @Test
+  public void shouldReturnDefaultErrorCodeWhenOptimisticLockingExceptionThrown() {
+    // given
+    User user = identityService.newUser("kermit");
+    identityService.saveUser(user);
+
+    User user1 = identityService.createUserQuery().singleResult();
+    User user2 = identityService.createUserQuery().singleResult();
+
+    user1.setFirstName("name one");
+    identityService.saveUser(user1);
+
+    user2.setFirstName("name two");
+
+    // when/then
+    assertThatThrownBy(() -> identityService.saveUser(user2))
+        .extracting("code")
+        .contains(BuiltinExceptionCode.FALLBACK.getCode());
+  }
+
+  @Test
+  public void shouldPassCodeFromDelegationCode() {
+    // given
+    BpmnModelInstance myProcess = Bpmn.createExecutableProcess("foo")
+        .startEvent()
+        .serviceTask()
+          .camundaClass(FailingJavaDelegateWithErrorCode.class)
+        .endEvent()
+        .done();
+
+    testRule.deploy(myProcess);
+
+    // when
+    ThrowableAssert.ThrowingCallable callable =
+        () -> runtimeService.startProcessInstanceByKey("foo",
+            Variables.putValue("code", 999_999));
+
+    // then
+    assertThatThrownBy(callable)
+        .extracting("code")
+        .contains(999_999);
+  }
+
+  @Test
+  public void shouldPassReservedCodeFromDelegationCode() {
+    // given
+    BpmnModelInstance myProcess = Bpmn.createExecutableProcess("foo")
+        .startEvent()
+        .serviceTask()
+          .camundaClass(FailingJavaDelegateWithErrorCode.class)
+        .endEvent()
+        .done();
+
+    testRule.deploy(myProcess);
+
+    // when
+    ThrowableAssert.ThrowingCallable callable =
+        () -> runtimeService.startProcessInstanceByKey("foo",
+            Variables.putValue("code", 1000));
+
+    // then
+    assertThatThrownBy(callable)
+        .extracting("code")
+        .contains(1000);
+  }
+
+  // helper ////////////////////////////////////////////////////////////////////////////////////////
+
+  protected String generateString(int size) {
+    return new String(new char[size]).replace('\0', 'a');
+  }
+
+}


### PR DESCRIPTION
* The error code allows your client application (using the REST or Open API) or your Engine Java API wrapper to identify errors in an automated fashion.
* When an error occurs, the engine checks if it falls into one of the following categories and assigns a static error code:
  * `OptimisticLockingException` / `CrdbTransactionRetryException`
     * Code: 1
  * Deadlock situation.
     * Code: 10,000
  * Foreign key constraint violation.
     * Code: 10,001
  * Column size too small.
     * Code: 10,002
* The engine sets the code on the `ProcessEngineException`; the REST and Open API expose the code.
* You can assign a custom code to a `ProcessEngineException` via delegation code or by implementing a custom `ExceptionCodeProvider`.
* You can disable the entire feature via the `disableExceptionCode` flag in the process engine configuration.
* This commit refactors and simplifies identifying persistence problems by only looking at the first `java.sql.SQLException` when a JDBC batch fails.

related to CAM-14083, closes #1943