### PR TITLE
Integrate revoke stages into engine unit tests

### DIFF
--- a/.ci/config/matrices.yaml
+++ b/.ci/config/matrices.yaml
@@ -21,7 +21,6 @@ engine-webapp-unit:
   - 'sqlserver_2019'
   stages:
   - 'db-unit'
-  - 'db-unit-authorizations'
 engine-rest:
   stages:
   - 'engine-rest-unit-jersey-2'
@@ -51,7 +50,6 @@ sidetrack-stages:
   - 'azure_sql_db_150'
   stages:
   - 'db-unit'
-  - 'db-unit-authorizations'
   - 'sql-scripts'
   - 'instance-migration'
   - 'old-engine'

--- a/.ci/config/stage-types.yaml
+++ b/.ci/config/stage-types.yaml
@@ -34,15 +34,6 @@ db-unit:
   - 'sqlserver'
   - 'postgresql'
   - 'cockroachdb'
-  - 'authorizations'
-  jdkVersion: 'openjdk-jdk-11-latest'
-db-unit-authorizations:
-  directory: '.'
-  command: 'clean package -pl "engine,webapps/assembly,webapps/assembly-jakarta" -Dskip.frontend.build=true -PcfgAuthorizationCheckRevokesAlways,'
-  stash:
-    runtimeStash: true
-  labels:
-  - 'authorizations'
   jdkVersion: 'openjdk-jdk-11-latest'
 sql-scripts:
   directory: 'distro/sql-script'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ pipeline {
               upstreamProjectName = "/" + env.JOB_NAME
               upstreamBuildNumber = env.BUILD_NUMBER
 
-              if (env.BRANCH_NAME == cambpmDefaultBranch() || cambpmWithLabels('webapp-integration', 'all-as', 'h2', 'websphere', 'weblogic', 'jbosseap', 'run', 'spring-boot', 'authorizations', 'e2e')) {
+              if (env.BRANCH_NAME == cambpmDefaultBranch() || cambpmWithLabels('webapp-integration', 'all-as', 'h2', 'websphere', 'weblogic', 'jbosseap', 'run', 'spring-boot', 'e2e')) {
                 cambpmTriggerDownstream(
                   platformVersionDir + "/cambpm-ee/" + eeMainProjectBranch,
                   [string(name: 'UPSTREAM_PROJECT_NAME', value: upstreamProjectName),
@@ -102,7 +102,7 @@ pipeline {
               // or PR builds only, master builds should be excluded.
               // The Sidetrack pipeline contains CRDB and Azure DB stages,
               // triggered with the cockroachdb and sqlserver PR labels.
-              if (env.BRANCH_NAME != cambpmDefaultBranch() && cambpmWithLabels('all-db', 'cockroachdb', 'sqlserver', 'authorizations')) {
+              if (env.BRANCH_NAME != cambpmDefaultBranch() && cambpmWithLabels('all-db', 'cockroachdb', 'sqlserver')) {
                 cambpmTriggerDownstream(
                   platformVersionDir + "/cambpm-ce/cambpm-sidetrack/${env.BRANCH_NAME}",
                   [string(name: 'UPSTREAM_PROJECT_NAME', value: upstreamProjectName),
@@ -143,7 +143,7 @@ pipeline {
         stage('db-UNIT-h2') {
           when {
             expression {
-              cambpmWithLabels('h2', 'rolling-update', 'migration', 'all-db', 'default-build', 'authorizations')
+              cambpmWithLabels('h2', 'rolling-update', 'migration', 'all-db', 'default-build')
             }
           }
           steps {
@@ -155,25 +155,6 @@ pipeline {
               postFailure: {
                 cambpmPublishTestResult()
                 cambpmAddFailedStageType(failedStageTypes, 'db-unit')
-              }
-            ])
-          }
-        }
-        stage('db-UNIT-authorizations-h2') {
-          when {
-            expression {
-              cambpmWithLabels('h2', 'authorizations')
-            }
-          }
-          steps {
-            cambpmConditionalRetry([
-              agentLabel: 'h2',
-              runSteps: {
-                cambpmRunMavenByStageType('db-unit-authorizations', 'h2')
-              },
-              postFailure: {
-                cambpmPublishTestResult()
-                cambpmAddFailedStageType(failedStageTypes, 'db-unit-authorizations')
               }
             ])
           }

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -641,13 +641,6 @@
     </profile>
 
     <profile>
-      <id>cfgAuthorizationCheckRevokesAlways</id>
-      <properties>
-        <authorizationCheckRevokes>always</authorizationCheckRevokes>
-      </properties>
-    </profile>
-
-    <profile>
       <id>cfgJdbcBatchProcessingOff</id>
       <properties>
         <jdbcBatchProcessing>false</jdbcBatchProcessing>

--- a/engine/src/main/java/org/camunda/bpm/engine/test/ProcessEngineRule.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/test/ProcessEngineRule.java
@@ -20,7 +20,6 @@ import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
 import org.camunda.bpm.engine.AuthorizationService;
 import org.camunda.bpm.engine.CaseService;
 import org.camunda.bpm.engine.DecisionService;
@@ -153,7 +152,14 @@ public class ProcessEngineRule extends TestWatcher implements ProcessEngineServi
 
   @Override
   public void starting(Description description) {
-    deploymentId = TestHelper.annotationDeploymentSetUp(processEngine, description.getTestClass(), description.getMethodName(),
+    String methodName = description.getMethodName();
+    if (methodName != null) {
+      // cut off method variant suffix "[variant name]" for parameterized tests
+      int methodNameVariantStart = description.getMethodName().indexOf('[');
+      int methodNameEnd = methodNameVariantStart < 0 ? description.getMethodName().length() : methodNameVariantStart;
+      methodName = description.getMethodName().substring(0, methodNameEnd);
+    }
+    deploymentId = TestHelper.annotationDeploymentSetUp(processEngine, description.getTestClass(), methodName,
         description.getAnnotation(Deployment.class));
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/AuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/AuthorizationTest.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
-
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.authorization.Authorization;
 import org.camunda.bpm.engine.authorization.Permission;
@@ -57,10 +57,15 @@ import org.camunda.bpm.engine.variable.VariableMap;
 import org.camunda.bpm.engine.variable.Variables;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 /**
  * @author Roman Smirnov
  */
+@RunWith(Parameterized.class)
 public abstract class AuthorizationTest extends PluggableProcessEngineTest {
 
   protected String userId = "test";
@@ -72,6 +77,22 @@ public abstract class AuthorizationTest extends PluggableProcessEngineTest {
   protected static final String VARIABLE_VALUE = "aVariableValue";
   protected List<String> deploymentIds = new ArrayList<>();
 
+  @Parameter(0)
+  public String authorizationRevokeMode;
+  protected String defaultAuthorizationRevokeMode;
+
+  /**
+   * Parameters:
+   * authorizationRevokeMode: The revoke authorization mode to use in engine configuration
+   */
+  @Parameters(name = "revoke check mode {0}")
+  public static List<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+        { ProcessEngineConfiguration.AUTHORIZATION_CHECK_REVOKE_ALWAYS },
+        { ProcessEngineConfiguration.AUTHORIZATION_CHECK_REVOKE_AUTO }
+    });
+  }
+
   @Before
   public void setUp() throws Exception {
     user = createUser(userId);
@@ -81,11 +102,15 @@ public abstract class AuthorizationTest extends PluggableProcessEngineTest {
 
     identityService.setAuthentication(userId, Arrays.asList(groupId));
     processEngineConfiguration.setAuthorizationEnabled(true);
+
+    defaultAuthorizationRevokeMode = processEngineConfiguration.getAuthorizationCheckRevokes();
+    processEngineConfiguration.setAuthorizationCheckRevokes(authorizationRevokeMode);
   }
 
   @After
   public void tearDown() {
     processEngineConfiguration.setAuthorizationEnabled(false);
+    processEngineConfiguration.setAuthorizationCheckRevokes(defaultAuthorizationRevokeMode);
     for (User user : identityService.createUserQuery().list()) {
       identityService.deleteUser(user.getId());
     }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/DeploymentAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/DeploymentAuthorizationTest.java
@@ -44,7 +44,6 @@ import org.camunda.bpm.engine.authorization.AuthorizationQuery;
 import org.camunda.bpm.engine.authorization.Groups;
 import org.camunda.bpm.engine.authorization.Resources;
 import org.camunda.bpm.engine.authorization.SystemPermissions;
-import org.camunda.bpm.engine.impl.AbstractQuery;
 import org.camunda.bpm.engine.repository.Deployment;
 import org.camunda.bpm.engine.repository.DeploymentQuery;
 import org.camunda.bpm.engine.repository.Resource;
@@ -897,10 +896,6 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   // helper /////////////////////////////////////////////////////////
-
-  protected void verifyQueryResults(DeploymentQuery query, int countExpected) {
-    verifyQueryResults((AbstractQuery<?, ?>) query, countExpected);
-  }
 
   protected String createDeployment(String name) {
     return createDeployment(name, FIRST_RESOURCE, SECOND_RESOURCE).getId();

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/DeploymentAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/DeploymentAuthorizationTest.java
@@ -35,7 +35,6 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
 import org.camunda.bpm.application.ProcessApplicationReference;
 import org.camunda.bpm.application.ProcessApplicationRegistration;
 import org.camunda.bpm.application.impl.EmbeddedProcessApplication;
@@ -153,6 +152,21 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
 
     // then
     verifyQueryResults(query, 2);
+  }
+
+  @Test
+  public void shouldNotFindDeploymentWithRevokedReadPermissionOnAnyDeployment() {
+    // given
+    createDeployment("first");
+    createDeployment("second");
+    createGrantAuthorization(DEPLOYMENT, ANY, ANY, READ);
+    createRevokeAuthorization(DEPLOYMENT, ANY, userId, READ);
+
+    // when
+    DeploymentQuery query = repositoryService.createDeploymentQuery();
+
+    // then
+    verifyQueryResults(query, 0);
   }
 
   // create deployment ///////////////////////////////////////////////

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/DeploymentStatisticsAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/DeploymentStatisticsAuthorizationTest.java
@@ -27,8 +27,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.List;
-
-import org.camunda.bpm.engine.impl.AbstractQuery;
 import org.camunda.bpm.engine.management.DeploymentStatistics;
 import org.camunda.bpm.engine.management.DeploymentStatisticsQuery;
 import org.camunda.bpm.engine.management.IncidentStatistics;
@@ -50,6 +48,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   protected String secondDeploymentId;
   protected String thirdDeploymentId;
 
+  @Override
   @Before
   public void setUp() throws Exception {
     firstDeploymentId = createDeployment("first", "org/camunda/bpm/engine/test/api/authorization/oneIncidentProcess.bpmn20.xml").getId();
@@ -58,6 +57,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
     super.setUp();
   }
 
+  @Override
   @After
   public void tearDown() {
     super.tearDown();
@@ -122,6 +122,19 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
     for (DeploymentStatistics statistics : result) {
       verifyStatisticsResult(statistics, 0, 0, 0);
     }
+  }
+
+  @Test
+  public void shouldNotFindStatisticsWithRevokedReadPermissionOnAnyDeployment() {
+    // given
+    createGrantAuthorization(DEPLOYMENT, ANY, ANY, READ);
+    createRevokeAuthorization(DEPLOYMENT, ANY, userId, READ);
+
+    // when
+    DeploymentStatisticsQuery query = managementService.createDeploymentStatisticsQuery();
+
+    // then
+    verifyQueryResults(query, 0);
   }
 
   // deployment statistics query (including process instances) /////////////////////////////////////////////
@@ -781,10 +794,6 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   // helper ///////////////////////////////////////////////////////////////////////////
-
-  protected void verifyQueryResults(DeploymentStatisticsQuery query, int countExpected) {
-    verifyQueryResults((AbstractQuery<?, ?>) query, countExpected);
-  }
 
   protected void verifyStatisticsResult(DeploymentStatistics statistics, int instances, int failedJobs, int incidents) {
     assertEquals("Instances", instances, statistics.getInstances());

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/ExecutionAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/ExecutionAuthorizationTest.java
@@ -24,7 +24,6 @@ import static org.camunda.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import org.camunda.bpm.engine.impl.AbstractQuery;
 import org.camunda.bpm.engine.runtime.Execution;
 import org.camunda.bpm.engine.runtime.ExecutionQuery;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
@@ -40,6 +39,7 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
   protected static final String ONE_TASK_PROCESS_KEY = "oneTaskProcess";
   protected static final String MESSAGE_BOUNDARY_PROCESS_KEY = "messageBoundaryProcess";
 
+  @Override
   @Before
   public void setUp() throws Exception {
     testRule.deploy(
@@ -106,6 +106,20 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
 
     // then
     verifyQueryResults(query, 1);
+  }
+
+  @Test
+  public void shouldNotFindExecutionWithRevokedReadPermissionOnProcess() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
+    createGrantAuthorization(PROCESS_INSTANCE, ANY, ANY, READ);
+    createRevokeAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
+
+    // when
+    ExecutionQuery query = runtimeService.createExecutionQuery();
+
+    // then
+    verifyQueryResults(query, 0);
   }
 
   @Test
@@ -262,7 +276,4 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
     verifyQueryResults(query, 2);
   }
 
-  protected void verifyQueryResults(ExecutionQuery query, int countExpected) {
-    verifyQueryResults((AbstractQuery<?, ?>) query, countExpected);
-  }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/JobDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/JobDefinitionAuthorizationTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.camunda.bpm.engine.AuthorizationException;
-import org.camunda.bpm.engine.impl.AbstractQuery;
 import org.camunda.bpm.engine.management.JobDefinition;
 import org.camunda.bpm.engine.management.JobDefinitionQuery;
 import org.camunda.bpm.engine.runtime.Job;
@@ -44,6 +43,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   protected static final String TIMER_START_PROCESS_KEY = "timerStartProcess";
   protected static final String TIMER_BOUNDARY_PROCESS_KEY = "timerBoundaryProcess";
 
+  @Override
   @Before
   public void setUp() throws Exception {
     testRule.deploy(
@@ -100,6 +100,19 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
 
     // then
     verifyQueryResults(query, 2);
+  }
+
+  @Test
+  public void shouldNotFindJobDefinitionWithRevokedReadPermissionOnProcessDefinition() {
+    // given
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ);
+    createRevokeAuthorization(PROCESS_DEFINITION, TIMER_START_PROCESS_KEY, userId, READ);
+
+    // when
+    JobDefinitionQuery query = managementService.createJobDefinitionQuery();
+
+    // then
+    verifyQueryResults(query, 0);
   }
 
   // suspend job definition by id ///////////////////////////////
@@ -1112,10 +1125,6 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   // helper /////////////////////////////////////////////////////
-
-  protected void verifyQueryResults(JobDefinitionQuery query, int countExpected) {
-    verifyQueryResults((AbstractQuery<?, ?>) query, countExpected);
-  }
 
   protected JobDefinition selectJobDefinitionByProcessDefinitionKey(String processDefinitionKey) {
     disableAuthorization();

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/ProcessDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/ProcessDefinitionAuthorizationTest.java
@@ -36,12 +36,10 @@ import static org.junit.Assert.fail;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
-
 import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.authorization.Authorization;
 import org.camunda.bpm.engine.authorization.ProcessDefinitionPermissions;
 import org.camunda.bpm.engine.authorization.ProcessInstancePermissions;
-import org.camunda.bpm.engine.impl.AbstractQuery;
 import org.camunda.bpm.engine.impl.RepositoryServiceImpl;
 import org.camunda.bpm.engine.impl.pvm.ReadOnlyProcessDefinition;
 import org.camunda.bpm.engine.repository.CalledProcessDefinition;
@@ -63,6 +61,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   protected static final String ONE_TASK_PROCESS_KEY = "oneTaskProcess";
   protected static final String TWO_TASKS_PROCESS_KEY = "twoTasksProcess";
 
+  @Override
   @Before
   public void setUp() throws Exception {
     testRule.deploy(
@@ -1339,10 +1338,6 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   // helper /////////////////////////////////////////////////////////////////////
-
-  protected void verifyQueryResults(ProcessDefinitionQuery query, int countExpected) {
-    verifyQueryResults((AbstractQuery<?, ?>) query, countExpected);
-  }
 
   protected void verifyProcessDefinitionSuspendedByKeyIncludingInstances() {
     ProcessDefinition definition = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/SetTaskPropertyAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/SetTaskPropertyAuthorizationTest.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import org.camunda.bpm.engine.AuthorizationException;
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.util.ClockTestUtil;
@@ -40,11 +41,9 @@ import org.camunda.bpm.engine.test.util.TriConsumer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-@RunWith(Parameterized.class)
 public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
 
   protected static final String PROCESS_KEY = "oneTaskProcess";
@@ -52,10 +51,14 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
   @Rule
   public EntityRemoveRule entityRemoveRule = EntityRemoveRule.of(testRule);
 
-  protected final String operationName;
-  protected final TriConsumer<TaskService, String, Object> operation;
-  protected final String taskId;
-  protected final Object value;
+  @Parameter(1)
+  public String operationName;
+  @Parameter(2)
+  public TriConsumer<TaskService, String, Object> operation;
+  @Parameter(3)
+  public String taskId;
+  @Parameter(4)
+  public Object value;
 
   protected boolean deleteTask;
 
@@ -67,7 +70,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
    * setValue: The value to use to set property to
    * taskQueryBuilderMethodName: The corresponding taskQuery builder method name to use for assertion purposes
    */
-  @Parameters(name = "{0}")
+  @Parameters(name = "{1} (mode {0})")
   public static List<Object[]> data() {
     TriConsumer<TaskService, String, Object> setPriority = (taskService, taskId, value) -> taskService.setPriority(taskId, (int) value);
     TriConsumer<TaskService, String, Object> setName = (taskService, taskId, value) -> taskService.setName(taskId, (String) value);
@@ -76,22 +79,20 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
     TriConsumer<TaskService, String, Object> setFollowUpDate = (taskService, taskId, value) -> taskService.setFollowUpDate(taskId, (Date) value);
 
     return Arrays.asList(new Object[][] {
-        { "setPriority", setPriority, "taskId", 80 },
-        { "setName", setName, "taskId", "name" },
-        { "setDescription", setDescription, "taskId", "description" },
-        { "setDueDate", setDueDate, "taskId",  ClockTestUtil.setClockToDateWithoutMilliseconds() },
-        { "setFollowUpDate", setFollowUpDate, "taskId", ClockTestUtil.setClockToDateWithoutMilliseconds() }
+        { ProcessEngineConfiguration.AUTHORIZATION_CHECK_REVOKE_ALWAYS, "setPriority", setPriority, "taskId", 80 },
+        { ProcessEngineConfiguration.AUTHORIZATION_CHECK_REVOKE_ALWAYS, "setName", setName, "taskId", "name" },
+        { ProcessEngineConfiguration.AUTHORIZATION_CHECK_REVOKE_ALWAYS, "setDescription", setDescription, "taskId", "description" },
+        { ProcessEngineConfiguration.AUTHORIZATION_CHECK_REVOKE_ALWAYS, "setDueDate", setDueDate, "taskId",  ClockTestUtil.setClockToDateWithoutMilliseconds() },
+        { ProcessEngineConfiguration.AUTHORIZATION_CHECK_REVOKE_ALWAYS, "setFollowUpDate", setFollowUpDate, "taskId", ClockTestUtil.setClockToDateWithoutMilliseconds() },
+        { ProcessEngineConfiguration.AUTHORIZATION_CHECK_REVOKE_AUTO, "setPriority", setPriority, "taskId", 80 },
+        { ProcessEngineConfiguration.AUTHORIZATION_CHECK_REVOKE_AUTO, "setName", setName, "taskId", "name" },
+        { ProcessEngineConfiguration.AUTHORIZATION_CHECK_REVOKE_AUTO, "setDescription", setDescription, "taskId", "description" },
+        { ProcessEngineConfiguration.AUTHORIZATION_CHECK_REVOKE_AUTO, "setDueDate", setDueDate, "taskId",  ClockTestUtil.setClockToDateWithoutMilliseconds()},
+        { ProcessEngineConfiguration.AUTHORIZATION_CHECK_REVOKE_AUTO, "setFollowUpDate", setFollowUpDate, "taskId", ClockTestUtil.setClockToDateWithoutMilliseconds() }
     });
   }
 
-  // Constructor to pass data entries to parameterized test instance instance fields
-  public SetTaskPropertyAuthorizationTest(String operationName, TriConsumer<TaskService, String, Object> operation, String taskId, Object value) {
-    this.operationName = operationName;
-    this.operation = operation;
-    this.taskId = taskId;
-    this.value = value;
-  }
-
+  @Override
   @Before
   public void setUp() throws Exception {
     testRule.deploy("org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml");

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/TaskAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/TaskAuthorizationTest.java
@@ -213,8 +213,8 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   public void shouldNotFindTaskWithRevokedReadTaskPermissionOnDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
-    createGrantAuthorization(PROCESS_DEFINITION, ANY, "*", ALL);
-    createGrantAuthorization(TASK, ANY, "*", ALL);
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, ALL);
+    createGrantAuthorization(TASK, ANY, ANY, ALL);
     createRevokeAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_TASK);
 
     // when

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/batch/BatchQueryAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/batch/BatchQueryAuthorizationTest.java
@@ -16,9 +16,10 @@
  */
 package org.camunda.bpm.engine.test.api.authorization.batch;
 
+import static org.camunda.bpm.engine.authorization.Authorization.ANY;
+
 import java.util.Arrays;
 import java.util.List;
-
 import org.camunda.bpm.engine.authorization.Permissions;
 import org.camunda.bpm.engine.authorization.Resources;
 import org.camunda.bpm.engine.batch.Batch;
@@ -135,7 +136,7 @@ public class BatchQueryAuthorizationTest {
   @Test
   public void testQueryListAccessAll() {
     // given
-    authRule.createGrantAuthorization(Resources.BATCH, "*", "user", Permissions.READ);
+    authRule.createGrantAuthorization(Resources.BATCH, ANY, "user", Permissions.READ);
 
     // when
     authRule.enableAuthorization("user");
@@ -150,7 +151,7 @@ public class BatchQueryAuthorizationTest {
   public void testQueryListMultiple() {
     // given
     authRule.createGrantAuthorization(Resources.BATCH, batch1.getId(), "user", Permissions.READ);
-    authRule.createGrantAuthorization(Resources.BATCH, "*", "user", Permissions.READ);
+    authRule.createGrantAuthorization(Resources.BATCH, ANY, "user", Permissions.READ);
 
     // when
     authRule.enableAuthorization("user");
@@ -159,5 +160,35 @@ public class BatchQueryAuthorizationTest {
 
     // then
     Assert.assertEquals(2, batches.size());
+  }
+
+  @Test
+  public void shouldFindEmptyBatchListWithRevokedReadPermissionOnAllBatches() {
+    // given
+    authRule.createGrantAuthorization(Resources.BATCH, ANY, ANY, Permissions.READ);
+    authRule.createRevokeAuthorization(Resources.BATCH, ANY, "user", Permissions.READ);
+
+    // when
+    authRule.enableAuthorization("user");
+    List<Batch> batches = engineRule.getManagementService().createBatchQuery().list();
+    authRule.disableAuthorization();
+
+    // then
+    Assert.assertEquals(0, batches.size());
+  }
+
+  @Test
+  public void shouldFindNoBatchWithRevokedReadPermissionOnAllBatches() {
+    // given
+    authRule.createGrantAuthorization(Resources.BATCH, ANY, ANY, Permissions.READ);
+    authRule.createRevokeAuthorization(Resources.BATCH, ANY, "user", Permissions.READ);
+
+    // when
+    authRule.enableAuthorization("user");
+    long batchCount = engineRule.getManagementService().createBatchQuery().count();
+    authRule.disableAuthorization();
+
+    // then
+    Assert.assertEquals(0L, batchCount);
   }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/dmn/DecisionDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/dmn/DecisionDefinitionAuthorizationTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.io.InputStream;
-
 import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.repository.DecisionDefinition;
 import org.camunda.bpm.engine.repository.DecisionDefinitionQuery;
@@ -43,6 +42,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   protected static final String PROCESS_KEY = "testProcess";
   protected static final String DECISION_DEFINITION_KEY = "sampleDecision";
 
+  @Override
   @Before
   public void setUp() throws Exception {
     testRule.deploy(
@@ -100,6 +100,18 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
 
     // then
     verifyQueryResults(query, 2);
+  }
+
+  @Test
+  public void shouldNotFindDefinitionWithRevokedReadPermissionOnDefinition() {
+    createGrantAuthorization(DECISION_DEFINITION, ANY, ANY, READ);
+    createRevokeAuthorization(DECISION_DEFINITION, ANY, userId, READ);
+
+    // when
+    DecisionDefinitionQuery query = repositoryService.createDecisionDefinitionQuery();
+
+    // then
+    verifyQueryResults(query, 0);
   }
 
   @Test

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/dmn/DecisionRequirementsDefinitionQueryAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/dmn/DecisionRequirementsDefinitionQueryAuthorizationTest.java
@@ -21,13 +21,12 @@ import static org.camunda.bpm.engine.authorization.Authorization.ANY;
 import static org.camunda.bpm.engine.authorization.Resources.DECISION_REQUIREMENTS_DEFINITION;
 import static org.camunda.bpm.engine.test.api.authorization.util.AuthorizationScenario.scenario;
 import static org.camunda.bpm.engine.test.api.authorization.util.AuthorizationSpec.grant;
-import static org.hamcrest.CoreMatchers.hasItems;
+import static org.camunda.bpm.engine.test.api.authorization.util.AuthorizationSpec.revoke;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-
 import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.authorization.Permissions;
 import org.camunda.bpm.engine.repository.DecisionRequirementsDefinition;
@@ -88,7 +87,12 @@ public class DecisionRequirementsDefinitionQueryAuthorizationTest {
           .withAuthorizations(
             grant(DECISION_REQUIREMENTS_DEFINITION, DEFINITION_KEY, "userId", Permissions.READ),
             grant(DECISION_REQUIREMENTS_DEFINITION, ANY, "userId", Permissions.READ))
-          .succeeds(), expectedDefinitions(DEFINITION_KEY, ANOTHER_DEFINITION_KEY) }
+          .succeeds(), expectedDefinitions(DEFINITION_KEY, ANOTHER_DEFINITION_KEY) },
+      { scenario()
+          .withAuthorizations(
+            grant(DECISION_REQUIREMENTS_DEFINITION, ANY, ANY, Permissions.READ),
+            revoke(DECISION_REQUIREMENTS_DEFINITION, ANY, "userId", Permissions.READ))
+          .succeeds(), expectedDefinitions() }
     });
   }
 
@@ -116,7 +120,7 @@ public class DecisionRequirementsDefinitionQueryAuthorizationTest {
 
     // then
     if (authRule.assertScenario(scenario)) {
-      assertThat(count).isEqualTo((long) expectedDefinitionKeys.length);
+      assertThat(count).isEqualTo(expectedDefinitionKeys.length);
 
       List<String> definitionKeys = getDefinitionKeys(definitions);
       assertThat(definitionKeys).containsExactlyInAnyOrder(expectedDefinitionKeys);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/externaltask/ExternalTaskQueryAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/externaltask/ExternalTaskQueryAuthorizationTest.java
@@ -38,6 +38,7 @@ public class ExternalTaskQueryAuthorizationTest extends AuthorizationTest {
   protected String instance1Id;
   protected String instance2Id;
 
+  @Override
   @Before
   public void setUp() throws Exception {
     deploymentId = testRule.deploy(
@@ -120,5 +121,18 @@ public class ExternalTaskQueryAuthorizationTest extends AuthorizationTest {
 
     // then
     verifyQueryResults(query, 2);
+  }
+
+  @Test
+  public void shouldNotFindTaskWithRevokedReadOnProcessInstance() {
+    // given
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
+    createRevokeAuthorization(PROCESS_INSTANCE, instance1Id, userId, READ);
+
+    // when
+    ExternalTaskQuery query = externalTaskService.createExternalTaskQuery();
+
+    // then
+    verifyQueryResults(query, 1);
   }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/externaltask/FetchExternalTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/externaltask/FetchExternalTaskAuthorizationTest.java
@@ -26,7 +26,6 @@ import static org.camunda.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
-
 import org.camunda.bpm.engine.externaltask.LockedExternalTask;
 import org.camunda.bpm.engine.test.api.authorization.AuthorizationTest;
 import org.junit.Before;
@@ -44,6 +43,7 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   protected String instance1Id;
   protected String instance2Id;
 
+  @Override
   @Before
   public void setUp() throws Exception {
     testRule.deploy(
@@ -243,4 +243,33 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
     assertEquals(instance1Id, tasks.get(0).getProcessInstanceId());
   }
 
+  @Test
+  public void shouldLockNoTaskWithRevokedUpdateInstanceOnAnyProcessDefinition() {
+    // given
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_INSTANCE, UPDATE_INSTANCE);
+    createRevokeAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
+
+    // when
+    List<LockedExternalTask> tasks = externalTaskService.fetchAndLock(5, WORKER_ID)
+      .topic("externalTaskTopic", LOCK_TIME)
+      .execute();
+
+    // then
+    assertEquals(0, tasks.size());
+  }
+
+  @Test
+  public void shouldNotLockAnyTaskWithRevokedUpdateInstancePermissionOnAnyProcessDefinition() {
+    // given
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_INSTANCE, UPDATE_INSTANCE);
+    createRevokeAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
+
+    // when
+    List<LockedExternalTask> tasks = externalTaskService.fetchAndLock(5, WORKER_ID)
+      .topic("externalTaskTopic", LOCK_TIME)
+      .execute();
+
+    // then
+    assertEquals(0, tasks.size());
+  }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/externaltask/FetchExternalTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/externaltask/FetchExternalTaskAuthorizationTest.java
@@ -244,10 +244,10 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldLockNoTaskWithRevokedUpdateInstanceOnAnyProcessDefinition() {
+  public void shouldLockNoTaskForProcessDefinitionWithRevokedUpdateInstancePermission() {
     // given
-    createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_INSTANCE, UPDATE_INSTANCE);
-    createRevokeAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE, UPDATE_INSTANCE);
+    createRevokeAuthorization(PROCESS_DEFINITION, "oneExternalTaskProcess", userId, UPDATE_INSTANCE);
 
     // when
     List<LockedExternalTask> tasks = externalTaskService.fetchAndLock(5, WORKER_ID)
@@ -255,21 +255,6 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
       .execute();
 
     // then
-    assertEquals(0, tasks.size());
-  }
-
-  @Test
-  public void shouldNotLockAnyTaskWithRevokedUpdateInstancePermissionOnAnyProcessDefinition() {
-    // given
-    createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_INSTANCE, UPDATE_INSTANCE);
-    createRevokeAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
-
-    // when
-    List<LockedExternalTask> tasks = externalTaskService.fetchAndLock(5, WORKER_ID)
-      .topic("externalTaskTopic", LOCK_TIME)
-      .execute();
-
-    // then
-    assertEquals(0, tasks.size());
+    assertEquals(1, tasks.size());
   }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricActivityInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricActivityInstanceAuthorizationTest.java
@@ -28,7 +28,6 @@ import org.camunda.bpm.engine.authorization.ProcessDefinitionPermissions;
 import org.camunda.bpm.engine.authorization.Resources;
 import org.camunda.bpm.engine.history.HistoricActivityInstanceQuery;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
-import org.camunda.bpm.engine.impl.AbstractQuery;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.RequiredHistoryLevel;
 import org.camunda.bpm.engine.test.api.authorization.AuthorizationTest;
@@ -362,12 +361,6 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
     assertThat(query.list())
         .extracting("processInstanceId")
         .containsExactly(processInstanceId, processInstanceId);
-  }
-
-  // helper ////////////////////////////////////////////////////////
-
-  protected void verifyQueryResults(HistoricActivityInstanceQuery query, int countExpected) {
-    verifyQueryResults((AbstractQuery<?, ?>) query, countExpected);
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricActivityInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricActivityInstanceAuthorizationTest.java
@@ -22,7 +22,6 @@ import static org.camunda.bpm.engine.authorization.Permissions.READ_HISTORY;
 import static org.camunda.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 
 import java.util.List;
-
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.authorization.HistoricProcessInstancePermissions;
 import org.camunda.bpm.engine.authorization.ProcessDefinitionPermissions;
@@ -49,6 +48,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
 
   protected String deploymentId;
 
+  @Override
   @Before
   public void setUp() throws Exception {
     deploymentId = createDeployment(null,
@@ -58,6 +58,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
     super.setUp();
   }
 
+  @Override
   @After
   public void tearDown() {
     super.tearDown();
@@ -117,6 +118,20 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
 
     // then
     verifyQueryResults(query, 2);
+  }
+
+  @Test
+  public void shouldNotFindInstanceWithRevokedReadHistoryPermissionOnAnyProcessDefinition() {
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_HISTORY);
+    createRevokeAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
+
+    // when
+    HistoricActivityInstanceQuery query = historyService.createHistoricActivityInstanceQuery();
+
+    // then
+    verifyQueryResults(query, 0);
   }
 
   // historic activity instance query (multiple process instances) ////////////////////////

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricActivityStatisticsAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricActivityStatisticsAuthorizationTest.java
@@ -134,8 +134,8 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
 
-    createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_HISTORY);
-    createRevokeAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
+    createRevokeAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
 
     // when
     HistoricActivityStatisticsQuery query = historyService.createHistoricActivityStatisticsQuery(processDefinitionId);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricActivityStatisticsAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricActivityStatisticsAuthorizationTest.java
@@ -23,11 +23,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.util.List;
-
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.history.HistoricActivityStatistics;
 import org.camunda.bpm.engine.history.HistoricActivityStatisticsQuery;
-import org.camunda.bpm.engine.impl.AbstractQuery;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.RequiredHistoryLevel;
 import org.camunda.bpm.engine.test.api.authorization.AuthorizationTest;
@@ -43,6 +41,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
 
   protected static final String PROCESS_KEY = "oneTaskProcess";
 
+  @Override
   @Before
   public void setUp() throws Exception {
     testRule.deploy(
@@ -124,6 +123,25 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
     // then
     verifyQueryResults(query, 1);
     verifyStatisticsResult(query.singleResult(), 3, 0, 0, 0);
+  }
+
+  @Test
+  public void shouldNotFindStatisticsWithRevokedReadHistoryPermissionOnAnyProcessDefinition() {
+    // given
+    String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
+
+    startProcessInstanceByKey(PROCESS_KEY);
+    startProcessInstanceByKey(PROCESS_KEY);
+    startProcessInstanceByKey(PROCESS_KEY);
+
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_HISTORY);
+    createRevokeAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
+
+    // when
+    HistoricActivityStatisticsQuery query = historyService.createHistoricActivityStatisticsQuery(processDefinitionId);
+
+    // then
+    verifyQueryResults(query, 0);
   }
 
   // historic activity statistics query (including finished) //////////////////////////////////
@@ -504,10 +522,6 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   }
 
   // helper ////////////////////////////////////////////////////////
-
-  protected void verifyQueryResults(HistoricActivityStatisticsQuery query, int countExpected) {
-    verifyQueryResults((AbstractQuery<?, ?>) query, countExpected);
-  }
 
   protected void verifyStatisticsResult(HistoricActivityStatistics statistics, int instances, int finished, int canceled, int completeScope) {
     assertEquals("Instances", instances, statistics.getInstances());

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricDetailAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricDetailAuthorizationTest.java
@@ -32,7 +32,6 @@ import org.camunda.bpm.engine.authorization.ProcessDefinitionPermissions;
 import org.camunda.bpm.engine.history.HistoricDetail;
 import org.camunda.bpm.engine.history.HistoricDetailQuery;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
-import org.camunda.bpm.engine.impl.AbstractQuery;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.RequiredHistoryLevel;
 import org.camunda.bpm.engine.test.api.authorization.AuthorizationTest;
@@ -1199,12 +1198,6 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
     assertThat(query.list())
         .extracting("processInstanceId")
         .containsExactly(processInstanceId);
-  }
-
-  // helper ////////////////////////////////////////////////////////
-
-  protected void verifyQueryResults(HistoricDetailQuery query, int countExpected) {
-    verifyQueryResults((AbstractQuery<?, ?>) query, countExpected);
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricDetailAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricDetailAuthorizationTest.java
@@ -25,7 +25,6 @@ import static org.camunda.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
-
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.authorization.HistoricProcessInstancePermissions;
 import org.camunda.bpm.engine.authorization.HistoricTaskPermissions;
@@ -54,6 +53,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
 
   protected String deploymentId;
 
+  @Override
   @Before
   public void setUp() throws Exception {
     deploymentId = testRule.deploy(
@@ -64,6 +64,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
     super.setUp();
   }
 
+  @Override
   @After
   public void tearDown() {
     super.tearDown();
@@ -144,6 +145,20 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
 
     // then
     verifyQueryResults(query, 1);
+  }
+
+  @Test
+  public void shouldNotFindDetailWithRevokedReadHistoryPermissionOnProcessDefinition() {
+    // given
+    startProcessInstanceByKey(PROCESS_KEY, getVariables());
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
+    createRevokeAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
+
+    // when
+    HistoricDetailQuery query = historyService.createHistoricDetailQuery().variableUpdates();
+
+    // then
+    verifyQueryResults(query, 0);
   }
 
   // historic variable update query (multiple process instances) ///////////////////////////////////////////

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricExternalTaskLogAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricExternalTaskLogAuthorizationTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import java.util.List;
-
 import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.authorization.HistoricProcessInstancePermissions;
@@ -53,6 +52,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   protected final String ERROR_DETAILS = "These are the error details!";
   protected final String ANOTHER_PROCESS_KEY = "AnotherProcess";
 
+  @Override
   @Before
   public void setUp() throws Exception {
     BpmnModelInstance defaultModel = createDefaultExternalTaskModel().build();
@@ -61,6 +61,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
     super.setUp();
   }
 
+  @Override
   @After
   public void tearDown() {
     super.tearDown();
@@ -157,6 +158,20 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
 
     // then
     verifyQueryResults(query, 8);
+  }
+
+  @Test
+  public void shouldNotFindLogsWithRevokedHistoryReadPermissionOnAnyProcessDefinition() {
+    // given
+    startThreeProcessInstancesDeleteOneAndCompleteTwoWithFailure();
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_HISTORY);
+    createRevokeAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
+
+    // when
+    HistoricExternalTaskLogQuery query = historyService.createHistoricExternalTaskLogQuery();
+
+    // then
+    verifyQueryResults(query, 0);
   }
 
   @Test

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricIdentityLinkLogAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricIdentityLinkLogAuthorizationTest.java
@@ -25,7 +25,6 @@ import static org.camunda.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
-
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.authorization.HistoricProcessInstancePermissions;
 import org.camunda.bpm.engine.authorization.HistoricTaskPermissions;
@@ -45,6 +44,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   protected static final String ONE_PROCESS_KEY = "demoAssigneeProcess";
   protected static final String CASE_KEY = "oneTaskCase";
 
+  @Override
   @Before
   public void setUp() throws Exception {
     testRule.deploy( "org/camunda/bpm/engine/test/api/authorization/oneTaskProcess.bpmn20.xml",
@@ -52,6 +52,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
     super.setUp();
   }
 
+  @Override
   @After
   public void tearDown() {
     super.tearDown();
@@ -135,6 +136,24 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
 
     // then
     verifyQueryResults(query, 1);
+  }
+
+  @Test
+  public void shouldNotFindLinkWithRevokedReadHistoryPermissionOnAnyProcessDefinition() {
+    // given
+    disableAuthorization();
+    startProcessInstanceByKey(ONE_PROCESS_KEY);
+
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
+    createRevokeAuthorization(PROCESS_DEFINITION, ONE_PROCESS_KEY, userId, READ_HISTORY);
+
+    enableAuthorization();
+
+    // when
+    HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
+
+    // then
+    verifyQueryResults(query, 0);
   }
 
   @Test

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricJobLogAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricJobLogAuthorizationTest.java
@@ -36,7 +36,6 @@ import org.camunda.bpm.engine.authorization.Resources;
 import org.camunda.bpm.engine.history.HistoricJobLog;
 import org.camunda.bpm.engine.history.HistoricJobLogQuery;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
-import org.camunda.bpm.engine.impl.AbstractQuery;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
@@ -577,12 +576,6 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
     assertThat(query.list())
         .extracting("jobDefinitionType", "processInstanceId")
         .containsExactly(tuple("batch-seed-job", null));
-  }
-
-  // helper ////////////////////////////////////////////////////////
-
-  protected void verifyQueryResults(HistoricJobLogQuery query, int countExpected) {
-    verifyQueryResults((AbstractQuery<?, ?>) query, countExpected);
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricJobLogAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricJobLogAuthorizationTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.fail;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-
 import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.authorization.HistoricProcessInstancePermissions;
@@ -63,6 +62,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   protected String batchId;
   protected String deploymentId;
 
+  @Override
   @Before
   public void setUp() throws Exception {
     deploymentId = testRule.deploy(
@@ -73,11 +73,13 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
     super.setUp();
   }
 
+  @Override
   @After
   public void tearDown() {
     super.tearDown();
     CommandExecutor commandExecutor = processEngineConfiguration.getCommandExecutorTxRequired();
     commandExecutor.execute(new Command<Object>() {
+      @Override
       public Object execute(CommandContext commandContext) {
         commandContext.getHistoricJobLogManager().deleteHistoricJobLogsByHandlerType(TimerSuspendProcessDefinitionHandler.TYPE);
         return null;
@@ -181,6 +183,20 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
 
     // then
     verifyQueryResults(query, 5);
+  }
+
+  @Test
+  public void shouldNotFindJobLogWithRevokedHistoryReadPermissionOnAnyProcessDefinition() {
+    // given
+    startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_HISTORY);
+    createRevokeAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
+
+    // when
+    HistoricJobLogQuery query = historyService.createHistoricJobLogQuery();
+
+    // then
+    verifyQueryResults(query, 0);
   }
 
   // historic job log query (multiple process instance) ////////////////////////////////////////////////

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricProcessInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricProcessInstanceAuthorizationTest.java
@@ -41,7 +41,6 @@ import org.camunda.bpm.engine.history.CleanableHistoricProcessInstanceReportResu
 import org.camunda.bpm.engine.history.DurationReportResult;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
 import org.camunda.bpm.engine.history.HistoricProcessInstanceQuery;
-import org.camunda.bpm.engine.impl.AbstractQuery;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.camunda.bpm.engine.query.PeriodUnit;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
@@ -907,10 +906,6 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   // helper ////////////////////////////////////////////////////////
-
-  protected void verifyQueryResults(HistoricProcessInstanceQuery query, int countExpected) {
-    verifyQueryResults((AbstractQuery<?, ?>) query, countExpected);
-  }
 
   protected void prepareProcessInstances(String key, int daysInThePast, Integer historyTimeToLive, int instanceCount) {
     ProcessDefinition processDefinition = selectProcessDefinitionByKey(key);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricProcessInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricProcessInstanceAuthorizationTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.fail;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
 import org.apache.commons.lang3.time.DateUtils;
 import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
@@ -66,6 +65,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
 
   protected String deploymentId;
 
+  @Override
   @Before
   public void setUp() throws Exception {
     deploymentId = testRule.deploy(
@@ -75,6 +75,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
     super.setUp();
   }
 
+  @Override
   @After
   public void tearDown() {
     super.tearDown();
@@ -141,6 +142,20 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
 
     // then
     verifyQueryResults(query, 1);
+  }
+
+  @Test
+  public void shouldNotFindInstanceWithRevokedReadHistoryPermissionOnAnyProcessDefinition() {
+    // given
+    startProcessInstanceByKey(PROCESS_KEY).getId();
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_HISTORY);
+    createRevokeAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
+
+    // when
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // then
+    verifyQueryResults(query, 0);
   }
 
   // historic process instance query (multiple process instances) ////////////////////////
@@ -650,6 +665,23 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
 
     // then
     assertEquals(0, reportResults.size());
+  }
+
+  @Test
+  public void shouldNotFindCleanupReportWithRevokedReadHistoryPermissionOnProcessDefinition() {
+    // given
+    prepareProcessInstances(PROCESS_KEY, -6, 5, 10);
+
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, Permissions.READ, Permissions.READ_HISTORY);
+    createRevokeAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, Permissions.READ_HISTORY);
+
+    List<CleanableHistoricProcessInstanceReportResult> reportResults = historyService.createCleanableHistoricProcessInstanceReport().list();
+
+    // then
+    assertEquals(1, reportResults.size());
+    assertEquals(MESSAGE_START_PROCESS_KEY, reportResults.get(0).getProcessDefinitionKey());
+    assertEquals(0, reportResults.get(0).getCleanableProcessInstanceCount());
+    assertEquals(0, reportResults.get(0).getFinishedProcessInstanceCount());
   }
 
   @Test

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricTaskInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricTaskInstanceAuthorizationTest.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.List;
-
 import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.authorization.Authorization;
@@ -46,7 +45,6 @@ import org.camunda.bpm.engine.history.HistoricProcessInstance;
 import org.camunda.bpm.engine.history.HistoricTaskInstance;
 import org.camunda.bpm.engine.history.HistoricTaskInstanceQuery;
 import org.camunda.bpm.engine.history.HistoricTaskInstanceReportResult;
-import org.camunda.bpm.engine.impl.AbstractQuery;
 import org.camunda.bpm.engine.query.PeriodUnit;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.RequiredHistoryLevel;
@@ -68,6 +66,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
 
   protected String deploymentId;
 
+  @Override
   @Before
   public void setUp() throws Exception {
     deploymentId = testRule.deploy(
@@ -78,6 +77,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
 
   }
 
+  @Override
   @After
   public void tearDown() {
     super.tearDown();
@@ -153,6 +153,20 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
 
     // then
     verifyQueryResults(query, 1);
+  }
+
+  @Test
+  public void shouldNottFindTaskWithRevokedReadHistoryPermissionOnProcessDefinition() {
+    // given
+    startProcessInstanceByKey(PROCESS_KEY);
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_HISTORY);
+    createRevokeAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
+
+    // when
+    HistoricTaskInstanceQuery query = historyService.createHistoricTaskInstanceQuery();
+
+    // then
+    verifyQueryResults(query, 0);
   }
 
   // historic task instance query (multiple process instances) ////////////////////////
@@ -1123,12 +1137,6 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
     assertThat(query.list())
         .extracting("processInstanceId")
         .containsExactly(processInstanceId);
-  }
-
-  // helper ////////////////////////////////////////////////////////
-
-  protected void verifyQueryResults(HistoricTaskInstanceQuery query, int countExpected) {
-    verifyQueryResults((AbstractQuery<?, ?>) query, countExpected);
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricVariableInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricVariableInstanceAuthorizationTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.util.List;
-
 import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.authorization.HistoricProcessInstancePermissions;
@@ -60,6 +59,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   protected boolean ensureSpecificVariablePermission;
   protected String deploymentId;
 
+  @Override
   @Before
   public void setUp() throws Exception {
     deploymentId = testRule.deploy(
@@ -72,6 +72,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
     super.setUp();
   }
 
+  @Override
   @After
   public void tearDown() {
     super.tearDown();
@@ -196,6 +197,21 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
 
     // then
     verifyQueryResults(query, 1);
+  }
+
+  @Test
+  public void shouldNotFindVariableWithRevokedReadHistoryVariablePermissionOnProcessDefinition() {
+    setReadHistoryVariableAsDefaultReadPermission();
+
+    startProcessInstanceByKey(PROCESS_KEY, getVariables());
+    createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_HISTORY_VARIABLE);
+    createRevokeAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY_VARIABLE);
+
+    // when
+    HistoricVariableInstanceQuery query = historyService.createHistoricVariableInstanceQuery();
+
+    // then
+    verifyQueryResults(query, 0);
   }
 
   // historic variable instance query (multiple process instances) ////////////////////////
@@ -455,7 +471,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   public void testDeleteHistoricProcessVariableInstanceWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
-    
+
     disableAuthorization();
     String variableInstanceId = historyService.createHistoricVariableInstanceQuery().singleResult().getId();
     assertEquals(1L, historyService.createHistoricDetailQuery().count());
@@ -474,13 +490,13 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
       testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
     }
   }
-  
+
   @Test
   public void testDeleteHistoricProcessVariableInstanceWithDeleteHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, DELETE_HISTORY);
-    
+
     disableAuthorization();
     String variableInstanceId = historyService.createHistoricVariableInstanceQuery().singleResult().getId();
     assertEquals(1L, historyService.createHistoricDetailQuery().count());
@@ -505,9 +521,9 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
     disableAuthorization();
     taskService.complete(taskId);
     enableAuthorization();
-    
+
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, DELETE_HISTORY);
-    
+
     disableAuthorization();
     repositoryService.deleteDeployment(deploymentId);
     String variableInstanceId = historyService.createHistoricVariableInstanceQuery().singleResult().getId();
@@ -524,13 +540,13 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
     verifyVariablesDeleted();
     cleanUpAfterDeploymentDeletion();
   }
-  
+
   // delete historic variable instance (case variables) /////////////////////////////////////////////
   @Test
   public void testDeleteHistoricCaseVariableInstance() {
     // given
     createCaseInstanceByKey(CASE_KEY, getVariables());
-    
+
     disableAuthorization();
     String variableInstanceId = historyService.createHistoricVariableInstanceQuery().singleResult().getId();
     assertEquals(1L, historyService.createHistoricDetailQuery().count());
@@ -542,7 +558,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
     // then
     verifyVariablesDeleted();
   }
-  
+
   // delete historic variable instance (task variables) /////////////////////////////////////////////
   @Test
   public void testDeleteHistoricStandaloneTaskVariableInstance() {
@@ -562,17 +578,17 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
     // then
     verifyVariablesDeleted();
     deleteTask(taskId, true);
-    
+
     // XXX if CAM-6570 is implemented, there should be a check for variables of standalone tasks here as well
   }
-  
+
   // delete historic variable instances (process variables) /////////////////////////////////////////////
   @Test
   public void testDeleteHistoricProcessVariableInstancesWithoutAuthorization() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY, getVariables());
     verifyVariablesCreated();
-    
+
     try {
       // when
       historyService.deleteHistoricVariableInstancesByProcessInstanceId(instance.getId());
@@ -593,7 +609,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY, getVariables());
     verifyVariablesCreated();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, DELETE_HISTORY);
-    
+
     try {
       // when
       historyService.deleteHistoricVariableInstancesByProcessInstanceId(instance.getId());
@@ -603,7 +619,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
     // then
     verifyVariablesDeleted();
   }
-  
+
   // delete deployment (cascade = false)
   @Test
   public void testDeleteHistoricProcessVariableInstancesAfterDeletingDeployment() {
@@ -613,10 +629,10 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
     disableAuthorization();
     taskService.complete(taskId);
     enableAuthorization();
-    
+
     verifyVariablesCreated();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, DELETE_HISTORY);
-    
+
     disableAuthorization();
     repositoryService.deleteDeployment(deploymentId);
     enableAuthorization();
@@ -627,7 +643,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
     } catch (AuthorizationException e) {
       fail("It should be possible to delete the historic variable instance with granted permissions after the process definition is deleted");
     }
-    
+
     // then
     verifyVariablesDeleted();
     cleanUpAfterDeploymentDeletion();
@@ -638,21 +654,21 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   protected void verifyQueryResults(HistoricVariableInstanceQuery query, int countExpected) {
     verifyQueryResults((AbstractQuery<?, ?>) query, countExpected);
   }
-  
+
   protected void verifyVariablesDeleted() {
     disableAuthorization();
     assertEquals(0L, historyService.createHistoricVariableInstanceQuery().count());
     assertEquals(0L, historyService.createHistoricDetailQuery().count());
     enableAuthorization();
   }
-  
+
   protected void verifyVariablesCreated() {
     disableAuthorization();
     assertEquals(1L, historyService.createHistoricVariableInstanceQuery().count());
     assertEquals(1L, historyService.createHistoricDetailQuery().count());
     enableAuthorization();
   }
-  
+
   protected void cleanUpAfterDeploymentDeletion() {
     disableAuthorization();
     List<HistoricProcessInstance> instances = historyService.createHistoricProcessInstanceQuery().list();

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricVariableInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/HistoricVariableInstanceAuthorizationTest.java
@@ -36,7 +36,6 @@ import org.camunda.bpm.engine.authorization.ProcessDefinitionPermissions;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
 import org.camunda.bpm.engine.history.HistoricVariableInstance;
 import org.camunda.bpm.engine.history.HistoricVariableInstanceQuery;
-import org.camunda.bpm.engine.impl.AbstractQuery;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.RequiredHistoryLevel;
@@ -650,10 +649,6 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   // helper ////////////////////////////////////////////////////////
-
-  protected void verifyQueryResults(HistoricVariableInstanceQuery query, int countExpected) {
-    verifyQueryResults((AbstractQuery<?, ?>) query, countExpected);
-  }
 
   protected void verifyVariablesDeleted() {
     disableAuthorization();

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/UserOperationLogAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/history/UserOperationLogAuthorizationTest.java
@@ -36,7 +36,6 @@ import static org.junit.Assert.fail;
 
 import java.util.Date;
 import java.util.List;
-
 import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.authorization.HistoricProcessInstancePermissions;
@@ -48,7 +47,6 @@ import org.camunda.bpm.engine.history.HistoricIncident;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
 import org.camunda.bpm.engine.history.UserOperationLogEntry;
 import org.camunda.bpm.engine.history.UserOperationLogQuery;
-import org.camunda.bpm.engine.impl.AbstractQuery;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.interceptor.Command;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
@@ -77,6 +75,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   protected String deploymentId;
   protected String taskId;
 
+  @Override
   @Before
   public void setUp() throws Exception {
     deploymentId = testRule.deploy(
@@ -87,6 +86,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     super.setUp();
   }
 
+  @Override
   @After
   public void tearDown() {
     super.tearDown();
@@ -115,90 +115,90 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     deleteTask(taskId, true);
   }
-  
+
   @Test
   public void testQueryCreateStandaloneTaskUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
     // given
     String taskId = "myTask";
     createTask(taskId);
-    
+
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ_HISTORY);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
-    
+
     // then
     verifyQueryResults(query, 0);
-    
+
     deleteTask(taskId, true);
   }
-  
+
   // CAM-9888
   public void failing_testQueryCreateStandaloneTaskUserOperationLogWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     String taskId = "myTask";
     createTask(taskId);
-    
+
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
-    
+
     // then
     verifyQueryResults(query, 0);
-    
+
     deleteTask(taskId, true);
   }
-  
+
   @Test
   public void testQueryCreateStandaloneTaskUserOperationLogWithReadPermissionOnCategory() {
     // given
     String taskId = "myTask";
     createTask(taskId);
-    
+
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, CATEGORY_TASK_WORKER, userId, READ);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
-    
+
     // then
     verifyQueryResults(query, 1);
-    
+
     deleteTask(taskId, true);
   }
-  
+
   @Test
   public void testQueryCreateStandaloneTaskUserOperationLogWithReadPermissionOnAnyCategory() {
     // given
     String taskId = "myTask";
     createTask(taskId);
-    
+
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, ANY, userId, READ);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
-    
+
     // then
     verifyQueryResults(query, 1);
-    
+
     deleteTask(taskId, true);
   }
-  
+
   @Test
   public void testQueryCreateStandaloneTaskUserOperationLogWithReadPermissionOnAnyCategoryAndRevokeReadHistoryOnProcessDefinition() {
     // given
     String taskId = "myTask";
     createTask(taskId);
-    
+
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, ANY, userId, READ);
     createRevokeAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ_HISTORY);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
-    
+
     // then
     verifyQueryResults(query, 1);// "revoke specific process definition" has no effect since task log is not related to a definition
-    
+
     deleteTask(taskId, true);
   }
 
@@ -207,17 +207,17 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     // given
     String taskId = "myTask";
     createTask(taskId);
-    
+
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, ANY, userId, READ);
     createRevokeAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
-    
+
     // then
-    // "grant all categories" should preceed over "revoke all process definitions" 
+    // "grant all categories" should preceed over "revoke all process definitions"
     verifyQueryResults(query, 1);
-    
+
     deleteTask(taskId, true);
   }
 
@@ -236,25 +236,25 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     deleteTask(taskId, true);
   }
-  
+
   @Test
   public void testQuerySetAssigneeStandaloneTaskUserOperationLogWithReadPermissionOnProcessDefinition() {
     // given
     String taskId = "myTask";
     createTask(taskId);
     setAssignee(taskId, "demo");
-    
+
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ_HISTORY);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
-    
+
     // then
     verifyQueryResults(query, 0);
-    
+
     deleteTask(taskId, true);
   }
-  
+
   // CAM-9888
   public void failing_testQuerySetAssigneeStandaloneTaskUserOperationLogWithReadPermissionOnAnyProcessDefinition() {
     // given
@@ -263,7 +263,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     setAssignee(taskId, "demo");
 
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
@@ -272,14 +272,14 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     deleteTask(taskId, true);
   }
-  
+
   @Test
   public void testQuerySetAssigneeStandaloneTaskUserOperationLogWithReadPermissionOnCategory() {
     // given
     String taskId = "myTask";
     createTask(taskId);
     setAssignee(taskId, "demo");
-    
+
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, CATEGORY_TASK_WORKER, userId, READ);
 
     // when
@@ -290,14 +290,14 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     deleteTask(taskId, true);
   }
-  
+
   @Test
   public void testQuerySetAssigneeStandaloneTaskUserOperationLogWithReadPermissionOnAnyCategory() {
     // given
     String taskId = "myTask";
     createTask(taskId);
     setAssignee(taskId, "demo");
-    
+
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, ANY, userId, READ);
 
     // when
@@ -799,7 +799,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     // then
     verifyQueryResults(query, 2);
   }
-  
+
   @Test
   public void testQuerySetAssigneeTaskUserOperationLogWithReadPermissionOnAnyCategoryAndRevokeOnProcessDefinition() {
     // given
@@ -816,7 +816,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     // then
     verifyQueryResults(query, 0);// "revoke process definition" wins over "grant all categories" since task log is related to the definition
   }
-  
+
   @Test
   public void testQuerySetAssigneeTaskUserOperationLogWithReadPermissionOnAnyCategoryAndRevokeOnUnrelatedProcessDefinition() {
     // given
@@ -833,7 +833,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     // then
     verifyQueryResults(query, 2);// "revoke process definition" has no effect since task log is not related to the definition
   }
-  
+
   @Test
   public void testQuerySetAssigneeTaskUserOperationLogWithReadPermissionOnAnyCategoryAndRevokeOnAnyProcessDefinition() {
     // given
@@ -866,7 +866,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     // then
     verifyQueryResults(query, 0);
   }
-  
+
   @Test
   public void testQuerySetAssigneeHumanTaskUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
     // given
@@ -875,14 +875,14 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     setAssignee(taskId, "demo");
 
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ONE_TASK_CASE_KEY, userId, READ_HISTORY);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
     // then
     verifyQueryResults(query, 0);
   }
