### PR TITLE
CAM-14757: feat(qa): add test coverage for weld 2.4

### DIFF
--- a/engine-cdi/compatibility-test-weld2/pom.xml
+++ b/engine-cdi/compatibility-test-weld2/pom.xml
@@ -2,8 +2,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <name>Camunda Platform - engine - Cdi - Compatbility Test Weld 3</name>
-  <artifactId>camunda-engine-cdi-compatibility-test-weld3</artifactId>
+  <name>Camunda Platform - engine - Cdi - Compatbility Test Weld 2</name>
+  <artifactId>camunda-engine-cdi-compatibility-test-weld2</artifactId>
   <packaging>jar</packaging>
 
   <parent>
@@ -16,9 +16,9 @@
   <properties>
     <arquillian.container.version>2.1.0.Final</arquillian.container.version>
     <arquillian.junit.version>1.6.0.Final</arquillian.junit.version>
-    <weld.version>3.1.9.Final</weld.version>
-    <javaee.spec>jboss-javaee-8.0</javaee.spec>
-    <javaee.spec.version>1.0.4.Final</javaee.spec.version>
+    <weld.version>2.4.8.Final</weld.version>
+    <javaee.spec>jboss-javaee-7.0</javaee.spec>
+    <javaee.spec.version>1.1.1.Final</javaee.spec.version>
   </properties>
   
   <dependencyManagement>
@@ -83,11 +83,6 @@
     <dependency>
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-core-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.weld.module</groupId>
-      <artifactId>weld-web</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/engine-cdi/pom.xml
+++ b/engine-cdi/pom.xml
@@ -15,13 +15,14 @@
 
   <!--
   Why this module structure?
-  Core is the user-facing camunda-engine-spring artifact and is compiled against Spring 5 and JPA 2.0.
-  The compatibility module runs the tests contained in core with Spring 4 respectively.
+  Core is the user-facing camunda-engine-cdi artifact and is compiled against Weld 1.1.11.Final.
+  The compatibility modules run the tests contained in core with Weld 2.4.x and Weld 3.x respectively.
   This is implemented as separate modules and not as profiles of the core module, in order
-  to test the artifact that was compiled against Spring 5 (i.e. to ensure binary compatibility).
+  to test the artifact that was compiled against Weld 1.1.11.Final (i.e. to ensure binary compatibility).
   -->
   <modules>
     <module>core</module>
+    <module>compatibility-test-weld2</module>
     <module>compatibility-test-weld3</module>
   </modules>
   


### PR DESCRIPTION
* As part of adding support for WebSphere Liberty, we need to ensure that there is test coverage for the CDI implementations that Liberty provides and Camunda supports. Liberty provides support for CDI 1.2 through Weld 2.4.8.Final.

Related to CAM-14757