### PR TITLE
2949: change exception type when signalling single execution

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/impl/SignalRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/impl/SignalRestServiceImpl.java
@@ -18,10 +18,12 @@ package org.camunda.bpm.engine.rest.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.exception.NotFoundException;
 import org.camunda.bpm.engine.rest.SignalRestService;
 import org.camunda.bpm.engine.rest.dto.SignalDto;
 import org.camunda.bpm.engine.rest.dto.VariableValueDto;
 import org.camunda.bpm.engine.rest.exception.InvalidRequestException;
+import org.camunda.bpm.engine.rest.exception.RestException;
 import org.camunda.bpm.engine.runtime.SignalEventReceivedBuilder;
 
 import javax.ws.rs.core.Response.Status;
@@ -44,7 +46,13 @@ public class SignalRestServiceImpl extends AbstractRestProcessEngineAware implem
     }
 
     SignalEventReceivedBuilder signalEvent = createSignalEventReceivedBuilder(dto);
-    signalEvent.send();
+    try {
+      signalEvent.send();
+    } catch (NotFoundException e) {
+      // keeping compatibility with older versions where ProcessEngineException (=> 500) was
+      // thrown; NotFoundException translates to 400 by default
+      throw new RestException(Status.INTERNAL_SERVER_ERROR, e, e.getMessage());
+    }
   }
 
   protected SignalEventReceivedBuilder createSignalEventReceivedBuilder(SignalDto dto) {

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/SignalRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/SignalRestServiceTest.java
@@ -20,8 +20,10 @@ import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.BadUserRequestException;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.exception.NotFoundException;
 import org.camunda.bpm.engine.impl.SignalEventReceivedBuilderImpl;
 import org.camunda.bpm.engine.rest.exception.InvalidRequestException;
+import org.camunda.bpm.engine.rest.exception.RestException;
 import org.camunda.bpm.engine.rest.util.VariablesBuilder;
 import org.camunda.bpm.engine.rest.util.container.TestContainerRule;
 import org.camunda.bpm.engine.runtime.SignalEventReceivedBuilder;
@@ -452,6 +454,27 @@ public class SignalRestServiceTest extends AbstractRestServiceTest {
       .expect()
         .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode())
         .body("type", equalTo(ProcessEngineException.class.getSimpleName()))
+        .body("message", equalTo(message))
+    .when()
+      .post(SIGNAL_URL);
+  }
+
+  @Test
+  public void shouldThrowNotFoundException() {
+    String message = "expected exception";
+    doThrow(new NotFoundException(message)).when(signalBuilderMock).send();
+
+    Map<String, Object> requestBody = new HashMap<String, Object>();
+    requestBody.put("name", "aSignalName");
+    requestBody.put("executionId", "foo");
+
+    given()
+      .contentType(POST_JSON_CONTENT_TYPE)
+      .body(requestBody)
+    .then()
+      .expect()
+        .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode())
+        .body("type", equalTo(RestException.class.getSimpleName()))
         .body("message", equalTo(message))
     .when()
       .post(SIGNAL_URL);

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/SignalRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/SignalRestServiceTest.java
@@ -460,7 +460,7 @@ public class SignalRestServiceTest extends AbstractRestServiceTest {
   }
 
   @Test