-  
+
   // CAM-9888
   public void failing_testQuerySetAssigneeHumanTaskUserOperationLogWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
@@ -891,14 +891,14 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     setAssignee(taskId, "demo");
 
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
     // then
     verifyQueryResults(query, 0);
   }
-  
+
   @Test
   public void testQuerySetAssigneeHumanTaskUserOperationLogWithReadPermissionOnCategory() {
     // given
@@ -907,14 +907,14 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     setAssignee(taskId, "demo");
 
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, CATEGORY_TASK_WORKER, userId, READ);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
     // then
     verifyQueryResults(query, 1);
   }
-  
+
   @Test
   public void testQuerySetAssigneeHumanTaskUserOperationLogWithReadPermissionOnAnyCategory() {
     // given
@@ -923,7 +923,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     setAssignee(taskId, "demo");
 
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, ANY, userId, READ);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
@@ -957,24 +957,24 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     clearDatabase();
   }
-  
+
   @Test
   public void testQuerySetStandaloneJobRetriesUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
     // given
     disableAuthorization();
     repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, new Date());
     enableAuthorization();
-    
+
     disableAuthorization();
     String jobId = managementService.createJobQuery().singleResult().getId();
     managementService.setJobRetries(jobId, 5);
     enableAuthorization();
-    
+
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ_HISTORY);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
-    
+
     // then only user operation logs of non standalone jobs are visible
     verifyQueryResults(query, 2);
     assertEquals(ONE_TASK_PROCESS_KEY, query.list().get(0).getProcessDefinitionKey());
