### PR TITLE
fix(engine): Fix SetProperty & Multi-tenancy Problem with MySQL ms Precision

### DIFF
--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/SetTaskPropertyAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/SetTaskPropertyAuthorizationTest.java
@@ -26,12 +26,14 @@ import static org.camunda.bpm.engine.authorization.Permissions.UPDATE_TASK;
 import static org.camunda.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.camunda.bpm.engine.authorization.Resources.TASK;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.task.Task;
+import org.camunda.bpm.engine.test.util.ClockTestUtil;
 import org.camunda.bpm.engine.test.util.EntityRemoveRule;
 import org.camunda.bpm.engine.test.util.ObjectProperty;
 import org.camunda.bpm.engine.test.util.RemoveAfter;
@@ -79,8 +81,8 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
         { "setPriority", setPriority, "taskId", 80 },
         { "setName", setName, "taskId", "name" },
         { "setDescription", setDescription, "taskId", "description" },
-        { "setDueDate", setDueDate, "taskId",  DateTime.now().toInstant().withMillis(0).toDate() },
-        { "setFollowUpDate", setFollowUpDate, "taskId", DateTime.now().toInstant().withMillis(0).toDate() }
+        { "setDueDate", setDueDate, "taskId",  ClockTestUtil.setClockToDateWithoutMilliseconds() },
+        { "setFollowUpDate", setFollowUpDate, "taskId", ClockTestUtil.setClockToDateWithoutMilliseconds() }
     });
   }
 
@@ -308,5 +310,10 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
     } catch (Exception e) {
       fail("Failed to assert property for operationName=" + operationName + " due to : " + e.getMessage());
     }
+  }
+
+  public static void main(String[] args) {
+
+    System.out.println(ClockTestUtil.setClockToDateWithoutMilliseconds());
   }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/SetTaskPropertyAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/SetTaskPropertyAuthorizationTest.java
@@ -26,7 +26,6 @@ import static org.camunda.bpm.engine.authorization.Permissions.UPDATE_TASK;
 import static org.camunda.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.camunda.bpm.engine.authorization.Resources.TASK;
 
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -38,7 +37,6 @@ import org.camunda.bpm.engine.test.util.EntityRemoveRule;
 import org.camunda.bpm.engine.test.util.ObjectProperty;
 import org.camunda.bpm.engine.test.util.RemoveAfter;
 import org.camunda.bpm.engine.test.util.TriConsumer;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -310,10 +308,5 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
     } catch (Exception e) {
       fail("Failed to assert property for operationName=" + operationName + " due to : " + e.getMessage());
     }
-  }
-
-  public static void main(String[] args) {
-
-    System.out.println(ClockTestUtil.setClockToDateWithoutMilliseconds());
   }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/SetTaskPropertyAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/SetTaskPropertyAuthorizationTest.java
@@ -79,8 +79,8 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
         { "setPriority", setPriority, "taskId", 80 },
         { "setName", setName, "taskId", "name" },
         { "setDescription", setDescription, "taskId", "description" },
-        { "setDueDate", setDueDate, "taskId",  DateTime.now().toDate()},
-        { "setFollowUpDate", setFollowUpDate, "taskId", DateTime.now().toDate() }
+        { "setDueDate", setDueDate, "taskId",  DateTime.now().toInstant().withMillis(0).toDate() },
+        { "setFollowUpDate", setFollowUpDate, "taskId", DateTime.now().toInstant().withMillis(0).toDate() }
     });
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancySetTaskPropertyTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancySetTaskPropertyTest.java
@@ -105,8 +105,8 @@ public class MultiTenancySetTaskPropertyTest {
         { "setPriority", setPriority, 1, "taskPriority"},
         { "setName", setName, "name", "taskName" },
         { "setDescription", setDescription, "description", "taskDescription" },
-        { "setDueDate", setDueDate, DateTime.now().toDate(), "dueDate" },
-        { "setFollowUpDate", setFollowUpDate, DateTime.now().toDate(), "followUpDate" }
+        { "setDueDate", setDueDate, DateTime.now().toInstant().withMillis(0).toDate(), "dueDate" },
+        { "setFollowUpDate", setFollowUpDate, DateTime.now().toInstant().withMillis(0).toDate(), "followUpDate" }
     });
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancySetTaskPropertyTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancySetTaskPropertyTest.java
@@ -30,6 +30,7 @@ import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.task.TaskQuery;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.util.ClockTestUtil;
 import org.camunda.bpm.engine.test.util.MethodInvocation;
 import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
 import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
@@ -105,8 +106,8 @@ public class MultiTenancySetTaskPropertyTest {
         { "setPriority", setPriority, 1, "taskPriority"},
         { "setName", setName, "name", "taskName" },
         { "setDescription", setDescription, "description", "taskDescription" },
-        { "setDueDate", setDueDate, DateTime.now().toInstant().withMillis(0).toDate(), "dueDate" },
-        { "setFollowUpDate", setFollowUpDate, DateTime.now().toInstant().withMillis(0).toDate(), "followUpDate" }
+        { "setDueDate", setDueDate, ClockTestUtil.setClockToDateWithoutMilliseconds(), "dueDate" },
+        { "setFollowUpDate", setFollowUpDate, ClockTestUtil.setClockToDateWithoutMilliseconds(), "followUpDate" }
     });
   }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancySetTaskPropertyTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancySetTaskPropertyTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+
 import org.camunda.bpm.engine.IdentityService;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.TaskService;
@@ -37,7 +38,6 @@ import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.camunda.bpm.engine.test.util.TriConsumer;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
-import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;


### PR DESCRIPTION
This fix enforces the tests of MultiTenancySetTaskPropertyTest, SetTaskPropertyAuthorizationTest to always choose dates with zero ms precision to avoid issues with MySQL TIMESTAMP or DATETIME types getting rounded.

Related to: #3477, #3154