### PR TITLE
chore(distro/wildfly): remove JBoss Web dependency

### DIFF
--- a/distro/wildfly/modules/src/main/modules/org/camunda/bpm/wildfly/camunda-wildfly-subsystem/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/camunda/bpm/wildfly/camunda-wildfly-subsystem/main/module.xml
@@ -30,7 +30,6 @@
     <module name="org.jboss.as.ejb3" />
     <module name="org.jboss.metadata.common" />
     <module name="org.jboss.metadata.web" />
-    <module name="org.jboss.as.web" />
     <module name="org.jboss.as.web-common" />
     <module name="org.jboss.invocation" />
 

--- a/distro/wildfly26/modules/src/main/modules/org/camunda/bpm/wildfly/camunda-wildfly-subsystem/main/module.xml
+++ b/distro/wildfly26/modules/src/main/modules/org/camunda/bpm/wildfly/camunda-wildfly-subsystem/main/module.xml
@@ -30,7 +30,6 @@
     <module name="org.jboss.as.ejb3" />
     <module name="org.jboss.metadata.common" />
     <module name="org.jboss.metadata.web" />
-    <module name="org.jboss.as.web" />
     <module name="org.jboss.as.web-common" />
     <module name="org.jboss.invocation" />
 

--- a/qa/wildfly-runtime/src/main/common/modules/org/camunda/bpm/wildfly/camunda-wildfly-subsystem/main/module.xml
+++ b/qa/wildfly-runtime/src/main/common/modules/org/camunda/bpm/wildfly/camunda-wildfly-subsystem/main/module.xml
@@ -30,7 +30,6 @@
     <module name="org.jboss.as.ejb3" />
     <module name="org.jboss.metadata.common" />
     <module name="org.jboss.metadata.web" />
-    <module name="org.jboss.as.web" />
     <module name="org.jboss.as.web-common" />
     <module name="org.jboss.invocation" />
 

--- a/qa/wildfly26-runtime/src/main/common/modules/org/camunda/bpm/wildfly/camunda-wildfly-subsystem/main/module.xml
+++ b/qa/wildfly26-runtime/src/main/common/modules/org/camunda/bpm/wildfly/camunda-wildfly-subsystem/main/module.xml
@@ -30,7 +30,6 @@
     <module name="org.jboss.as.ejb3" />
     <module name="org.jboss.metadata.common" />
     <module name="org.jboss.metadata.web" />
-    <module name="org.jboss.as.web" />
     <module name="org.jboss.as.web-common" />
     <module name="org.jboss.invocation" />
 


### PR DESCRIPTION
* Removes the `org.jboss.as.web` module dependency from the Camunda WildFly subsystem since we only need `org.jboss.as.web-common`