@@ -983,7 +983,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     disableAuthorization();
     managementService.deleteJob(jobId);
     enableAuthorization();
-    
+
     clearDatabase();
   }
 
@@ -1003,7 +1003,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
 
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
@@ -1016,7 +1016,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     clearDatabase();
   }
-  
+
   @Test
   public void testQuerySetStandaloneJobRetriesUserOperationLogWithReadPermissionOnCategory() {
     // given
@@ -1030,7 +1030,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
 
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, CATEGORY_OPERATOR, userId, READ);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
@@ -1044,7 +1044,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     clearDatabase();
   }
-  
+
   @Test
   public void testQuerySetStandaloneJobRetriesUserOperationLogWithReadPermissionOnAnyCategory() {
     // given
@@ -1058,7 +1058,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
 
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, ANY, userId, READ);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
@@ -1085,7 +1085,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
 
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, CATEGORY_TASK_WORKER, userId, READ);
-    
+
     // when
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
 
@@ -1155,7 +1155,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     // then
     verifyQueryResults(query, 2);
   }
-  
+
   @Test
   public void testQuerySetJobRetriesUserOperationLogWithReadPermissionOnCategory() {
     // given
@@ -1239,7 +1239,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     clearDatabase();
   }
-  
+
   @Test
   public void testQuerySuspendProcessDefinitionUserOperationLogWithReadHPermissionOnCategory() {
     // given
@@ -1254,7 +1254,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     clearDatabase();
   }
