### PR TITLE
fix(rest): Remove additionalProperties from Unnecessary Responses

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/telemetry/TelemetryDataDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/telemetry/TelemetryDataDto.ftl
@@ -10,8 +10,8 @@
 
     <@lib.property
         name = "product"
-        type = "object"
-        additionalProperties = true
+        type = "ref"
+        additionalProperties = false
         dto = "TelemetryProductDto"
         desc = "Information about the product collection telemetry data."
         last = true

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/telemetry/TelemetryInternalsDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/telemetry/TelemetryInternalsDto.ftl
@@ -3,22 +3,22 @@
 
     <@lib.property
         name = "database"
-        type = "object"
-        additionalProperties = true
+        type = "ref"
+        additionalProperties = false
         dto = "AbstractVendorVersionInformationDto"
         desc = "Vendor and version of the connected database."/>
 
     <@lib.property
         name = "application-server"
-        type = "object"
-        additionalProperties = true
+        type = "ref"
+        additionalProperties = false
         dto = "AbstractVendorVersionInformationDto"
         desc = "Vendor and version of the application server."/>
 
     <@lib.property
         name = "license-key"
-        type = "object"
-        additionalProperties = true
+        type = "ref"
+        additionalProperties = false
         dto = "TelemetryLicenseKeyDto"
         desc = "Information about the Camunda license key."/>
 
@@ -50,8 +50,8 @@
 
     <@lib.property
         name = "jdk"
-        type = "object"
-        additionalProperties = true
+        type = "ref"
+        additionalProperties = false
         dto = "AbstractVendorVersionInformationDto"
         desc = "Vendor and version of the installed JDK."/>
 

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/telemetry/TelemetryProductDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/telemetry/TelemetryProductDto.ftl
@@ -18,8 +18,8 @@
 
     <@lib.property
         name = "internals"
-        type = "object"
-        additionalProperties = true
+        type = "ref"
+        additionalProperties = false
         dto = "TelemetryInternalsDto"
         last = true
         desc = "Internal data and metrics collected by the product."/>


### PR DESCRIPTION
- The following DTOs do not contain entries with dynamic keys but have additionalProperties=true: TelemetryProductDto TelemetryLicenseKeyDto AbstractVendorVersionInformationDto

related to: camunda/camunda-bpm-platform#3186