### PR TITLE
fix(spring-boot-starter and engine): added form suffix for auto-deployment

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/container/impl/deployment/scanning/ProcessApplicationScanningUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/container/impl/deployment/scanning/ProcessApplicationScanningUtil.java
@@ -24,6 +24,7 @@ import org.camunda.bpm.container.impl.deployment.scanning.spi.ProcessApplication
 import org.camunda.bpm.engine.impl.bpmn.deployer.BpmnDeployer;
 import org.camunda.bpm.engine.impl.cmmn.deployer.CmmnDeployer;
 import org.camunda.bpm.engine.impl.dmn.deployer.DecisionDefinitionDeployer;
+import org.camunda.bpm.engine.impl.form.deployer.CamundaFormDefinitionDeployer;
 
 public class ProcessApplicationScanningUtil {
 
@@ -72,7 +73,8 @@ public class ProcessApplicationScanningUtil {
   public static boolean isDeployable(String filename) {
     return hasSuffix(filename, BpmnDeployer.BPMN_RESOURCE_SUFFIXES)
       || hasSuffix(filename, CmmnDeployer.CMMN_RESOURCE_SUFFIXES)
-      || hasSuffix(filename, DecisionDefinitionDeployer.DMN_RESOURCE_SUFFIXES);
+      || hasSuffix(filename, DecisionDefinitionDeployer.DMN_RESOURCE_SUFFIXES)
+      || hasSuffix(filename, CamundaFormDefinitionDeployer.FORM_RESOURCE_SUFFIXES);
   }
 
   public static boolean isDeployable(String filename, String[] additionalResourceSuffixes) {

--- a/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/CamundaBpmProperties.java
+++ b/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/CamundaBpmProperties.java
@@ -41,12 +41,14 @@ public class CamundaBpmProperties {
   public static final String[] DEFAULT_BPMN_RESOURCE_SUFFIXES = new String[]{"bpmn20.xml", "bpmn" };
   public static final String[] DEFAULT_CMMN_RESOURCE_SUFFIXES = new String[]{"cmmn11.xml", "cmmn10.xml", "cmmn" };
   public static final String[] DEFAULT_DMN_RESOURCE_SUFFIXES = new String[]{"dmn11.xml", "dmn" };
+  public static final String[] DEFAULT_FORM_RESOURCE_SUFFIXES = new String[]{"form" };
 
   static String[] initDeploymentResourcePattern() {
     final Set<String> suffixes = new HashSet<>();
     suffixes.addAll(Arrays.asList(DEFAULT_DMN_RESOURCE_SUFFIXES));
     suffixes.addAll(Arrays.asList(DEFAULT_BPMN_RESOURCE_SUFFIXES));
     suffixes.addAll(Arrays.asList(DEFAULT_CMMN_RESOURCE_SUFFIXES));
+    suffixes.addAll(Arrays.asList(DEFAULT_FORM_RESOURCE_SUFFIXES));
 
     final Set<String> patterns = new HashSet<>();
     for (String suffix : suffixes) {


### PR DESCRIPTION

Updated CamundaBpmProperties#initDeploymentResourcePattern and ProcessApplicationScanningUtil#isDeployable, added form suffix so that camunda forms are automatically deployed.

related to #2038