### PR TITLE
fix(quarkus): Invoke the `quarkus-extension-maven-plugin`

### DIFF
--- a/quarkus-extension/engine/runtime/pom.xml
+++ b/quarkus-extension/engine/runtime/pom.xml
@@ -45,12 +45,6 @@
   </dependencies>
 
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
     <plugins>
       <plugin>
         <groupId>io.quarkus</groupId>

--- a/quarkus-extension/engine/runtime/pom.xml
+++ b/quarkus-extension/engine/runtime/pom.xml
@@ -53,6 +53,22 @@
     </resources>
     <plugins>
       <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extension-maven-plugin</artifactId>
+        <version>${version.quarkus}</version>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>extension-descriptor</goal>
+            </goals>
+            <configuration>
+              <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>      
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <annotationProcessorPaths>

--- a/quarkus-extension/engine/runtime/src/main/resources/META-INF/quarkus-extension.properties
+++ b/quarkus-extension/engine/runtime/src/main/resources/META-INF/quarkus-extension.properties
@@ -1,1 +1,0 @@
-deployment-artifact=${project.groupId}\:${project.artifactId}-deployment\:${project.version}

--- a/quarkus-extension/engine/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/quarkus-extension/engine/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,16 +1,16 @@
 ---
 artifact: ${project.groupId}:${project.artifactId}:${project.version}
-name: "Camunda Platform Engine"
-description: "Quarkus Extension for the Camunda Platform Engine"
+name: "Camunda Platform 7 Engine"
+description: "Quarkus Extension for the Camunda Platform 7 Engine"
 metadata:
   keywords:
     - "camunda"
-    - "camunda-platform"
+    - "camunda-7"
+    - "camunda-platform-7"
     - "processes"
     - "decisions"
     - "bpmn"
     - "dmn"
-  guide: "https://docs.camunda.org/manual/"
+  guide: "https://docs.camunda.org/manual/latest/user-guide/quarkus-integration/"
   categories:
     - "business-automation"
-  status: "preview"


### PR DESCRIPTION
- This plugin is needed to fill the missing parts in the extension descriptor