### PR TITLE
CAM-14456: avoid propagation of skipIoMappings after cancellation

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExecutionEntity.java
@@ -502,19 +502,18 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
    * removed afterwards.
    */
   @Override
-  public void destroy() {
-
+  public void destroy(boolean alwaysSkipIoMappings) {
     ensureParentInitialized();
 
     // execute Output Mappings (if they exist).
     ensureActivityInitialized();
-    if (activity != null && activity.getIoMapping() != null && !skipIoMapping) {
+    if (activity != null && activity.getIoMapping() != null && !skipIoMapping && !alwaysSkipIoMappings) {
       activity.getIoMapping().executeOutputParameters(this);
     }
 
     clearExecution();
 
-    super.destroy();
+    super.destroy(alwaysSkipIoMappings);
 
     removeEventSubscriptionsExceptCompensation();
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/PvmExecutionImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/PvmExecutionImpl.java
@@ -46,6 +46,7 @@ import org.camunda.bpm.engine.impl.incident.IncidentContext;
 import org.camunda.bpm.engine.impl.incident.IncidentHandler;
 import org.camunda.bpm.engine.impl.incident.IncidentHandling;
 import org.camunda.bpm.engine.impl.persistence.entity.DelayedVariableEvent;
+import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.IncidentEntity;
 import org.camunda.bpm.engine.impl.pvm.PvmActivity;
 import org.camunda.bpm.engine.impl.pvm.PvmException;
@@ -315,6 +316,14 @@ public abstract class PvmExecutionImpl extends CoreExecution implements
 
   @Override
   public void destroy() {
+    destroy(false);
+  }
+
+  /**
+   * @param alwaysSkipIoMappings set to true to always skip IO mappings,
+   * regardless of internal state of execution (=> {@link CoreExecution#isSkipIoMappings()})
+   */
+  public void destroy(boolean alwaysSkipIoMappings) {
     LOG.destroying(this);
     setScope(false);
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/BoundaryEventInputOutputTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/BoundaryEventInputOutputTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.bpmn.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.List;
+
+import org.camunda.bpm.engine.history.HistoricVariableInstance;
+import org.camunda.bpm.engine.test.bpmn.iomapping.VariableLogDelegate;
+import org.camunda.bpm.engine.test.util.PluggableProcessEngineTest;
+import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BoundaryEventInputOutputTest extends PluggableProcessEngineTest {
+
+  protected static final BpmnModelInstance EVENT_GATEWAY_PROCESS =
+    Bpmn.createExecutableProcess("process")
+      .startEvent()
+      .manualTask("manualTask")
+      .boundaryEvent()
+        .conditionalEventDefinition()
+        .condition("${moveOn}")
+        .conditionalEventDefinitionDone()
+      .serviceTask("inputParameterTask")
+        .camundaInputParameter("variable1", "testValue")
+        .camundaClass(VariableLogDelegate.class)
+      .endEvent()
+      .moveToActivity("manualTask")
+      .endEvent()
+      .done();
+
+  protected boolean skipOutputMappingVal;
+
+  @Before
+  public void setUp() {
+    skipOutputMappingVal = processEngineConfiguration.isSkipOutputMappingOnCanceledActivities();
+    processEngineConfiguration.setSkipOutputMappingOnCanceledActivities(true);
+    VariableLogDelegate.reset();
+  }
+
+  @After
+  public void tearDown() {
+    processEngineConfiguration.setSkipOutputMappingOnCanceledActivities(skipOutputMappingVal);
+    VariableLogDelegate.reset();
+  }
+
+  @Test
+  public void shouldProcessInputOutputParametersAfterEventGateway() {
+    // given
+    testRule.deploy(EVENT_GATEWAY_PROCESS);
+
+    // when
+    runtimeService.startProcessInstanceByKey("process", Variables.putValue("moveOn", true));
+
+    // then
+    List<HistoricVariableInstance> vars = historyService.createHistoricVariableInstanceQuery()
+        .variableName("variable1")
+        .list();
+    assertThat(vars).hasSize(1);
+    assertThat(vars.get(0).getValue()).isEqualTo("testValue");
+  }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/gateway/EventBasedGatewayInputOutputTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/gateway/EventBasedGatewayInputOutputTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.bpmn.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.camunda.bpm.engine.history.HistoricVariableInstance;
+import org.camunda.bpm.engine.test.bpmn.iomapping.VariableLogDelegate;
+import org.camunda.bpm.engine.test.util.PluggableProcessEngineTest;
+import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EventBasedGatewayInputOutputTest extends PluggableProcessEngineTest {
+
+  protected static final BpmnModelInstance EVENT_GATEWAY_PROCESS =
+    Bpmn.createExecutableProcess("process")
+      .startEvent()
+      .eventBasedGateway()
+      .intermediateCatchEvent("conditionalEvent")
+        .camundaOutputParameter("eventOutput", "foo")
+        .conditionalEventDefinition()
+        .condition("${moveOn}")
+        .conditionalEventDefinitionDone()
+      .serviceTask("inputParameterTask")
+        .camundaInputParameter("variable1", "testValue")
+        .camundaClass(VariableLogDelegate.class)
+      .endEvent()
+      .done();
+
+  protected boolean skipOutputMappingVal;
+
+  @Before
+  public void setUp() {
+    skipOutputMappingVal = processEngineConfiguration.isSkipOutputMappingOnCanceledActivities();
+    processEngineConfiguration.setSkipOutputMappingOnCanceledActivities(true);
+    VariableLogDelegate.reset();
+  }
+
+  @After
+  public void tearDown() {
+    processEngineConfiguration.setSkipOutputMappingOnCanceledActivities(skipOutputMappingVal);
+    VariableLogDelegate.reset();
+  }
+
+  @Test
+  public void shouldProcessInputOutputParametersAfterEventGateway() {
+    // given
+    testRule.deploy(EVENT_GATEWAY_PROCESS);
+
+    // when
+    runtimeService.startProcessInstanceByKey("process", Variables.putValue("moveOn", true));
+
+    // then
+    List<HistoricVariableInstance> vars = historyService.createHistoricVariableInstanceQuery()
+        .variableName("eventOutput")
+        .list();
+    assertThat(vars).hasSize(1);
+    assertThat(vars.get(0).getValue()).isEqualTo("foo");
+
+    assertThat(VariableLogDelegate.LOCAL_VARIABLES).hasSize(1);
+    vars = historyService.createHistoricVariableInstanceQuery()
+        .variableName("variable1")
+        .list();
+    assertThat(vars).hasSize(1);
+    assertThat(vars.get(0).getValue()).isEqualTo("testValue");
+  }
+
+  @Test
+  public void shouldNotProcessInputOutputParametersAfterEventGatewayDeletion() {
+    // given
+    testRule.deploy(EVENT_GATEWAY_PROCESS);
+    String instanceId = runtimeService.startProcessInstanceByKey("process", Variables.putValue("moveOn", false)).getId();
+
+    // when
+    runtimeService.deleteProcessInstance(instanceId, "manual cancelation");
+
+    // then
+    assertThat(VariableLogDelegate.LOCAL_VARIABLES).isEmpty();
+    assertThat(historyService.createHistoricVariableInstanceQuery()
+        .variableName("eventOutput")
+        .count()).isEqualTo(0L);
+    assertThat(historyService.createHistoricVariableInstanceQuery()
+        .variableName("variable1")
+        .count()).isEqualTo(0L);
+  }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/iomapping/VariableLogDelegate.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/iomapping/VariableLogDelegate.java
@@ -29,16 +29,18 @@ import org.camunda.bpm.engine.delegate.JavaDelegate;
  */
 public class VariableLogDelegate implements JavaDelegate, ExecutionListener {
 
-  public static Map<String, Object> LOCAL_VARIABLES= new HashMap<String, Object>();
+  public static Map<String, Object> LOCAL_VARIABLES= new HashMap<>();
 
+  @Override
   public void execute(DelegateExecution execution) throws Exception {
     LOCAL_VARIABLES = execution.getVariablesLocal();
   }
 
   public static void reset() {
-    LOCAL_VARIABLES = new HashMap<String, Object>();
+    LOCAL_VARIABLES = new HashMap<>();
   }
 
+  @Override
   public void notify(DelegateExecution execution) throws Exception {
     LOCAL_VARIABLES = execution.getVariablesLocal();
   }


### PR DESCRIPTION
* when the engine config flag skipOutputMappingOnCanceledActivities
  is used, it should stop applying for any IO mappings performed
  after the cancellation (e.g. tasks following a boundary event
  or event-based gateway)

related to CAM-14456