### PR TITLE
CAM-14756: feat(qa): adjust IT tests to better support was liberty

### DIFF
--- a/database/pom.xml
+++ b/database/pom.xml
@@ -284,6 +284,7 @@
         <database.driver>org.h2.Driver</database.driver>
         <database.datasource.class>org.h2.jdbcx.JdbcDataSource</database.datasource.class>
         <jboss.datasource.filename>h2-ds.xml</jboss.datasource.filename>
+        <was.liberty.datasource.filename>h2-config.xml</was.liberty.datasource.filename>
         <hibernate.dialect>org.hibernate.dialect.H2Dialect</hibernate.dialect>
       </properties>
       <dependencies>
@@ -498,6 +499,7 @@
         <database.driver>org.postgresql.Driver</database.driver>
         <database.datasource.class>org.postgresql.ds.PGSimpleDataSource</database.datasource.class>
         <jboss.datasource.filename>postgresql-ds.xml</jboss.datasource.filename>
+        <was.liberty.datasource.filename>postgresql-config.xml</was.liberty.datasource.filename>
         <hibernate.dialect>org.hibernate.dialect.PostgreSQLDialect</hibernate.dialect>
         <database.tc.url>campostgresql:13.2</database.tc.url>
       </properties>
@@ -532,6 +534,7 @@
       <properties>
         <database.datasource.class>org.postgresql.xa.PGXADataSource</database.datasource.class>
         <jboss.datasource.filename>postgresql-xa-ds.xml</jboss.datasource.filename>
+        <was.liberty.datasource.filename>postgresql-xa-config.xml</was.liberty.datasource.filename>
       </properties>
     </profile>
     <profile>

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/camunda/bpm/AbstractWebappUiIntegrationTest.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/camunda/bpm/AbstractWebappUiIntegrationTest.java
@@ -60,7 +60,10 @@ public class AbstractWebappUiIntegrationTest extends AbstractWebIntegrationTest 
 
     ChromeOptions chromeOptions = new ChromeOptions()
         .setHeadless(true)
-        .addArguments("--window-size=1920,1200");
+        .addArguments("--window-size=1920,1200")
+        .addArguments("--disable-gpu")
+        .addArguments("--no-sandbox")
+        .addArguments("--disable-dev-shm-usage");
 
     driver = new ChromeDriver(chromeDriverService, chromeOptions);
   }


### PR DESCRIPTION
* Add database configuration filenames for WAS Liberty in the DB profiles for H2 and PostgreSQL.
* Optimize ChromeDriver configuration. Add additional flags that make ChromeDriver more efficient in k8s/Jenkins environments. The previous configuration failed with OOM errors on WAS Liberty.

Related to CAM-14741, CAM-14756