### PR TITLE
docs(camunda-engine): Fix invalid links, typos, formatting

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/history/HistoricProcessInstanceQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/history/HistoricProcessInstanceQuery.java
@@ -21,9 +21,10 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
-import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.query.Query;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
 
 /**
@@ -35,30 +36,44 @@ import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
  */
 public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInstanceQuery, HistoricProcessInstance> {
 
-  /** Only select historic process instances with the given process instance.
-   * {@link ProcessInstance) ids and {@link HistoricProcessInstance} ids match. */
+  /**
+   * Only select historic process instances with the given process instance.
+   * {@link ProcessInstance) ids and {@link HistoricProcessInstance} ids match.
+   */
   HistoricProcessInstanceQuery processInstanceId(String processInstanceId);
 
-  /** Only select historic process instances whose id is in the given set of ids.
-   * {@link ProcessInstance) ids and {@link HistoricProcessInstance} ids match. */
+  /**
+   * Only select historic process instances whose id is in the given set of ids.
+   * {@link ProcessInstance) ids and {@link HistoricProcessInstance} ids match.
+   */
   HistoricProcessInstanceQuery processInstanceIds(Set<String> processInstanceIds);
 
-  /** Only select historic process instances for the given process definition */
+  /**
+   * Only select historic process instances for the given process definition
+   */
   HistoricProcessInstanceQuery processDefinitionId(String processDefinitionId);
 
-  /** Only select historic process instances that are defined by a process
-   * definition with the given key.  */
+  /**
+   * Only select historic process instances that are defined by a process
+   * definition with the given key.
+   */
   HistoricProcessInstanceQuery processDefinitionKey(String processDefinitionKey);
 
-  /** Only select historic process instances that are defined by any given process
-   * definition key.  */
+  /**
+   * Only select historic process instances that are defined by any given process
+   * definition key.
+   */
   HistoricProcessInstanceQuery processDefinitionKeyIn(String... processDefinitionKeys);
 
-  /** Only select historic process instances that don't have a process-definition of which the key is present in the given list */
+  /**
+   * Only select historic process instances that don't have a process-definition of which the key is present in the given list
+   */
   HistoricProcessInstanceQuery processDefinitionKeyNotIn(List<String> processDefinitionKeys);
 
-  /** Only select historic process instances that are defined by a process
-   * definition with the given name.  */
+  /**
+   * Only select historic process instances that are defined by a process
+   * definition with the given name.
+   */
   HistoricProcessInstanceQuery processDefinitionName(String processDefinitionName);
 
   /**
@@ -66,28 +81,36 @@ public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInsta
    * is like the given value.
    *
    * @param nameLike The string can include the wildcard character '%' to express
-   *    like-strategy: starts with (string%), ends with (%string) or contains (%string%).
+   *                 like-strategy: starts with (string%), ends with (%string) or contains (%string%).
    */
   HistoricProcessInstanceQuery processDefinitionNameLike(String nameLike);
 
-  /** Only select historic process instances with the given business key */
+  /**
+   * Only select historic process instances with the given business key
+   */
   HistoricProcessInstanceQuery processInstanceBusinessKey(String processInstanceBusinessKey);
 
-  /** Only select historic process instances whose business key is in the given set. */
+  /**
+   * Only select historic process instances whose business key is in the given set.
+   */
   HistoricProcessInstanceQuery processInstanceBusinessKeyIn(String... processInstanceBusinessKeyIn);
 
   /**
    * Only select historic process instances which had a business key like the given value.
    *
    * @param processInstanceBusinessKeyLike The string can include the wildcard character '%' to express
-   *    like-strategy: starts with (string%), ends with (%string) or contains (%string%).
+   *                                       like-strategy: starts with (string%), ends with (%string) or contains (%string%).
    */
   HistoricProcessInstanceQuery processInstanceBusinessKeyLike(String processInstanceBusinessKeyLike);
 
-  /** Only select historic process instances that are completely finished. */
+  /**
+   * Only select historic process instances that are completely finished.
+   */
   HistoricProcessInstanceQuery finished();
 
-  /** Only select historic process instance that are not yet finished. */
+  /**
+   * Only select historic process instance that are not yet finished.
+   */
   HistoricProcessInstanceQuery unfinished();
 
   /**
@@ -104,7 +127,8 @@ public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInsta
    */
   HistoricProcessInstanceQuery withRootIncidents();
 
-  /** Only select historic process instances with incident status either 'open' or 'resolved'.
+  /**
+   * Only select historic process instances with incident status either 'open' or 'resolved'.
    * To get all process instances with incidents, use {@link HistoricProcessInstanceQuery#withIncidents()}.
    *
    * @param status indicates the incident status, which is either 'open' or 'resolved'
@@ -121,7 +145,6 @@ public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInsta
    * Only select historic process instances with the given incident message.
    *
    * @param incidentMessage Incidents Message for which the historic process instances should be selected
-   *
    * @return HistoricProcessInstanceQuery
    */
   HistoricProcessInstanceQuery incidentMessage(String incidentMessage);
@@ -130,13 +153,14 @@ public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInsta
    * Only select historic process instances which had an incident message like the given value.
    *
    * @param incidentMessageLike The string can include the wildcard character '%' to express
-   *    like-strategy: starts with (string%), ends with (%string) or contains (%string%).
-   *
+   *                            like-strategy: starts with (string%), ends with (%string) or contains (%string%).
    * @return HistoricProcessInstanceQuery
    */
   HistoricProcessInstanceQuery incidentMessageLike(String incidentMessageLike);
 
-  /** Only select historic process instances which are associated with the given case instance id. */
+  /**
+   * Only select historic process instances which are associated with the given case instance id.
+   */
   HistoricProcessInstanceQuery caseInstanceId(String caseInstanceId);
 
   /**
@@ -149,145 +173,206 @@ public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInsta
    */
   HistoricProcessInstanceQuery matchVariableValuesIgnoreCase();
 
-  /** Only select process instances which had a global variable with the given value
+  /**
+   * Only select process instances which had a global variable with the given value
    * when they ended. Only select process instances which have a variable value
    * greater than the passed value. The type only applies to already ended
-   * process instances, otherwise use a {@link ProcessInstanceQuery} instead! of
+   * process instances, otherwise use a {@link ProcessInstanceQuery} instead! The type of the
    * variable is determined based on the value, using types configured in
-   * {@link ProcessEngineConfiguration#getVariableSerializers()}. Byte-arrays and
+   * {@link ProcessEngineConfigurationImpl#getVariableSerializers()}. Byte-arrays and
    * {@link Serializable} objects (which are not primitive type wrappers) are
    * not supported.
-   * @param name of the variable, cannot be null. */
+   *
+   * @param name of the variable, cannot be null.
+   */
   HistoricProcessInstanceQuery variableValueEquals(String name, Object value);
 
-  /** Only select process instances which had a global variable with the given name, but
+  /**
+   * Only select process instances which had a global variable with the given name, but
    * with a different value than the passed value when they ended. Only select
    * process instances which have a variable value greater than the passed
    * value. Byte-arrays and {@link Serializable} objects (which are not
    * primitive type wrappers) are not supported.
-   * @param name of the variable, cannot be null. */
+   *
+   * @param name of the variable, cannot be null.
+   */
   HistoricProcessInstanceQuery variableValueNotEquals(String name, Object value);
 
-  /** Only select process instances which had a global variable value greater than the
+  /**
+   * Only select process instances which had a global variable value greater than the
    * passed value when they ended. Booleans, Byte-arrays and
    * {@link Serializable} objects (which are not primitive type wrappers) are
    * not supported. Only select process instances which have a variable value
    * greater than the passed value.
-   * @param name cannot be null.
-   * @param value cannot be null. */
+   *
+   * @param name  cannot be null.
+   * @param value cannot be null.
+   */
   HistoricProcessInstanceQuery variableValueGreaterThan(String name, Object value);
 
-  /** Only select process instances which had a global variable value greater than or
+  /**
+   * Only select process instances which had a global variable value greater than or
    * equal to the passed value when they ended. Booleans, Byte-arrays and
    * {@link Serializable} objects (which are not primitive type wrappers) are
    * not supported. Only applies to already ended process instances, otherwise
    * use a {@link ProcessInstanceQuery} instead!
-   * @param name cannot be null.
-   * @param value cannot be null. */
+   *
+   * @param name  cannot be null.
+   * @param value cannot be null.
+   */
   HistoricProcessInstanceQuery variableValueGreaterThanOrEqual(String name, Object value);
 
-  /** Only select process instances which had a global variable value less than the
+  /**
+   * Only select process instances which had a global variable value less than the
    * passed value when the ended. Only applies to already ended process
    * instances, otherwise use a {@link ProcessInstanceQuery} instead! Booleans,
    * Byte-arrays and {@link Serializable} objects (which are not primitive type
    * wrappers) are not supported.
-   * @param name cannot be null.
-   * @param value cannot be null. */
+   *
+   * @param name  cannot be null.
+   * @param value cannot be null.
+   */
   HistoricProcessInstanceQuery variableValueLessThan(String name, Object value);
 
-  /** Only select process instances which has a global variable value less than or equal
+  /**
+   * Only select process instances which has a global variable value less than or equal
    * to the passed value when they ended. Only applies to already ended process
    * instances, otherwise use a {@link ProcessInstanceQuery} instead! Booleans,
    * Byte-arrays and {@link Serializable} objects (which are not primitive type
    * wrappers) are not supported.
-   * @param name cannot be null.
-   * @param value cannot be null. */
+   *
+   * @param name  cannot be null.
+   * @param value cannot be null.
+   */
   HistoricProcessInstanceQuery variableValueLessThanOrEqual(String name, Object value);
 
-  /** Only select process instances which had global variable value like the given value
+  /**
+   * Only select process instances which had global variable value like the given value
    * when they ended. Only applies to already ended process instances, otherwise
    * use a {@link ProcessInstanceQuery} instead! This can be used on string
    * variables only.
-   * @param name cannot be null.
+   *
+   * @param name  cannot be null.
    * @param value cannot be null. The string can include the
-   *          wildcard character '%' to express like-strategy: starts with
-   *          (string%), ends with (%string) or contains (%string%). */
+   *              wildcard character '%' to express like-strategy: starts with
+   *              (string%), ends with (%string) or contains (%string%).
+   */
   HistoricProcessInstanceQuery variableValueLike(String name, String value);
 
-  /** Only select historic process instances that were started before the given date. */
+  /**
+   * Only select historic process instances that were started before the given date.
+   */
   HistoricProcessInstanceQuery startedBefore(Date date);
 
-  /** Only select historic process instances that were started after the given date. */
+  /**
+   * Only select historic process instances that were started after the given date.
+   */
   HistoricProcessInstanceQuery startedAfter(Date date);
 
-  /** Only select historic process instances that were started before the given date. */
+  /**
+   * Only select historic process instances that were started before the given date.
+   */
   HistoricProcessInstanceQuery finishedBefore(Date date);
 
-  /** Only select historic process instances that were started after the given date. */
+  /**
+   * Only select historic process instances that were started after the given date.
+   */
   HistoricProcessInstanceQuery finishedAfter(Date date);
 
-  /** Only select historic process instance that are started by the given user. */
+  /**
+   * Only select historic process instance that are started by the given user.
+   */
   HistoricProcessInstanceQuery startedBy(String userId);
 
-  /** Order by the process instance id (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by the process instance id (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   HistoricProcessInstanceQuery orderByProcessInstanceId();
 
-  /** Order by the process definition id (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by the process definition id (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   HistoricProcessInstanceQuery orderByProcessDefinitionId();
 
-  /** Order by the process definition key (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by the process definition key (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   HistoricProcessInstanceQuery orderByProcessDefinitionKey();
 
-  /** Order by the process definition name (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by the process definition name (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   HistoricProcessInstanceQuery orderByProcessDefinitionName();
 
-  /** Order by the process definition version (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by the process definition version (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   HistoricProcessInstanceQuery orderByProcessDefinitionVersion();
 
-  /** Order by the business key (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by the business key (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   HistoricProcessInstanceQuery orderByProcessInstanceBusinessKey();
 
-  /** Order by the start time (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by the start time (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   HistoricProcessInstanceQuery orderByProcessInstanceStartTime();
 
-  /** Order by the end time (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by the end time (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   HistoricProcessInstanceQuery orderByProcessInstanceEndTime();
 
-  /** Order by the duration of the process instance (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by the duration of the process instance (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   HistoricProcessInstanceQuery orderByProcessInstanceDuration();
 
-  /** Only select historic process instances that are top level process instances. */
+  /**
+   * Only select historic process instances that are top level process instances.
+   */
   HistoricProcessInstanceQuery rootProcessInstances();
 
-  /** Only select historic process instances started by the given process
+  /**
+   * Only select historic process instances started by the given process
    * instance. {@link ProcessInstance) ids and {@link HistoricProcessInstance}
-   * ids match. */
+   * ids match.
+   */
   HistoricProcessInstanceQuery superProcessInstanceId(String superProcessInstanceId);
 
-  /** Only select historic process instances having a sub process instance
+  /**
+   * Only select historic process instances having a sub process instance
    * with the given process instance id.
-   *
+   * <p>
    * Note that there will always be maximum only <b>one</b>
    * such process instance that can be the result of this query.
    */
   HistoricProcessInstanceQuery subProcessInstanceId(String subProcessInstanceId);
 
-  /** Only select historic process instances started by the given case
-   * instance. */
+  /**
+   * Only select historic process instances started by the given case
+   * instance.
+   */
   HistoricProcessInstanceQuery superCaseInstanceId(String superCaseInstanceId);
 
-  /** Only select historic process instances having a sub case instance
+  /**
+   * Only select historic process instances having a sub case instance
    * with the given case instance id.
-   *
+   * <p>
    * Note that there will always be maximum only <b>one</b>
    * such process instance that can be the result of this query.
    */
   HistoricProcessInstanceQuery subCaseInstanceId(String subCaseInstanceId);
 
-  /** Only select historic process instances with one of the given tenant ids. */
+  /**
+   * Only select historic process instances with one of the given tenant ids.
+   */
   HistoricProcessInstanceQuery tenantIdIn(String... tenantIds);
 
-  /** Only selects historic process instances which have no tenant id. */
+  /**
+   * Only selects historic process instances which have no tenant id.
+   */
   HistoricProcessInstanceQuery withoutTenantId();
 
   /**
@@ -296,59 +381,93 @@ public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInsta
    */
   HistoricProcessInstanceQuery orderByTenantId();
 
-  /** Only select historic process instances that were started as of the provided
+  /**
+   * Only select historic process instances that were started as of the provided
    * date. (Date will be adjusted to reflect midnight)
-   * @deprecated use {@link #startedAfter(Date)} and {@link #startedBefore(Date)} instead */
+   *
+   * @deprecated use {@link #startedAfter(Date)} and {@link #startedBefore(Date)} instead
+   */
   @Deprecated
   HistoricProcessInstanceQuery startDateBy(Date date);
 
-  /** Only select historic process instances that were started on the provided date.
-   * @deprecated use {@link #startedAfter(Date)} and {@link #startedBefore(Date)} instead */
+  /**
+   * Only select historic process instances that were started on the provided date.
+   *
+   * @deprecated use {@link #startedAfter(Date)} and {@link #startedBefore(Date)} instead
+   */
   @Deprecated
   HistoricProcessInstanceQuery startDateOn(Date date);
 
-  /** Only select historic process instances that were finished as of the
+  /**
+   * Only select historic process instances that were finished as of the
    * provided date. (Date will be adjusted to reflect one second before midnight)
-   * @deprecated use {@link #startedAfter(Date)} and {@link #startedBefore(Date)} instead */
+   *
+   * @deprecated use {@link #startedAfter(Date)} and {@link #startedBefore(Date)} instead
+   */
   @Deprecated
   HistoricProcessInstanceQuery finishDateBy(Date date);
 
-  /** Only select historic process instances that were finished on provided date.
-   * @deprecated use {@link #startedAfter(Date)} and {@link #startedBefore(Date)} instead */
+  /**
+   * Only select historic process instances that were finished on provided date.
+   *
+   * @deprecated use {@link #startedAfter(Date)} and {@link #startedBefore(Date)} instead
+   */
   @Deprecated
   HistoricProcessInstanceQuery finishDateOn(Date date);
 
-  /** Only select historic process instances that executed an activity after the given date. */
+  /**
+   * Only select historic process instances that executed an activity after the given date.
+   */
   HistoricProcessInstanceQuery executedActivityAfter(Date date);
 
-  /** Only select historic process instances that executed an activity before the given date. */
+  /**
+   * Only select historic process instances that executed an activity before the given date.
+   */
   HistoricProcessInstanceQuery executedActivityBefore(Date date);
 
-  /** Only select historic process instances that executed activities with given ids. */
+  /**
+   * Only select historic process instances that executed activities with given ids.
+   */
   HistoricProcessInstanceQuery executedActivityIdIn(String... ids);
 
-  /** Only select historic process instances that have active activities with given ids. */
+  /**
+   * Only select historic process instances that have active activities with given ids.
+   */
   HistoricProcessInstanceQuery activeActivityIdIn(String... ids);
 
-  /** Only select historic process instances that executed an job after the given date. */
+  /**
+   * Only select historic process instances that executed an job after the given date.
+   */
   HistoricProcessInstanceQuery executedJobAfter(Date date);
 
-  /** Only select historic process instances that executed an job before the given date. */
+  /**
+   * Only select historic process instances that executed an job before the given date.
+   */
   HistoricProcessInstanceQuery executedJobBefore(Date date);
 
-  /** Only select historic process instances that are active. */
+  /**
+   * Only select historic process instances that are active.
+   */
   HistoricProcessInstanceQuery active();
 
-  /** Only select historic process instances that are suspended. */
+  /**
+   * Only select historic process instances that are suspended.
+   */
   HistoricProcessInstanceQuery suspended();
 
-  /** Only select historic process instances that are completed. */
+  /**
+   * Only select historic process instances that are completed.
+   */
   HistoricProcessInstanceQuery completed();
 
-  /** Only select historic process instances that are externallyTerminated. */
+  /**
+   * Only select historic process instances that are externallyTerminated.
+   */
   HistoricProcessInstanceQuery externallyTerminated();
 
-  /** Only select historic process instances that are internallyTerminated. */
+  /**
+   * Only select historic process instances that are internallyTerminated.
+   */
   HistoricProcessInstanceQuery internallyTerminated();
 
   /**
@@ -358,11 +477,10 @@ public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInsta
    *
    * @return an object of the type {@link HistoricProcessInstanceQuery} on which an arbitrary amount of filter criteria could be applied.
    * The several filter criteria will be linked together by an OR expression.
-   *
    * @throws ProcessEngineException when or() has been invoked directly after or() or after or() and trailing filter
-   * criteria. To prevent throwing this exception, {@link #endOr()} must be invoked after a chain of filter criteria to
-   * mark the end of the OR query.
-   * */
+   *                                criteria. To prevent throwing this exception, {@link #endOr()} must be invoked after a chain of filter criteria to
+   *                                mark the end of the OR query.
+   */
   HistoricProcessInstanceQuery or();
 
   /**
@@ -372,9 +490,8 @@ public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInsta
    *
    * @return an object of the type {@link HistoricProcessInstanceQuery} on which an arbitrary amount of filter criteria could be applied.
    * The filter criteria will be linked together by an AND expression.
-   *
    * @throws ProcessEngineException when endOr() has been invoked before {@link #or()} was invoked. To prevent throwing
-   * this exception, {@link #or()} must be invoked first.
-   * */
+   *                                this exception, {@link #or()} must be invoked first.
+   */
   HistoricProcessInstanceQuery endOr();
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/runtime/ExecutionQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/runtime/ExecutionQuery.java
@@ -18,34 +18,45 @@ package org.camunda.bpm.engine.runtime;
 
 import java.io.Serializable;
 
-import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.query.Query;
 
-
-
-/** Allows programmatic querying of {@link Execution}s.
+/**
+ * Allows programmatic querying of {@link Execution}s.
  *
  * @author Joram Barrez
  * @author Frederik Heremans
  */
-public interface ExecutionQuery extends Query<ExecutionQuery, Execution>{
+public interface ExecutionQuery extends Query<ExecutionQuery, Execution> {
 
-  /** Only select executions which have the given process definition key. **/
+  /**
+   * Only select executions which have the given process definition key.
+   **/
   ExecutionQuery processDefinitionKey(String processDefinitionKey);
 
-  /** Only select executions which have the given process definition id. **/
+  /**
+   * Only select executions which have the given process definition id.
+   **/
   ExecutionQuery processDefinitionId(String processDefinitionId);
 
-  /** Only select executions which have the given process instance id. **/
+  /**
+   * Only select executions which have the given process instance id.
+   **/
   ExecutionQuery processInstanceId(String processInstanceId);
 
-  /** Only select executions that belong to a process instance with the given business key */
+  /**
+   * Only select executions that belong to a process instance with the given business key
+   */
   ExecutionQuery processInstanceBusinessKey(String processInstanceBusinessKey);
 
-  /** Only select executions with the given id. **/
+  /**
+   * Only select executions with the given id.
+   **/
   ExecutionQuery executionId(String executionId);
 
-  /** Only select executions which contain an activity with the given id. **/
+  /**
+   * Only select executions which contain an activity with the given id.
+   **/
   ExecutionQuery activityId(String activityId);
 
   /**
@@ -61,9 +72,10 @@ public interface ExecutionQuery extends Query<ExecutionQuery, Execution>{
   /**
    * Only select executions which have a local variable with the given value. The type
    * of variable is determined based on the value, using types configured in
-   * {@link ProcessEngineConfiguration#getVariableSerializers()}.
+   * {@link ProcessEngineConfigurationImpl#getVariableSerializers()}.
    * Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
+   *
    * @param name name of the variable, cannot be null.
    */
   ExecutionQuery variableValueEquals(String name, Object value);
@@ -73,16 +85,17 @@ public interface ExecutionQuery extends Query<ExecutionQuery, Execution>{
    * with a different value than the passed value.
    * Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
+   *
    * @param name name of the variable, cannot be null.
    */
   ExecutionQuery variableValueNotEquals(String name, Object value);
-
 
   /**
    * Only select executions which have a local variable value greater than the passed value.
    * Booleans, Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
-   * @param name variable name, cannot be null.
+   *
+   * @param name  variable name, cannot be null.
    * @param value variable value, cannot be null.
    */
   ExecutionQuery variableValueGreaterThan(String name, Object value);
@@ -91,7 +104,8 @@ public interface ExecutionQuery extends Query<ExecutionQuery, Execution>{
    * Only select executions which have a local variable value greater than or equal to
    * the passed value. Booleans, Byte-arrays and {@link Serializable} objects (which
    * are not primitive type wrappers) are not supported.
-   * @param name variable name, cannot be null.
+   *
+   * @param name  variable name, cannot be null.
    * @param value variable value, cannot be null.
    */
   ExecutionQuery variableValueGreaterThanOrEqual(String name, Object value);
@@ -100,7 +114,8 @@ public interface ExecutionQuery extends Query<ExecutionQuery, Execution>{
    * Only select executions which have a local variable value less than the passed value.
    * Booleans, Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
-   * @param name variable name, cannot be null.
+   *
+   * @param name  variable name, cannot be null.
    * @param value variable value, cannot be null.
    */
   ExecutionQuery variableValueLessThan(String name, Object value);
@@ -109,7 +124,8 @@ public interface ExecutionQuery extends Query<ExecutionQuery, Execution>{
    * Only select executions which have a local variable value less than or equal to the passed value.
    * Booleans, Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
-   * @param name variable name, cannot be null.
+   *
+   * @param name  variable name, cannot be null.
    * @param value variable value, cannot be null.
    */
   ExecutionQuery variableValueLessThanOrEqual(String name, Object value);
@@ -117,10 +133,11 @@ public interface ExecutionQuery extends Query<ExecutionQuery, Execution>{
   /**
    * Only select executions which have a local variable value like the given value.
    * This be used on string variables only.
-   * @param name variable name, cannot be null.
+   *
+   * @param name  variable name, cannot be null.
    * @param value variable value, cannot be null. The string can include the
-   * wildcard character '%' to express like-strategy:
-   * starts with (string%), ends with (%string) or contains (%string%).
+   *              wildcard character '%' to express like-strategy:
+   *              starts with (string%), ends with (%string) or contains (%string%).
    */
   ExecutionQuery variableValueLike(String name, String value);
 
@@ -149,7 +166,7 @@ public interface ExecutionQuery extends Query<ExecutionQuery, Execution>{
   /**
    * Only select executions which have a signal event subscription
    * for the given signal name.
-   *
+   * <p>
    * (The signalName is specified using the 'name' attribute of the signal element
    * in the BPMN 2.0 XML.)
    *
@@ -160,7 +177,7 @@ public interface ExecutionQuery extends Query<ExecutionQuery, Execution>{
   /**
    * Only select executions which have a message event subscription
    * for the given messageName.
-   *
+   * <p>
    * (The messageName is specified using the 'name' attribute of the message element
    * in the BPMN 2.0 XML.)
    *
@@ -205,25 +222,37 @@ public interface ExecutionQuery extends Query<ExecutionQuery, Execution>{
    */
   ExecutionQuery incidentMessageLike(String incidentMessageLike);
 
-   /** Only selects executions with one of the given tenant ids. */
+  /**
+   * Only selects executions with one of the given tenant ids.
+   */
   ExecutionQuery tenantIdIn(String... tenantIds);
 
-  /** Only selects executions which have no tenant id. */
+  /**
+   * Only selects executions which have no tenant id.
+   */
   ExecutionQuery withoutTenantId();
 
   //ordering //////////////////////////////////////////////////////////////
 
-  /** Order by id (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by id (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   ExecutionQuery orderByProcessInstanceId();
 
-  /** Order by process definition key (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by process definition key (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   ExecutionQuery orderByProcessDefinitionKey();
 
-  /** Order by process definition id (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by process definition id (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   ExecutionQuery orderByProcessDefinitionId();
 
-  /** Order by tenant id (needs to be followed by {@link #asc()} or {@link #desc()}).
-   * Note that the ordering of executions without tenant id is database-specific. */
+  /**
+   * Order by tenant id (needs to be followed by {@link #asc()} or {@link #desc()}).
+   * Note that the ordering of executions without tenant id is database-specific.
+   */
   ExecutionQuery orderByTenantId();
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/runtime/ProcessInstanceQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/runtime/ProcessInstanceQuery.java
@@ -19,7 +19,7 @@ package org.camunda.bpm.engine.runtime;
 import java.io.Serializable;
 import java.util.Set;
 
-import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.query.Query;
 
@@ -32,23 +32,31 @@ import org.camunda.bpm.engine.query.Query;
  */
 public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, ProcessInstance> {
 
-  /** Select the process instance with the given id */
+  /**
+   * Select the process instance with the given id
+   */
   ProcessInstanceQuery processInstanceId(String processInstanceId);
 
-  /** Select process instances whose id is in the given set of ids */
+  /**
+   * Select process instances whose id is in the given set of ids
+   */
   ProcessInstanceQuery processInstanceIds(Set<String> processInstanceIds);
 
-  /** Select process instances with the given business key */
+  /**
+   * Select process instances with the given business key
+   */
   ProcessInstanceQuery processInstanceBusinessKey(String processInstanceBusinessKey);
 
-  /** Select process instance with the given business key, unique for the given process definition */
+  /**
+   * Select process instance with the given business key, unique for the given process definition
+   */
   ProcessInstanceQuery processInstanceBusinessKey(String processInstanceBusinessKey, String processDefinitionKey);
 
   /**
    * Select process instances with a business key like the given value.
    *
    * @param processInstanceBusinessKeyLike The string can include the wildcard character '%' to express
-   *    like-strategy: starts with (string%), ends with (%string) or contains (%string%).
+   *                                       like-strategy: starts with (string%), ends with (%string) or contains (%string%).
    */
   ProcessInstanceQuery processInstanceBusinessKeyLike(String processInstanceBusinessKeyLike);
 
@@ -63,7 +71,9 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
    */
   ProcessInstanceQuery processDefinitionKeyIn(String... processDefinitionKeys);
 
-  /** Select historic process instances that don't have a process-definition of which the key is present in the given list */
+  /**
+   * Select historic process instances that don't have a process-definition of which the key is present in the given list
+   */
   ProcessInstanceQuery processDefinitionKeyNotIn(String... processDefinitionKeys);
 
   /**
@@ -74,6 +84,7 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
 
   /**
    * Selects the process instances which belong to the given deployment id.
+   *
    * @since 7.4
    */
   ProcessInstanceQuery deploymentId(String deploymentId);
@@ -125,10 +136,11 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
 
   /**
    * Only select process instances which have a global variable with the given value. The type
-   * of variable is determined based on the value, using types configured in
-   * {@link ProcessEngineConfiguration#getVariableSerializers()}.
+   * of the variable is determined based on the value, using types configured in
+   * {@link ProcessEngineConfigurationImpl#getVariableSerializers()}.
    * Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
+   *
    * @param name name of the variable, cannot be null.
    */
   ProcessInstanceQuery variableValueEquals(String name, Object value);
@@ -138,16 +150,17 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
    * with a different value than the passed value.
    * Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
+   *
    * @param name name of the variable, cannot be null.
    */
   ProcessInstanceQuery variableValueNotEquals(String name, Object value);
-
 
   /**
    * Only select process instances which have a variable value greater than the passed value.
    * Booleans, Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
-   * @param name variable name, cannot be null.
+   *
+   * @param name  variable name, cannot be null.
    * @param value variable value, cannot be null.
    */
   ProcessInstanceQuery variableValueGreaterThan(String name, Object value);
@@ -156,7 +169,8 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
    * Only select process instances which have a global variable value greater than or equal to
    * the passed value. Booleans, Byte-arrays and {@link Serializable} objects (which
    * are not primitive type wrappers) are not supported.
-   * @param name variable name, cannot be null.
+   *
+   * @param name  variable name, cannot be null.
    * @param value variable value, cannot be null.
    */
   ProcessInstanceQuery variableValueGreaterThanOrEqual(String name, Object value);
@@ -165,7 +179,8 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
    * Only select process instances which have a global variable value less than the passed value.
    * Booleans, Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
-   * @param name variable name, cannot be null.
+   *
+   * @param name  variable name, cannot be null.
    * @param value variable value, cannot be null.
    */
   ProcessInstanceQuery variableValueLessThan(String name, Object value);
@@ -174,7 +189,8 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
    * Only select process instances which have a global variable value less than or equal to the passed value.
    * Booleans, Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
-   * @param name variable name, cannot be null.
+   *
+   * @param name  variable name, cannot be null.
    * @param value variable value, cannot be null.
    */
   ProcessInstanceQuery variableValueLessThanOrEqual(String name, Object value);
@@ -182,10 +198,11 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
   /**
    * Only select process instances which have a global variable value like the given value.
    * This be used on string variables only.
-   * @param name variable name, cannot be null.
+   *
+   * @param name  variable name, cannot be null.
    * @param value variable value, cannot be null. The string can include the
-   * wildcard character '%' to express like-strategy:
-   * starts with (string%), ends with (%string) or contains (%string%).
+   *              wildcard character '%' to express like-strategy:
+   *              starts with (string%), ends with (%string) or contains (%string%).
    */
   ProcessInstanceQuery variableValueLike(String name, String value);
 
@@ -228,10 +245,14 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
    */
   ProcessInstanceQuery incidentMessageLike(String incidentMessageLike);
 
-  /** Only select process instances with one of the given tenant ids. */
+  /**
+   * Only select process instances with one of the given tenant ids.
+   */
   ProcessInstanceQuery tenantIdIn(String... tenantIds);
 
-  /** Only selects process instances which have no tenant id. */
+  /**
+   * Only selects process instances which have no tenant id.
+   */
   ProcessInstanceQuery withoutTenantId();
 
   /**
@@ -245,24 +266,36 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
    */
   ProcessInstanceQuery activityIdIn(String... activityIds);
 
-  /** Only selects process instances which are top level process instances. */
+  /**
+   * Only selects process instances which are top level process instances.
+   */
   ProcessInstanceQuery rootProcessInstances();
 
-  /** Only selects process instances which don't have subprocesses and thus are leaves of the execution tree. */
+  /**
+   * Only selects process instances which don't have subprocesses and thus are leaves of the execution tree.
+   */
   ProcessInstanceQuery leafProcessInstances();
 
-  /** Only selects process instances which process definition has no tenant id. */
+  /**
+   * Only selects process instances which process definition has no tenant id.
+   */
   ProcessInstanceQuery processDefinitionWithoutTenantId();
 
   //ordering /////////////////////////////////////////////////////////////////
 
-  /** Order by id (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by id (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   ProcessInstanceQuery orderByProcessInstanceId();
 
-  /** Order by process definition key (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by process definition key (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   ProcessInstanceQuery orderByProcessDefinitionKey();
 
-  /** Order by process definition id (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by process definition id (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   ProcessInstanceQuery orderByProcessDefinitionId();
 
   /**
@@ -271,7 +304,9 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
    */
   ProcessInstanceQuery orderByTenantId();
 
-  /** Order by the business key (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by the business key (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   ProcessInstanceQuery orderByBusinessKey();
 
   /**
@@ -281,11 +316,10 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
    *
    * @return an object of the type {@link ProcessInstanceQuery} on which an arbitrary amount of filter criteria could be applied.
    * The several filter criteria will be linked together by an OR expression.
-   *
    * @throws ProcessEngineException when or() has been invoked directly after or() or after or() and trailing filter
-   * criteria. To prevent throwing this exception, {@link #endOr()} must be invoked after a chain of filter criteria to
-   * mark the end of the OR query.
-   * */
+   *                                criteria. To prevent throwing this exception, {@link #endOr()} must be invoked after a chain of filter criteria to
+   *                                mark the end of the OR query.
+   */
   ProcessInstanceQuery or();
 
   /**
@@ -295,9 +329,8 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
    *
    * @return an object of the type {@link ProcessInstanceQuery} on which an arbitrary amount of filter criteria could be applied.
    * The filter criteria will be linked together by an AND expression.
-   *
    * @throws ProcessEngineException when endOr() has been invoked before {@link #or()} was invoked. To prevent throwing
-   * this exception, {@link #or()} must be invoked first.
-   * */
+   *                                this exception, {@link #or()} must be invoked first.
+   */
   ProcessInstanceQuery endOr();
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/runtime/VariableInstanceQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/runtime/VariableInstanceQuery.java
@@ -18,7 +18,7 @@ package org.camunda.bpm.engine.runtime;
 
 import java.io.Serializable;
 
-import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.query.Query;
 
 /**
@@ -26,50 +26,74 @@ import org.camunda.bpm.engine.query.Query;
  */
 public interface VariableInstanceQuery extends Query<VariableInstanceQuery, VariableInstance> {
 
-  /** Only select the variable with the given Id
-   * @param the id of the variable to select
-   * @return the query object */
+  /**
+   * Only select the variable with the given Id
+   *
+   * @param id the id of the variable to select
+   * @return the query object
+   */
   VariableInstanceQuery variableId(String id);
 
-  /** Only select variable instances which have the variable name. **/
+  /**
+   * Only select variable instances which have the variable name.
+   **/
   VariableInstanceQuery variableName(String variableName);
 
-  /** Only select variable instances which have one of the variables names. **/
+  /**
+   * Only select variable instances which have one of the variables names.
+   **/
   VariableInstanceQuery variableNameIn(String... variableNames);
 
-  /** Only select variable instances which have the name like the assigned variable name.
+  /**
+   * Only select variable instances which have the name like the assigned variable name.
    * The string can include the wildcard character '%' to express like-strategy:
    * starts with (string%), ends with (%string) or contains (%string%).
    **/
   VariableInstanceQuery variableNameLike(String variableNameLike);
 
-  /** Only select variable instances which have one of the executions ids. **/
+  /**
+   * Only select variable instances which have one of the executions ids.
+   **/
   VariableInstanceQuery executionIdIn(String... executionIds);
 
-  /** Only select variable instances which have one of the process instance ids. **/
+  /**
+   * Only select variable instances which have one of the process instance ids.
+   **/
   VariableInstanceQuery processInstanceIdIn(String... processInstanceIds);
 
-  /** Only select variable instances which have one of the case execution ids. **/
+  /**
+   * Only select variable instances which have one of the case execution ids.
+   **/
   VariableInstanceQuery caseExecutionIdIn(String... caseExecutionIds);
 
-  /** Only select variable instances which have one of the case instance ids. **/
+  /**
+   * Only select variable instances which have one of the case instance ids.
+   **/
   VariableInstanceQuery caseInstanceIdIn(String... caseInstanceIds);
 
-  /** Only select variable instances which have one of the task ids. **/
+  /**
+   * Only select variable instances which have one of the task ids.
+   **/
   VariableInstanceQuery taskIdIn(String... taskIds);
 
-  /** Only select variable instances which are related to one of the given batch ids. **/
+  /**
+   * Only select variable instances which are related to one of the given batch ids.
+   **/
   VariableInstanceQuery batchIdIn(String... batchIds);
 
-  /** Only select variables instances which have on of the variable scope ids. **/
+  /**
+   * Only select variables instances which have on of the variable scope ids.
+   **/
   VariableInstanceQuery variableScopeIdIn(String... variableScopeIds);
 
-  /** Only select variable instances which have one of the activity instance ids. **/
+  /**
+   * Only select variable instances which have one of the activity instance ids.
+   **/
   VariableInstanceQuery activityInstanceIdIn(String... activityInstanceIds);
 
   /**
    * The query will match the names of variables in a case-insensitive way.<br>
-   * Note: This affects all <code>variableValueXXX</code> filters: 
+   * Note: This affects all <code>variableValueXXX</code> filters:
    * <ul>
    *  <li>{@link #variableValueEquals(String, Object)}</li>
    *  <li>{@link #variableValueGreaterThan(String, Object)}</li>
@@ -90,7 +114,7 @@ public interface VariableInstanceQuery extends Query<VariableInstanceQuery, Vari
 
   /**
    * The query will match the values of variables in a case-insensitive way.<br>
-   * Note: This affects all <code>variableValueXXX</code> filters: 
+   * Note: This affects all <code>variableValueXXX</code> filters:
    * <ul>
    *  <li>{@link #variableValueEquals(String, Object)}</li>
    *  <li>{@link #variableValueGreaterThan(String, Object)}</li>
@@ -106,10 +130,11 @@ public interface VariableInstanceQuery extends Query<VariableInstanceQuery, Vari
   /**
    * Only select variables instances which have the given name and value. The type
    * of variable is determined based on the value, using types configured in
-   * {@link ProcessEngineConfiguration#getVariableSerializers()}.
+   * {@link ProcessEngineConfigurationImpl#getVariableSerializers()}.
    * Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
-   * @param name name of the variable, cannot be null.
+   *
+   * @param name  name of the variable, cannot be null.
    * @param value variable value, can be null.
    */
   VariableInstanceQuery variableValueEquals(String name, Object value);
@@ -119,7 +144,8 @@ public interface VariableInstanceQuery extends Query<VariableInstanceQuery, Vari
    * with a different value than the passed value.
    * Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
-   * @param name name of the variable, cannot be null.
+   *
+   * @param name  name of the variable, cannot be null.
    * @param value variable value, can be null.
    */
   VariableInstanceQuery variableValueNotEquals(String name, Object value);
@@ -128,7 +154,8 @@ public interface VariableInstanceQuery extends Query<VariableInstanceQuery, Vari
    * Only select variable instances which value is greater than the passed value.
    * Booleans, Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
-   * @param name variable name, cannot be null.
+   *
+   * @param name  variable name, cannot be null.
    * @param value variable value, cannot be null.
    */
   VariableInstanceQuery variableValueGreaterThan(String name, Object value);
@@ -137,7 +164,8 @@ public interface VariableInstanceQuery extends Query<VariableInstanceQuery, Vari
    * Only select variable instances which value is greater than or equal to
    * the passed value. Booleans, Byte-arrays and {@link Serializable} objects (which
    * are not primitive type wrappers) are not supported.
-   * @param name variable name, cannot be null.
+   *
+   * @param name  variable name, cannot be null.
    * @param value variable value, cannot be null.
    */
   VariableInstanceQuery variableValueGreaterThanOrEqual(String name, Object value);
@@ -146,7 +174,8 @@ public interface VariableInstanceQuery extends Query<VariableInstanceQuery, Vari
    * Only select variable instances which value is less than the passed value.
    * Booleans, Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
-   * @param name variable name, cannot be null.
+   *
+   * @param name  variable name, cannot be null.
    * @param value variable value, cannot be null.
    */
   VariableInstanceQuery variableValueLessThan(String name, Object value);
@@ -155,7 +184,8 @@ public interface VariableInstanceQuery extends Query<VariableInstanceQuery, Vari
    * Only select variable instances which value is less than or equal to the passed value.
    * Booleans, Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
-   * @param name variable name, cannot be null.
+   *
+   * @param name  variable name, cannot be null.
    * @param value variable value, cannot be null.
    */
   VariableInstanceQuery variableValueLessThanOrEqual(String name, Object value);
@@ -180,23 +210,32 @@ public interface VariableInstanceQuery extends Query<VariableInstanceQuery, Vari
   /**
    * Only select variable instances which value is like the given value.
    * This be used on string variables only.
-   * @param name variable name, cannot be null.
+   *
+   * @param name  variable name, cannot be null.
    * @param value variable value, cannot be null. The string can include the
-   * wildcard character '%' to express like-strategy:
-   * starts with (string%), ends with (%string) or contains (%string%).
+   *              wildcard character '%' to express like-strategy:
+   *              starts with (string%), ends with (%string) or contains (%string%).
    */
   VariableInstanceQuery variableValueLike(String name, String value);
 
-  /** Only select variable instances with one of the given tenant ids. */
+  /**
+   * Only select variable instances with one of the given tenant ids.
+   */
   VariableInstanceQuery tenantIdIn(String... tenantIds);
 
-  /** Order by variable name (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by variable name (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   VariableInstanceQuery orderByVariableName();
 
-  /** Order by variable type (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by variable type (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   VariableInstanceQuery orderByVariableType();
 
-  /** Order by activity instance id (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  /**
+   * Order by activity instance id (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
   VariableInstanceQuery orderByActivityInstanceId();
 
   /**

--- a/engine/src/main/java/org/camunda/bpm/engine/task/TaskQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/task/TaskQuery.java
@@ -21,8 +21,8 @@ import java.util.Date;
 import java.util.List;
 
 import org.camunda.bpm.engine.BadUserRequestException;
-import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.query.Query;
 import org.camunda.bpm.engine.variable.type.ValueType;
 
@@ -32,7 +32,7 @@ import org.camunda.bpm.engine.variable.type.ValueType;
  * @author Joram Barrez
  * @author Falko Menge
  */
-public interface TaskQuery extends Query<TaskQuery, Task>{
+public interface TaskQuery extends Query<TaskQuery, Task> {
 
   /**
    * Only select tasks with the given task id (in practice, there will be
@@ -40,7 +40,9 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    */
   TaskQuery taskId(String taskId);
 
-  /** Only select tasks with the given task ids. */
+  /**
+   * Only select tasks with the given task ids.
+   */
   TaskQuery taskIdIn(String... taskIds);
 
   /**
@@ -82,82 +84,103 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    */
   TaskQuery taskDescriptionLike(String descriptionLike);
 
-  /** Only select tasks with the given priority. */
+  /**
+   * Only select tasks with the given priority.
+   */
   TaskQuery taskPriority(Integer priority);
 
-  /** Only select tasks with the given priority or higher. */
+  /**
+   * Only select tasks with the given priority or higher.
+   */
   TaskQuery taskMinPriority(Integer minPriority);
 
-  /** Only select tasks with the given priority or lower. */
+  /**
+   * Only select tasks with the given priority or lower.
+   */
   TaskQuery taskMaxPriority(Integer maxPriority);
 
-  /** Only select tasks which are assigned to the given user. */
+  /**
+   * Only select tasks which are assigned to the given user.
+   */
   TaskQuery taskAssignee(String assignee);
 
   /**
-   *  <p>Only select tasks which are assigned to the user described by the given expression.</p>
+   * <p>Only select tasks which are assigned to the user described by the given expression.</p>
    *
-   * @throws BadUserRequestException
-   *   <ul><li>When the query is executed and expressions are disabled for adhoc queries
-   *  (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
-   *  or stored queries (in case the query is stored along with a filter).
-   *  Expression evaluation can be activated by setting the process engine configuration properties
-   *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
-   *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
+   * @throws BadUserRequestException <ul><li>When the query is executed and expressions are disabled for adhoc queries
+   *                                 (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
+   *                                 or stored queries (in case the query is stored along with a filter).
+   *                                 Expression evaluation can be activated by setting the process engine configuration properties
+   *                                 <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
+   *                                 <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
   TaskQuery taskAssigneeExpression(String assigneeExpression);
 
-  /** Only select tasks which are matching the given user.
-   *  The syntax is that of SQL: for example usage: nameLike(%camunda%)*/
+  /**
+   * Only select tasks which are matching the given user.
+   * The syntax is that of SQL: for example usage: nameLike(%camunda%)
+   */
   TaskQuery taskAssigneeLike(String assignee);
 
   /**
    * <p>Only select tasks which are assigned to the user described by the given expression.
-   *  The syntax is that of SQL: for example usage: taskAssigneeLikeExpression("${'%test%'}")</p>
+   * The syntax is that of SQL: for example usage: taskAssigneeLikeExpression("${'%test%'}")</p>
    *
-   * @throws BadUserRequestException
-   *   <ul><li>When the query is executed and expressions are disabled for adhoc queries
-   *  (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
-   *  or stored queries (in case the query is stored along with a filter).
-   *  Expression evaluation can be activated by setting the process engine configuration properties
-   *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
-   *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
+   * @throws BadUserRequestException <ul><li>When the query is executed and expressions are disabled for adhoc queries
+   *                                 (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
+   *                                 or stored queries (in case the query is stored along with a filter).
+   *                                 Expression evaluation can be activated by setting the process engine configuration properties
+   *                                 <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
+   *                                 <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
   TaskQuery taskAssigneeLikeExpression(String assigneeLikeExpression);
 
-  /** Only select tasks which are assigned to one of the given users. */
+  /**
+   * Only select tasks which are assigned to one of the given users.
+   */
   TaskQuery taskAssigneeIn(String... assignees);
 
-  /** Only select tasks which are not assigned to any of the given users. */
+  /**
+   * Only select tasks which are not assigned to any of the given users.
+   */
   TaskQuery taskAssigneeNotIn(String... assignees);
 
-  /** Only select tasks for which the given user is the owner. */
+  /**
+   * Only select tasks for which the given user is the owner.
+   */
   TaskQuery taskOwner(String owner);
 
   /**
    * <p>Only select tasks for which the described user by the given expression is the owner.</p>
    *
-   * @throws BadUserRequestException
-   *   <ul><li>When the query is executed and expressions are disabled for adhoc queries
-   *  (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
-   *  or stored queries (in case the query is stored along with a filter).
-   *  Expression evaluation can be activated by setting the process engine configuration properties
-   *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
-   *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
+   * @throws BadUserRequestException <ul><li>When the query is executed and expressions are disabled for adhoc queries
+   *                                 (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
+   *                                 or stored queries (in case the query is stored along with a filter).
+   *                                 Expression evaluation can be activated by setting the process engine configuration properties
+   *                                 <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
+   *                                 <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
   TaskQuery taskOwnerExpression(String ownerExpression);
 
-  /** Only select tasks which don't have an assignee. */
+  /**
+   * Only select tasks which don't have an assignee.
+   */
   TaskQuery taskUnassigned();
 
-  /** @see {@link #taskUnassigned} */
+  /**
+   * @see #taskUnassigned()
+   */
   @Deprecated
   TaskQuery taskUnnassigned();
 
-  /** Only select tasks which have an assignee. */
+  /**
+   * Only select tasks which have an assignee.
+   */
   TaskQuery taskAssigned();
 
-  /** Only select tasks with the given {@link DelegationState}. */
+  /**
+   * Only select tasks with the given {@link DelegationState}.
+   */
   TaskQuery taskDelegationState(DelegationState delegationState);
 
   /**
@@ -169,21 +192,18 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * {@link #includeAssignedTasks()} in your query.
    * </p>
    *
-   * @throws ProcessEngineException
-   *   <ul><li>When query is executed and {@link #taskCandidateGroup(String)} or
-   *     {@link #taskCandidateGroupIn(List)} has been executed on the "and query" instance.
-   *     No exception is thrown when query is executed and {@link #taskCandidateGroup(String)} or
-   *     {@link #taskCandidateGroupIn(List)} has been executed on the "or query" instance.
-   *   <li>When passed user is <code>null</code>.
-   *   </ul>
-   * @throws BadUserRequestException
-   *   <ul><li>When the query is executed and expressions are disabled for adhoc queries
-   *  (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
-   *  or stored queries (in case the query is stored along with a filter).
-   *  Expression evaluation can be activated by setting the process engine configuration properties
-   *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
-   *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
-   *
+   * @throws ProcessEngineException  <ul><li>When query is executed and {@link #taskCandidateGroup(String)} or
+   *                                 {@link #taskCandidateGroupIn(List)} has been executed on the "and query" instance.
+   *                                 No exception is thrown when query is executed and {@link #taskCandidateGroup(String)} or
+   *                                 {@link #taskCandidateGroupIn(List)} has been executed on the "or query" instance.
+   *                                 <li>When passed user is <code>null</code>.
+   *                                 </ul>
+   * @throws BadUserRequestException <ul><li>When the query is executed and expressions are disabled for adhoc queries
+   *                                 (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
+   *                                 or stored queries (in case the query is stored along with a filter).
+   *                                 Expression evaluation can be activated by setting the process engine configuration properties
+   *                                 <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
+   *                                 <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
   TaskQuery taskCandidateUser(String candidateUser);
 
@@ -196,35 +216,34 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * {@link #includeAssignedTasks()} in your query.
    * </p>
    *
-   * @throws ProcessEngineException
-   *   <ul><li>When query is executed and {@link #taskCandidateGroup(String)} or
-   *     {@link #taskCandidateGroupIn(List)} has been executed on the query instance.
-   *   <li>When passed user is <code>null</code>.
-   *   </ul>
-   * @throws BadUserRequestException
-   *   <ul><li>When the query is executed and expressions are disabled for adhoc queries
-   *  (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
-   *  or stored queries (in case the query is stored along with a filter).
-   *  Expression evaluation can be activated by setting the process engine configuration properties
-   *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
-   *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
+   * @throws ProcessEngineException  <ul><li>When query is executed and {@link #taskCandidateGroup(String)} or
+   *                                 {@link #taskCandidateGroupIn(List)} has been executed on the query instance.
+   *                                 <li>When passed user is <code>null</code>.
+   *                                 </ul>
+   * @throws BadUserRequestException <ul><li>When the query is executed and expressions are disabled for adhoc queries
+   *                                 (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
+   *                                 or stored queries (in case the query is stored along with a filter).
+   *                                 Expression evaluation can be activated by setting the process engine configuration properties
+   *                                 <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
+   *                                 <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
   TaskQuery taskCandidateUserExpression(String candidateUserExpression);
 
-  /** Only select tasks for which there exist an {@link IdentityLink} with the given user */
+  /**
+   * Only select tasks for which there exist an {@link IdentityLink} with the given user
+   */
   TaskQuery taskInvolvedUser(String involvedUser);
 
   /**
    * <p>Only select tasks for which there exist an {@link IdentityLink} with the
    * described user by the given expression</p>
    *
-   * @throws BadUserRequestException
-   *   <ul><li>When the query is executed and expressions are disabled for adhoc queries
-   *  (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
-   *  or stored queries (in case the query is stored along with a filter).
-   *  Expression evaluation can be activated by setting the process engine configuration properties
-   *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
-   *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
+   * @throws BadUserRequestException <ul><li>When the query is executed and expressions are disabled for adhoc queries
+   *                                 (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
+   *                                 or stored queries (in case the query is stored along with a filter).
+   *                                 Expression evaluation can be activated by setting the process engine configuration properties
+   *                                 <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
+   *                                 <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
   TaskQuery taskInvolvedUserExpression(String involvedUserExpression);
 
@@ -257,7 +276,7 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
   TaskQuery withoutCandidateUsers();
 
   /**
-   *  Only select tasks for which users in the given group are candidates.
+   * Only select tasks for which users in the given group are candidates.
    *
    * <p>
    * Per default it only selects tasks which are not already assigned
@@ -265,12 +284,11 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * {@link #includeAssignedTasks()} in your query.
    * </p>
    *
-   * @throws ProcessEngineException
-   *   <ul><li>When query is executed and {@link #taskCandidateUser(String)} or
-   *     {@link #taskCandidateGroupIn(List)} has been executed on the "and query" instance.</li>
-   *   No exception is thrown when query is executed and {@link #taskCandidateUser(String)} or
-   *   {@link #taskCandidateGroupIn(List)} has been executed on the "or query" instance.</li>
-   *   <li>When passed group is <code>null</code>.</li></ul>
+   * @throws ProcessEngineException <ul><li>When query is executed and {@link #taskCandidateUser(String)} or
+   *                                {@link #taskCandidateGroupIn(List)} has been executed on the "and query" instance.</li>
+   *                                No exception is thrown when query is executed and {@link #taskCandidateUser(String)} or
+   *                                {@link #taskCandidateGroupIn(List)} has been executed on the "or query" instance.</li>
+   *                                <li>When passed group is <code>null</code>.</li></ul>
    */
   TaskQuery taskCandidateGroup(String candidateGroup);
 
@@ -283,18 +301,16 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * {@link #includeAssignedTasks()} in your query.
    * </p>
    *
-   * @throws ProcessEngineException
-   *   <ul><li>When query is executed and {@link #taskCandidateUser(String)} or
-   *     {@link #taskCandidateGroupIn(List)} has been executed on the query instance.
-   *   <li>When passed group is <code>null</code>.
-   *   </ul>
-   * @throws BadUserRequestException
-   *   <ul><li>When the query is executed and expressions are disabled for adhoc queries
-   *  (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
-   *  or stored queries (in case the query is stored along with a filter).
-   *  Expression evaluation can be activated by setting the process engine configuration properties
-   *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
-   *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
+   * @throws ProcessEngineException  <ul><li>When query is executed and {@link #taskCandidateUser(String)} or
+   *                                 {@link #taskCandidateGroupIn(List)} has been executed on the query instance.
+   *                                 <li>When passed group is <code>null</code>.
+   *                                 </ul>
+   * @throws BadUserRequestException <ul><li>When the query is executed and expressions are disabled for adhoc queries
+   *                                 (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
+   *                                 or stored queries (in case the query is stored along with a filter).
+   *                                 Expression evaluation can be activated by setting the process engine configuration properties
+   *                                 <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
+   *                                 <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
   TaskQuery taskCandidateGroupExpression(String candidateGroupExpression);
 
@@ -307,12 +323,11 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * {@link #includeAssignedTasks()} in your query.
    * </p>
    *
-   * @throws ProcessEngineException
-   *   <ul><li>When query is executed and {@link #taskCandidateGroup(String)} or
-   *     {@link #taskCandidateUser(String)} has been executed on the "and query" instance.</li>
-   *   No exception is thrown when query is executed and {@link #taskCandidateGroup(String)} or
-   *   {@link #taskCandidateUser(String)} has been executed on the "or query" instance.</li>
-   *   <li>When passed group list is empty or <code>null</code>.</li></ul>
+   * @throws ProcessEngineException <ul><li>When query is executed and {@link #taskCandidateGroup(String)} or
+   *                                {@link #taskCandidateUser(String)} has been executed on the "and query" instance.</li>
+   *                                No exception is thrown when query is executed and {@link #taskCandidateGroup(String)} or
+   *                                {@link #taskCandidateUser(String)} has been executed on the "or query" instance.</li>
+   *                                <li>When passed group list is empty or <code>null</code>.</li></ul>
    */
   TaskQuery taskCandidateGroupIn(List<String> candidateGroups);
 
@@ -325,17 +340,15 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * {@link #includeAssignedTasks()} in your query.
    * </p>
    *
-   * @throws ProcessEngineException
-   *   <ul><li>When query is executed and {@link #taskCandidateGroup(String)} or
-   *     {@link #taskCandidateUser(String)} has been executed on the query instance.
-   *   <li>When passed group list is empty or <code>null</code>.</ul>
-   * @throws BadUserRequestException
-   *   <ul><li>When the query is executed and expressions are disabled for adhoc queries
-   *  (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
-   *  or stored queries (in case the query is stored along with a filter).
-   *  Expression evaluation can be activated by setting the process engine configuration properties
-   *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
-   *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
+   * @throws ProcessEngineException  <ul><li>When query is executed and {@link #taskCandidateGroup(String)} or
+   *                                 {@link #taskCandidateUser(String)} has been executed on the query instance.
+   *                                 <li>When passed group list is empty or <code>null</code>.</ul>
+   * @throws BadUserRequestException <ul><li>When the query is executed and expressions are disabled for adhoc queries
+   *                                 (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
+   *                                 or stored queries (in case the query is stored along with a filter).
+   *                                 Expression evaluation can be activated by setting the process engine configuration properties
+   *                                 <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
+   *                                 <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
   TaskQuery taskCandidateGroupInExpression(String candidateGroupsExpression);
 
@@ -346,21 +359,28 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * and {@link #taskCandidateGroupIn(List)} queries only select not assigned tasks.
    * </p>
    *
-   * @throws ProcessEngineException
-   *    When no candidate user or group(s) are specified beforehand
+   * @throws ProcessEngineException When no candidate user or group(s) are specified beforehand
    */
   TaskQuery includeAssignedTasks();
 
-  /** Only select tasks for the given process instance id. */
+  /**
+   * Only select tasks for the given process instance id.
+   */
   TaskQuery processInstanceId(String processInstanceId);
 
-  /** Only select tasks for the given process instance ids. */
+  /**
+   * Only select tasks for the given process instance ids.
+   */
   TaskQuery processInstanceIdIn(String... processInstanceIds);
 
-  /** Only select tasks for the given process instance business key */
+  /**
+   * Only select tasks for the given process instance business key
+   */
   TaskQuery processInstanceBusinessKey(String processInstanceBusinessKey);
 
-  /** Only select tasks for the given process instance business key described by the given expression */
+  /**
+   * Only select tasks for the given process instance business key described by the given expression
+   */
   TaskQuery processInstanceBusinessKeyExpression(String processInstanceBusinessKeyExpression);
 
   /**
@@ -368,45 +388,71 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    */
   TaskQuery processInstanceBusinessKeyIn(String... processInstanceBusinessKeys);
 
-  /** Only select tasks matching the given process instance business key.
-   *  The syntax is that of SQL: for example usage: nameLike(%camunda%)*/
+  /**
+   * Only select tasks matching the given process instance business key.
+   * The syntax is that of SQL: for example usage: nameLike(%camunda%)
+   */
   TaskQuery processInstanceBusinessKeyLike(String processInstanceBusinessKey);
 
-  /** Only select tasks matching the given process instance business key described by the given expression.
-   *  The syntax is that of SQL: for example usage: processInstanceBusinessKeyLikeExpression("${ '%camunda%' }")*/
+  /**
+   * Only select tasks matching the given process instance business key described by the given expression.
+   * The syntax is that of SQL: for example usage: processInstanceBusinessKeyLikeExpression("${ '%camunda%' }")
+   */
   TaskQuery processInstanceBusinessKeyLikeExpression(String processInstanceBusinessKeyExpression);
 
-  /** Only select tasks for the given execution. */
+  /**
+   * Only select tasks for the given execution.
+   */
   TaskQuery executionId(String executionId);
 
-  /** Only select task which have one of the activity instance ids. **/
+  /**
+   * Only select task which have one of the activity instance ids.
+   **/
   TaskQuery activityInstanceIdIn(String... activityInstanceIds);
 
-  /** Only select tasks that are created on the given date. **/
+  /**
+   * Only select tasks that are created on the given date.
+   **/
   TaskQuery taskCreatedOn(Date createTime);
 
-  /** Only select tasks that are created on the date resolved from the given expression. **/
+  /**
+   * Only select tasks that are created on the date resolved from the given expression.
+   **/
   TaskQuery taskCreatedOnExpression(String createTimeExpression);
 
-  /** Only select tasks that are created before the given date. **/
+  /**
+   * Only select tasks that are created before the given date.
+   **/
   TaskQuery taskCreatedBefore(Date before);
 
-  /** Only select tasks that are created before the date resolved from the given expression. **/
+  /**
+   * Only select tasks that are created before the date resolved from the given expression.
+   **/
   TaskQuery taskCreatedBeforeExpression(String beforeExpression);
 
-  /** Only select tasks that are created after the given date. **/
+  /**
+   * Only select tasks that are created after the given date.
+   **/
   TaskQuery taskCreatedAfter(Date after);
 
-  /** Only select tasks that are created after the date resolved from the given expression. **/
+  /**
+   * Only select tasks that are created after the date resolved from the given expression.
+   **/
   TaskQuery taskCreatedAfterExpression(String afterExpression);
 
-  /** Only select tasks that were updated after the given date. **/
+  /**
+   * Only select tasks that were updated after the given date.
+   **/
   TaskQuery taskUpdatedAfter(Date after);
 
-  /** Only select tasks that were updated after the date resolved from the given expression. **/
+  /**
+   * Only select tasks that were updated after the date resolved from the given expression.
+   **/
   TaskQuery taskUpdatedAfterExpression(String afterExpression);
 
-  /** Only select tasks that have no parent (i.e. do not select subtasks). **/
+  /**
+   * Only select tasks that have no parent (i.e. do not select subtasks).
+   **/
   TaskQuery excludeSubtasks();
 
   /**
@@ -418,13 +464,15 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
 
   /**
    * Only select tasks with a taskDefinitionKey that match the given parameter.
-   *  The syntax is that of SQL: for example usage: taskDefinitionKeyLike("%camunda%").
+   * The syntax is that of SQL: for example usage: taskDefinitionKeyLike("%camunda%").
    * The task definition key is the id of the userTask:
    * &lt;userTask id="xxx" .../&gt;
    **/
   TaskQuery taskDefinitionKeyLike(String keyLike);
 
-  /** Only select tasks which have one of the taskDefinitionKeys. **/
+  /**
+   * Only select tasks which have one of the taskDefinitionKeys.
+   **/
   TaskQuery taskDefinitionKeyIn(String... taskDefinitionKeys);
 
   /**
@@ -432,17 +480,25 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    */
   TaskQuery taskParentTaskId(String parentTaskId);
 
-  /** Only select tasks for the given case instance id. */
+  /**
+   * Only select tasks for the given case instance id.
+   */
   TaskQuery caseInstanceId(String caseInstanceId);
 
-  /** Only select tasks for the given case instance business key */
+  /**
+   * Only select tasks for the given case instance business key
+   */
   TaskQuery caseInstanceBusinessKey(String caseInstanceBusinessKey);
 
-  /** Only select tasks matching the given case instance business key.
-   *  The syntax is that of SQL: for example usage: nameLike(%aBusinessKey%)*/
+  /**
+   * Only select tasks matching the given case instance business key.
+   * The syntax is that of SQL: for example usage: nameLike(%aBusinessKey%)
+   */
   TaskQuery caseInstanceBusinessKeyLike(String caseInstanceBusinessKeyLike);
 
-  /** Only select tasks for the given case execution. */
+  /**
+   * Only select tasks for the given case execution.
+   */
   TaskQuery caseExecutionId(String caseExecutionId);
 
   /**
@@ -466,7 +522,8 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
   /**
    * Only select tasks which are part of a case instance which case definition
    * name is like the given parameter.
-   * The syntax is that of SQL: for example usage: nameLike(%processDefinitionName%)*/
+   * The syntax is that of SQL: for example usage: nameLike(%processDefinitionName%)
+   */
   TaskQuery caseDefinitionNameLike(String caseDefinitionNameLike);
 
   /**
@@ -541,13 +598,15 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
   /**
    * Only select tasks which are part of a process that have a variable
    * with the given name and matching the given value.
-   * The syntax is that of SQL: for example usage: valueLike(%value%)*/
+   * The syntax is that of SQL: for example usage: valueLike(%value%)
+   */
   TaskQuery processVariableValueLike(String variableName, String variableValue);
 
   /**
    * Only select tasks which are part of a process that have a variable
    * with the given name and not matching the given value.
-   * The syntax is that of SQL: for example usage: valueNotLike(%value%)*/
+   * The syntax is that of SQL: for example usage: valueNotLike(%value%)
+   */
   TaskQuery processVariableValueNotLike(String variableName, String variableValue);
 
   /**
@@ -577,12 +636,12 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
   /**
    * Only select tasks which are part of a case instance that have a variable
    * with the given name set to the given value. The type of variable is determined based
-   * on the value, using types configured in {@link ProcessEngineConfiguration#getVariableSerializers()}.
-   *
+   * on the value, using types configured in {@link ProcessEngineConfigurationImpl#getVariableSerializers()}.
+   * <p>
    * Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
    *
-   * @param name name of the variable, cannot be null.
+   * @param variableName name of the variable, cannot be null.
    */
   TaskQuery caseInstanceVariableValueEquals(String variableName, Object variableValue);
 
@@ -590,84 +649,82 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * Only select tasks which are part of a case instance that have a variable
    * with the given name, but with a different value than the passed value. The
    * type of variable is determined based on the value, using types configured
-   * in {@link ProcessEngineConfiguration#getVariableSerializers()}.
-   *
+   * in {@link ProcessEngineConfigurationImpl#getVariableSerializers()}.
+   * <p>
    * Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
    *
-   * @param name name of the variable, cannot be null.
+   * @param variableName name of the variable, cannot be null.
    */
   TaskQuery caseInstanceVariableValueNotEquals(String variableName, Object variableValue);
 
   /**
    * Only select tasks which are part of a case instance that have a variable value
    * like the given value.
-   *
+   * <p>
    * This be used on string variables only.
    *
-   * @param name variable name, cannot be null.
-   *
-   * @param value variable value. The string can include the
-   * wildcard character '%' to express like-strategy:
-   * starts with (string%), ends with (%string) or contains (%string%).
+   * @param variableName  variable name, cannot be null.
+   * @param variableValue variable value. The string can include the
+   *                      wildcard character '%' to express like-strategy:
+   *                      starts with (string%), ends with (%string) or contains (%string%).
    */
   TaskQuery caseInstanceVariableValueLike(String variableName, String variableValue);
 
   /**
    * Only select tasks which are part of a case instance that have a variable value
    * not like the given value.
-   *
+   * <p>
    * This be used on string variables only.
    *
-   * @param name variable name, cannot be null.
-   *
-   * @param value variable value. The string can include the
-   * wildcard character '%' to express like-strategy:
-   * starts with (string%), ends with (%string) or contains (%string%).
+   * @param variableName  variable name, cannot be null.
+   * @param variableValue variable value. The string can include the
+   *                      wildcard character '%' to express like-strategy:
+   *                      starts with (string%), ends with (%string) or contains (%string%).
    */
   TaskQuery caseInstanceVariableValueNotLike(String variableName, String variableValue);
 
   /**
    * Only select tasks which are part of a case instance that have a variable
    * with the given name and a variable value greater than the passed value.
-   *
+   * <p>
    * Booleans, Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
    *
-   * @param name variable name, cannot be null.
+   * @param variableName variable name, cannot be null.
    */
   TaskQuery caseInstanceVariableValueGreaterThan(String variableName, Object variableValue);
 
   /**
    * Only select tasks which are part of a case instance that have a
    * variable value greater than or equal to the passed value.
-   *
+   * <p>
    * Booleans, Byte-arrays and {@link Serializable} objects (which
    * are not primitive type wrappers) are not supported.
    *
-   * @param name variable name, cannot be null.
+   * @param variableName variable name, cannot be null.
    */
   TaskQuery caseInstanceVariableValueGreaterThanOrEquals(String variableName, Object variableValue);
 
   /**
    * Only select tasks which are part of a case instance that have a variable
    * value less than the passed value.
-   *
+   * <p>
    * Booleans, Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
    *
-   * @param name variable name, cannot be null.
+   * @param variableName variable name, cannot be null.
    */
   TaskQuery caseInstanceVariableValueLessThan(String variableName, Object variableValue);
 
   /**
    * Only select tasks which are part of a case instance that have a variable
    * value less than or equal to the passed value.
-   *
+   * <p>
    * Booleans, Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
    * are not supported.
    *
-   * @param name variable name, cannot be null.
+   * @param variableName variable name, cannot be null.
    */
   TaskQuery caseInstanceVariableValueLessThanOrEquals(String variableName, Object variableValue);
 
@@ -698,7 +755,8 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
   /**
    * Only select tasks which are part of a process instance which process definition
    * name  is like the given parameter.
-   * The syntax is that of SQL: for example usage: nameLike(%processDefinitionName%)*/
+   * The syntax is that of SQL: for example usage: nameLike(%processDefinitionName%)
+   */
   TaskQuery processDefinitionNameLike(String processDefinitionName);
 
   /**
@@ -709,13 +767,12 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
   /**
    * <p>Only select tasks with the described due date by the given expression.</p>
    *
-   * @throws BadUserRequestException
-   *   <ul><li>When the query is executed and expressions are disabled for adhoc queries
-   *  (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
-   *  or stored queries (in case the query is stored along with a filter).
-   *  Expression evaluation can be activated by setting the process engine configuration properties
-   *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
-   *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
+   * @throws BadUserRequestException <ul><li>When the query is executed and expressions are disabled for adhoc queries
+   *                                 (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
+   *                                 or stored queries (in case the query is stored along with a filter).
+   *                                 Expression evaluation can be activated by setting the process engine configuration properties
+   *                                 <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
+   *                                 <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
   TaskQuery dueDateExpression(String dueDateExpression);
 
@@ -727,13 +784,12 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
   /**
    * <p>Only select tasks which have a due date before the described date by the given expression.</p>
    *
-   * @throws BadUserRequestException
-   *   <ul><li>When the query is executed and expressions are disabled for adhoc queries
-   *  (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
-   *  or stored queries (in case the query is stored along with a filter).
-   *  Expression evaluation can be activated by setting the process engine configuration properties
-   *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
-   *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
+   * @throws BadUserRequestException <ul><li>When the query is executed and expressions are disabled for adhoc queries
+   *                                 (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
+   *                                 or stored queries (in case the query is stored along with a filter).
+   *                                 Expression evaluation can be activated by setting the process engine configuration properties
+   *                                 <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
+   *                                 <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
   TaskQuery dueBeforeExpression(String dueDateExpression);
 
@@ -745,13 +801,12 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
   /**
    * <p>Only select tasks which have a due date after the described date by the given expression.</p>
    *
-   * @throws BadUserRequestException
-   *   <ul><li>When the query is executed and expressions are disabled for adhoc queries
-   *  (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
-   *  or stored queries (in case the query is stored along with a filter).
-   *  Expression evaluation can be activated by setting the process engine configuration properties
-   *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
-   *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
+   * @throws BadUserRequestException <ul><li>When the query is executed and expressions are disabled for adhoc queries
+   *                                 (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
+   *                                 or stored queries (in case the query is stored along with a filter).
+   *                                 Expression evaluation can be activated by setting the process engine configuration properties
+   *                                 <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
+   *                                 <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
   TaskQuery dueAfterExpression(String dueDateExpression);
 
@@ -763,13 +818,12 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
   /**
    * <p>Only select tasks with the described follow-up date by the given expression.</p>
    *
-   * @throws BadUserRequestException
-   *   <ul><li>When the query is executed and expressions are disabled for adhoc queries
-   *  (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
-   *  or stored queries (in case the query is stored along with a filter).
-   *  Expression evaluation can be activated by setting the process engine configuration properties
-   *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
-   *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
+   * @throws BadUserRequestException <ul><li>When the query is executed and expressions are disabled for adhoc queries
+   *                                 (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
+   *                                 or stored queries (in case the query is stored along with a filter).
+   *                                 Expression evaluation can be activated by setting the process engine configuration properties
+   *                                 <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
+   *                                 <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
   TaskQuery followUpDateExpression(String followUpDateExpression);
 
@@ -781,13 +835,12 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
   /**
    * <p>Only select tasks which have a follow-up date before the described date by the given expression.</p>
    *
-   * @throws BadUserRequestException
-   *   <ul><li>When the query is executed and expressions are disabled for adhoc queries
-   *  (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
-   *  or stored queries (in case the query is stored along with a filter).
-   *  Expression evaluation can be activated by setting the process engine configuration properties
-   *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
-   *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
+   * @throws BadUserRequestException <ul><li>When the query is executed and expressions are disabled for adhoc queries
+   *                                 (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
+   *                                 or stored queries (in case the query is stored along with a filter).
+   *                                 Expression evaluation can be activated by setting the process engine configuration properties
+   *                                 <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
+   *                                 <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
   TaskQuery followUpBeforeExpression(String followUpDateExpression);
 
@@ -801,13 +854,12 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * <p>Only select tasks which have no follow-up date or a follow-up date before the described date by the given expression.
    * Serves the typical use case "give me all tasks without follow-up or follow-up date which is already due"</p>
    *
-   * @throws BadUserRequestException
-   *   <ul><li>When the query is executed and expressions are disabled for adhoc queries
-   *  (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
-   *  or stored queries (in case the query is stored along with a filter).
-   *  Expression evaluation can be activated by setting the process engine configuration properties
-   *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
-   *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
+   * @throws BadUserRequestException <ul><li>When the query is executed and expressions are disabled for adhoc queries
+   *                                 (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
+   *                                 or stored queries (in case the query is stored along with a filter).
+   *                                 Expression evaluation can be activated by setting the process engine configuration properties
+   *                                 <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
+   *                                 <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
   TaskQuery followUpBeforeOrNotExistentExpression(String followUpDateExpression);
 
@@ -819,13 +871,12 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
   /**
    * <p>Only select tasks which have a follow-up date after the described date by the given expression.</p>
    *
-   * @throws BadUserRequestException
-   *   <ul><li>When the query is executed and expressions are disabled for adhoc queries
-   *  (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
-   *  or stored queries (in case the query is stored along with a filter).
-   *  Expression evaluation can be activated by setting the process engine configuration properties
-   *  <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
-   *  <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
+   * @throws BadUserRequestException <ul><li>When the query is executed and expressions are disabled for adhoc queries
+   *                                 (in case the query is executed via {@link #list()}, {@link #listPage(int, int)}, {@link #singleResult()}, or {@link #count()})
+   *                                 or stored queries (in case the query is stored along with a filter).
+   *                                 Expression evaluation can be activated by setting the process engine configuration properties
+   *                                 <code>enableExpressionsInAdhocQueries</code> (default <code>false</code>) and
+   *                                 <code>enableExpressionsInStoredQueries</code> (default <code>true</code>) to <code>true</code>.
    */
   TaskQuery followUpAfterExpression(String followUpDateExpression);
 
@@ -844,24 +895,21 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * {@link Task#getFormKey()} and {@link Task#getCamundaFormRef()} will return a value (in
    * case the task has is linked to a form).
    *
-   * @throws ProcessEngineException
-   *   When method has been executed within "or query". Method must be executed on the base query.
-   *
    * @return the query itself
+   * @throws ProcessEngineException When method has been executed within "or query". Method must be executed on the base query.
    */
   TaskQuery initializeFormKeys();
 
   /**
    * Only select tasks with one of the given tenant ids.
    *
-   * @throws ProcessEngineException
-   *   <ul>
-   *     <li>When a query is executed and {@link #withoutTenantId()} has been executed on
-   *         the "and query" instance. No exception is thrown when a query is executed
-   *         and {@link #withoutTenantId()} has been executed on the "or query" instance.
-   *     </li>
-   *     <li>When a <code>null</code> tenant id is passed.</li>
-   *   </ul>
+   * @throws ProcessEngineException <ul>
+   *                                <li>When a query is executed and {@link #withoutTenantId()} has been executed on
+   *                                the "and query" instance. No exception is thrown when a query is executed
+   *                                and {@link #withoutTenantId()} has been executed on the "or query" instance.
+   *                                </li>
+   *                                <li>When a <code>null</code> tenant id is passed.</li>
+   *                                </ul>
    */
   TaskQuery tenantIdIn(String... tenantIds);
 
@@ -869,8 +917,8 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * Only select tasks which have no tenant id.
    *
    * @throws ProcessEngineException When query is executed and {@link #tenantIdIn(String...)}
-   *     has been executed on the "and query" instance. No exception is thrown when query is
-   *     executed and {@link #tenantIdIn(String...)} has been executed on the "or query" instance.
+   *                                has been executed on the "and query" instance. No exception is thrown when query is
+   *                                executed and {@link #tenantIdIn(String...)} has been executed on the "or query" instance.
    */
   TaskQuery withoutTenantId();
 
@@ -885,49 +933,49 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * Order by task id (needs to be followed by {@link #asc()} or {@link #desc()}).
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByTaskId();
 
   /**
    * Order by task name (needs to be followed by {@link #asc()} or {@link #desc()}).
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByTaskName();
 
   /**
    * Order by task name case insensitive (needs to be followed by {@link #asc()} or {@link #desc()}).
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByTaskNameCaseInsensitive();
 
   /**
    * Order by description (needs to be followed by {@link #asc()} or {@link #desc()}).
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByTaskDescription();
 
   /**
    * Order by priority (needs to be followed by {@link #asc()} or {@link #desc()}).
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByTaskPriority();
 
   /**
    * Order by assignee (needs to be followed by {@link #asc()} or {@link #desc()}).
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByTaskAssignee();
 
   /**
    * Order by the time on which the tasks were created (needs to be followed by {@link #asc()} or {@link #desc()}).
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByTaskCreateTime();
 
   /**
@@ -941,42 +989,42 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * Order by process instance id (needs to be followed by {@link #asc()} or {@link #desc()}).
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByProcessInstanceId();
 
   /**
    * Order by case instance id (needs to be followed by {@link #asc()} or {@link #desc()}).
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByCaseInstanceId();
 
   /**
    * Order by execution id (needs to be followed by {@link #asc()} or {@link #desc()}).
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByExecutionId();
 
   /**
    * Order by case execution id (needs to be followed by {@link #asc()} or {@link #desc()}).
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByCaseExecutionId();
 
   /**
    * Order by due date (needs to be followed by {@link #asc()} or {@link #desc()}).
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByDueDate();
 
   /**
    * Order by follow-up date (needs to be followed by {@link #asc()} or {@link #desc()}).
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByFollowUpDate();
 
   /**
@@ -985,7 +1033,7 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * values is database-specific.
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByProcessVariable(String variableName, ValueType valueType);
 
   /**
@@ -994,7 +1042,7 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * values is database-specific.
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByExecutionVariable(String variableName, ValueType valueType);
 
   /**
@@ -1003,7 +1051,7 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * values is database-specific.
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByTaskVariable(String variableName, ValueType valueType);
 
   /**
@@ -1012,7 +1060,7 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * values is database-specific.
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByCaseExecutionVariable(String variableName, ValueType valueType);
 
   /**
@@ -1021,7 +1069,7 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * values is database-specific.
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByCaseInstanceVariable(String variableName, ValueType valueType);
 
   /**
@@ -1029,7 +1077,7 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    * Note that the ordering of tasks without tenant id is database-specific.
    *
    * @throws ProcessEngineException When method has been executed within "or query".
-   * */
+   */
   TaskQuery orderByTenantId();
 
   /**
@@ -1039,11 +1087,10 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    *
    * @return an object of the type {@link TaskQuery} on which an arbitrary amount of filter criteria could be applied.
    * The several filter criteria will be linked together by an OR expression.
-   *
    * @throws ProcessEngineException when or() has been invoked directly after or() or after or() and trailing filter
-   * criteria. To prevent throwing this exception, {@link #endOr()} must be invoked after a chain of filter criteria to
-   * mark the end of the OR query.
-   * */
+   *                                criteria. To prevent throwing this exception, {@link #endOr()} must be invoked after a chain of filter criteria to
+   *                                mark the end of the OR query.
+   */
   TaskQuery or();
 
   /**
@@ -1053,9 +1100,8 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    *
    * @return an object of the type {@link TaskQuery} on which an arbitrary amount of filter criteria could be applied.
    * The filter criteria will be linked together by an AND expression.
-   *
    * @throws ProcessEngineException when endOr() has been invoked before {@link #or()} was invoked. To prevent throwing
-   * this exception, {@link #or()} must be invoked first.
-   * */
+   *                                this exception, {@link #or()} must be invoked first.
+   */
   TaskQuery endOr();
 }


### PR DESCRIPTION
Contains the following javadoc improvements:

- Fix invalid links to `ProcessEngineConfiguration#getVariableSerializers()`; use `ProcessEngineConfigurationImpl` instead.
- Fix some invalid `@param` names, not properly renamed on prior refactoring
- Fix typos / cut-off sentences
- Format docs with camunda formatter