### PR TITLE
CAMTEAM-280: import correct secret from vault

### DIFF
--- a/.github/workflows/extract-issue-links.yml
+++ b/.github/workflows/extract-issue-links.yml
@@ -23,7 +23,7 @@ jobs:
           secrets: |
             secret/data/products/cambpm/ci/github-workflow SUPPORT_CHANNEL_SLACK_WEBHOOK_URL;
             secret/data/products/cambpm/ci/github-workflow SEC_CHANNEL_SLACK_WEBHOOK_URL;
-            secret/data/products/cambpm/ci/github-workflow TECH_LEAD_SLACK_HANDLE;
+            secret/data/products/cambpm/ci/github-workflow TECH_LEAD_SLACK_ID;
       - uses: "actions/checkout@v2"
       - name: Generate release notes links
         id: generate-release-notes


### PR DESCRIPTION
Fixes the failed workflow run: https://github.com/camunda/camunda-bpm-platform/actions/runs/3480233918/jobs/5819763303

related to CAMTEAM-280