-  
+
   @Test
   public void testQuerySuspendProcessDefinitionUserOperationLogWithReadHPermissionOnAnyCategory() {
     // given
@@ -1320,7 +1320,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     clearDatabase();
   }
-  
+
   @Test
   public void testQuerySuspendProcessInstanceUserOperationLogWithReadPermissionOnCategory() {
     // given
@@ -1337,7 +1337,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     clearDatabase();
   }
-  
+
   @Test
   public void testQuerySuspendProcessInstanceUserOperationLogWithReadPermissionOnAnyCategory() {
     // given
@@ -1383,7 +1383,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     }
     enableAuthorization();
   }
-  
+
   @Test
   public void testQueryAfterDeletingDeploymentWithReadHistoryPermissionOnProcessDefinition() {
     // given
@@ -1411,7 +1411,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     }
     enableAuthorization();
   }
-  
+
   @Test
   public void testQueryAfterDeletingDeploymentWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
@@ -1439,7 +1439,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     }
     enableAuthorization();
   }
-  
+
   @Test
   public void testQueryAfterDeletingDeploymentWithReadPermissionOnCategory() {
     // given
@@ -1459,10 +1459,10 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     // then expect 1 entry (start process instance)
     verifyQueryResults(query, 1);
-    
+
     // and when
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, CATEGORY_TASK_WORKER, userId, READ);
-    
+
     // then expect 3 entries (start process instance, set assignee, complete task)
     verifyQueryResults(query, 3);
 