-  public void shouldThrowNotFoundException() {
+  public void shouldReturnInternalServerErrorResponseForNotFoundException() {
     String message = "expected exception";
     doThrow(new NotFoundException(message)).when(signalBuilderMock).send();
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SignalEventReceivedCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SignalEventReceivedCmd.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.camunda.bpm.engine.exception.NotFoundException;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.SignalEventReceivedBuilderImpl;
 import org.camunda.bpm.engine.impl.cfg.CommandChecker;
@@ -119,11 +120,11 @@ public class SignalEventReceivedCmd implements Command<Void> {
 
     ExecutionManager executionManager = commandContext.getExecutionManager();
     ExecutionEntity execution = executionManager.findExecutionById(executionId);
-    ensureNotNull("Cannot find execution with id '" + executionId + "'", "execution", execution);
+    ensureNotNull(NotFoundException.class, "Cannot find execution with id '" + executionId + "'", "execution", execution);
 
     EventSubscriptionManager eventSubscriptionManager = commandContext.getEventSubscriptionManager();
     List<EventSubscriptionEntity> signalEvents = eventSubscriptionManager.findSignalEventSubscriptionsByNameAndExecution(signalName, executionId);
-    ensureNotEmpty("Execution '" + executionId + "' has not subscribed to a signal event with name '" + signalName + "'.", signalEvents);
+    ensureNotEmpty(NotFoundException.class, "Execution '" + executionId + "' has not subscribed to a signal event with name '" + signalName + "'.", signalEvents);
 
     checkAuthorizationOfCatchSignals(commandContext, signalEvents);
     notifyExecutions(signalEvents);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SignalEventReceivedCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SignalEventReceivedCmd.java
@@ -120,7 +120,7 @@ public class SignalEventReceivedCmd implements Command<Void> {
 
     ExecutionManager executionManager = commandContext.getExecutionManager();
     ExecutionEntity execution = executionManager.findExecutionById(executionId);
-    ensureNotNull(NotFoundException.class, "Cannot find execution with id '" + executionId + "'", "execution", execution);
+    ensureNotNull("Cannot find execution with id '" + executionId + "'", "execution", execution);
 
     EventSubscriptionManager eventSubscriptionManager = commandContext.getEventSubscriptionManager();
     List<EventSubscriptionEntity> signalEvents = eventSubscriptionManager.findSignalEventSubscriptionsByNameAndExecution(signalName, executionId);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/signal/SignalEventReceivedBuilderTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/signal/SignalEventReceivedBuilderTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
-import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.exception.NotFoundException;
 import org.camunda.bpm.engine.runtime.EventSubscription;
 import org.camunda.bpm.engine.runtime.Execution;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
@@ -160,7 +160,7 @@ public class SignalEventReceivedBuilderTest extends PluggableProcessEngineTest {
     try {
       runtimeService.createSignalEvent("signal").executionId("nonExisting").send();
 
-    } catch (ProcessEngineException e) {
+    } catch (NotFoundException e) {
       assertThat(e.getMessage()).contains("Cannot find execution with id 'nonExisting'");
     }
   }
@@ -179,7 +179,7 @@ public class SignalEventReceivedBuilderTest extends PluggableProcessEngineTest {
     try {
       runtimeService.createSignalEvent("signal").executionId(executionId).send();
 
-    } catch (ProcessEngineException e) {
+    } catch (NotFoundException e) {
       assertThat(e.getMessage()).contains("Execution '" + executionId + "' has not subscribed to a signal event with name 'signal'");
     }
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/signal/SignalEventReceivedBuilderTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/signal/SignalEventReceivedBuilderTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Map;
 
 import org.camunda.bpm.engine.exception.NotFoundException;
+import org.camunda.bpm.engine.exception.NullValueException;
 import org.camunda.bpm.engine.runtime.EventSubscription;
 import org.camunda.bpm.engine.runtime.Execution;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
@@ -160,7 +161,7 @@ public class SignalEventReceivedBuilderTest extends PluggableProcessEngineTest {
     try {
       runtimeService.createSignalEvent("signal").executionId("nonExisting").send();
 
-    } catch (NotFoundException e) {
+    } catch (NullValueException e) {
       assertThat(e.getMessage()).contains("Cannot find execution with id 'nonExisting'");
     }
   }


### PR DESCRIPTION
- when execution is not found or execution is not expecting this signal, then it now throws NotFoundException instead of ProcessEngineException so that callers can handle these cases explicitly

related to camunda/camunda-bpm-platform#2949