### PR TITLE
docs(engine-rest): return stacktrace as text/plain

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/history/job-log/{id}/stacktrace/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/history/job-log/{id}/stacktrace/get.ftl
@@ -24,22 +24,28 @@
 
   "responses": {
 
-    <@lib.response
-        code = "200"
-        mediaType= "text/plain"
-        desc = "Request successful."
-        examples = ['"example-1": {
-                       "summary": "response",
-                       "description": "GET `history/job-log/someId/stacktrace`
+    200": {
+      "description": "Request successful.",
+      "content": {
+        "text/plain": {
+          "schema": {
+            "type": "string",
+            "description": "The result is the corresponding stacktrace as plain text."
+          },
+          "examples": {
+            "example-1": {
+              "description": "GET `history/job-log/someId/stacktrace`
+              "value": "java.lang.RuntimeException: A exception message!
+                        at org.camunda.bpm.pa.service.FailingDelegate.execute(FailingDelegate.java:10)
+                        at org.camunda.bpm.engine.impl.delegate.JavaDelegateInvocation.invoke(JavaDelegateInvocation.java:34)
+                        at org.camunda.bpm.engine.impl.delegate.DelegateInvocation.proceed(DelegateInvocation.java:37)
+                        ..."
+            }
+          }
+        }
+      }
+    },
 
-                                       The result is the corresponding stacktrace as plain text.",
-                       "value": "java.lang.RuntimeException: A exception message!
-                                  at org.camunda.bpm.pa.service.FailingDelegate.execute(FailingDelegate.java:10)
-                                  at org.camunda.bpm.engine.impl.delegate.JavaDelegateInvocation.invoke(JavaDelegateInvocation.java:34)
-                                  at org.camunda.bpm.engine.impl.delegate.DelegateInvocation.proceed(DelegateInvocation.java:37)
-                                  ..."
-                     }']
-    />
 
     <@lib.response
         code = "404"

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/job/{id}/stacktrace/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/job/{id}/stacktrace/get.ftl
@@ -23,19 +23,28 @@
 
   "responses": {
 
-    <@lib.response
-        code = "200"
-        mediaType= "text/plain"
-        desc = "Request successful."
-        examples = ['"example-1": {
-                       "description": "GET `/job/aJobId/stacktrace`",
-                       "value": "java.lang.RuntimeException: A exception message!
-                                 at org.camunda.bpm.pa.service.FailingDelegate.execute(FailingDelegate.java:10)
-                                 at org.camunda.bpm.engine.impl.delegate.JavaDelegateInvocation.invoke(JavaDelegateInvocation.java:34)
-                                 at org.camunda.bpm.engine.impl.delegate.DelegateInvocation.proceed(DelegateInvocation.java:37)
-                                 ..."
-                     }']
-    />
+    "200": {
+      "description": "Request successful.",
+      "content": {
+        "text/plain": {
+          "schema": {
+            "type": "string",
+            "description": "The stacktrace of the job."
+          },
+          "examples": {
+            "example-1": {
+              "description": "GET `/job/aJobId/stacktrace`",
+              "value": "java.lang.RuntimeException: A exception message!
+                        at org.camunda.bpm.pa.service.FailingDelegate.execute(FailingDelegate.java:10)
+                        at org.camunda.bpm.engine.impl.delegate.JavaDelegateInvocation.invoke(JavaDelegateInvocation.java:34)
+                        at org.camunda.bpm.engine.impl.delegate.DelegateInvocation.proceed(DelegateInvocation.java:37)
+                        ..."
+            }
+          }
+        }
+      }
+    },
+
 
     <@lib.response
         code = "404"


### PR DESCRIPTION
Specifies the schema for plain text responses as type 'string'. This is required for generated API clients to work properly, as they usually default to application/json.

Fixed:
* history/job-log/{id}/stacktrace
* /job/{id}/stacktrace