@@ -1473,7 +1473,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     }
     enableAuthorization();
   }
-  
+
   @Test
   public void testQueryAfterDeletingDeploymentWithReadPermissionOnAnyCategory() {
     // given
@@ -1509,11 +1509,11 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     // given
     String taskId = "myTask";
     createTask(taskId);
-    
+
     disableAuthorization();
     String entryId = historyService.createUserOperationLogQuery().singleResult().getId();
     enableAuthorization();
-    
+
     // when
     try {
       historyService.deleteUserOperationLogEntry(entryId);
@@ -1526,10 +1526,10 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
       testRule.assertTextPresent(OPERATION_LOG_CATEGORY.resourceName(), message);
       testRule.assertTextPresent(CATEGORY_TASK_WORKER, message);
     }
-    
+
     deleteTask(taskId, true);
   }
-  
+
   @Test
   public void testDeleteStandaloneEntryWithDeleteHistoryPermissionOnProcessDefinition() {
     // given
@@ -1539,7 +1539,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     disableAuthorization();
     String entryId = historyService.createUserOperationLogQuery().singleResult().getId();
     enableAuthorization();
-    
+
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, DELETE_HISTORY);
 
     // when
@@ -1554,10 +1554,10 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
       testRule.assertTextPresent(OPERATION_LOG_CATEGORY.resourceName(), message);
       testRule.assertTextPresent(CATEGORY_TASK_WORKER, message);
     }
