### PR TITLE
fix(engine): adjust exception handling in external tasks

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/HandleExternalTaskCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/HandleExternalTaskCmd.java
@@ -60,6 +60,7 @@ public abstract class HandleExternalTaskCmd extends ExternalTaskCmd {
     try {
       execute(externalTask);
     } catch (NotFoundException e) {
+      // wrap up NotFoundExceptions reported for entities different than external tasks
       throw new ProcessEngineException(e.getMessage(), e);
     }
 

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.shouldThrowProcessEngineExceptionWhenOtherResourceIsNotFound.bpmn20.xml
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.shouldThrowProcessEngineExceptionWhenOtherResourceIsNotFound.bpmn20.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0cv21hf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.7.0">
+  <bpmn:process id="oneExternalAndScriptTask" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0h3dhqj</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0h3dhqj" sourceRef="StartEvent_1" targetRef="Activity_0vvwq4z" />
+    <bpmn:serviceTask id="Activity_0vvwq4z" name="ExternalTask" camunda:type="external" camunda:topic="externalTaskTopic">
+      <bpmn:extensionElements />
+      <bpmn:incoming>Flow_0h3dhqj</bpmn:incoming>
+      <bpmn:outgoing>Flow_0a7f6ee</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1wwk2pk">
+      <bpmn:incoming>Flow_0epsz8z</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0a7f6ee" sourceRef="Activity_0vvwq4z" targetRef="Activity_13x3lm7" />
+    <bpmn:sequenceFlow id="Flow_0epsz8z" sourceRef="Activity_13x3lm7" targetRef="Event_1wwk2pk" />
+    <bpmn:scriptTask id="Activity_13x3lm7" name="ScriptTask" scriptFormat="groovy" camunda:resource="foo">
+      <bpmn:incoming>Flow_0a7f6ee</bpmn:incoming>
+      <bpmn:outgoing>Flow_0epsz8z</bpmn:outgoing>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="oneExternalAndScriptTask">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0r35yvc_di" bpmnElement="Activity_0vvwq4z">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1qcnpv4_di" bpmnElement="Activity_13x3lm7">
+        <dc:Bounds x="440" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1wwk2pk_di" bpmnElement="Event_1wwk2pk">
+        <dc:Bounds x="612" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0h3dhqj_di" bpmnElement="Flow_0h3dhqj">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0a7f6ee_di" bpmnElement="Flow_0a7f6ee">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="440" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0epsz8z_di" bpmnElement="Flow_0epsz8z">
+        <di:waypoint x="540" y="117" />
+        <di:waypoint x="612" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
prevent throwing NotFoundExceptions for other resources instead throw a ProcessEngineException

https://github.com/camunda/camunda-bpm-platform/issues/3138