### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 42.4.1

### DIFF
--- a/database/pom.xml
+++ b/database/pom.xml
@@ -27,7 +27,7 @@
     <version.sqlserver>8.2.2.jre8</version.sqlserver>
     <version.db2-11.5>11.5.0.0</version.db2-11.5>
     <version.db2>${version.db2-11.5}</version.db2>
-    <version.postgresql>42.3.3</version.postgresql>
+    <version.postgresql>42.4.1</version.postgresql>
     <version.liquibase>4.8.0</version.liquibase>
 
     <!-- CockroachDB is compatible with PostgreSQL 9.5,


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.postgresql:postgresql 42.3.3
- [CVE-2022-31197](https://www.oscs1024.com/hd/CVE-2022-31197)


### What did I do？
Upgrade org.postgresql:postgresql from 42.3.3 to 42.4.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS