### PR TITLE
fix(engine): handle foreign key constraint violations on db2

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/ExceptionUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/ExceptionUtil.java
@@ -207,9 +207,8 @@ public class ExceptionUtil {
           // H2
           "23506".equals(sqlState) && errorCode == 23506 ||
           // DB2
-          message.contains("sqlstate=23503") && message.toLowerCase().contains("sqlcode=-530") ||
-          // DB2 zOS
-          "23503".equals(sqlState) && errorCode == -530;
+          "23503".equals(sqlState) && errorCode == -530 ||
+          "23504".equals(sqlState) && errorCode == -532;
     }
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/BuiltinExceptionCodeForeignKeyConstraintViolationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/BuiltinExceptionCodeForeignKeyConstraintViolationTest.java
@@ -74,14 +74,11 @@ public class BuiltinExceptionCodeForeignKeyConstraintViolationTest extends Concu
   }
 
   /**
-   * This test case doesn't lead to a foreign key constraint violation on DB2.
-   * Instead, the following error is thrown: https://www.sqlerror.de/db2_sql_error_-532_sqlstate_23504.html
-   *
    * This test case doesn't lead to a foreign key constraint violation on CRDB.
    * Instead, a deadlock error is detected.
    */
   @Deployment(resources = "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
-  @RequiredDatabase(excludes = {DbSqlSessionFactory.DB2, DbSqlSessionFactory.CRDB})
+  @RequiredDatabase(excludes = {DbSqlSessionFactory.CRDB})
   @Test
   public void shouldReturnForeignKeyConstraintErrorCode() {
     // given

--- a/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/ExceptionBuiltinCodesTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/errorcode/ExceptionBuiltinCodesTest.java
@@ -147,12 +147,7 @@ public class ExceptionBuiltinCodesTest {
         .contains(BuiltinExceptionCode.OPTIMISTIC_LOCKING.getCode());
   }
 
-  /**
-   * This test case doesn't lead to a foreign key constraint violation on DB2.
-   * Instead, the following error is thrown: https://www.sqlerror.de/db2_sql_error_-532_sqlstate_23504.html
-   */
   @Test
-  @RequiredDatabase(excludes = DbSqlSessionFactory.DB2)
   public void shouldHaveForeignKeyConstraintViolationCode() {
     BpmnModelInstance modelInstance = Bpmn.createExecutableProcess("calling")
         .startEvent()


### PR DESCRIPTION
Previously, the following foreign key constraint violations weren't handled for DB2:
* A non-null update of a foreign key in a child table must reference an existing primary key in the parent table.
* When a foreign key reference exists in the child table, the respective row in the parent table cannot be deleted.

related to CAM-14752