### PR TITLE
fix(engine): return copied list in #getIdentityLinksForTask()

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/GetIdentityLinksForTaskCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/GetIdentityLinksForTaskCmd.java
@@ -20,6 +20,7 @@ import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.camunda.bpm.engine.impl.cfg.CommandChecker;
 import org.camunda.bpm.engine.impl.interceptor.Command;
@@ -44,7 +45,6 @@ public class GetIdentityLinksForTaskCmd implements Command<List<IdentityLink>>, 
     this.taskId = taskId;
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes" })
   public List<IdentityLink> execute(CommandContext commandContext) {
     ensureNotNull("taskId", taskId);
 
@@ -54,7 +54,7 @@ public class GetIdentityLinksForTaskCmd implements Command<List<IdentityLink>>, 
 
     checkGetIdentityLink(task, commandContext);
 
-    List<IdentityLink> identityLinks = (List) task.getIdentityLinks();
+    List<IdentityLink> identityLinks = task.getIdentityLinks().stream().collect(Collectors.toList());
 
     // assignee is not part of identity links in the db.
     // so if there is one, we add it here.
@@ -79,7 +79,7 @@ public class GetIdentityLinksForTaskCmd implements Command<List<IdentityLink>>, 
       identityLinks.add(identityLink);
     }
 
