### PR TITLE
docs(engine-rest): External Tasks File Base64

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/VariableValueDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/VariableValueDto.ftl
@@ -5,7 +5,8 @@
         name = "value"
         type = "ref"
         dto = "AnyValue"
-        desc = "The variable's value. Value differs depending on the variable's type and on the deserializeValues parameter."/>
+        desc = "The variable's value. Value differs depending on the variable's type and on the deserializeValues parameter.
+                For variables of type File the value has to be submitted as Base64 encoded string."/>
 
     <@lib.property
         name = "type"


### PR DESCRIPTION
Add a note that variable values of type 'File' need to be Base64 encoded. The same note exists for the JS implementation. For java clients, the Base64 encoding is done within the external task client. For custom implementation (e.g. other languages), this hint could be helpful.