### PR TITLE
CAM-14741: feat(qa): adjust IT tests to better support was liberty

### DIFF
--- a/database/pom.xml
+++ b/database/pom.xml
@@ -284,6 +284,7 @@
         <database.driver>org.h2.Driver</database.driver>
         <database.datasource.class>org.h2.jdbcx.JdbcDataSource</database.datasource.class>
         <jboss.datasource.filename>h2-ds.xml</jboss.datasource.filename>
+        <was.liberty.datasource.filename>h2-config.xml</was.liberty.datasource.filename>
         <hibernate.dialect>org.hibernate.dialect.H2Dialect</hibernate.dialect>
       </properties>
       <dependencies>
@@ -498,6 +499,7 @@
         <database.driver>org.postgresql.Driver</database.driver>
         <database.datasource.class>org.postgresql.ds.PGSimpleDataSource</database.datasource.class>
         <jboss.datasource.filename>postgresql-ds.xml</jboss.datasource.filename>
+        <was.liberty.datasource.filename>postgresql-config.xml</was.liberty.datasource.filename>
         <hibernate.dialect>org.hibernate.dialect.PostgreSQLDialect</hibernate.dialect>
         <database.tc.url>campostgresql:13.2</database.tc.url>
       </properties>
@@ -532,6 +534,7 @@
       <properties>
         <database.datasource.class>org.postgresql.xa.PGXADataSource</database.datasource.class>
         <jboss.datasource.filename>postgresql-xa-ds.xml</jboss.datasource.filename>
+        <was.liberty.datasource.filename>postgresql-xa-config.xml</was.liberty.datasource.filename>
       </properties>
     </profile>
     <profile>

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -358,8 +358,8 @@
 
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock-standalone</artifactId>
-        <version>2.27.2</version>
+        <artifactId>wiremock-jre8</artifactId>
+        <version>${version.wiremock-jre8}</version>
         <scope>test</scope>
       </dependency>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -41,6 +41,7 @@
     <version.assertj>2.9.1</version.assertj>
     <version.mockito>4.3.1</version.mockito>
     <version.wiremock>1.58</version.wiremock>
+    <version.wiremock-jre8>2.27.2</version.wiremock-jre8>
     <version.testcontainers>1.16.0</version.testcontainers>
 
     <version.commonj>1.1.0</version.commonj>

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -85,7 +85,7 @@
 
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-standalone</artifactId>
+      <artifactId>wiremock-jre8</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/telemetry/TelemetryConnectPluginTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/functional/telemetry/TelemetryConnectPluginTest.java
@@ -47,6 +47,7 @@ import org.camunda.bpm.engine.impl.util.ParseUtil;
 import org.camunda.bpm.engine.telemetry.Command;
 import org.camunda.bpm.engine.telemetry.Metric;
 import org.camunda.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+import org.camunda.bpm.integrationtest.util.DeploymentHelper;
 import org.camunda.bpm.integrationtest.util.TestContainer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
@@ -97,12 +98,7 @@ public class TelemetryConnectPluginTest extends AbstractFoxPlatformIntegrationTe
   public static WebArchive createDeployment() {
     final WebArchive webArchive =
         initWebArchiveDeployment("paConnectPlugin.war", "org/camunda/bpm/integrationtest/telemetry/processes-connectPlugin.xml")
-        .addAsLibraries(Maven.resolver()
-            .offline()
-            .loadPomFromFile("pom.xml")
-            .resolve("com.github.tomakehurst:wiremock-standalone")
-            .withTransitivity()
-            .as(JavaArchive.class));
+        .addAsLibraries(DeploymentHelper.getWiremock());
 
     TestContainer.addContainerSpecificProcessEngineConfigurationClass(webArchive);
     return webArchive;

--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/util/DeploymentHelper.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/util/DeploymentHelper.java
@@ -33,6 +33,7 @@ public class DeploymentHelper {
   private static JavaArchive CACHED_ENGINE_CDI_ASSET;
   private static JavaArchive[] CACHED_WELD_ASSETS;
   private static JavaArchive[] CACHED_SPRING_ASSETS;
+  private static JavaArchive[] CACHED_WIREMOCK_ASSETS;
 
   public static JavaArchive getEjbClient() {
     if(CACHED_CLIENT_ASSET != null) {
@@ -97,6 +98,30 @@ public class DeploymentHelper {
       }
     }
 
+  }
+
+  public static JavaArchive[] getWiremock() {
+    if(CACHED_WIREMOCK_ASSETS != null) {
+      return CACHED_WIREMOCK_ASSETS;
+    } else {
+
+      JavaArchive[] resolvedArchives = Maven.configureResolver()
+          .workOffline()
+          .loadPomFromFile("pom.xml")
+          .addDependencies(
+              MavenDependencies.createDependency("com.github.tomakehurst:wiremock-jre8", ScopeType.COMPILE, false,
+                                                 MavenDependencies.createExclusion("org.slf4j:slf4j-api")))
+          .resolve()
+          .withTransitivity()
+          .as(JavaArchive.class);
+
+      if(resolvedArchives.length == 0) {
+        throw new RuntimeException("could not resolve com.github.tomakehurst:wiremock-jre8");
+      } else {
+        CACHED_WIREMOCK_ASSETS = resolvedArchives;
+        return CACHED_WIREMOCK_ASSETS;
+      }
+    }
   }
 
   public static JavaArchive[] getEngineSpring() {

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/camunda/bpm/AbstractWebappUiIntegrationTest.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/camunda/bpm/AbstractWebappUiIntegrationTest.java
@@ -60,7 +60,10 @@ public class AbstractWebappUiIntegrationTest extends AbstractWebIntegrationTest 
 
     ChromeOptions chromeOptions = new ChromeOptions()
         .setHeadless(true)
-        .addArguments("--window-size=1920,1200");
+        .addArguments("--window-size=1920,1200")
+        .addArguments("--disable-gpu")
+        .addArguments("--no-sandbox")
+        .addArguments("--disable-dev-shm-usage");
 
     driver = new ChromeDriver(chromeDriverService, chromeOptions);
   }


### PR DESCRIPTION
* Add database configuration filenames for WAS Liberty in the DB profiles for H2 and PostgreSQL.
* Refactor the TelemetryConnectPluginTest to use wiremock-jre8 instead of wiremock-standalone. The standalone artifact shades slf4j-api and causes classloadere conflicts in WAS Liberty.
* Optimize ChromeDriver configuration. Add additional flags that make ChromeDriver more efficient in k8s/Jenkins environments. The previous configuration failed with OOM errors on WAS Liberty.

Related to CAM-14741