-    
+
     deleteTask(taskId, true);
   }
-  
+
   @Test
   public void testDeleteStandaloneEntryWithDeleteHistoryPermissionOnAnyProcessDefinition() {
     // given
@@ -1567,7 +1567,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     disableAuthorization();
     String entryId = historyService.createUserOperationLogQuery().singleResult().getId();
     enableAuthorization();
-    
+
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ANY, userId, DELETE_HISTORY);
 
     // when
@@ -1582,10 +1582,10 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
       testRule.assertTextPresent(OPERATION_LOG_CATEGORY.resourceName(), message);
       testRule.assertTextPresent(CATEGORY_TASK_WORKER, message);
     }
-    
+
     deleteTask(taskId, true);
   }
-  
+
   @Test
   public void testDeleteStandaloneEntryWithDeletePermissionOnCategory() {
     // given
@@ -1595,7 +1595,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     disableAuthorization();
     String entryId = historyService.createUserOperationLogQuery().singleResult().getId();
     enableAuthorization();
-    
+
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, CATEGORY_TASK_WORKER, userId, DELETE);
 
     // when
@@ -1606,7 +1606,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     deleteTask(taskId, true);
   }
-  
+
   @Test
   public void testDeleteStandaloneEntryWithDeletePermissionOnAnyCategory() {
     // given
@@ -1616,7 +1616,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     disableAuthorization();
     String entryId = historyService.createUserOperationLogQuery().singleResult().getId();
     enableAuthorization();
-    
+
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, ANY, userId, DELETE);
 
     // when
