### PR TITLE
fix(engine): remove permission for transient user creation

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/identity/db/DbIdentityServiceProvider.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/identity/db/DbIdentityServiceProvider.java
@@ -55,11 +55,12 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
 
   // users ////////////////////////////////////////////////////////
 
+  @Override
   public UserEntity createNewUser(String userId) {
-    checkAuthorization(Permissions.CREATE, Resources.USER, null);
     return new UserEntity(userId);
   }
 
+  @Override
   public IdentityOperationResult saveUser(User user) {
     UserEntity userEntity = (UserEntity) user;
 
@@ -81,6 +82,7 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
     return new IdentityOperationResult(userEntity, operation);
   }
 
+  @Override
   public IdentityOperationResult deleteUser(final String userId) {
     checkAuthorization(Permissions.DELETE, Resources.USER, userId);
     UserEntity user = findUserById(userId);
@@ -109,6 +111,7 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
     return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_NONE);
   }
 
+  @Override
   public boolean checkPassword(String userId, String password) {
     UserEntity user = findUserById(userId);
     if (user == null || password == null) {
@@ -168,6 +171,7 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
     getIdentityInfoManager().updateUserLock(user, attempts, lockExpirationTime);
   }
 
+  @Override
   public IdentityOperationResult unlockUser(String userId) {
     UserEntity user = findUserById(userId);
     if(user != null) {
@@ -186,11 +190,12 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
 
   // groups ////////////////////////////////////////////////////////
 
+  @Override
   public GroupEntity createNewGroup(String groupId) {
-    checkAuthorization(Permissions.CREATE, Resources.GROUP, null);
     return new GroupEntity(groupId);
   }
 
+  @Override
   public IdentityOperationResult saveGroup(Group group) {
     GroupEntity groupEntity = (GroupEntity) group;
     String operation = null;
@@ -207,6 +212,7 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
     return new IdentityOperationResult(groupEntity, operation);
   }
 
+  @Override
   public IdentityOperationResult deleteGroup(final String groupId) {
     checkAuthorization(Permissions.DELETE, Resources.GROUP, groupId);
     GroupEntity group = findGroupById(groupId);
@@ -236,11 +242,12 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
 
   // tenants //////////////////////////////////////////////////////
 
+  @Override
   public Tenant createNewTenant(String tenantId) {
-    checkAuthorization(Permissions.CREATE, Resources.TENANT, null);
     return new TenantEntity(tenantId);
   }
 
+  @Override
   public IdentityOperationResult saveTenant(Tenant tenant) {
     TenantEntity tenantEntity = (TenantEntity) tenant;
     String operation = null;
@@ -257,6 +264,7 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
     return new IdentityOperationResult(tenantEntity, operation);
   }
 
+  @Override
   public IdentityOperationResult deleteTenant(String tenantId) {
     checkAuthorization(Permissions.DELETE, Resources.TENANT, tenantId);
     TenantEntity tenant = findTenantById(tenantId);
@@ -272,6 +280,7 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
 
   // membership //////////////////////////////////////////////////////
 
+  @Override
   public IdentityOperationResult createMembership(String userId, String groupId) {
     checkAuthorization(Permissions.CREATE, Resources.GROUP_MEMBERSHIP, groupId);
     UserEntity user = findUserById(userId);
@@ -286,12 +295,13 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
     return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_CREATE);
   }
 
+  @Override
   public IdentityOperationResult deleteMembership(String userId, String groupId) {
     checkAuthorization(Permissions.DELETE, Resources.GROUP_MEMBERSHIP, groupId);
     if (existsMembership(userId, groupId)) {
       deleteAuthorizations(Resources.GROUP_MEMBERSHIP, groupId);
-  
-      Map<String, Object> parameters = new HashMap<String, Object>();
+
+      Map<String, Object> parameters = new HashMap<>();
       parameters.put("userId", userId);
       parameters.put("groupId", groupId);
       getDbEntityManager().delete(MembershipEntity.class, "deleteMembership", parameters);
@@ -308,6 +318,7 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
     getDbEntityManager().delete(MembershipEntity.class, "deleteMembershipsByGroupId", groupId);
   }
 
+  @Override
   public IdentityOperationResult createTenantUserMembership(String tenantId, String userId) {
     checkAuthorization(Permissions.CREATE, Resources.TENANT_MEMBERSHIP, tenantId);
 
@@ -327,6 +338,7 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
     return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_CREATE);
   }
 
+  @Override
   public IdentityOperationResult createTenantGroupMembership(String tenantId, String groupId) {
     checkAuthorization(Permissions.CREATE, Resources.TENANT_MEMBERSHIP, tenantId);
 
@@ -346,14 +358,15 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
     return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_CREATE);
   }
 
+  @Override
   public IdentityOperationResult deleteTenantUserMembership(String tenantId, String userId) {
     checkAuthorization(Permissions.DELETE, Resources.TENANT_MEMBERSHIP, tenantId);
     if (existsTenantMembership(tenantId, userId, null)) {
       deleteAuthorizations(Resources.TENANT_MEMBERSHIP, userId);
-  
+
       deleteAuthorizationsForUser(Resources.TENANT, tenantId, userId);
-  
-      Map<String, Object> parameters = new HashMap<String, Object>();
+
+      Map<String, Object> parameters = new HashMap<>();
       parameters.put("tenantId", tenantId);
       parameters.put("userId", userId);
       getDbEntityManager().delete(TenantMembershipEntity.class, "deleteTenantMembership", parameters);
@@ -362,15 +375,16 @@ public class DbIdentityServiceProvider extends DbReadOnlyIdentityServiceProvider
     return new IdentityOperationResult(null, IdentityOperationResult.OPERATION_NONE);
   }
 
+  @Override
   public IdentityOperationResult deleteTenantGroupMembership(String tenantId, String groupId) {
     checkAuthorization(Permissions.DELETE, Resources.TENANT_MEMBERSHIP, tenantId);
-    
+
     if (existsTenantMembership(tenantId, null, groupId)) {
       deleteAuthorizations(Resources.TENANT_MEMBERSHIP, groupId);
-  
+
       deleteAuthorizationsForGroup(Resources.TENANT, tenantId, groupId);
-  
-      Map<String, Object> parameters = new HashMap<String, Object>();
+
+      Map<String, Object> parameters = new HashMap<>();
       parameters.put("tenantId", tenantId);
       parameters.put("groupId", groupId);
       getDbEntityManager().delete(TenantMembershipEntity.class, "deleteTenantMembership", parameters);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/identity/IdentityServiceAuthorizationsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/identity/IdentityServiceAuthorizationsTest.java
@@ -56,7 +56,6 @@ import org.camunda.bpm.engine.identity.Tenant;
 import org.camunda.bpm.engine.identity.TenantQuery;
 import org.camunda.bpm.engine.identity.User;
 import org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity;
-import org.camunda.bpm.engine.impl.persistence.entity.GroupEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.TenantEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.UserEntity;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
@@ -81,7 +80,29 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
   }
 
   @Test
-  public void testUserCreateAuthorizations() {
+  public void shouldCreateTransientUserWithoutPermission() {
+    // given nobody has CREATE permission on USER resource
+    Authorization basePerms = authorizationService.createNewAuthorization(AUTH_TYPE_GLOBAL);
+    basePerms.setResource(USER);
+    basePerms.setResourceId(ANY);
+    basePerms.addPermission(ALL); // add all then remove 'create'
+    basePerms.removePermission(CREATE);
+    authorizationService.saveAuthorization(basePerms);
+
+    processEngineConfiguration.setAuthorizationEnabled(true);
+    identityService.setAuthenticatedUserId(jonny2);
+
+    // when
+    try {
+      identityService.newUser("jonny1");
+    } catch (AuthorizationException e) {
+      // then
+      fail("no authorization exception expected");
+    }
+  }
+
+  @Test
+  public void testUserInsertionAuthorizations() {
 
     // add base permission which allows nobody to create users:
     Authorization basePerms = authorizationService.createNewAuthorization(AUTH_TYPE_GLOBAL);
@@ -94,19 +115,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     processEngineConfiguration.setAuthorizationEnabled(true);
     identityService.setAuthenticatedUserId(jonny2);
 
-    try {
-      identityService.newUser("jonny1");
-      fail("exception expected");
-
-    } catch (AuthorizationException e) {
-      assertEquals(1, e.getMissingAuthorizations().size());
-      MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
-      assertExceptionInfo(CREATE.getName(), USER.resourceName(), null, info);
-    }
-
-    // circumvent auth check to get new transient userobject
-    User newUser = new UserEntity("jonny1");
+    User newUser = identityService.newUser("jonny1");
 
     try {
       identityService.saveUser(newUser);
@@ -192,9 +201,8 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
   @Test
   public void testUserUpdateAuthorizations() {
 
-    // crate user while still in god-mode:
-    User jonny1 = identityService.newUser("jonny1");
-    identityService.saveUser(jonny1);
+    // insert user while still in god-mode:
+    identityService.saveUser(identityService.newUser("jonny1"));
 
     // create global auth
     Authorization basePerms = authorizationService.createNewAuthorization(AUTH_TYPE_GLOBAL);
@@ -209,13 +217,12 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     identityService.setAuthenticatedUserId(jonny2);
 
     // fetch user:
-    jonny1 = identityService.createUserQuery().singleResult();
+    User jonny1 = identityService.createUserQuery().singleResult();
     jonny1.setFirstName("Jonny");
 
     try {
       identityService.saveUser(jonny1);
       fail("exception expected");
-
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
@@ -224,8 +231,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     }
 
     // but I can create a new user:
-    User jonny3 = identityService.newUser("jonny3");
-    identityService.saveUser(jonny3);
+    identityService.saveUser(identityService.newUser("jonny3"));
 
   }
 
@@ -310,7 +316,29 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
   }
 
   @Test
-  public void testGroupCreateAuthorizations() {
+  public void shouldCreateTransientGroupWithoutPermission() {
+    // given nobody has CREATE permission on GROUP resource
+    Authorization basePerms = authorizationService.createNewAuthorization(AUTH_TYPE_GLOBAL);
+    basePerms.setResource(GROUP);
+    basePerms.setResourceId(ANY);
+    basePerms.addPermission(ALL); // add all then remove 'create'
+    basePerms.removePermission(CREATE);
+    authorizationService.saveAuthorization(basePerms);
+
+    processEngineConfiguration.setAuthorizationEnabled(true);
+    identityService.setAuthenticatedUserId(jonny2);
+
+    // when
+    try {
+      identityService.newGroup("group1");
+    } catch (AuthorizationException e) {
+      // then
+      fail("no authorization exception expected");
+    }
+  }
+
+  @Test
+  public void testGroupInsertionAuthorizations() {
 
     // add base permission which allows nobody to create groups:
     Authorization basePerms = authorizationService.createNewAuthorization(AUTH_TYPE_GLOBAL);
@@ -323,19 +351,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     processEngineConfiguration.setAuthorizationEnabled(true);
     identityService.setAuthenticatedUserId(jonny2);
 
-    try {
-      identityService.newGroup("group1");
-      fail("exception expected");
-
-    } catch (AuthorizationException e) {
-      assertEquals(1, e.getMissingAuthorizations().size());
-      MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
-      assertExceptionInfo(CREATE.getName(), GROUP.resourceName(), null, info);
-    }
-
-    // circumvent auth check to get new transient userobject
-    Group group = new GroupEntity("group1");
+    Group group = identityService.newGroup("group1");
 
     try {
       identityService.saveGroup(group);
@@ -460,7 +476,29 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
   }
 
   @Test
-  public void testTenantCreateAuthorizations() {
+  public void shouldCreateTransientTenantWithoutPermission() {
+    // given nobody has CREATE permission on TENANT resource
+    Authorization basePerms = authorizationService.createNewAuthorization(AUTH_TYPE_GLOBAL);
+    basePerms.setResource(TENANT);
+    basePerms.setResourceId(ANY);
+    basePerms.addPermission(ALL); // add all then remove 'create'
+    basePerms.removePermission(CREATE);
+    authorizationService.saveAuthorization(basePerms);
+
+    processEngineConfiguration.setAuthorizationEnabled(true);
+    identityService.setAuthenticatedUserId(jonny2);
+
+    // when
+    try {
+      identityService.newTenant("tenant");
+    } catch (AuthorizationException e) {
+      // then
+      fail("no authorization exception expected");
+    }
+  }
+
+  @Test
+  public void testTenantInsertionAuthorizations() {
 
     // add base permission which allows nobody to create tenants:
     Authorization basePerms = authorizationService.createNewAuthorization(AUTH_TYPE_GLOBAL);
@@ -473,19 +511,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     processEngineConfiguration.setAuthorizationEnabled(true);
     identityService.setAuthenticatedUserId(jonny2);
 
-    try {
-      identityService.newTenant("tenant");
-
-      fail("exception expected");
-    } catch (AuthorizationException e) {
-      assertEquals(1, e.getMissingAuthorizations().size());
-      MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
-      assertExceptionInfo(CREATE.getName(), TENANT.resourceName(), null, info);
-    }
-
-    // circumvent auth check to get new transient userobject
-    Tenant tenant = new TenantEntity("tenant");
+    Tenant tenant = identityService.newTenant("tenant");
 
     try {
       identityService.saveTenant(tenant);


### PR DESCRIPTION
* Remove the check for CREATE permission on resources USER, GROUP, and TENANT
  when creating the transient objects. The `saveXYZ` methods still check this
  permission when persisting the objects. The `newXYZ` methods are used by
  other components (e.g. the REST API) to create transient objects, e.g. for
  password policy checks. This must not require CREATE permissions as users
  might otherwise not be able to modify their own passwords.

fixes #2762