### PR TITLE
fix(engine): handle cycles with start date correctly

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/DurationHelper.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/calendar/DurationHelper.java
@@ -56,9 +56,9 @@ public class DurationHelper {
   public DurationHelper(String expressions) throws Exception {
     this(expressions, null);
   }
-  
+
   public DurationHelper(String expressions, Date startDate) throws Exception {
-    List<String> expression = new ArrayList<String>();
+    List<String> expression = new ArrayList<>();
     if(expressions != null) {
       expression = Arrays.asList(expressions.split("/"));
     }
@@ -80,6 +80,9 @@ public class DurationHelper {
       start = DateTimeUtil.parseDate(expression.get(0));
       if (isDuration(expression.get(1))) {
         period = parsePeriod(expression.get(1));
+        // In cases like R2/1970-01-01T00:01:00/PT10S, the timer will trigger two times. At 1970-01-01T00:01:00 and 10 seconds after.
+        // Since we expect only one repetition after the first trigger, we need to reduce the repetition count in this case.
+        times = Math.max(0, times - 1);
       } else {
         end = DateTimeUtil.parseDate(expression.get(1));
         period = datatypeFactory.newDuration(end.getTime()-start.getTime());
@@ -93,7 +96,7 @@ public class DurationHelper {
   public Date getDateAfter() {
     return getDateAfter(null);
   }
-  
+
   public Date getDateAfter(Date date) {
     if (isRepeat) {
       return getDateAfterRepeat(date == null ? ClockUtil.getCurrentTime() : date);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/TimerDeclarationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/TimerDeclarationImpl.java
@@ -31,7 +31,6 @@ import org.camunda.bpm.engine.impl.el.StartProcessVariableScope;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.TimerEntity;
 import org.camunda.bpm.engine.impl.pvm.PvmScope;
-import org.camunda.bpm.engine.impl.util.ClockUtil;
 
 /**
  * @author Tom Baeyens
@@ -77,6 +76,7 @@ public class TimerDeclarationImpl extends JobDeclaration<ExecutionEntity, TimerE
     return eventScopeActivityId;
   }
 
+  @Override
   protected TimerEntity newJobInstance(ExecutionEntity execution) {
 
     TimerEntity timer = new TimerEntity(this);
@@ -102,7 +102,7 @@ public class TimerDeclarationImpl extends JobDeclaration<ExecutionEntity, TimerE
 
       // See ACT-1427: A boundary timer with a cancelActivity='true', doesn't need to repeat itself
       if (!isInterruptingTimer) {
-        String prepared = prepareRepeat(dueDateString);
+        String prepared = prepareRepeat(dueDateString, job);
         job.setRepeat(prepared);
       }
     }
@@ -154,14 +154,15 @@ public class TimerDeclarationImpl extends JobDeclaration<ExecutionEntity, TimerE
     return dueDateString;
   }
 
+  @Override
   protected void postInitialize(ExecutionEntity execution, TimerEntity timer) {
     initializeConfiguration(execution, timer);
   }
 
-  protected String prepareRepeat(String dueDate) {
+  protected String prepareRepeat(String dueDate, TimerEntity job) {
     if (dueDate.startsWith("R") && dueDate.split("/").length==2) {
       SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-      return dueDate.replace("/","/"+sdf.format(ClockUtil.getCurrentTime())+"/");
+      return dueDate.replace("/","/"+sdf.format(job.getDuedate())+"/");
     }
     return dueDate;
   }
@@ -194,6 +195,7 @@ public class TimerDeclarationImpl extends JobDeclaration<ExecutionEntity, TimerE
       .schedule(timer);
   }
 
+  @Override
   protected ExecutionEntity resolveExecution(ExecutionEntity context) {
     return context;
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
@@ -645,7 +645,7 @@ public class BoundaryTimerNonInterruptingEventTest {
     // there should be a single timer job (R5/PT1H)
     TimerEntity timerJob = (TimerEntity) managementService.createJobQuery().singleResult();
     assertNotNull(timerJob);
-    assertEquals("R5/" + sdf.format(ClockUtil.getCurrentTime()) + "/PT1H", timerJob.getRepeat());
+    assertEquals("R5/" + sdf.format(timerJob.getDuedate()) + "/PT1H", timerJob.getRepeat());
 
     // WHEN
     // we update the repeat property of the timer job

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/timer/StartTimerEventTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/timer/StartTimerEventTest.java
@@ -168,8 +168,16 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     moveByMinutes(5);
     executeAllJobs();
     assertEquals(2, piq.count());
-    assertEquals(0, jobQuery.count());
+    assertEquals(1, jobQuery.count());
 
+    // ensure that the deployment Id is set on the new job
+    job = jobQuery.singleResult();
+    assertNotNull(job.getDeploymentId());
+
+    moveByMinutes(5);
+    executeAllJobs();
+    assertEquals(3, piq.count());
+    assertEquals(0, jobQuery.count());
   }
 
   @Deployment
@@ -219,7 +227,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
 
     assertEquals(0, jobQuery.count());
   }
-  
+
   @Deployment
   @Test
   public void testRecalculateExpressionStartTimerEvent() throws Exception {
@@ -228,19 +236,19 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     ProcessInstanceQuery processInstanceQuery = runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample");
     assertEquals(1, jobQuery.count());
     assertEquals(0, processInstanceQuery.count());
-    
+
     Job job = jobQuery.singleResult();
     Date oldDate = job.getDuedate();
-    
+
     // when
     moveByMinutes(2);
     Date currentTime = ClockUtil.getCurrentTime();
     managementService.recalculateJobDuedate(job.getId(), false);
-    
+
     // then
     assertEquals(1, jobQuery.count());
     assertEquals(0, processInstanceQuery.count());
-    
+
     Date newDate = jobQuery.singleResult().getDuedate();
     assertNotEquals(oldDate, newDate);
     assertTrue(oldDate.before(newDate));
@@ -256,7 +264,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
 
     assertEquals(0, jobQuery.count());
   }
-  
+
   @Deployment(resources = "org/camunda/bpm/engine/test/bpmn/event/timer/StartTimerEventTest.testRecalculateExpressionStartTimerEvent.bpmn20.xml")
   @Test
   public void testRecalculateUnchangedExpressionStartTimerEventCreationDateBased() throws Exception {
@@ -265,15 +273,15 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     ProcessInstanceQuery processInstanceQuery = runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample");
     assertEquals(1, jobQuery.count());
     assertEquals(0, processInstanceQuery.count());
-    
+
     // when
     moveByMinutes(1);
     managementService.recalculateJobDuedate(jobQuery.singleResult().getId(), true);
-    
+
     // then due date should be based on the creation time
     assertEquals(1, jobQuery.count());
     assertEquals(0, processInstanceQuery.count());
-    
+
     Job jobUpdated = jobQuery.singleResult();
     Date expectedDate = LocalDateTime.fromDateFields(jobUpdated.getCreateTime()).plusHours(2).toDate();
     assertEquals(expectedDate, jobUpdated.getDuedate());
@@ -429,7 +437,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     ProcessInstance startedProcessInstance = runtimeService.createProcessInstanceQuery().singleResult();
     // make sure process instance was started
     assertThat(processInstance.getId()).isEqualTo(startedProcessInstance.getId());
-    
+
   }
 
   @Deployment
@@ -1241,7 +1249,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     String anotherJobId = jobQuery.singleResult().getId();
     assertFalse(jobId.equals(anotherJobId));
   }
-  
+
   @Test
   public void testRecalculateTimeCycleExpressionCurrentDateBased() throws Exception {
     // given
@@ -1257,7 +1265,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
 
     testRule.deploy(repositoryService.createDeployment()
       .addModelInstance("process.bpmn", modelInstance));
-    
+
     JobQuery jobQuery = managementService.createJobQuery();
     assertEquals(1, jobQuery.count());
 
@@ -1274,7 +1282,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     assertEquals(jobId, jobUpdated.getId());
     assertNotEquals(oldDuedate, jobUpdated.getDuedate());
     assertTrue(oldDuedate.before(jobUpdated.getDuedate()));
-    
+
     // when
     Mocks.register("cycle", "R/PT10M");
     managementService.recalculateJobDuedate(jobId, false);
@@ -1284,10 +1292,10 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     assertEquals(jobId, jobUpdated.getId());
     assertNotEquals(oldDuedate, jobUpdated.getDuedate());
     assertTrue(oldDuedate.after(jobUpdated.getDuedate()));
-    
+
     Mocks.reset();
   }
-  
+
   @Test
   public void testRecalculateTimeCycleExpressionCreationDateBased() throws Exception {
     // given
@@ -1303,7 +1311,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
 
     testRule.deploy(repositoryService.createDeployment()
       .addModelInstance("process.bpmn", modelInstance));
-    
+
     JobQuery jobQuery = managementService.createJobQuery();
     assertEquals(1, jobQuery.count());
 
@@ -1320,7 +1328,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     assertEquals(jobId, jobUpdated.getId());
     Date expectedDate = LocalDateTime.fromDateFields(jobUpdated.getCreateTime()).plusMinutes(15).toDate();
     assertEquals(expectedDate, jobUpdated.getDuedate());
-    
+
     // when
     Mocks.register("cycle", "R/PT10M");
     managementService.recalculateJobDuedate(jobId, true);
@@ -1332,10 +1340,10 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     assertTrue(oldDuedate.after(jobUpdated.getDuedate()));
     expectedDate = LocalDateTime.fromDateFields(jobUpdated.getCreateTime()).plusMinutes(10).toDate();
     assertEquals(expectedDate, jobUpdated.getDuedate());
-    
+
     Mocks.reset();
   }
-  
+
   @Deployment
   @Test
   public void testFailingTimeCycle() throws Exception {
@@ -1505,7 +1513,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     // then
     assertEquals(1, taskService.createTaskQuery().taskName("taskInSubprocess").list().size());
   }
-  
+
   @Test
   public void testRecalculateNonInterruptingWithUnchangedDurationExpressionInEventSubprocessCurrentDateBased() throws Exception {
     // given
@@ -1524,14 +1532,14 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     testRule.deploy(repositoryService.createDeployment()
       .addModelInstance("process.bpmn", modelInstance));
 
-    runtimeService.startProcessInstanceByKey("process", 
+    runtimeService.startProcessInstanceByKey("process",
         Variables.createVariables().putValue("duration", "PT70S"));
-    
+
     JobQuery jobQuery = managementService.createJobQuery();
     Job job = jobQuery.singleResult();
     String jobId = job.getId();
     Date oldDueDate = job.getDuedate();
-    
+
     // when
     moveByMinutes(2);
     Date currentTime = ClockUtil.getCurrentTime();
@@ -1544,11 +1552,11 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     assertTrue(oldDueDate.before(newDuedate));
     Date expectedDate = LocalDateTime.fromDateFields(currentTime).plusSeconds(70).toDate();
     assertThat(newDuedate).isCloseTo(expectedDate, 1000l);
-    
+
     managementService.executeJob(jobId);
     assertEquals(1, taskService.createTaskQuery().taskName("taskInSubprocess").list().size());
   }
-  
+
   @Test
   public void testRecalculateNonInterruptingWithChangedDurationExpressionInEventSubprocessCreationDateBased() throws Exception {
     // given
@@ -1567,14 +1575,14 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     testRule.deploy(repositoryService.createDeployment()
       .addModelInstance("process.bpmn", modelInstance));
 
-    ProcessInstance pi = runtimeService.startProcessInstanceByKey("process", 
+    ProcessInstance pi = runtimeService.startProcessInstanceByKey("process",
         Variables.createVariables().putValue("duration", "PT60S"));
-    
+
     JobQuery jobQuery = managementService.createJobQuery();
     Job job = jobQuery.singleResult();
     String jobId = job.getId();
     Date oldDueDate = job.getDuedate();
-    
+
     // when
     runtimeService.setVariable(pi.getId(), "duration", "PT2M");
     managementService.recalculateJobDuedate(jobId, true);
@@ -1585,7 +1593,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     Date expectedDate = LocalDateTime.fromDateFields(jobQuery.singleResult().getCreateTime()).plusMinutes(2).toDate();
     assertTrue(oldDueDate.before(newDuedate));
     assertTrue(expectedDate.equals(newDuedate));
-    
+
     managementService.executeJob(jobId);
     assertEquals(1, taskService.createTaskQuery().taskName("taskInSubprocess").list().size());
   }
@@ -1640,6 +1648,37 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     assertEquals(1, managementService.createJobQuery().withException().count());
     assertEquals(0, managementService.createJobQuery().noRetriesLeft().count());
     assertEquals(2, managementService.createJobQuery().withRetriesLeft().count());
+  }
+
+  @Deployment
+  @Test
+  public void testFixedDateWithRepeatStartTimerEvent() throws Exception {
+    // given a process definition with a start timer event with the following expression: R2/2036-11-15T11:00/PT10S
+    ProcessInstanceQuery piQuery = runtimeService.createProcessInstanceQuery().processDefinitionKey("startTimerEventExample");
+
+    ClockUtil.setCurrentTime(new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("15/11/2036 11:00:00"));
+    executeAllJobs();
+    List<ProcessInstance> at110000 = piQuery.list();
+
+    ClockUtil.setCurrentTime(new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("15/11/2036 11:00:15"));
+    executeAllJobs();
+    List<ProcessInstance> at110015 = piQuery.list();
+
+    ClockUtil.setCurrentTime(new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("15/11/2036 11:00:30"));
+    executeAllJobs();
+    List<ProcessInstance> at110030 = piQuery.list();
+
+    ClockUtil.setCurrentTime(new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("15/11/2036 11:00:45"));
+    executeAllJobs();
+
+    List<ProcessInstance> at110045 = piQuery.list();
+
+    // then
+    assertThat(at110000).hasSize(1);
+    assertThat(at110015).hasSize(2);
+    assertThat(at110030).hasSize(3);
+    // should only start 3 instances
+    assertThat(at110045).hasSize(3);
   }
 
   // util methods ////////////////////////////////////////

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/event/timer/StartTimerEventTest.testFixedDateWithRepeatStartTimerEvent.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/bpmn/event/timer/StartTimerEventTest.testFixedDateWithRepeatStartTimerEvent.bpmn20.xml
@@ -4,29 +4,29 @@
              xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
              targetNamespace="Examples">
 
-    <process id="startTimerEventExampleCycle" name="Timer start event example" isExecutable="true">
+    <process id="startTimerEventExample" name="Timer start event example" isExecutable="true">
 
         <startEvent id="theStart">
             <timerEventDefinition>
-                <timeCycle>R3/PT5M</timeCycle>
+                <timeCycle>R3/2036-11-15T11:00/PT10S</timeCycle>
             </timerEventDefinition>
         </startEvent>    
 
-        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="receive"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="userTask"/>
 
-        <receiveTask id="receive"/>
+        <userTask id="userTask"/>
 
-        <sequenceFlow id="flow2" sourceRef="receive" targetRef="theEnd"/>
+        <sequenceFlow id="flow2" sourceRef="userTask" targetRef="theEnd"/>
 
         <endEvent id="theEnd"/>
 
     </process>
     <bpmndi:BPMNDiagram id="diagram">
-       <bpmndi:BPMNPlane bpmnElement="startTimerEventExampleCycle" id="startTimerEventExample_di">
+       <bpmndi:BPMNPlane bpmnElement="startTimerEventExample" id="startTimerEventExample_di">
           <bpmndi:BPMNShape bpmnElement="theStart" id="theStart_di">
              <omgdc:Bounds height="30.0" width="30.0" x="114.0" y="185.0"/>
           </bpmndi:BPMNShape>
-          <bpmndi:BPMNShape bpmnElement="receive" id="timer_di">
+          <bpmndi:BPMNShape bpmnElement="userTask" id="timer_di">
              <omgdc:Bounds height="30.0" width="30.0" x="195.0" y="185.0"/>
           </bpmndi:BPMNShape>
           <bpmndi:BPMNShape bpmnElement="theEnd" id="theEnd_di">


### PR DESCRIPTION
* Repeats cycles with start date one time less than defined in R
  since the start date is the first repeat already.
* Uses the due date of the first timer as start date of the follow-up
  repeats because that is the actual start date of the cycle.

related to CAM-14772