### PR TITLE
The getMethod() helper should find package methods

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/test/TestHelper.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/test/TestHelper.java
@@ -321,7 +321,7 @@ public abstract class TestHelper {
   }
 
   protected static Method getMethod(Class<?> clazz, String methodName, Class<?>... parameterTypes) throws SecurityException, NoSuchMethodException {
-    return clazz.getMethod(methodName, parameterTypes);
+    return clazz.getDeclaredMethod(methodName, parameterTypes);
   }
 
   /**


### PR DESCRIPTION
Junit tests can be written using package-protected methods. Currently, our TestHelper.getMethod() is not able to find them.

This leads to the behaviour that a package-protected ProcessUnitTest will ignore the @Deployment annotation.

This fix will solve this issue.