### PR TITLE
chore(webapps): prettier overrides editorconfig

### DIFF
--- a/webapps/frontend/.prettierrc
+++ b/webapps/frontend/.prettierrc
@@ -3,5 +3,7 @@
   "semi": true,
   "singleQuote": true,
   "bracketSpacing": false,
-  "endOfLine": "auto"
+  "endOfLine": "auto",
+  "printWidth": 80,
+  "useTabs": false
 }


### PR DESCRIPTION
* Prettier respects the `.editorconfig` file in the `camunda/camunda-bpm-release-scripts`.
* `.editorconfig` can be overridden via `.prettierrc`.

related to camunda/camunda-bpm-platform#2748