### PR TITLE
CAMTEAM-280: fix release notes workflow

### DIFF
--- a/.github/actions/common/dist/index.js
+++ b/.github/actions/common/dist/index.js
@@ -9671,7 +9671,7 @@ module.exports = async function () {
     var linksToIssues = collectionUtils.revertMultiMap(links); // url => [issue id, ..]
     linksToIssues = collectionUtils.sortMapByIntKeys(linksToIssues);
         
-    core.debug(`Result links: ${jsonUtils.stringifyMapToJSON(links)}`);
+    core.info(`Result links: ${jsonUtils.stringifyMapToJSON(links)}`);
     core.debug(`Result reverse links: ${jsonUtils.stringifyMapToJSON(linksToIssues)}`);
     core.debug(`Issues: ${jsonUtils.stringifyMapToJSON(issues)}`);
     

--- a/.github/actions/common/src/extract-links.js
+++ b/.github/actions/common/src/extract-links.js
@@ -70,7 +70,7 @@ module.exports = async function () {
     var linksToIssues = collectionUtils.revertMultiMap(links); // url => [issue id, ..]
     linksToIssues = collectionUtils.sortMapByIntKeys(linksToIssues);
         
-    core.debug(`Result links: ${jsonUtils.stringifyMapToJSON(links)}`);
+    core.info(`Result links: ${jsonUtils.stringifyMapToJSON(links)}`);
     core.debug(`Result reverse links: ${jsonUtils.stringifyMapToJSON(linksToIssues)}`);
     core.debug(`Issues: ${jsonUtils.stringifyMapToJSON(issues)}`);
     

--- a/.github/workflows/extract-issue-links.yml
+++ b/.github/workflows/extract-issue-links.yml
@@ -91,5 +91,3 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.SEC_CHANNEL_SLACK_WEBHOOK_URL }} # from previous step that fetches secrets from Vault
-      - name: Display links
-        run: echo "The extracted links are ${{ steps.extract-issue-links.outputs.links }}"


### PR DESCRIPTION
- avoid echoing the links map to the console, as that was not escaped properly

related to CAMTEAM-280