@@ -1699,7 +1699,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     assertNull(historyService.createUserOperationLogQuery().entityType("Task").singleResult());
     enableAuthorization();
   }
-  
+
   @Test
   public void testDeleteEntryWithDeletePermissionOnCategory() {
     // given
@@ -1720,7 +1720,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     assertNull(historyService.createUserOperationLogQuery().entityType("Task").singleResult());
     enableAuthorization();
   }
-  
+
   @Test
   public void testDeleteEntryWithDeletePermissionOnAnyCategory() {
     // given
@@ -1778,11 +1778,11 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
     testRule.createCaseInstanceByKey(ONE_TASK_CASE_KEY);
     String taskId = selectSingleTask().getId();
     setAssignee(taskId, "demo");
-    
+
     disableAuthorization();
     String entryId = historyService.createUserOperationLogQuery().singleResult().getId();
     enableAuthorization();
-    
+
     // when
     try {
       historyService.deleteUserOperationLogEntry(entryId);
@@ -1796,20 +1796,20 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
       testRule.assertTextPresent(CATEGORY_TASK_WORKER, message);
     }
   }
-  
+
   @Test
   public void testCaseDeleteEntryWithDeleteHistoryPermissionOnProcessDefinition() {
     // given
     testRule.createCaseInstanceByKey(ONE_TASK_CASE_KEY);
     String taskId = selectSingleTask().getId();
     setAssignee(taskId, "demo");
-    
+
     disableAuthorization();
     String entryId = historyService.createUserOperationLogQuery().singleResult().getId();
     enableAuthorization();
-    
+
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ONE_TASK_CASE_KEY, userId, DELETE_HISTORY);
-    
+
     // when
     try {
       historyService.deleteUserOperationLogEntry(entryId);
@@ -1823,20 +1823,20 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
       testRule.assertTextPresent(CATEGORY_TASK_WORKER, message);
     }
   }
-  
+
   @Test
   public void testCaseDeleteEntryWithDeleteHistoryPermissionOnAnyProcessDefinition() {
     // given
     testRule.createCaseInstanceByKey(ONE_TASK_CASE_KEY);
     String taskId = selectSingleTask().getId();
     setAssignee(taskId, "demo");
-    
+
     disableAuthorization();
     String entryId = historyService.createUserOperationLogQuery().singleResult().getId();
     enableAuthorization();
-    
+
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ANY, userId, DELETE_HISTORY);
-    
+
     // when
     try {
       historyService.deleteUserOperationLogEntry(entryId);
@@ -1850,43 +1850,43 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
       testRule.assertTextPresent(CATEGORY_TASK_WORKER, message);
     }
   }
-  
+
   @Test
   public void testCaseDeleteEntryWithDeletePermissionOnCategory() {
     // given
     testRule.createCaseInstanceByKey(ONE_TASK_CASE_KEY);
     String taskId = selectSingleTask().getId();
     setAssignee(taskId, "demo");
-    
+
     disableAuthorization();
     String entryId = historyService.createUserOperationLogQuery().singleResult().getId();
     enableAuthorization();
-    
+
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, CATEGORY_TASK_WORKER, userId, DELETE);
-    
+
     // when
     historyService.deleteUserOperationLogEntry(entryId);
-    
+
     // then
     assertNull(historyService.createUserOperationLogQuery().singleResult());
   }
-  
+
   @Test
   public void testCaseDeleteEntryWithDeletePermissionOnAnyCategory() {
     // given
     testRule.createCaseInstanceByKey(ONE_TASK_CASE_KEY);
     String taskId = selectSingleTask().getId();
     setAssignee(taskId, "demo");
-    
+
     disableAuthorization();
     String entryId = historyService.createUserOperationLogQuery().singleResult().getId();
     enableAuthorization();
-    
+
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, ANY, userId, DELETE);
-    
+
     // when
     historyService.deleteUserOperationLogEntry(entryId);
-    
+
     // then
     assertNull(historyService.createUserOperationLogQuery().singleResult());
   }
@@ -2166,10 +2166,6 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
   // helper ////////////////////////////////////////////////////////
 
