### PR TITLE
fix(engine): use primitive type for job priority range config properties

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -519,8 +519,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected PriorityProvider<JobDeclaration<?, ?>> jobPriorityProvider;
 
-  protected Long jobExecutorPriorityRangeMin = null;
-  protected Long jobExecutorPriorityRangeMax = null;
+  protected long jobExecutorPriorityRangeMin = 0;
+  protected long jobExecutorPriorityRangeMax = Long.MAX_VALUE;
 
   // EXTERNAL TASK /////////////////////////////////////////////////////////////
   protected PriorityProvider<ExternalTaskActivityBehavior> externalTaskPriorityProvider;
@@ -2352,23 +2352,20 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       }
     }
 
-    long effectiveJobExecutorPriorityRangeMin = jobExecutorPriorityRangeMin == null ? 0 : jobExecutorPriorityRangeMin;
-    long effectiveJobExecutorPriorityRangeMax = jobExecutorPriorityRangeMax == null ? Long.MAX_VALUE : jobExecutorPriorityRangeMax;
-
     // verify job executor priority range is configured correctly
-    if (effectiveJobExecutorPriorityRangeMin > effectiveJobExecutorPriorityRangeMax) {
+    if (jobExecutorPriorityRangeMin > jobExecutorPriorityRangeMax) {
       throw ProcessEngineLogger.JOB_EXECUTOR_LOGGER.jobExecutorPriorityRangeException(
           "jobExecutorPriorityRangeMin can not be greater than jobExecutorPriorityRangeMax");
     }
-    if (effectiveJobExecutorPriorityRangeMin < 0) {
+    if (jobExecutorPriorityRangeMin < 0) {
       throw ProcessEngineLogger.JOB_EXECUTOR_LOGGER
           .jobExecutorPriorityRangeException("job executor priority range can not be negative");
     }
 
-    if (effectiveJobExecutorPriorityRangeMin > historyCleanupJobPriority || effectiveJobExecutorPriorityRangeMax < historyCleanupJobPriority) {
+    if (jobExecutorPriorityRangeMin > historyCleanupJobPriority || jobExecutorPriorityRangeMax < historyCleanupJobPriority) {
       ProcessEngineLogger.JOB_EXECUTOR_LOGGER.infoJobExecutorDoesNotHandleHistoryCleanupJobs(this);
     }
-    if (effectiveJobExecutorPriorityRangeMin > batchJobPriority || effectiveJobExecutorPriorityRangeMax < batchJobPriority) {
+    if (jobExecutorPriorityRangeMin > batchJobPriority || jobExecutorPriorityRangeMax < batchJobPriority) {
       ProcessEngineLogger.JOB_EXECUTOR_LOGGER.infoJobExecutorDoesNotHandleBatchJobs(this);
     }
   }
@@ -3197,20 +3194,20 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     this.jobPriorityProvider = jobPriorityProvider;
   }
 
-  public Long getJobExecutorPriorityRangeMin() {
+  public long getJobExecutorPriorityRangeMin() {
     return jobExecutorPriorityRangeMin;
   }
 
-  public ProcessEngineConfigurationImpl setJobExecutorPriorityRangeMin(Long jobExecutorPriorityRangeMin) {
+  public ProcessEngineConfigurationImpl setJobExecutorPriorityRangeMin(long jobExecutorPriorityRangeMin) {
     this.jobExecutorPriorityRangeMin = jobExecutorPriorityRangeMin;
     return this;
   }
 
-  public Long getJobExecutorPriorityRangeMax() {
+  public long getJobExecutorPriorityRangeMax() {
     return jobExecutorPriorityRangeMax;
   }
 
-  public ProcessEngineConfigurationImpl setJobExecutorPriorityRangeMax(Long jobExecutorPriorityRangeMax) {
+  public ProcessEngineConfigurationImpl setJobExecutorPriorityRangeMax(long jobExecutorPriorityRangeMax) {
     this.jobExecutorPriorityRangeMax = jobExecutorPriorityRangeMax;
     return this;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/JobExecutorLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/jobexecutor/JobExecutorLogger.java
@@ -194,22 +194,18 @@ public class JobExecutorLogger extends ProcessEngineLogger {
   }
 
   public void infoJobExecutorDoesNotHandleHistoryCleanupJobs(ProcessEngineConfigurationImpl config) {
-    Long jobExecutorPriorityRangeMin = config.getJobExecutorPriorityRangeMin();
-    Long jobExecutorPriorityRangeMax = config.getJobExecutorPriorityRangeMax();
     logInfo("029",
         "JobExecutor is configured for priority range {}-{}. History cleanup jobs will not be handled, because they are outside the priority range ({}).",
-        jobExecutorPriorityRangeMin == null ? 0 : jobExecutorPriorityRangeMin,
-        jobExecutorPriorityRangeMax == null ? Long.MAX_VALUE : jobExecutorPriorityRangeMax,
+        config.getJobExecutorPriorityRangeMin(),
+        config.getJobExecutorPriorityRangeMax(),
         config.getHistoryCleanupJobPriority());
   }
 
   public void infoJobExecutorDoesNotHandleBatchJobs(ProcessEngineConfigurationImpl config) {
-    Long jobExecutorPriorityRangeMin = config.getJobExecutorPriorityRangeMin();
-    Long jobExecutorPriorityRangeMax = config.getJobExecutorPriorityRangeMax();
     logInfo("030",
         "JobExecutor is configured for priority range {}-{}. Batch jobs will not be handled, because they are outside the priority range ({}).",
-        jobExecutorPriorityRangeMin == null ? 0 : jobExecutorPriorityRangeMin,
-        jobExecutorPriorityRangeMax == null ? Long.MAX_VALUE : jobExecutorPriorityRangeMax,
+        config.getJobExecutorPriorityRangeMin(),
+        config.getJobExecutorPriorityRangeMax(),
         config.getBatchJobPriority());
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/JobManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/JobManager.java
@@ -178,10 +178,8 @@ public class JobManager extends AbstractManager {
 
   protected boolean isJobPriorityInJobExecutorPriorityRange(long jobPriority) {
     ProcessEngineConfigurationImpl configuration = Context.getProcessEngineConfiguration();
-    Long jobExecutorPriorityRangeMin = configuration.getJobExecutorPriorityRangeMin();
-    Long jobExecutorPriorityRangeMax = configuration.getJobExecutorPriorityRangeMax();
-    return (jobExecutorPriorityRangeMin == null || jobExecutorPriorityRangeMin <= jobPriority)
-        && (jobExecutorPriorityRangeMax == null || jobExecutorPriorityRangeMax >= jobPriority);
+    return (configuration.getJobExecutorPriorityRangeMin() <= jobPriority)
+        && (configuration.getJobExecutorPriorityRangeMax() >= jobPriority);
   }
 
   public void cancelTimers(ExecutionEntity execution) {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/BatchJobPriorityRangeTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/BatchJobPriorityRangeTest.java
@@ -49,8 +49,8 @@ public class BatchJobPriorityRangeTest {
 
   protected long defaultBatchJobPriority;
   protected int defaultBatchJobsPerSeed;
-  protected Long defaultJobExecutorPriorityRangeMin;
-  protected Long defaultJobExecutorPriorityRangeMax;
+  protected long defaultJobExecutorPriorityRangeMin;
+  protected long defaultJobExecutorPriorityRangeMax;
 
   @Before
   public void setup() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsForPriorityRangeTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsForPriorityRangeTest.java
@@ -34,10 +34,10 @@ public class JobExecutorAcquireJobsForPriorityRangeTest extends AbstractJobExecu
   }
 
   @Test
-  public void shouldAcquireAllJobsNoBounds() {
+  public void shouldAcquireAllJobs() {
     // given
-    configuration.setJobExecutorPriorityRangeMin(null);
-    configuration.setJobExecutorPriorityRangeMax(null);
+    configuration.setJobExecutorPriorityRangeMin(0);
+    configuration.setJobExecutorPriorityRangeMax(Long.MAX_VALUE);
 
     // when
     List<AcquirableJobEntity> acquirableJobs = findAcquirableJobs();
@@ -55,7 +55,7 @@ public class JobExecutorAcquireJobsForPriorityRangeTest extends AbstractJobExecu
   @Test
   public void shouldAcquireOnlyJobsInRangeWithUpperBound() {
     // given
-    configuration.setJobExecutorPriorityRangeMin(null);
+    configuration.setJobExecutorPriorityRangeMin(0);
     configuration.setJobExecutorPriorityRangeMax(7L);
 
     // when
@@ -72,7 +72,7 @@ public class JobExecutorAcquireJobsForPriorityRangeTest extends AbstractJobExecu
   public void shouldAcquireOnlyJobsInRangeWithLowerBound() {
     // given
     configuration.setJobExecutorPriorityRangeMin(7L);
-    configuration.setJobExecutorPriorityRangeMax(null);
+    configuration.setJobExecutorPriorityRangeMax(Long.MAX_VALUE);
 
     // when
     List<AcquirableJobEntity> acquirableJobs = findAcquirableJobs();

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorFollowUpTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorFollowUpTest.java
@@ -114,8 +114,8 @@ public class JobExecutorFollowUpTest {
   protected static ThreadControl executionThread;
 
   protected ProcessEngineConfigurationImpl configuration;
-  protected Long defaultJobExecutorPriorityRangeMin;
-  protected Long defaultJobExecutorPriorityRangeMax;
+  protected long defaultJobExecutorPriorityRangeMin;
+  protected long defaultJobExecutorPriorityRangeMax;
 
   @Before
   public void setUp() throws Exception {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorPriorityRangeConfigurationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/jobexecutor/JobExecutorPriorityRangeConfigurationTest.java
@@ -77,7 +77,7 @@ public class JobExecutorPriorityRangeConfigurationTest {
   @Test
   public void shouldThrowExceptionOnNegativeMaxPriorityRangeConfiguration() {
     // given
-    config.setJobExecutorPriorityRangeMin(null);
+    config.setJobExecutorPriorityRangeMin(0L);
     config.setJobExecutorPriorityRangeMax(-10L);
 
     // then


### PR DESCRIPTION
Related to #2826