### PR TITLE
fix(engine): add candidate starter identity links only for new deployments

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/deployer/BpmnDeployer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/bpmn/deployer/BpmnDeployer.java
@@ -142,10 +142,10 @@ public class BpmnDeployer extends AbstractDefinitionDeployer<ProcessDefinitionEn
 
     if (deployment.isNew()) {
       adjustStartEventSubscriptions(definition, latestDefinition);
-    }
 
-    // add "authorizations"
-    addAuthorizations(definition);
+      // add "authorizations"
+      addAuthorizations(definition);
+    }
   }
 
   @Override


### PR DESCRIPTION
avoid creation during re-caching of processes

Related to camunda/camunda-bpm-platform#3120