-  protected void verifyQueryResults(UserOperationLogQuery query, int countExpected) {
-    verifyQueryResults((AbstractQuery<?, ?>) query, countExpected);
-  }
-
   protected Job selectSingleJob() {
     disableAuthorization();
     Job job = managementService.createJobQuery().singleResult();
@@ -2180,6 +2176,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   protected void clearDatabase() {
     CommandExecutor commandExecutor = processEngineConfiguration.getCommandExecutorTxRequired();
     commandExecutor.execute(new Command<Object>() {
+      @Override
       public Object execute(CommandContext commandContext) {
         commandContext.getHistoricJobLogManager().deleteHistoricJobLogsByHandlerType(TimerSuspendProcessDefinitionHandler.TYPE);
         List<HistoricIncident> incidents = Context.getProcessEngineConfiguration().getHistoryService().createHistoricIncidentQuery().list();

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/task/updatevariable/StandaloneTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/task/updatevariable/StandaloneTaskAuthorizationTest.java
@@ -21,13 +21,13 @@ import static org.camunda.bpm.engine.authorization.Resources.TASK;
 import static org.camunda.bpm.engine.authorization.TaskPermissions.UPDATE_VARIABLE;
 import static org.camunda.bpm.engine.test.api.authorization.util.AuthorizationScenario.scenario;
 import static org.camunda.bpm.engine.test.api.authorization.util.AuthorizationSpec.grant;
+import static org.camunda.bpm.engine.test.api.authorization.util.AuthorizationSpec.revoke;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.util.Arrays;
 import java.util.Collection;
-
 import org.camunda.bpm.engine.HistoryService;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.RuntimeService;
@@ -102,7 +102,14 @@ public class StandaloneTaskAuthorizationTest {
       scenario()
         .withAuthorizations(
           grant(TASK, "*", userId, UPDATE_VARIABLE))
-        .succeeds()
+        .succeeds(),
+      scenario()
+        .withAuthorizations(
+          grant(TASK, "*", "*", UPDATE),
+          revoke(TASK, "taskId", userId, UPDATE))
+        .failsDueToRequired(
+          grant(TASK, "taskId", userId, UPDATE),
+          grant(TASK, "taskId", userId, UPDATE_VARIABLE))
       );
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/util/AuthorizationTestBaseRule.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/util/AuthorizationTestBaseRule.java
@@ -18,7 +18,6 @@ package org.camunda.bpm.engine.test.api.authorization.util;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import org.camunda.bpm.engine.authorization.Authorization;
 import org.camunda.bpm.engine.authorization.Permission;
 import org.camunda.bpm.engine.authorization.Resource;
@@ -57,6 +56,7 @@ public class AuthorizationTestBaseRule extends TestWatcher {
     engineRule.getIdentityService().clearAuthentication();
   }
 
+  @Override
   protected void finished(Description description) {
     engineRule.getIdentityService().clearAuthentication();
 
@@ -88,6 +88,17 @@ public class AuthorizationTestBaseRule extends TestWatcher {
     authorization.setUserId(userId);
     for (Permission permission : permissions) {
       authorization.addPermission(permission);
+    }
+
+    engineRule.getAuthorizationService().saveAuthorization(authorization);
+    manageAuthorization(authorization);
+  }
+
+  public void createRevokeAuthorization(Resource resource, String resourceId, String userId, Permission... permissions) {
+    Authorization authorization = createAuthorization(Authorization.AUTH_TYPE_REVOKE, resource, resourceId);
+    authorization.setUserId(userId);
+    for (Permission permission : permissions) {
+      authorization.removePermission(permission);
     }
 
     engineRule.getAuthorizationService().saveAuthorization(authorization);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/filter/FilterAuthorizationsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/filter/FilterAuthorizationsTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.util.List;
-
 import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.EntityTypes;
 import org.camunda.bpm.engine.ProcessEngineException;
@@ -32,6 +31,7 @@ import org.camunda.bpm.engine.authorization.Permissions;
 import org.camunda.bpm.engine.authorization.Resources;
 import org.camunda.bpm.engine.filter.Filter;
 import org.camunda.bpm.engine.identity.User;
+import org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.FilterEntity;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.util.PluggableProcessEngineTest;
@@ -265,6 +265,59 @@ public class FilterAuthorizationsTest extends PluggableProcessEngineTest {
   }
 
   @Test
+  public void shouldNotFindFilterWithRevokedReadPermissionOnAnyFilter() {
+    Filter filter = createTestFilter();
+
+    revokeReadFilter(filter.getId());
+
+    long count = filterService.createFilterQuery().count();
+    assertEquals(0, count);
+
+    Filter returnedFilter = filterService.createFilterQuery().filterId(filter.getId()).singleResult();
+    assertNull(returnedFilter);
+
+    try {
+      filterService.getFilter(filter.getId());
+      fail("Exception expected");
+    }
+    catch (AuthorizationException e) {
+      // expected
+    }
+
+    try {
+      filterService.singleResult(filter.getId());
+      fail("Exception expected");
+    }
+    catch (AuthorizationException e) {
+      // expected
+    }
+
+    try {
+      filterService.list(filter.getId());
+      fail("Exception expected");
+    }
+    catch (AuthorizationException e) {
+      // expected
+    }
+
+    try {
+      filterService.listPage(filter.getId(), 1, 2);
+      fail("Exception expected");
+    }
+    catch (AuthorizationException e) {
+      // expected
+    }
+
+    try {
+      filterService.count(filter.getId());
+      fail("Exception expected");
+    }
+    catch (AuthorizationException e) {
+      // expected
+    }
+  }
+
+  @Test
   public void testReadFilterPermittedWithMultiple() {
     Filter filter = createTestFilter();
 
@@ -416,6 +469,11 @@ public class FilterAuthorizationsTest extends PluggableProcessEngineTest {
     assertFilterPermission(Permissions.READ, testUser, filterId, true);
   }
 
+  protected void revokeReadFilter(String filterId) {
+    revokeFilterPermission(readAuthorization, filterId);
+    assertFilterPermission(Permissions.READ, testUser, filterId, false);
+  }
+
   protected void grantDeleteFilter(String filterId) {
     grantFilterPermission(deleteAuthorization, filterId);
     assertFilterPermission(Permissions.DELETE, testUser, filterId, true);
@@ -425,6 +483,14 @@ public class FilterAuthorizationsTest extends PluggableProcessEngineTest {
     if (filterId != null) {
       authorization.setResourceId(filterId);
     }
+    authorizationService.saveAuthorization(authorization);
+  }
+
+  protected void revokeFilterPermission(Authorization authorization, String filterId) {
+    if (filterId != null) {
+      authorization.setResourceId(filterId);
+    }
+    ((AuthorizationEntity) authorization).setAuthorizationType(Authorization.AUTH_TYPE_REVOKE);
     authorizationService.saveAuthorization(authorization);
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/filter/FilterAuthorizationsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/filter/FilterAuthorizationsTest.java
@@ -268,6 +268,7 @@ public class FilterAuthorizationsTest extends PluggableProcessEngineTest {
   public void shouldNotFindFilterWithRevokedReadPermissionOnAnyFilter() {
     Filter filter = createTestFilter();
 
+    grantReadFilter(filter.getId());
     revokeReadFilter(filter.getId());
 
     long count = filterService.createFilterQuery().count();

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/identity/AuthorizationQueryAuthorizationsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/identity/AuthorizationQueryAuthorizationsTest.java
@@ -218,7 +218,7 @@ public class AuthorizationQueryAuthorizationsTest {
   }
 
   @Test
-  public void shouldNotFindAllAuthorizationsWithRevokedReadPermissionOnOneAuthorization () throws Exception {
+  public void shouldNotFindAllAuthorizationsWithRevokedReadPermissionOnOneAuthorization() throws Exception {
     // given
     Authorization authorization = authorizationService.createNewAuthorization(AUTH_TYPE_GRANT);
     authorization.setUserId("userId");

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/identity/AuthorizationQueryAuthorizationsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/identity/AuthorizationQueryAuthorizationsTest.java
@@ -18,14 +18,15 @@ package org.camunda.bpm.engine.test.api.identity;
 
 import static org.camunda.bpm.engine.authorization.Authorization.ANY;
 import static org.camunda.bpm.engine.authorization.Authorization.AUTH_TYPE_GRANT;
+import static org.camunda.bpm.engine.authorization.Authorization.AUTH_TYPE_REVOKE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-
 import org.camunda.bpm.engine.AuthorizationService;
 import org.camunda.bpm.engine.authorization.Authorization;
+import org.camunda.bpm.engine.authorization.AuthorizationQuery;
 import org.camunda.bpm.engine.authorization.BatchPermissions;
 import org.camunda.bpm.engine.authorization.Permissions;
 import org.camunda.bpm.engine.authorization.ProcessDefinitionPermissions;
@@ -216,7 +217,47 @@ public class AuthorizationQueryAuthorizationsTest {
         .count());
   }
 
+  @Test
+  public void shouldNotFindAllAuthorizationsWithRevokedReadPermissionOnOneAuthorization () throws Exception {
+    // given
+    Authorization authorization = authorizationService.createNewAuthorization(AUTH_TYPE_GRANT);
+    authorization.setUserId("userId");
+    authorization.setResource(Resources.PROCESS_DEFINITION);
+    authorization.addPermission(Permissions.READ);
+    authorization.addPermission(ProcessDefinitionPermissions.RETRY_JOB);
+    authorization.setResourceId(ANY);
+    authorizationService.saveAuthorization(authorization);
+
+    authorization = authorizationService.createNewAuthorization(AUTH_TYPE_GRANT);
+    authorization.setUserId("*");
+    authorization.setResource(Resources.AUTHORIZATION);
+    authorization.addPermission(Permissions.READ);
+    authorization.setResourceId(ANY);
+    authorizationService.saveAuthorization(authorization);
+
+    authorization = authorizationService.createNewAuthorization(AUTH_TYPE_REVOKE);
+    authorization.setUserId("userId");
+    authorization.setResource(Resources.AUTHORIZATION);
+    authorization.addPermission(Permissions.READ);
+    authorization.setResourceId(ANY);
+    authorizationService.saveAuthorization(authorization);
+
+    processEngineConfiguration.setAuthorizationEnabled(true);
+    processEngineConfiguration.getIdentityService().setAuthenticatedUserId("userId");
+
+    AuthorizationQuery authQuery = authorizationService.createAuthorizationQuery();
+
+    // when
+    long authorizationsCount = authQuery.count();
+    List<Authorization> authorizations = authQuery.list();
+
+    // then
+    assertEquals(0, authorizationsCount);
+    assertEquals(0, authorizations.size());
+  }
+
   protected void cleanupAfterTest() {
+    processEngineConfiguration.getIdentityService().clearAuthentication();
     for (Authorization authorization : authorizationService.createAuthorizationQuery().list()) {
       authorizationService.deleteAuthorization(authorization.getId());
     }

--- a/webapps/assembly-jakarta/pom.xml
+++ b/webapps/assembly-jakarta/pom.xml
@@ -604,13 +604,6 @@
       </properties>
     </profile>
 
-    <profile>
-      <id>cfgAuthorizationCheckRevokesAlways</id>
-      <properties>
-        <authorizationCheckRevokes>always</authorizationCheckRevokes>
-      </properties>
-    </profile>
-
     <!--  check history audit -->
     <profile>
       <id>cfghistoryaudit</id>

--- a/webapps/assembly/pom.xml
+++ b/webapps/assembly/pom.xml
@@ -587,13 +587,6 @@
       </build>
     </profile>
 
-    <profile>
-      <id>cfgAuthorizationCheckRevokesAlways</id>
-      <properties>
-        <authorizationCheckRevokes>always</authorizationCheckRevokes>
-      </properties>
-    </profile>
-
     <!--  check history audit -->
     <profile>
       <id>cfghistoryaudit</id>

--- a/webapps/assembly/src/test/java/org/camunda/bpm/cockpit/plugin/base/authorization/AuthorizationTest.java
+++ b/webapps/assembly/src/test/java/org/camunda/bpm/cockpit/plugin/base/authorization/AuthorizationTest.java
@@ -23,11 +23,12 @@ import static org.camunda.bpm.engine.authorization.Resources.AUTHORIZATION;
 import static org.camunda.bpm.engine.authorization.Resources.USER;
 
 import java.util.Arrays;
-
+import java.util.List;
 import org.camunda.bpm.cockpit.plugin.test.AbstractCockpitPluginTest;
 import org.camunda.bpm.engine.AuthorizationService;
 import org.camunda.bpm.engine.IdentityService;
 import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.authorization.Authorization;
@@ -43,11 +44,16 @@ import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 /**
  * @author Roman Smirnov
  *
  */
+@RunWith(Parameterized.class)
 public abstract class AuthorizationTest extends AbstractCockpitPluginTest {
 
   protected ProcessEngine processEngine;
@@ -63,6 +69,22 @@ public abstract class AuthorizationTest extends AbstractCockpitPluginTest {
   protected String groupId = "accounting";
   protected User user;
   protected Group group;
+
+  @Parameter(0)
+  public String authorizationRevokeMode;
+  protected String defaultAuthorizationRevokeMode;
+
+  /**
+   * Parameters:
+   * authorizationRevokeMode: The revoke authorization mode to use in engine configuration
+   */
+  @Parameters(name = "revoke check mode {0}")
+  public static List<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+        { ProcessEngineConfiguration.AUTHORIZATION_CHECK_REVOKE_ALWAYS },
+        { ProcessEngineConfiguration.AUTHORIZATION_CHECK_REVOKE_AUTO }
+    });
+  }
 
   @Before
   public void setUp() throws Exception {
@@ -84,11 +106,15 @@ public abstract class AuthorizationTest extends AbstractCockpitPluginTest {
 
     identityService.setAuthentication(userId, Arrays.asList(groupId));
     enableAuthorization();
+
+    defaultAuthorizationRevokeMode = processEngineConfiguration.getAuthorizationCheckRevokes();
+    processEngineConfiguration.setAuthorizationCheckRevokes(authorizationRevokeMode);
   }
 
   @After
   public void tearDown() {
     disableAuthorization();
+    processEngineConfiguration.setAuthorizationCheckRevokes(defaultAuthorizationRevokeMode);
     for (User user : identityService.createUserQuery().list()) {
       identityService.deleteUser(user.getId());
     }


### PR DESCRIPTION
* Adds revoke tests for all query interfaces currently missing them.
* Runs authorization test classes (engine and webapps) with revoke
  modes AUTO and ALWAYS using parameterized test execution.
* Allows automatic resource deployment for parameterized tests via
  `ProcessEngineRule`.
* Removes all CI stages for revoke tests.

related to https://github.com/camunda/camunda-bpm-platform/issues/3430