### PR TITLE
[2835] chore(engine): Reorder mappings to improve loading times

### DIFF
--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/mappings.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/mappings.xml
@@ -24,7 +24,11 @@
 		<setting name="lazyLoadingEnabled" value="false" />
 	</settings>
 	<mappers>
+    <!-- Mappings are ordered so that cross-references can always be resolved by already loaded mappings -->
     <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/Commons.xml" />
+    <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/Authorization.xml" />
+    <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/Report.xml" />
+    <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/Tenant.xml" />
     
     <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/Attachment.xml" />
     <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/Comment.xml" />
@@ -62,14 +66,11 @@
     <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/VariableInstance.xml" />
     <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/EventSubscription.xml" />
     <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/Statistics.xml" />
-    <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/Authorization.xml" />
     <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/Filter.xml" />
     <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/Metrics.xml" />
     <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/ExternalTask.xml" />
-    <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/Report.xml" />
     <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/Batch.xml" />
     <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/HistoricBatch.xml" />
-    <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/Tenant.xml" />
     <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/TenantMembership.xml" />
     <mapper resource="org/camunda/bpm/engine/impl/mapping/entity/CamundaFormDefinition.xml" />
 


### PR DESCRIPTION
This performance optimization looks so simple but it actually makes the bootstrapping of the process engine quite a bit faster: about 0,5 secs on my Macbook Pro M1. Every slower hardware (that should be a lot of systems) will profit even more. Please measure yourself and post the results.

It will also help in test suites which bootstrap the process engine multiple times (e.g. integration tests with `@DirtiesContext` in Spring Boot ) and even more in matrix builds.

The order of the mappings is crucial because mappings should be ordered so that cross-references can always be resolved by previously loaded mappings. Otherwise a BuilderException is thrown and the mapping is parsed again later.

It is actually possible to order the mappings in a way that the BuilderException is not thrown at all, see pull request.

To debug this add the following breakpoint configuration in IntelliJ and see 2198 (!) BuilderExceptions!
<img width="1349" alt="image" src="https://user-images.githubusercontent.com/5685151/195175176-b7150029-50c2-4658-898b-8c8d3b121fa8.png">

These are the logged exceptions:
[statements.txt](https://github.com/camunda/camunda-bpm-platform/files/9759054/statements.txt)


Once you reorder the mappings the number of BuilderExceptions goes down to 0.

Whohoo! 🥳

The energy saved for all C7 installations will lower our carbon footprint: 🌲🌲🌲

closes #2835