### PR TITLE
fix(engine): Fix Broken Tests

### DIFF
--- a/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/spi/transform/DmnElementTransformHandler.java
+++ b/engine-dmn/engine/src/main/java/org/camunda/bpm/dmn/engine/impl/spi/transform/DmnElementTransformHandler.java
@@ -19,7 +19,9 @@ package org.camunda.bpm.dmn.engine.impl.spi.transform;
 import org.camunda.bpm.model.dmn.instance.DmnModelElementInstance;
 
 /**
- * Handler to transform a DMN model element.
+ * Handler to transform a DMN model element. By design, all handler implementations have to be stateless since they are
+ * stored by the static context of DefaultElementTransformHandlerRegistry & can be shared across different
+ * DmnEngineConfigurations or ProcessEngineConfiguration.
  *
  * @param <Source> the type of the transformation input
  * @param <Target> the type of the transformation output

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -2641,8 +2641,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
           .dmnHistoryEventProducer(dmnHistoryEventProducer)
           .scriptEngineResolver(scriptingEngines)
           .feelCustomFunctionProviders(dmnFeelCustomFunctionProviders)
-          .enableFeelLegacyBehavior(dmnFeelEnableLegacyBehavior)
-          .historyTimeToLive(historyTimeToLive);
+          .enableFeelLegacyBehavior(dmnFeelEnableLegacyBehavior);
 
       if (dmnElProvider != null) {
         dmnEngineConfigurationBuilder.elProvider(dmnElProvider);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/configuration/DmnEngineConfigurationBuilder.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/configuration/DmnEngineConfigurationBuilder.java
@@ -49,7 +49,6 @@ public class DmnEngineConfigurationBuilder {
   protected DmnScriptEngineResolver scriptEngineResolver;
   protected ElProvider elProvider;
   protected List<FeelCustomFunctionProvider> feelCustomFunctionProviders;
-  protected String historyTimeToLive;
 
   /**
    * Creates a new builder to modify the given DMN engine configuration.
@@ -95,7 +94,7 @@ public class DmnEngineConfigurationBuilder {
     // override the decision table handler
     DmnTransformer dmnTransformer = dmnEngineConfiguration.getTransformer();
     dmnTransformer.getElementTransformHandlerRegistry().addHandler(Definitions.class, new DecisionRequirementsDefinitionTransformHandler());
-    dmnTransformer.getElementTransformHandlerRegistry().addHandler(Decision.class, new DecisionDefinitionHandler(historyTimeToLive));
+    dmnTransformer.getElementTransformHandlerRegistry().addHandler(Decision.class, new DecisionDefinitionHandler());
 
     // do not override the script engine resolver if set
     if (dmnEngineConfiguration.getScriptEngineResolver() == null) {
@@ -134,11 +133,6 @@ public class DmnEngineConfigurationBuilder {
   public DmnEngineConfigurationBuilder enableFeelLegacyBehavior(boolean dmnFeelEnableLegacyBehavior) {
     dmnEngineConfiguration
         .enableFeelLegacyBehavior(dmnFeelEnableLegacyBehavior);
-    return this;
-  }
-
-  public DmnEngineConfigurationBuilder historyTimeToLive(String historyTimeToLive) {
-    this.historyTimeToLive = historyTimeToLive;
     return this;
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/transformer/DecisionDefinitionHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/dmn/transformer/DecisionDefinitionHandler.java
@@ -19,17 +19,12 @@ package org.camunda.bpm.engine.impl.dmn.transformer;
 import org.camunda.bpm.dmn.engine.impl.DmnDecisionImpl;
 import org.camunda.bpm.dmn.engine.impl.spi.transform.DmnElementTransformContext;
 import org.camunda.bpm.dmn.engine.impl.transform.DmnDecisionTransformHandler;
+import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.dmn.entity.repository.DecisionDefinitionEntity;
 import org.camunda.bpm.engine.impl.util.ParseUtil;
 import org.camunda.bpm.model.dmn.instance.Decision;
 
 public class DecisionDefinitionHandler extends DmnDecisionTransformHandler {
-
-  protected final Integer configuredHistoryTTL;
-
-  public DecisionDefinitionHandler(String configuredHistoryTTL) {
-    this.configuredHistoryTTL = ParseUtil.parseHistoryTimeToLive(configuredHistoryTTL);
-  }
 
   @Override
   protected DmnDecisionImpl createDmnElement() {
@@ -55,6 +50,7 @@ public class DecisionDefinitionHandler extends DmnDecisionTransformHandler {
     if (localHistoryTimeToLive != null) {
       decisionDefinition.setHistoryTimeToLive(localHistoryTimeToLive);
     } else {
+      Integer configuredHistoryTTL = ParseUtil.parseHistoryTimeToLive(Context.getProcessEngineConfiguration().getHistoryTimeToLive());
       decisionDefinition.setHistoryTimeToLive(configuredHistoryTTL);
     }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/dmn/deployment/DecisionDefinitionTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/dmn/deployment/DecisionDefinitionTest.java
@@ -55,11 +55,11 @@ import org.junit.rules.RuleChain;
 public class DecisionDefinitionTest {
 
   @ClassRule
-  public static ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule(configuration -> {
+  public static ProcessEngineBootstrapRule BOOTSTRAP_RULE = new ProcessEngineBootstrapRule(configuration -> {
     configuration.setHistoryTimeToLive("P30D");
   });
 
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule(bootstrapRule);
+  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule(BOOTSTRAP_RULE);
 
   protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/dmn/deployment/DecisionDefinitionTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/dmn/deployment/DecisionDefinitionTest.java
@@ -25,11 +25,13 @@ import java.util.HashMap;
 import java.util.Map;
 import org.camunda.bpm.engine.DecisionService;
 import org.camunda.bpm.engine.HistoryService;
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.history.HistoricDecisionInstance;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.camunda.bpm.engine.repository.DeploymentBuilder;
 import org.camunda.bpm.engine.repository.DeploymentWithDefinitions;
+import org.camunda.bpm.engine.test.RequiredHistoryLevel;
 import org.camunda.bpm.engine.test.util.ProcessEngineBootstrapRule;
 import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
 import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
@@ -45,13 +47,15 @@ import org.camunda.bpm.model.dmn.instance.InputExpression;
 import org.camunda.bpm.model.dmn.instance.Output;
 import org.camunda.bpm.model.dmn.instance.Text;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
 public class DecisionDefinitionTest {
 
-  protected ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule(configuration -> {
+  @ClassRule
+  public static ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule(configuration -> {
     configuration.setHistoryTimeToLive("P30D");
   });
 
@@ -60,7 +64,8 @@ public class DecisionDefinitionTest {
   protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
 
   @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(bootstrapRule).around(engineRule).around(testRule);
+  public RuleChain ruleChain = RuleChain.outerRule(engineRule)
+      .around(testRule);
 
   protected RepositoryService repositoryService;
   protected DecisionService decisionService;
@@ -103,6 +108,7 @@ public class DecisionDefinitionTest {
     assertThat(deployment.getDeployedDecisionDefinitions().get(0).getHistoryTimeToLive()).isEqualTo(10);
   }
 
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
   @Test
   public void shouldApplyHistoryTTLOnRemovalTimeOfDecisionInstanceLocal() {
     // given
@@ -130,6 +136,7 @@ public class DecisionDefinitionTest {
     assertThat(result.getRemovalTime()).isInSameDayAs(expectedRemovalDate);
   }
 
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
   @Test
   public void shouldApplyHistoryTTLOnRemovalTimeOfDecisionInstanceGlobal() {
     // given


### PR DESCRIPTION
* Fix DecisionDefinitionHandler to be stateless

**historyTimeToLive** was shared between different ProcessEngineConfiguration among different unit-tests that use the same field because DefaultElementTransformHandlerRegistry has a static **handlers** map field that stored the handlers per type.

That map is shared across different ProcessEngineConfigurations. In order for this to work, all handlers need to stateless...
The fix fetches processTimeToLive from Context during the parsing time of decision instead.

Related to: #2496