### PR TITLE
style(settings): Adjust IntelliJ formatter.xml to Make Static Imports Precede Imports

### DIFF
--- a/settings/intellij-idea/formatter.xml
+++ b/settings/intellij-idea/formatter.xml
@@ -5,8 +5,8 @@
       <option name="TAB_SIZE" value="2" />
     </value>
   </option>
-  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="5" />
-  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="3" />
+  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99999" />
+  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
   <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
   <JavaCodeStyleSettings>
     <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99999" />

--- a/settings/intellij-idea/formatter.xml
+++ b/settings/intellij-idea/formatter.xml
@@ -5,12 +5,19 @@
       <option name="TAB_SIZE" value="2" />
     </value>
   </option>
-  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99999" />
-  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
+  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="5" />
+  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="3" />
   <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
   <JavaCodeStyleSettings>
     <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99999" />
     <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
+    <option name="IMPORT_LAYOUT_TABLE">
+      <value>
+        <package name="" withSubpackages="true" static="true" />
+        <emptyLine />
+        <package name="" withSubpackages="true" static="false" />
+      </value>
+    </option>
   </JavaCodeStyleSettings>
   <codeStyleSettings language="CFML">
     <indentOptions>


### PR DESCRIPTION
This commit fixes optimizing imports (manually or automatically) using IntelliJ in the right order

related to: #3310