### PR TITLE
chore(engine): Bump commons-fileupload

### DIFF
--- a/distro/license-book/src/main/resources/license-book.txt
+++ b/distro/license-book/src/main/resources/license-book.txt
@@ -1182,7 +1182,7 @@ Copyright (c) 2008 Alexander Beider & Stephen P. Morse.
 Licensed under Apache 2.0
 
 ===========================================================================================
-commons-fileupload:commons-fileupload:jar:1.4
+commons-fileupload:commons-fileupload:jar:1.5
 https://commons.apache.org/proper/commons-fileupload/download_fileupload.cgi
 Notice file
 ======================================================================

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -67,7 +67,7 @@
       <dependency>
         <groupId>commons-fileupload</groupId>
         <artifactId>commons-fileupload</artifactId>
-        <version>1.4</version>
+        <version>1.5</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Bump commons-fileupload to 1.5 to fix [CVE-2023-24998](https://nvd.nist.gov/vuln/detail/CVE-2023-24998)