### PR TITLE
chore(ci): exclude WildFly Modules from Javadoc stage

### DIFF
--- a/.ci/daily/Jenkinsfile
+++ b/.ci/daily/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
                 sh(label: 'Create webapps target dir', script: 'mkdir -p ./webapps/assembly/target/webapp')
                 sh(label: 'Create webapps Jakarta target dir', script: 'mkdir -p ./webapps/assembly-jakarta/target/webapp')
                 cambpmRunMaven('.',
-                  'package javadoc:javadoc javadoc:aggregate -Pdistro,distro-wildfly,distro-webjar,javadocs -pl '!distro/wildfly/modules,!distro/wildfly26/modules' -DskipTests=true -Dskip.frontend.build=true',
+                  "package javadoc:javadoc javadoc:aggregate -Pdistro,distro-wildfly,distro-webjar,javadocs -pl '!distro/wildfly/modules,!distro/wildfly26/modules' -DskipTests=true -Dskip.frontend.build=true",
                   withNpm: true,
                   jdkVersion: 'jdk-11-latest')
               },


### PR DESCRIPTION
* The WildFly 26 Modules module doesn't create any Javadoc but fails to run out of the box with `mvn package`. You can find further details in https://github.com/camunda/camunda-bpm-platform/issues/3253.