-    return (List) task.getIdentityLinks();
+    return identityLinks;
   }
 
   protected void checkGetIdentityLink(TaskEntity task, CommandContext commandContext) {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskIdentityLinksTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskIdentityLinksTest.java
@@ -16,21 +16,29 @@
  */
 package org.camunda.bpm.engine.test.api.task;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.util.List;
 
+import org.camunda.bpm.engine.delegate.TaskListener;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.task.Event;
 import org.camunda.bpm.engine.task.IdentityLink;
 import org.camunda.bpm.engine.task.IdentityLinkType;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.bpmn.tasklistener.util.GetIdentityLinksTaskListener;
 import org.camunda.bpm.engine.test.util.PluggableProcessEngineTest;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.camunda.commons.testing.ProcessEngineLoggingRule;
+import org.junit.Rule;
 import org.junit.Test;
 
+import ch.qos.logback.classic.Level;
 
 
 
@@ -39,6 +47,9 @@ import org.junit.Test;
  * @author Falko Menge
  */
 public class TaskIdentityLinksTest extends PluggableProcessEngineTest {
+
+  @Rule
+  public ProcessEngineLoggingRule loggingRule = new ProcessEngineLoggingRule().level(Level.ERROR);
 
   @Deployment(resources="org/camunda/bpm/engine/test/api/task/IdentityLinksProcess.bpmn20.xml")
   @Test
@@ -60,6 +71,9 @@ public class TaskIdentityLinksTest extends PluggableProcessEngineTest {
     assertEquals(IdentityLinkType.CANDIDATE, identityLink.getType());
     assertEquals(taskId, identityLink.getTaskId());
 
+    assertEquals(1, identityLinks.size());
+
+    identityLinks = taskService.getIdentityLinksForTask(taskId);
     assertEquals(1, identityLinks.size());
 
     taskService.deleteCandidateUser(taskId, "kermit");
@@ -137,6 +151,10 @@ public class TaskIdentityLinksTest extends PluggableProcessEngineTest {
     assertEquals("assignee", identityLink.getUserId());
     assertEquals("task", identityLink.getTaskId());
 
+    // second call should return the same list size
+    identityLinks = taskService.getIdentityLinksForTask(task.getId());
+    assertEquals(1, identityLinks.size());
+
     taskService.deleteTask(task.getId(), true);
   }
 
@@ -154,6 +172,10 @@ public class TaskIdentityLinksTest extends PluggableProcessEngineTest {
     assertEquals(IdentityLinkType.OWNER, identityLink.getType());
     assertEquals("owner", identityLink.getUserId());
     assertEquals("task", identityLink.getTaskId());
+
+    // second call should return the same list size
+    identityLinks = taskService.getIdentityLinksForTask(task.getId());
+    assertEquals(1, identityLinks.size());
 
     taskService.deleteTask(task.getId(), true);
   }
@@ -253,4 +275,63 @@ public class TaskIdentityLinksTest extends PluggableProcessEngineTest {
     taskService.deleteTask(task.getId(), true);
   }
 
+  @Test
+  public void testAssigneeGetIdentityLinksInCompleteListener() {
+    // given
+    BpmnModelInstance model = Bpmn.createExecutableProcess("process")
+      .startEvent()
+      .userTask("task1")
+      .camundaTaskListenerClass(TaskListener.EVENTNAME_COMPLETE, GetIdentityLinksTaskListener.class.getName())
+      .userTask("task2")
+      .endEvent()
+      .done();
+
+    testRule.deploy(model);
+    String processInstanceId = runtimeService.startProcessInstanceByKey("process").getId();
+
+    Task task = taskService.createTaskQuery().singleResult();
+    String taskId = task.getId();
+    // create identity links
+    task.setAssignee("elmo");
+    taskService.saveTask(task);
+    taskService.addUserIdentityLink(taskId, "kermit", "interestee");
+
+    // when
+    taskService.complete(taskId);
+
+    // then no NPE is thrown and there were 2 identity links during the listener execution
+    assertThat(loggingRule.getLog()).isEmpty();
+    assertEquals(2, runtimeService.getVariable(processInstanceId, "identityLinksSize"));
+    assertEquals(2, runtimeService.getVariable(processInstanceId, "secondCallidentityLinksSize"));
+  }
+
+  @Test
+  public void testOwnerGetIdentityLinksInCompleteListener() {
+    // given
+    BpmnModelInstance model = Bpmn.createExecutableProcess("process")
+      .startEvent()
+      .userTask("task1")
+      .camundaTaskListenerClass(TaskListener.EVENTNAME_COMPLETE, GetIdentityLinksTaskListener.class.getName())
+      .userTask("task2")
+      .endEvent()
+      .done();
+
+    testRule.deploy(model);
+    String processInstanceId = runtimeService.startProcessInstanceByKey("process").getId();
+
+    Task task = taskService.createTaskQuery().singleResult();
+    String taskId = task.getId();
+    // create identity links
+    task.setOwner("gonzo");
+    taskService.saveTask(task);
+    taskService.addUserIdentityLink(taskId, "kermit", "interestee");
+
+    // when
+    taskService.complete(taskId);
+
+    // then no NPE is thrown and there were 2 identity links during the listener execution
+    assertThat(loggingRule.getLog()).isEmpty();
+    assertEquals(2, runtimeService.getVariable(processInstanceId, "identityLinksSize"));
+    assertEquals(2, runtimeService.getVariable(processInstanceId, "secondCallidentityLinksSize"));
+  }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/tasklistener/util/GetIdentityLinksTaskListener.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/tasklistener/util/GetIdentityLinksTaskListener.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.bpmn.tasklistener.util;
+
+import java.util.List;
+
+import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.delegate.DelegateTask;
+import org.camunda.bpm.engine.delegate.TaskListener;
+import org.camunda.bpm.engine.task.IdentityLink;
+
+public class GetIdentityLinksTaskListener implements TaskListener {
+
+  public void notify(DelegateTask delegateTask) {
+    TaskService taskService = delegateTask.getProcessEngine().getTaskService();
+    List<IdentityLink> identityLinksForTask = taskService.getIdentityLinksForTask(delegateTask.getId());
+
+    delegateTask.getExecution().setVariable("identityLinksSize", identityLinksForTask.size());
+
+    // second call should return the same list size
+    identityLinksForTask = taskService.getIdentityLinksForTask(delegateTask.getId());
+    delegateTask.getExecution().setVariable("secondCallidentityLinksSize", identityLinksForTask.size());
+  }
+
+}


### PR DESCRIPTION
Related to CAM-8494