### PR TITLE
getELResolver() support for Quarkus (issue 2610)

### DIFF
--- a/quarkus-extension/engine/runtime/src/main/java/org/camunda/bpm/quarkus/engine/extension/QuarkusCdiELResolver.java
+++ b/quarkus-extension/engine/runtime/src/main/java/org/camunda/bpm/quarkus/engine/extension/QuarkusCdiELResolver.java
@@ -1,0 +1,108 @@
+package org.camunda.bpm.quarkus.engine.extension;
+
+import org.camunda.bpm.engine.impl.javax.el.ELContext;
+import org.camunda.bpm.engine.impl.javax.el.ELException;
+import org.camunda.bpm.engine.impl.javax.el.ELResolver;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.CDI;
+import java.beans.FeatureDescriptor;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class QuarkusCdiELResolver extends ELResolver
+{
+    private final BeanManager beanManager;
+    private final Map<String, Optional<Object>> cachedProxies;
+
+    public QuarkusCdiELResolver()
+    {
+        beanManager = CDI.current().getBeanManager();
+        cachedProxies = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public Class<?> getCommonPropertyType(ELContext arg0, Object arg1)
+    {
+        return null;
+    }
+
+    @Override
+    public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext arg0, Object arg1)
+    {
+        return null;
+    }
+
+    @Override
+    public Class<?> getType(ELContext arg0, Object arg1, Object arg2) throws ELException
+    {
+        return null;
+    }
+
+    @Override
+    public Object getValue(ELContext context, Object base, Object property) throws ELException
+    {
+        //we only check root beans
+        if (base != null)
+        {
+            return null;
+        }
+
+        String beanName = (String) property;
+
+        Optional<Object> contextualInstance = cachedProxies.get(beanName);
+        if (contextualInstance == null)
+        {
+            contextualInstance = resolveProxy(beanName);
+            cachedProxies.put(beanName, contextualInstance);
+        }
+
+        if (contextualInstance.isPresent())
+        {
+            context.setPropertyResolved(true);
+            return contextualInstance.get();
+        }
+
+        return null;
+    }
+
+    protected Optional<Object> resolveProxy(String beanName)
+    {
+        Object contextualInstance = null;
+
+        Set<Bean<?>> beans = beanManager.getBeans(beanName);
+        if (beans != null && !beans.isEmpty())
+        {
+            Bean<?> bean = beanManager.resolve(beans);
+
+            if (bean.getScope().equals(Dependent.class))
+            {
+                throw new IllegalArgumentException("@Dependent on beans used in EL are currently not supported! "
+                        + " Class: " + bean.getBeanClass().toString());
+            }
+
+            CreationalContext<?> creationalContext = beanManager.createCreationalContext(bean);
+            contextualInstance = beanManager.getReference(bean, Object.class, creationalContext);
+        }
+
+        return contextualInstance == null ? Optional.empty() : Optional.of(contextualInstance);
+    }
+
+    @Override
+    public boolean isReadOnly(ELContext arg0, Object arg1, Object arg2) throws ELException
+    {
+        return false;
+    }
+
+    @Override
+    public void setValue(ELContext arg0, Object arg1, Object arg2, Object arg3) throws ELException
+    {
+
+    }
+}

--- a/quarkus-extension/engine/runtime/src/main/java/org/camunda/bpm/quarkus/engine/extension/QuarkusCdiExpressionManager.java
+++ b/quarkus-extension/engine/runtime/src/main/java/org/camunda/bpm/quarkus/engine/extension/QuarkusCdiExpressionManager.java
@@ -1,0 +1,27 @@
+package org.camunda.bpm.quarkus.engine.extension;
+
+import org.camunda.bpm.engine.cdi.CdiExpressionManager;
+import org.camunda.bpm.engine.impl.el.VariableContextElResolver;
+import org.camunda.bpm.engine.impl.el.VariableScopeElResolver;
+import org.camunda.bpm.engine.impl.javax.el.*;
+
+public class QuarkusCdiExpressionManager extends CdiExpressionManager {
+
+    @Override
+    protected ELResolver createElResolver() {
+        CompositeELResolver compositeElResolver = new CompositeELResolver();
+        compositeElResolver.add(new VariableScopeElResolver());
+        compositeElResolver.add(new VariableContextElResolver());
+
+//        compositeElResolver.add(new CdiResolver());
+        compositeElResolver.add(new QuarkusCdiELResolver());
+
+        compositeElResolver.add(new ArrayELResolver());
+        compositeElResolver.add(new ListELResolver());
+        compositeElResolver.add(new MapELResolver());
+        compositeElResolver.add(new BeanELResolver());
+
+        return compositeElResolver;
+    }
+
+}

--- a/quarkus-extension/engine/runtime/src/main/java/org/camunda/bpm/quarkus/engine/extension/QuarkusCdiJtaProcessEngineConfiguration.java
+++ b/quarkus-extension/engine/runtime/src/main/java/org/camunda/bpm/quarkus/engine/extension/QuarkusCdiJtaProcessEngineConfiguration.java
@@ -1,0 +1,13 @@
+package org.camunda.bpm.quarkus.engine.extension;
+
+import org.camunda.bpm.engine.impl.cfg.JtaProcessEngineConfiguration;
+
+
+public class QuarkusCdiJtaProcessEngineConfiguration extends JtaProcessEngineConfiguration {
+    @Override
+    protected void initExpressionManager() {
+//        expressionManager = new CdiExpressionManager();
+        expressionManager = new QuarkusCdiExpressionManager();
+        super.initExpressionManager();
+    }
+}

--- a/quarkus-extension/engine/runtime/src/main/java/org/camunda/bpm/quarkus/engine/extension/QuarkusProcessEngineConfiguration.java
+++ b/quarkus-extension/engine/runtime/src/main/java/org/camunda/bpm/quarkus/engine/extension/QuarkusProcessEngineConfiguration.java
@@ -16,7 +16,6 @@
  */
 package org.camunda.bpm.quarkus.engine.extension;
 
-import org.camunda.bpm.engine.cdi.CdiJtaProcessEngineConfiguration;
 import org.camunda.bpm.engine.impl.history.HistoryLevel;
 import org.camunda.bpm.engine.impl.interceptor.CommandContextInterceptor;
 import org.camunda.bpm.engine.impl.interceptor.CommandCounterInterceptor;
@@ -29,7 +28,7 @@ import javax.transaction.TransactionManager;
 import java.util.ArrayList;
 import java.util.List;
 
-public class QuarkusProcessEngineConfiguration extends CdiJtaProcessEngineConfiguration {
+public class QuarkusProcessEngineConfiguration extends QuarkusCdiJtaProcessEngineConfiguration {
 
   /**
    * Default values.


### PR DESCRIPTION
Expression Resolution support for named beans.
Alternative fix for https://github.com/camunda/camunda-bpm-platform/issues/2610