### PR TITLE
chore(engine): stabilize HistoricProcessInstanceTest

### DIFF
--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricProcessInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricProcessInstanceTest.java
@@ -72,7 +72,6 @@ import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.camunda.bpm.engine.variable.Variables;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -290,9 +289,10 @@ public class HistoricProcessInstanceTest {
   @Test
   @Deployment(resources = {"org/camunda/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})
   public void testHistoricProcessInstanceStartDate() {
+    ClockUtil.setCurrentTime(new Date());
     runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-    Date date = new Date();
+    Date date = ClockUtil.getCurrentTime();
 
     assertEquals(1, historyService.createHistoricProcessInstanceQuery().startDateOn(date).count());
     assertEquals(1, historyService.createHistoricProcessInstanceQuery().startDateBy(date).count());


### PR DESCRIPTION
* Fixes the start time of the process instance and the query date for
  "startDateOn" to be equal. Otherwise, the milliseconds between the
  instance start and the query date can lead to an overflow to the next
  second. This will break MySQL's seconds precision for datetime columns
  and yield an unexpected instance in the test.

related to CAM-13733