### PR TITLE
feat(ldap-plugin): add support for pagination

### DIFF
--- a/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapConfiguration.java
+++ b/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapConfiguration.java
@@ -33,7 +33,7 @@ public class LdapConfiguration {
   protected String initialContextFactory = "com.sun.jndi.ldap.LdapCtxFactory";
   protected String securityAuthentication = "simple";
 
-  protected Map<String, String> contextProperties = new HashMap<String, String>();
+  protected Map<String, String> contextProperties = new HashMap<>();
 
   protected String serverUrl;
   protected String managerDn = "";
@@ -66,6 +66,8 @@ public class LdapConfiguration {
   protected boolean allowAnonymousLogin = false;
 
   protected boolean authorizationCheckEnabled = true;
+
+  protected Integer pageSize = null; // null => disabled
 
   // getters / setters //////////////////////////////////////
 
@@ -282,6 +284,14 @@ public class LdapConfiguration {
 
   public void setAuthorizationCheckEnabled(boolean authorizationCheckEnabled) {
     this.authorizationCheckEnabled = authorizationCheckEnabled;
+  }
+
+  public Integer getPageSize() {
+    return pageSize;
+  }
+
+  public void setPageSize(Integer pageSize) {
+    this.pageSize = pageSize;
   }
 
 }

--- a/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
+++ b/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
@@ -19,8 +19,12 @@ package org.camunda.bpm.identity.impl.ldap;
 import static org.camunda.bpm.engine.authorization.Permissions.READ;
 import static org.camunda.bpm.engine.authorization.Resources.GROUP;
 import static org.camunda.bpm.engine.authorization.Resources.USER;
+import static org.camunda.bpm.engine.impl.context.Context.getCommandContext;
+import static org.camunda.bpm.engine.impl.context.Context.getProcessEngineConfiguration;
 
 import java.io.StringWriter;
+import java.io.IOException;
+
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
@@ -38,6 +42,8 @@ import javax.naming.ldap.Control;
 import javax.naming.ldap.InitialLdapContext;
 import javax.naming.ldap.LdapContext;
 import javax.naming.ldap.SortControl;
+import javax.naming.ldap.PagedResultsControl;
+import javax.naming.ldap.PagedResultsResponseControl;
 
 import org.camunda.bpm.engine.BadUserRequestException;
 import org.camunda.bpm.engine.authorization.Permission;
@@ -64,13 +70,11 @@ import org.camunda.bpm.identity.impl.ldap.util.LdapPluginLogger;
  * <p>LDAP {@link ReadOnlyIdentityProvider}.</p>
  *
  * @author Daniel Meyer
- *
  */
 public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
 
-  private final static Logger LOG = Logger.getLogger(LdapIdentityProviderSession.class.getName());
-
   protected LdapConfiguration ldapConfiguration;
+  // one object of this class is created per thread. One initialContext is created per thread.
   protected LdapContext initialContext;
 
   public LdapIdentityProviderSession(LdapConfiguration ldapConfiguration) {
@@ -107,34 +111,34 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
     env.put(Context.SECURITY_CREDENTIALS, password);
 
     // for anonymous login
-    if(ldapConfiguration.isAllowAnonymousLogin() && password.isEmpty()) {
+    if (ldapConfiguration.isAllowAnonymousLogin() && password.isEmpty()) {
       env.put(Context.SECURITY_AUTHENTICATION, "none");
     }
 
-    if(ldapConfiguration.isUseSsl()) {
+    if (ldapConfiguration.isUseSsl()) {
       env.put(Context.SECURITY_PROTOCOL, "ssl");
     }
 
     // add additional properties
     Map<String, String> contextProperties = ldapConfiguration.getContextProperties();
-    if(contextProperties != null) {
+    if (contextProperties != null) {
       env.putAll(contextProperties);
     }
 
     try {
       return new InitialLdapContext(env, null);
 
-    } catch(AuthenticationException e) {
+    } catch (AuthenticationException e) {
       throw new LdapAuthenticationException("Could not authenticate with LDAP server", e);
 
-    } catch(NamingException e) {
+    } catch (NamingException e) {
       throw new IdentityProviderException("Could not connect to LDAP server", e);
 
     }
   }
 
   protected void ensureContextInitialized() {
-    if(initialContext == null) {
+    if (initialContext == null) {
       initialContext = openContext(ldapConfiguration.getManagerDn(), ldapConfiguration.getManagerPassword());
     }
   }
@@ -142,17 +146,17 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
   // Users /////////////////////////////////////////////////
 
   public User findUserById(String userId) {
-    return createUserQuery(org.camunda.bpm.engine.impl.context.Context.getCommandContext())
-      .userId(userId)
-      .singleResult();
+    return createUserQuery(getCommandContext())
+            .userId(userId)
+            .singleResult();
   }
 
   public UserQuery createUserQuery() {
-    return new LdapUserQueryImpl(org.camunda.bpm.engine.impl.context.Context.getProcessEngineConfiguration().getCommandExecutorTxRequired());
+    return new LdapUserQueryImpl(getProcessEngineConfiguration().getCommandExecutorTxRequired(), ldapConfiguration);
   }
 
   public UserQueryImpl createUserQuery(CommandContext commandContext) {
-    return new LdapUserQueryImpl();
+    return new LdapUserQueryImpl(ldapConfiguration);
   }
 
   @Override
@@ -167,7 +171,7 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
 
   public List<User> findUserByQueryCriteria(LdapUserQueryImpl query) {
     ensureContextInitialized();
-    if(query.getGroupId() != null) {
+    if (query.getGroupId() != null) {
       // if restriction on groupId is provided, we need to search in group tree first, look for the group and then further restrict on the members
       return findUsersByGroupId(query);
     } else {
@@ -177,6 +181,12 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
   }
 
   protected List<User> findUsersByGroupId(LdapUserQueryImpl query) {
+    StringBuilder resultLogger = new StringBuilder();
+    if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+      resultLogger.append("findUsersByGroupId: from ");
+      resultLogger.append(query.getFirstResult());
+    }
+
     String baseDn = getDnForGroup(query.getGroupId());
 
     // compose group search filter
@@ -184,23 +194,38 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
 
     NamingEnumeration<SearchResult> enumeration = null;
     try {
-      enumeration = initialContext.search(baseDn, groupSearchFilter, ldapConfiguration.getSearchControls());
+      initializeControls(query, resultLogger);
 
       List<String> groupMemberList = new ArrayList<>();
+      int resultCount = 0;
+      int pageNumber = 0;
 
-      // first find group
-      while (enumeration.hasMoreElements()) {
-        SearchResult result = enumeration.nextElement();
-        Attribute memberAttribute = result.getAttributes().get(ldapConfiguration.getGroupMemberAttribute());
-        if (null != memberAttribute) {
-          NamingEnumeration<?> allMembers = memberAttribute.getAll();
+      do {
+        enumeration = initialContext.search(baseDn, groupSearchFilter, ldapConfiguration.getSearchControls());
+        pageNumber++;
+        if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+          resultLogger.append(", (page:");
+          resultLogger.append(pageNumber);
+          resultLogger.append(")");
+        }
 
-          // iterate group members
-          while (allMembers.hasMoreElements()) {
-            groupMemberList.add((String) allMembers.nextElement());
+        // first find group
+        while (enumeration.hasMoreElements()) {
+          SearchResult result = enumeration.nextElement();
+          Attribute memberAttribute = result.getAttributes().get(ldapConfiguration.getGroupMemberAttribute());
+          if (null != memberAttribute) {
+            NamingEnumeration<?> allMembers = memberAttribute.getAll();
+
+            // iterate group members
+            while (allMembers.hasMoreElements()) {
+              if (resultCount >= query.getFirstResult()) {
+                groupMemberList.add((String) allMembers.nextElement());
+              }
+              resultCount++;
+            }
           }
         }
-      }
+      } while (isNextPageDetected(resultLogger) && groupMemberList.size() < query.getMaxResults());
 
       List<User> userList = new ArrayList<>();
       String userBaseDn = composeDn(ldapConfiguration.getUserSearchBase(), ldapConfiguration.getBaseDn());
@@ -210,19 +235,29 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
           if (ldapConfiguration.isUsePosixGroups()) {
             query.userId(memberId);
           }
-          List<User> users = ldapConfiguration.isUsePosixGroups() ? findUsersWithoutGroupId(query, userBaseDn, true) : findUsersWithoutGroupId(query, memberId, true);
-          if (users.size() > 0) {
+          List<User> users = ldapConfiguration.isUsePosixGroups() ?
+                  findUsersWithoutGroupId(query, userBaseDn, true) :
+                  findUsersWithoutGroupId(query, memberId, true);
+          if (!users.isEmpty()) {
             userList.add(users.get(0));
           }
         }
         memberCount++;
       }
-
+      if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+        resultLogger.append("; Result size()=");
+        resultLogger.append(userList.size());
+        resultLogger.append(" FirstResult=");
+        resultLogger.append(userList.isEmpty() ? "--" : userList.get(0).getFirstName() + "]");
+      }
       return userList;
 
     } catch (NamingException e) {
-      throw new IdentityProviderException("Could not query for users", e);
-
+      if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+        resultLogger.append("; Exception ");
+        resultLogger.append(e);
+      }
+      throw new IdentityProviderException("Could not query for users " + resultLogger, e);
     } finally {
       try {
         if (enumeration != null) {
@@ -231,74 +266,96 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
       } catch (Exception e) {
         // ignore silently
       }
-    }
-  }
-
-  public List<User> findUsersWithoutGroupId(LdapUserQueryImpl query, String userBaseDn, boolean ignorePagination) {
-
-    if(ldapConfiguration.isSortControlSupported()) {
-      applyRequestControls(query);
-    }
-
-    NamingEnumeration<SearchResult> enumeration = null;
-    try {
-
-      String filter = getUserSearchFilter(query);
-      enumeration = initialContext.search(userBaseDn, filter, ldapConfiguration.getSearchControls());
-
-      // perform client-side paging
-      int resultCount = 0;
-      List<User> userList = new ArrayList<>();
-
-      StringBuilder resultLogger = new StringBuilder();
-      if (LdapPluginLogger.INSTANCE.isDebugEnabled())
-      {
-        resultLogger.append("LDAP user query results: [");
-      }
-
-      while (enumeration.hasMoreElements() && (userList.size() < query.getMaxResults() || ignorePagination)) {
-        SearchResult result = enumeration.nextElement();
-
-        UserEntity user = transformUser(result);
-
-        String userId = user.getId();
-
-        if (userId == null)
-        {
-          LdapPluginLogger.INSTANCE.invalidLdapUserReturned(user, result);
-        }
-        else
-        {
-          if(isAuthenticatedUser(user) || isAuthorized(READ, USER, userId)) {
-
-            if(resultCount >= query.getFirstResult() || ignorePagination) {
-              if (LdapPluginLogger.INSTANCE.isDebugEnabled())
-              {
-                resultLogger.append(user);
-                resultLogger.append(" based on ");
-                resultLogger.append(result);
-                resultLogger.append(", ");
-              }
-
-              userList.add(user);
-            }
-
-            resultCount ++;
-          }
-        }
-      }
-
-      if (LdapPluginLogger.INSTANCE.isDebugEnabled())
-      {
+      if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
         resultLogger.append("]");
         LdapPluginLogger.INSTANCE.userQueryResult(resultLogger.toString());
       }
 
+    }
+  }
+
+  public List<User> findUsersWithoutGroupId(LdapUserQueryImpl query, String userBaseDn, boolean ignorePagination) {
+    StringBuilder resultLogger = new StringBuilder();
+    if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+      resultLogger.append("findUsersWithoutGroupId: from ");
+      resultLogger.append(query.getFirstResult());
+    }
+
+    NamingEnumeration<SearchResult> enumeration = null;
+    try {
+      initializeControls(query, resultLogger);
+
+      List<User> userList = new ArrayList<>();
+      int resultCount = 0;
+      int pageNumber = 0;
+
+      do {
+        String filter = getUserSearchFilter(query);
+        if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+          resultLogger.append(" search userBaseDn[");
+          resultLogger.append(userBaseDn);
+          resultLogger.append("] filter[");
+          resultLogger.append(filter);
+          resultLogger.append("];");
+        }
+        enumeration = initialContext.search(userBaseDn, filter, ldapConfiguration.getSearchControls());
+
+        pageNumber++;
+        // perform client-side paging
+        if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+          resultLogger.append(" (page:");
+          resultLogger.append(pageNumber);
+          resultLogger.append(") ");
+        }
+
+        while (enumeration.hasMoreElements()
+                && (userList.size() < query.getMaxResults() || ignorePagination)) {
+          SearchResult result = enumeration.nextElement();
+
+          UserEntity user = transformUser(result);
+
+          String userId = user.getId();
+
+          if (userId == null) {
+            LdapPluginLogger.INSTANCE.invalidLdapUserReturned(user, result);
+          } else {
+            if (isAuthenticatedUser(user) || isAuthorized(READ, USER, userId)) {
+
+              if (resultCount >= query.getFirstResult() || ignorePagination) {
+                if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+                  resultLogger.append("id=");
+                  resultLogger.append(user.getId());
+                  resultLogger.append(", firstName=");
+                  resultLogger.append(user.getFirstName());
+                  resultLogger.append(", lastName=");
+                  resultLogger.append(user.getLastName());
+
+                  resultLogger.append(" based on ");
+                  resultLogger.append(result);
+                  resultLogger.append(", ");
+                }
+                userList.add(user);
+              }
+              resultCount++;
+            }
+          }
+        }
+      } while (isNextPageDetected(resultLogger) && userList.size() < query.getMaxResults());
+
+      if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+        resultLogger.append(";Result size()=");
+        resultLogger.append(userList.size());
+        resultLogger.append(" First[");
+        resultLogger.append(userList.isEmpty() ? "--" : userList.get(0).getFirstName() + "]");
+      }
       return userList;
 
     } catch (NamingException e) {
-      throw new IdentityProviderException("Could not query for users", e);
-
+      if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+        resultLogger.append(";Exception: ");
+        resultLogger.append(e);
+      }
+      throw new IdentityProviderException("Could not query for users " + resultLogger, e);
     } finally {
       try {
         if (enumeration != null) {
@@ -307,27 +364,33 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
       } catch (Exception e) {
         // ignore silently
       }
+
+      if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+        resultLogger.append("]");
+        LdapPluginLogger.INSTANCE.userQueryResult(resultLogger.toString());
+      }
+
     }
   }
 
   public boolean checkPassword(String userId, String password) {
 
     // prevent a null password
-    if(password == null) {
+    if (password == null) {
       return false;
     }
 
     // engine can't work without users
-    if(userId == null || userId.isEmpty()) {
+    if (userId == null || userId.isEmpty()) {
       return false;
     }
 
     /*
-    * We only allow login with no password if anonymous login is set.
-    * RFC allows such a behavior but discourages the usage so we provide it for
-    * user which have an ldap with anonymous login.
-    */
-    if(!ldapConfiguration.isAllowAnonymousLogin() && password.equals("")) {
+     * We only allow login with no password if anonymous login is set.
+     * RFC allows such a behavior but discourages the usage so we provide it for
+     * user which have an ldap with anonymous login.
+     */
+    if (!ldapConfiguration.isAllowAnonymousLogin() && password.equals("")) {
       return false;
     }
 
@@ -335,7 +398,7 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
     LdapUserEntity user = (LdapUserEntity) findUserById(userId);
     close();
 
-    if(user == null) {
+    if (user == null) {
       return false;
     } else {
 
@@ -346,7 +409,7 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
         context = openContext(user.getDn(), password);
         return true;
 
-      } catch(LdapAuthenticationException e) {
+      } catch (LdapAuthenticationException e) {
         return false;
 
       } finally {
@@ -367,10 +430,10 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
     search.write(ldapConfiguration.getUserSearchFilter());
 
     // add additional filters from query
-    if(query.getId() != null) {
+    if (query.getId() != null) {
       addFilter(ldapConfiguration.getUserIdAttribute(), escapeLDAPSearchFilter(query.getId()), search);
     }
-    if(query.getIds() != null && query.getIds().length > 0) {
+    if (query.getIds() != null && query.getIds().length > 0) {
       // wrap ids in OR statement
       search.write("(|");
       for (String userId : query.getIds()) {
@@ -378,22 +441,22 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
       }
       search.write(")");
     }
-    if(query.getEmail() != null) {
+    if (query.getEmail() != null) {
       addFilter(ldapConfiguration.getUserEmailAttribute(), query.getEmail(), search);
     }
-    if(query.getEmailLike() != null) {
+    if (query.getEmailLike() != null) {
       addFilter(ldapConfiguration.getUserEmailAttribute(), query.getEmailLike(), search);
     }
-    if(query.getFirstName() != null) {
+    if (query.getFirstName() != null) {
       addFilter(ldapConfiguration.getUserFirstnameAttribute(), query.getFirstName(), search);
     }
-    if(query.getFirstNameLike() != null) {
+    if (query.getFirstNameLike() != null) {
       addFilter(ldapConfiguration.getUserFirstnameAttribute(), query.getFirstNameLike(), search);
     }
-    if(query.getLastName() != null) {
+    if (query.getLastName() != null) {
       addFilter(ldapConfiguration.getUserLastnameAttribute(), query.getLastName(), search);
     }
-    if(query.getLastNameLike() != null) {
+    if (query.getLastNameLike() != null) {
       addFilter(ldapConfiguration.getUserLastnameAttribute(), query.getLastNameLike(), search);
     }
 
@@ -405,13 +468,13 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
   // Groups ///////////////////////////////////////////////
 
   public Group findGroupById(String groupId) {
-    return createGroupQuery(org.camunda.bpm.engine.impl.context.Context.getCommandContext())
-      .groupId(groupId)
-      .singleResult();
+    return createGroupQuery(getCommandContext())
+            .groupId(groupId)
+            .singleResult();
   }
 
   public GroupQuery createGroupQuery() {
-    return new LdapGroupQuery(org.camunda.bpm.engine.impl.context.Context.getProcessEngineConfiguration().getCommandExecutorTxRequired());
+    return new LdapGroupQuery(getProcessEngineConfiguration().getCommandExecutorTxRequired());
   }
 
   public GroupQuery createGroupQuery(CommandContext commandContext) {
@@ -424,72 +487,76 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
   }
 
   public List<Group> findGroupByQueryCriteria(LdapGroupQuery query) {
+    StringBuilder resultLogger = new StringBuilder();
+    if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+      resultLogger.append("findGroupByQueryCriteria: from ");
+      resultLogger.append(query.getFirstResult());
+    }
     ensureContextInitialized();
 
     String groupBaseDn = composeDn(ldapConfiguration.getGroupSearchBase(), ldapConfiguration.getBaseDn());
 
-    if(ldapConfiguration.isSortControlSupported()) {
-      applyRequestControls(query);
-    }
-
     NamingEnumeration<SearchResult> enumeration = null;
+
     try {
-
+      initializeControls(query, resultLogger);
       String filter = getGroupSearchFilter(query);
-      enumeration = initialContext.search(groupBaseDn, filter, ldapConfiguration.getSearchControls());
-
       // perform client-side paging
-      int resultCount = 0;
       List<Group> groupList = new ArrayList<>();
+      int resultCount = 0;
+      int pageNumber = 0;
 
-      StringBuilder resultLogger = new StringBuilder();
-      if (LdapPluginLogger.INSTANCE.isDebugEnabled())
-      {
-        resultLogger.append("LDAP group query results: [");
-      }
+      do {
+        enumeration = initialContext.search(groupBaseDn, filter, ldapConfiguration.getSearchControls());
+        pageNumber++;
 
-      while (enumeration.hasMoreElements() && groupList.size() < query.getMaxResults()) {
-        SearchResult result = enumeration.nextElement();
-
-        GroupEntity group = transformGroup(result);
-
-        String groupId = group.getId();
-
-        if (groupId == null)
-        {
-          LdapPluginLogger.INSTANCE.invalidLdapGroupReturned(group, result);
+        if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+          resultLogger.append("; (page:");
+          resultLogger.append(pageNumber);
+          resultLogger.append(") [");
         }
-        else
-        {
-          if(isAuthorized(READ, GROUP, groupId)) {
 
-            if(resultCount >= query.getFirstResult()) {
-              if (LdapPluginLogger.INSTANCE.isDebugEnabled())
-              {
-                resultLogger.append(group);
-                resultLogger.append(" based on ");
-                resultLogger.append(result);
-                resultLogger.append(", ");
+        while (enumeration.hasMoreElements() && groupList.size() < query.getMaxResults()) {
+          SearchResult result = enumeration.nextElement();
+
+          GroupEntity group = transformGroup(result);
+
+          String groupId = group.getId();
+
+          if (groupId == null) {
+            LdapPluginLogger.INSTANCE.invalidLdapGroupReturned(group, result);
+          } else {
+            if (isAuthorized(READ, GROUP, groupId)) {
+
+              if (resultCount >= query.getFirstResult()) {
+                if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+                  resultLogger.append(group);
+                  resultLogger.append(" based on ");
+                  resultLogger.append(result);
+                  resultLogger.append(", ");
+                }
+                groupList.add(group);
               }
-
-              groupList.add(group);
+              resultCount++;
             }
-
-            resultCount ++;
           }
         }
-      }
+      } while (isNextPageDetected(resultLogger) && groupList.size() < query.getMaxResults());
 
-      if (LdapPluginLogger.INSTANCE.isDebugEnabled())
-      {
-        resultLogger.append("]");
-        LdapPluginLogger.INSTANCE.groupQueryResult(resultLogger.toString());
+      if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+        resultLogger.append("; Result size()=");
+        resultLogger.append(groupList.size());
+        resultLogger.append(" FirstResult=");
+        resultLogger.append(groupList.isEmpty() ? "--" : groupList.get(0).getName() + "]");
       }
-
       return groupList;
 
     } catch (NamingException e) {
-      throw new IdentityProviderException("Could not query for users", e);
+      if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+        resultLogger.append("; Exception ");
+        resultLogger.append(e);
+      }
+      throw new IdentityProviderException("Could not query for users " + resultLogger, e);
 
     } finally {
       try {
@@ -499,6 +566,11 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
       } catch (Exception e) {
         // ignore silently
       }
+      if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+        resultLogger.append("]");
+        LdapPluginLogger.INSTANCE.groupQueryResult(resultLogger.toString());
+      }
+
     }
   }
 
@@ -511,25 +583,25 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
     search.write(ldapConfiguration.getGroupSearchFilter());
 
     // add additional filters from query
-    if(query.getId() != null) {
+    if (query.getId() != null) {
       addFilter(ldapConfiguration.getGroupIdAttribute(), query.getId(), search);
     }
-    if(query.getIds() != null && query.getIds().length > 0) {
+    if (query.getIds() != null && query.getIds().length > 0) {
       search.write("(|");
       for (String id : query.getIds()) {
         addFilter(ldapConfiguration.getGroupIdAttribute(), id, search);
       }
       search.write(")");
     }
-    if(query.getName() != null) {
+    if (query.getName() != null) {
       addFilter(ldapConfiguration.getGroupNameAttribute(), query.getName(), search);
     }
-    if(query.getNameLike() != null) {
+    if (query.getNameLike() != null) {
       addFilter(ldapConfiguration.getGroupNameAttribute(), query.getNameLike(), search);
     }
-    if(query.getUserId() != null) {
+    if (query.getUserId() != null) {
       String userDn = null;
-      if(ldapConfiguration.isUsePosixGroups()) {
+      if (ldapConfiguration.isUsePosixGroups()) {
         userDn = query.getUserId();
       } else {
         userDn = getDnForUser(query.getUserId());
@@ -544,10 +616,10 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
   // Utils ////////////////////////////////////////////
 
   protected String getDnForUser(String userId) {
-    LdapUserEntity user = (LdapUserEntity) createUserQuery(org.camunda.bpm.engine.impl.context.Context.getCommandContext())
-      .userId(userId)
-      .singleResult();
-    if(user == null) {
+    LdapUserEntity user = (LdapUserEntity) createUserQuery(getCommandContext())
+            .userId(userId)
+            .singleResult();
+    if (user == null) {
       return "";
     } else {
       return user.getDn();
@@ -555,10 +627,10 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
   }
 
   protected String getDnForGroup(String groupId) {
-    LdapGroupEntity group = (LdapGroupEntity) createGroupQuery(org.camunda.bpm.engine.impl.context.Context.getCommandContext())
-      .groupId(groupId)
-      .singleResult();
-    if(group == null) {
+    LdapGroupEntity group = (LdapGroupEntity) createGroupQuery(getCommandContext())
+            .groupId(groupId)
+            .singleResult();
+    if (group == null) {
       return "";
     } else {
       return group.getDn();
@@ -567,7 +639,7 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
 
   protected String getStringAttributeValue(String attrName, Attributes attributes) throws NamingException {
     Attribute attribute = attributes.get(attrName);
-    if(attribute != null){
+    if (attribute != null) {
       return (String) attribute.get();
     } else {
       return null;
@@ -603,52 +675,63 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
     return group;
   }
 
-  protected void applyRequestControls(AbstractQuery<?, ?> query) {
+  /**
+   * Return the list of Controls requested in the query
+   *
+   * @param query query asks, contains the order by requested
+   * @return list of control to send to LDAP
+   */
+  protected List<Control> getSortingControls(AbstractQuery<?, ?> query, StringBuilder resultLogger) {
 
     try {
       List<Control> controls = new ArrayList<>();
 
       List<QueryOrderingProperty> orderBy = query.getOrderingProperties();
-      if(orderBy != null) {
+      if (orderBy != null) {
         for (QueryOrderingProperty orderingProperty : orderBy) {
           String propertyName = orderingProperty.getQueryProperty().getName();
-          if(UserQueryProperty.USER_ID.getName().equals(propertyName)) {
+          if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+            resultLogger.append(", OrderBy[");
+            resultLogger.append(propertyName);
+            resultLogger.append("]");
+          }
+          if (UserQueryProperty.USER_ID.getName().equals(propertyName)) {
             controls.add(new SortControl(ldapConfiguration.getUserIdAttribute(), Control.CRITICAL));
 
-          } else if(UserQueryProperty.EMAIL.getName().equals(propertyName)) {
+          } else if (UserQueryProperty.EMAIL.getName().equals(propertyName)) {
             controls.add(new SortControl(ldapConfiguration.getUserEmailAttribute(), Control.CRITICAL));
 
-          } else if(UserQueryProperty.FIRST_NAME.getName().equals(propertyName)) {
+          } else if (UserQueryProperty.FIRST_NAME.getName().equals(propertyName)) {
             controls.add(new SortControl(ldapConfiguration.getUserFirstnameAttribute(), Control.CRITICAL));
 
-          } else if(UserQueryProperty.LAST_NAME.getName().equals(propertyName)) {
+          } else if (UserQueryProperty.LAST_NAME.getName().equals(propertyName)) {
             controls.add(new SortControl(ldapConfiguration.getUserLastnameAttribute(), Control.CRITICAL));
           }
         }
       }
 
-      initialContext.setRequestControls(controls.toArray(new Control[0]));
+      return controls;
 
-    } catch (Exception e) {
+    } catch (IOException e) {
       throw new IdentityProviderException("Exception while setting paging settings", e);
     }
   }
 
   protected String composeDn(String... parts) {
     StringWriter resultDn = new StringWriter();
-    for (int i = 0; i < parts.length; i++) {
-      String part = parts[i];
-      if(part == null || part.length()==0) {
+    for (String s : parts) {
+      String part = s;
+      if (part == null || part.length() == 0) {
         continue;
       }
-      if(part.endsWith(",")) {
-        part = part.substring(part.length()-2, part.length()-1);
+      if (part.endsWith(",")) {
+        part = part.substring(part.length() - 2, part.length() - 1);
       }
-      if(part.startsWith(",")) {
+      if (part.startsWith(",")) {
         part = part.substring(1);
       }
       String currentDn = resultDn.toString();
-      if(!currentDn.endsWith(",") && currentDn.length()>0) {
+      if (!currentDn.endsWith(",") && currentDn.length() > 0) {
         resultDn.write(",");
       }
       resultDn.write(part);
@@ -656,21 +739,20 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
     return resultDn.toString();
   }
 
-
   /**
    * @return true if the passed-in user is currently authenticated
    */
   protected boolean isAuthenticatedUser(UserEntity user) {
-    if(user.getId() == null) {
+    if (user.getId() == null) {
       return false;
     }
-    return user.getId().equalsIgnoreCase(org.camunda.bpm.engine.impl.context.Context.getCommandContext().getAuthenticatedUserId());
+    return user.getId().equalsIgnoreCase(getCommandContext().getAuthenticatedUserId());
   }
 
   protected boolean isAuthorized(Permission permission, Resource resource, String resourceId) {
-    return !ldapConfiguration.isAuthorizationCheckEnabled() || org.camunda.bpm.engine.impl.context.Context.getCommandContext()
-      .getAuthorizationManager()
-      .isAuthorized(permission, resource, resourceId);
+    return !ldapConfiguration.isAuthorizationCheckEnabled() || getCommandContext()
+            .getAuthorizationManager()
+            .isAuthorized(permission, resource, resourceId);
   }
 
   // Based on https://www.owasp.org/index.php/Preventing_LDAP_Injection_in_Java
@@ -678,32 +760,168 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < filter.length(); i++) {
       char curChar = filter.charAt(i);
-        switch (curChar) {
-          case '\\':
-            sb.append("\\5c");
-            break;
-          case '*':
-            sb.append("\\2a");
-            break;
-          case '(':
-            sb.append("\\28");
-            break;
-          case ')':
-            sb.append("\\29");
-            break;
-          case '\u0000':
-            sb.append("\\00");
-            break;
-          default:
-            sb.append(curChar);
-        }
+      switch (curChar) {
+        case '\\':
+          sb.append("\\5c");
+          break;
+        case '*':
+          sb.append("\\2a");
+          break;
+        case '(':
+          sb.append("\\28");
+          break;
+        case ')':
+          sb.append("\\29");
+          break;
+        case '\u0000':
+          sb.append("\\00");
+          break;
+        default:
+          sb.append(curChar);
+      }
     }
     return sb.toString();
   }
 
+  /**
+   * Initializes paged results and sort controls. Might not be supported by all LDAP implementations.
+   */
+  protected void initializeControls(AbstractQuery<?, ?> query, StringBuilder resultLogger) throws NamingException {
+    if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+      resultLogger.append(query.getFirstResult());
+
+      resultLogger.append(ldapConfiguration.isSortControlSupported() ? " -sort-" : "-nosort-");
+
+      if (!isPaginationSupported()) {
+        resultLogger.append(" -noPagination");
+
+      } else {
+        resultLogger.append(" -pagination(");
+        resultLogger.append(ldapConfiguration.getPageSize());
+        resultLogger.append(")");
+      }
+    }
+
+    List<Control> listControls = new ArrayList<>();
+    if (ldapConfiguration.isSortControlSupported()) {
+      listControls.addAll(getSortingControls(query, resultLogger));
+    }
+
+    try {
+      if (isPaginationSupported()) {
+        listControls.add(new PagedResultsControl(getPageSize(), Control.NONCRITICAL));
+      }
+      if (!listControls.isEmpty()) {
+        initialContext.setRequestControls(listControls.toArray(new Control[0]));
+      }
+    } catch (NamingException | IOException e) {
+      // page control is not supported by this LDAP
+      if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+        resultLogger.append("Unsupported page Control;");
+      }
+      // set supported list controls
+      if (!listControls.isEmpty()) {
+        try {
+          initialContext.setRequestControls(listControls.toArray(new Control[0]));
+        } catch (NamingException ne) {
+          // this exception is not related to the page control, so throw it
+          if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+            resultLogger.append("Unsupported Control;");
+          }
+          throw ne;
+        }
+      }
+    }
+  }
+
+  /**
+   * Check in the context if we reach the last page on the query
+   *
+   * @param resultLogger Logger to send information
+   * @return new page detected
+   */
+  protected boolean isNextPageDetected(StringBuilder resultLogger) {
+    // if the pagination is not activated, there isn't a next page.
+    if (!isPaginationSupported()) {
+      return false;
+    }
+
+    try {
+      Control[] controls = initialContext.getResponseControls();
+      if (controls == null) {
+        if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+          resultLogger.append("No-controls-from-the-server");
+        }
+        return false;
+      }
+
+      List<Control> newControlList = new ArrayList<>();
+      boolean newPageDetected = false;
+      for (Control control : controls) {
+        if (control instanceof PagedResultsResponseControl) {
+          PagedResultsResponseControl prrc = (PagedResultsResponseControl) control;
+          byte[] cookie = prrc.getCookie();
+
+          if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+            resultLogger.append("; End-of-page? ");
+            resultLogger.append((cookie == null ? "No-more-page" : "Next-page-detected"));
+          }
+          // Re-activate paged results
+          try {
+            newControlList.add(new PagedResultsControl(getPageSize(), cookie, Control.CRITICAL));
+          } catch (IOException e) {
+            if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+              resultLogger.append("Error-when-set-again-the-new-cookie ");
+              resultLogger.append(e);
+            }
+            // stop to loop
+            return false;
+          }
+          newPageDetected = cookie != null;
+        }
+      }
+      if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+        resultLogger.append("; SetAgain controlList.size()=");
+        resultLogger.append(newControlList.size());
+      }
+      if (!newControlList.isEmpty()) {
+        // This is more an UPDATE than a SET. All previous control (sorting) does not need to
+        // be set again, the current context keeps them, and the next page is correctly ordered for example.
+        // In the current context, just the PageResultControl must be re-set (even this a xxxResultxxx)
+        // All another result (SortResponseControl for example) must not be set again, nor the SortControl.
+        initialContext.setRequestControls(newControlList.toArray(new Control[0]));
+      }
+      if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+        resultLogger.append("; Done. NewPageDetected=");
+        resultLogger.append(newPageDetected);
+      }
+
+      return newPageDetected;
+    } catch (NamingException ne) {
+      if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+        resultLogger.append("Could not manage ResponseControl; ");
+        resultLogger.append(ne);
+      }
+      return false;
+    }
+  }
+
+  protected boolean isPaginationSupported() {
+    return getPageSize() != null;
+  }
+
+  /**
+   * Return the pageSize. Returns null if pagination is disabled.
+   *
+   * @return the pageSize
+   */
+  protected Integer getPageSize() {
+    return ldapConfiguration.getPageSize();
+  }
+
   @Override
   public TenantQuery createTenantQuery() {
-    return new LdapTenantQuery(org.camunda.bpm.engine.impl.context.Context.getProcessEngineConfiguration().getCommandExecutorTxRequired());
+    return new LdapTenantQuery(getProcessEngineConfiguration().getCommandExecutorTxRequired());
   }
 
   @Override

--- a/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapUserQueryImpl.java
+++ b/engine-plugins/identity-ldap/src/main/java/org/camunda/bpm/identity/impl/ldap/LdapUserQueryImpl.java
@@ -25,6 +25,7 @@ import org.camunda.bpm.engine.impl.UserQueryImpl;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 
+
 /**
  * @author Daniel Meyer
  *
@@ -32,13 +33,16 @@ import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 public class LdapUserQueryImpl extends UserQueryImpl {
 
   private static final long serialVersionUID = 1L;
+  private final LdapConfiguration ldapConfiguration;
 
-  public LdapUserQueryImpl() {
+  public LdapUserQueryImpl(LdapConfiguration ldapConfiguration) {
     super();
+    this.ldapConfiguration = ldapConfiguration;
   }
 
-  public LdapUserQueryImpl(CommandExecutor commandExecutor) {
+  public LdapUserQueryImpl(CommandExecutor commandExecutor, LdapConfiguration ldapConfiguration) {
     super(commandExecutor);
+    this.ldapConfiguration = ldapConfiguration;
   }
 
   // execute queries /////////////////////////////////////////
@@ -57,6 +61,7 @@ public class LdapUserQueryImpl extends UserQueryImpl {
     return (LdapIdentityProviderSession) commandContext.getReadOnlyIdentityProvider();
   }
 
+  @Override
   public UserQuery desc() {
     throw new UnsupportedOperationException("The LDAP identity provider does not support descending search order.");
   }

--- a/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapDisableAuthorizationCheckTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapDisableAuthorizationCheckTest.java
@@ -21,7 +21,6 @@ import static org.camunda.bpm.engine.authorization.Permissions.READ;
 import static org.camunda.bpm.engine.authorization.Resources.GROUP;
 import static org.camunda.bpm.engine.authorization.Resources.USER;
 
-
 import org.camunda.bpm.engine.authorization.Authorization;
 import org.camunda.bpm.engine.authorization.Permission;
 import org.camunda.bpm.engine.authorization.Resource;
@@ -60,7 +59,7 @@ public class LdapDisableAuthorizationCheckTest extends ResourceProcessEngineTest
   }
 
   public void testUserQueryPagination() {
-    LdapTestUtilities.testUserPaging(identityService);
+    LdapTestUtilities.testUserPaging(identityService, ldapTestEnvironment);
   }
 
   public void testUserQueryPaginationWithAuthenticatedUserWithoutAuthorizations() {
@@ -68,7 +67,7 @@ public class LdapDisableAuthorizationCheckTest extends ResourceProcessEngineTest
       processEngineConfiguration.setAuthorizationEnabled(true);
 
       identityService.setAuthenticatedUserId("oscar");
-      testUserPaging(identityService);
+      testUserPaging(identityService, ldapTestEnvironment);
 
     } finally {
       processEngineConfiguration.setAuthorizationEnabled(false);
@@ -86,7 +85,7 @@ public class LdapDisableAuthorizationCheckTest extends ResourceProcessEngineTest
       processEngineConfiguration.setAuthorizationEnabled(true);
 
       identityService.setAuthenticatedUserId("oscar");
-      testUserPaging(identityService);
+      testUserPaging(identityService, ldapTestEnvironment);
 
     } finally {
       processEngineConfiguration.setAuthorizationEnabled(false);

--- a/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapGroupLargeQueryTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapGroupLargeQueryTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.identity.impl.ldap;
+
+import org.camunda.bpm.engine.identity.Group;
+import org.camunda.bpm.engine.identity.GroupQuery;
+import org.camunda.bpm.engine.impl.test.ResourceProcessEngineTestCase;
+
+import java.util.List;
+
+public class LdapGroupLargeQueryTest extends ResourceProcessEngineTestCase {
+
+  LdapTestEnvironment ldapTestEnvironment;
+
+  public LdapGroupLargeQueryTest() {
+    // pageSize = 3 in this configuration
+    super("camunda.ldap.pages.cfg.xml");
+  }
+
+  protected void setUp() throws Exception {
+    ldapTestEnvironment = new LdapTestEnvironment();
+    // the TestEnvironment creates groups for roles
+    // Attention, stay under 80, there is a limitation in the query on 100
+    ldapTestEnvironment.init(5, 5, 80);
+    super.setUp();
+  }
+
+  protected void tearDown() throws Exception {
+    if (ldapTestEnvironment != null) {
+      ldapTestEnvironment.shutdown();
+      ldapTestEnvironment = null;
+    }
+    super.tearDown();
+  }
+
+  public void testAllGroupsQuery() {
+    List<Group> listGroups = identityService.createGroupQuery().list();
+
+    // In this group, we expect more than a page size
+    // Attention, in the test environment, a Role is implemented by a groupOfNames. the groupQuery search for groups
+    // So the comparison must be done via the Roles name
+    assertEquals(ldapTestEnvironment.getTotalNumberOfRolesCreated(), listGroups.size());
+  }
+
+  public void testPagesAllGroupsQuery() {
+    List<Group> listGroups = identityService.createGroupQuery().list();
+
+    assertEquals(ldapTestEnvironment.getTotalNumberOfRolesCreated(), listGroups.size());
+
+    // ask 3 pages
+    for (int firstResult = 2; firstResult < 10; firstResult += 4) {
+      List<Group> listPages = identityService.createGroupQuery().listPage(firstResult, 5);
+      assertTrue("Maximum 5 results expected", listPages.size() <= 5);
+
+      for (int i = 0; i < listPages.size(); i++) {
+        assertEquals(listGroups.get(firstResult + i).getId(), listPages.get(i).getId());
+        assertEquals(listGroups.get(firstResult + i).getName(), listPages.get(i).getName());
+      }
+
+    }
+  }
+
+  public void testQueryPaging() {
+    GroupQuery query = identityService.createGroupQuery();
+
+    assertEquals(86, query.listPage(0, Integer.MAX_VALUE).size());
+
+    // Verifying the un-paged results
+    assertEquals(86, query.count());
+    assertEquals(86, query.list().size());
+
+    // Verifying paged results
+    assertEquals(2, query.listPage(0, 2).size());
+    assertEquals(2, query.listPage(2, 2).size());
+    assertEquals(3, query.listPage(4, 3).size());
+    assertEquals(1, query.listPage(85, 3).size());
+    assertEquals(1, query.listPage(85, 1).size());
+
+    // Verifying odd usages
+    assertEquals(0, query.listPage(-1, -1).size());
+    assertEquals(0, query.listPage(86, 2).size()); // 86 is the last index with a result
+    assertEquals(86, query.listPage(0, 87).size()); // there are only 86 groups
+  }
+
+}

--- a/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapGroupQueryTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapGroupQueryTest.java
@@ -28,6 +28,9 @@ import org.camunda.bpm.engine.authorization.Authorization;
 import org.camunda.bpm.engine.authorization.Permission;
 import org.camunda.bpm.engine.authorization.Resource;
 import org.camunda.bpm.engine.identity.Group;
+import org.camunda.bpm.engine.identity.GroupQuery;
+import org.camunda.bpm.engine.identity.User;
+
 import static org.camunda.bpm.identity.impl.ldap.LdapTestUtilities.checkPagingResults;
 import static org.camunda.bpm.identity.impl.ldap.LdapTestUtilities.testGroupPaging;
 
@@ -37,6 +40,13 @@ import static org.camunda.bpm.identity.impl.ldap.LdapTestUtilities.testGroupPagi
  *
  */
 public class LdapGroupQueryTest extends LdapIdentityProviderTest {
+
+  public void testCountGroups() {
+    GroupQuery groupQuery = identityService.createGroupQuery();
+
+    assertEquals(6, groupQuery.listPage(0, Integer.MAX_VALUE).size());
+    assertEquals(6, groupQuery.count());
+  }
 
   public void testQueryNoFilter() {
     List<Group> groupList = identityService.createGroupQuery().list();

--- a/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapTestUtilities.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapTestUtilities.java
@@ -60,7 +60,7 @@ public final class LdapTestUtilities {
     assertEquals(0, groups.size());
   }
 
-  public static void testUserPaging(IdentityService identityService) {
+  public static void testUserPaging(IdentityService identityService, LdapTestEnvironment ldapTestEnvironment) {
     Set<String> userNames = new HashSet<String>();
     List<User> users = identityService.createUserQuery().listPage(0, 2);
     assertEquals(2, users.size());
@@ -78,7 +78,8 @@ public final class LdapTestUtilities {
     assertEquals(2, users.size());
     checkPagingResults(userNames, users.get(0).getId(), users.get(1).getId());
 
-    users = identityService.createUserQuery().listPage(12, 2);
+    // over the page.
+    users = identityService.createUserQuery().listPage(ldapTestEnvironment.getTotalNumberOfUsersCreated() + 1, 2);
     assertEquals(0, users.size());
   }
 

--- a/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapUserLargeQueryTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapUserLargeQueryTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.identity.impl.ldap;
+
+import org.camunda.bpm.engine.identity.User;
+import org.camunda.bpm.engine.identity.UserQuery;
+import org.camunda.bpm.engine.impl.test.ResourceProcessEngineTestCase;
+
+import java.util.List;
+
+public class LdapUserLargeQueryTest extends ResourceProcessEngineTestCase {
+
+  LdapTestEnvironment ldapTestEnvironment;
+
+  public LdapUserLargeQueryTest() {
+    // pageSize = 3 in this configuration
+    super("camunda.ldap.pages.cfg.xml");
+  }
+
+  protected void setUp() throws Exception {
+    ldapTestEnvironment = new LdapTestEnvironment();
+    // Attention, stay under 80, there is a limitation in the query on 100
+    ldapTestEnvironment.init(80, 5, 5);
+    super.setUp();
+  }
+
+  protected void tearDown() throws Exception {
+    if (ldapTestEnvironment != null) {
+      ldapTestEnvironment.shutdown();
+      ldapTestEnvironment = null;
+    }
+    super.tearDown();
+  }
+
+  public void testAllUsersQuery() {
+    List<User> listUsers = identityService.createUserQuery().list();
+
+    // In this group, we expect more than a page size
+    assertEquals(ldapTestEnvironment.getTotalNumberOfUsersCreated(), listUsers.size());
+  }
+
+  public void testPagesAllUsersQuery() {
+    List<User> listUsers = identityService.createUserQuery().list();
+
+    assertEquals(ldapTestEnvironment.getTotalNumberOfUsersCreated(), listUsers.size());
+
+    // ask 3 pages
+    for (int firstResult = 0; firstResult < 10; firstResult += 4) {
+      List<User> listPages = identityService.createUserQuery().listPage(firstResult, 5);
+      for (int i = 0; i < listPages.size(); i++) {
+        assertEquals(listUsers.get(firstResult + i).getId(), listPages.get(i).getId());
+        assertEquals(listUsers.get(firstResult + i).getLastName(), listPages.get(i).getLastName());
+      }
+
+    }
+  }
+
+  public void testQueryPaging() {
+    UserQuery query = identityService.createUserQuery();
+
+    assertEquals(92, query.listPage(0, Integer.MAX_VALUE).size());
+
+    // Verifying the un-paged results
+    assertEquals(92, query.count());
+    assertEquals(92, query.list().size());
+
+    // Verifying paged results
+    assertEquals(2, query.listPage(0, 2).size());
+    assertEquals(2, query.listPage(2, 2).size());
+    assertEquals(3, query.listPage(4, 3).size());
+    assertEquals(1, query.listPage(91, 3).size());
+    assertEquals(1, query.listPage(91, 1).size());
+
+    // Verifying odd usages
+    assertEquals(0, query.listPage(-1, -1).size());
+    assertEquals(0, query.listPage(92, 2).size()); // 92 is the last index with a result
+    assertEquals(92, query.listPage(0, 93).size()); // there are only 92 groups
+  }
+
+}

--- a/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapUserQueryTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/camunda/bpm/identity/impl/ldap/LdapUserQueryTest.java
@@ -29,19 +29,27 @@ import org.camunda.bpm.engine.authorization.Authorization;
 import org.camunda.bpm.engine.authorization.Permission;
 import org.camunda.bpm.engine.authorization.Resource;
 import org.camunda.bpm.engine.identity.User;
+import org.camunda.bpm.engine.identity.UserQuery;
+
 import static org.camunda.bpm.identity.impl.ldap.LdapTestUtilities.checkPagingResults;
 import static org.camunda.bpm.identity.impl.ldap.LdapTestUtilities.testUserPaging;
 import static org.camunda.bpm.identity.impl.ldap.LdapTestUtilities.testUserPagingWithMemberOfGroup;
 
 /**
  * @author Daniel Meyer
- *
  */
 public class LdapUserQueryTest extends LdapIdentityProviderTest {
 
+  public void testCountUsers() {
+    UserQuery userQuery = identityService.createUserQuery();
+
+    assertEquals(12, userQuery.listPage(0, Integer.MAX_VALUE).size());
+    assertEquals(12, userQuery.count());
+  }
+
   public void testQueryNoFilter() {
     List<User> result = identityService.createUserQuery().list();
-    assertEquals(12, result.size());
+    assertEquals(ldapTestEnvironment.getTotalNumberOfUsersCreated(), result.size());
   }
 
   public void testFilterByUserId() {
@@ -72,24 +80,23 @@ public class LdapUserQueryTest extends LdapIdentityProviderTest {
     assertNotNull(users);
     assertEquals(3, users.size());
   }
-  
-  public void testFilterByUserIdWithCapitalization() {
-	try {
-	  processEngineConfiguration.setAuthorizationEnabled(true);
-	  identityService.setAuthenticatedUserId("Oscar");
-	  User user = identityService.createUserQuery().userId("Oscar").singleResult();
-	  assertNotNull(user);
 
-	  // validate user
-	  assertEquals("oscar", user.getId());
-	  assertEquals("Oscar", user.getFirstName());
-	  assertEquals("The Crouch", user.getLastName());
-	  assertEquals("oscar@camunda.org", user.getEmail());
-	}
-	finally {
+  public void testFilterByUserIdWithCapitalization() {
+    try {
+      processEngineConfiguration.setAuthorizationEnabled(true);
+      identityService.setAuthenticatedUserId("Oscar");
+      User user = identityService.createUserQuery().userId("Oscar").singleResult();
+      assertNotNull(user);
+
+      // validate user
+      assertEquals("oscar", user.getId());
+      assertEquals("Oscar", user.getFirstName());
+      assertEquals("The Crouch", user.getLastName());
+      assertEquals("oscar@camunda.org", user.getEmail());
+    } finally {
       processEngineConfiguration.setAuthorizationEnabled(false);
-	  identityService.clearAuthentication();
-	}
+      identityService.clearAuthentication();
+    }
   }
 
   public void testFilterByFirstname() {
@@ -149,49 +156,49 @@ public class LdapUserQueryTest extends LdapIdentityProviderTest {
 
   public void testFilterByGroupIdAndFirstname() {
     List<User> result = identityService.createUserQuery()
-        .memberOfGroup("development")
-        .userFirstName("Oscar")
-        .list();
+            .memberOfGroup("development")
+            .userFirstName("Oscar")
+            .list();
     assertEquals(1, result.size());
   }
 
   public void testFilterByGroupIdAndId() {
     List<User> result = identityService.createUserQuery()
-        .memberOfGroup("development")
-        .userId("oscar")
-        .list();
+            .memberOfGroup("development")
+            .userId("oscar")
+            .list();
     assertEquals(1, result.size());
   }
 
   public void testFilterByGroupIdAndLastname() {
     List<User> result = identityService.createUserQuery()
-        .memberOfGroup("development")
-        .userLastName("The Crouch")
-        .list();
+            .memberOfGroup("development")
+            .userLastName("The Crouch")
+            .list();
     assertEquals(1, result.size());
   }
 
   public void testFilterByGroupIdAndEmail() {
     List<User> result = identityService.createUserQuery()
-        .memberOfGroup("development")
-        .userEmail("oscar@camunda.org")
-        .list();
+            .memberOfGroup("development")
+            .userEmail("oscar@camunda.org")
+            .list();
     assertEquals(1, result.size());
   }
 
   public void testFilterByGroupIdAndEmailLike() {
     List<User> result = identityService.createUserQuery()
-        .memberOfGroup("development")
-        .userEmailLike("*@camunda.org")
-        .list();
+            .memberOfGroup("development")
+            .userEmailLike("*@camunda.org")
+            .list();
     assertEquals(3, result.size());
   }
 
   public void testFilterByGroupIdAndIdForDnUsingCn() {
     List<User> result = identityService.createUserQuery()
-        .memberOfGroup("external")
-        .userId("fozzie")
-        .list();
+            .memberOfGroup("external")
+            .userId("fozzie")
+            .list();
     assertEquals(1, result.size());
   }
 
@@ -212,7 +219,7 @@ public class LdapUserQueryTest extends LdapIdentityProviderTest {
   }
 
   public void testPagination() {
-    testUserPaging(identityService);
+    testUserPaging(identityService, ldapTestEnvironment);
   }
 
   public void testPaginationWithMemberOfGroup() {

--- a/engine-plugins/identity-ldap/src/test/resources/camunda.ldap.pages.cfg.xml
+++ b/engine-plugins/identity-ldap/src/test/resources/camunda.ldap.pages.cfg.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="processEngineConfiguration" class="org.camunda.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+
+        <property name="processEngineName" value="LdapEnableSortControlSupportTest-engine" />
+
+        <property name="jdbcUrl" value="jdbc:h2:mem:LdapEnableSortControlSupportTest;DB_CLOSE_DELAY=1000" />
+        <property name="jdbcDriver" value="org.h2.Driver" />
+        <property name="jdbcUsername" value="sa" />
+        <property name="jdbcPassword" value="" />
+
+        <!-- Database configurations -->
+        <property name="history" value="audit" />
+        <property name="databaseSchemaUpdate" value="create-drop" />
+
+        <!-- job executor configurations -->
+        <property name="jobExecutorActivate" value="false" />
+
+        <property name="createDiagramOnDeploy" value="true" />
+
+        <property name="processEnginePlugins">
+            <list>
+                <ref bean="ldapIdentityProviderPlugin" />
+            </list>
+        </property>
+
+    </bean>
+
+    <bean id="ldapIdentityProviderPlugin" class="org.camunda.bpm.identity.impl.ldap.plugin.LdapIdentityProviderPlugin">
+
+        <property name="serverUrl" value="ldap://localhost:${ldap.server.port}/" />
+        <property name="managerDn" value="uid=daniel,ou=office-berlin,o=camunda,c=org" />
+        <property name="managerPassword" value="daniel" />
+        <property name="baseDn" value="o=camunda,c=org" />
+
+        <property name="userSearchBase" value="" />
+        <property name="userSearchFilter" value="(objectclass=person)" />
+        <property name="userIdAttribute" value="uid" />
+        <property name="userFirstnameAttribute" value="cn" />
+        <property name="userLastnameAttribute" value="sn" />
+        <property name="userEmailAttribute" value="mail" />
+        <property name="userPasswordAttribute" value="userpassword" />
+
+        <property name="groupSearchBase" value="" />
+        <property name="groupSearchFilter" value="(objectclass=groupOfNames)" />
+        <property name="groupIdAttribute" value="ou" />
+        <property name="groupNameAttribute" value="cn" />
+        <property name="groupMemberAttribute" value="member" />
+        <property name="allowAnonymousLogin" value="true" />
+
+        <property name="sortControlSupported" value="true" />
+        <property name="pageSize" value="3" />
+
+    </bean>
+
+</beans>


### PR DESCRIPTION
* Implements LDAPv3 Control for paged-results as defined in RFC 2696 [1].
* Pagination is disabled by default.
* Enable pagination by defining a `pageSize` in your plugin configuration.

[1] http://www.ietf.org/rfc/rfc2696.txt

related to camunda/camunda-bpm-platform#2799