### PR TITLE
fix(client): cancel pending HTTP requests when client is stopped

### DIFF
--- a/clients/java/client/src/main/java/org/camunda/bpm/client/impl/EngineClient.java
+++ b/clients/java/client/src/main/java/org/camunda/bpm/client/impl/EngineClient.java
@@ -164,4 +164,8 @@ public class EngineClient {
   public boolean isUsePriority() {
     return usePriority;
   }
+
+  public void close() {
+    engineInteraction.close();
+  }
 }

--- a/clients/java/client/src/main/java/org/camunda/bpm/client/impl/EngineClientLogger.java
+++ b/clients/java/client/src/main/java/org/camunda/bpm/client/impl/EngineClientLogger.java
@@ -66,4 +66,9 @@ public class EngineClientLogger extends ExternalTaskClientLogger {
       "008", "Exception while executing request interceptor: {}", e);
   }
 
+  protected void exceptionWhileClosingClient(IOException e) {
+    logError(
+            "009", "Exception while closing client", e);
+  }
+
 }

--- a/clients/java/client/src/main/java/org/camunda/bpm/client/impl/RequestExecutor.java
+++ b/clients/java/client/src/main/java/org/camunda/bpm/client/impl/RequestExecutor.java
@@ -24,17 +24,16 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.AbstractResponseHandler;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
-import org.camunda.bpm.client.exception.EngineException;
 import org.camunda.bpm.client.exception.RestException;
 import org.camunda.bpm.client.interceptor.impl.RequestInterceptorHandler;
 import org.camunda.commons.utils.IoUtil;
@@ -54,7 +53,7 @@ public class RequestExecutor {
   protected static final Header HEADER_CONTENT_TYPE_JSON = new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json");
   protected static final Header HEADER_USER_AGENT = new BasicHeader(HttpHeaders.USER_AGENT, "Camunda External Task Client");
 
-  protected HttpClient httpClient;
+  protected CloseableHttpClient httpClient;
   protected ObjectMapper objectMapper;
 
   protected RequestExecutor(RequestInterceptorHandler requestInterceptorHandler, ObjectMapper objectMapper) {
@@ -190,6 +189,14 @@ public class RequestExecutor {
       .addInterceptorLast(requestInterceptorHandler);
 
     this.httpClient = httpClientBuilder.build();
+  }
+
+  protected void close() {
+    try {
+      httpClient.close();
+    } catch (IOException e) {
+      LOG.exceptionWhileClosingClient(e);
+    }
   }
 
 }

--- a/clients/java/client/src/main/java/org/camunda/bpm/client/topic/impl/TopicSubscriptionManager.java
+++ b/clients/java/client/src/main/java/org/camunda/bpm/client/topic/impl/TopicSubscriptionManager.java
@@ -161,6 +161,8 @@ public class TopicSubscriptionManager implements Runnable {
   }
 
   public synchronized void stop() {
+    engineClient.close();
+
     if (isRunning.compareAndSet(true, false)) {
       resume();
 


### PR DESCRIPTION
Fixes #3282.

~Not tested, yet.~ Tested, fixes the issue.

~Btw, I am getting 404 when trying to sign the [CLA](https://cla-assistant.io/camunda/).~ It should be signed now; the platform was buggy.