### PR TITLE
chore(run): update Snakeyaml to 1.33

### DIFF
--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -18,13 +18,11 @@
   <dependencyManagement>
     <dependencies>
 
-      <!-- https://jira.camunda.com/browse/CAM-13717 -->
+      <!-- Explicit override tomcat version before spring-boot-dependencies -->
       <dependency>
-        <groupId>org.glassfish.jersey</groupId>
-        <artifactId>jersey-bom</artifactId>
-        <version>${version.jersey2}</version>
-        <scope>import</scope>
-        <type>pom</type>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>${version.snakeyaml}</version>
       </dependency>
 
       <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -36,6 +36,7 @@
     <version.jackson>2.14.1</version.jackson>
     <version.xml.bind-api>2.3.3</version.xml.bind-api>
     <version.xml.jaxb-impl>2.3.6</version.xml.jaxb-impl>
+    <version.snakeyaml>1.33</version.snakeyaml>
 
     <version.slf4j>1.7.26</version.slf4j>
     <version.logback>1.2.11</version.logback>


### PR DESCRIPTION
- also removes Jersey version override for Run, effectively bumping it to 2.35

related to camunda/camunda-bpm-platform#3030