### PR TITLE
test(engine-rest): retry server start when port still bound

### DIFF
--- a/engine-rest/engine-rest-jakarta/src/test/java-resteasy/org/camunda/bpm/engine/rest/util/container/ResteasySpecifics.java
+++ b/engine-rest/engine-rest-jakarta/src/test/java-resteasy/org/camunda/bpm/engine/rest/util/container/ResteasySpecifics.java
@@ -16,14 +16,12 @@
  */
 package org.camunda.bpm.engine.rest.util.container;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.undertow.servlet.Servlets;
 import io.undertow.servlet.api.DeploymentInfo;
 import jakarta.servlet.DispatcherType;
 import jakarta.ws.rs.core.Application;
-
+import java.util.HashMap;
+import java.util.Map;
 import org.camunda.bpm.engine.rest.CustomJacksonDateFormatTest;
 import org.camunda.bpm.engine.rest.ExceptionHandlerTest;
 import org.camunda.bpm.engine.rest.application.TestCustomResourceApplication;
@@ -126,6 +124,7 @@ public class ResteasySpecifics implements ContainerSpecifics {
             .addFilterUrlMapping("Resteasy", "/*", DispatcherType.REQUEST)));
   }
 
+  @Override
   public TestRule getTestRule(Class<?> testClass) {
     TestRuleFactory ruleFactory = DEFAULT_RULE_FACTORY;
 
@@ -144,15 +143,18 @@ public class ResteasySpecifics implements ContainerSpecifics {
       this.jaxRsApplication = jaxRsApplication;
     }
 
+    @Override
     public TestRule createTestRule() {
       return new ExternalResource() {
 
         ResteasyServerBootstrap bootstrap = new ResteasyServerBootstrap(jaxRsApplication);
 
+        @Override
         protected void before() throws Throwable {
           bootstrap.start();
         }
 
+        @Override
         protected void after() {
           bootstrap.stop();
         }
@@ -168,17 +170,20 @@ public class ResteasySpecifics implements ContainerSpecifics {
       this.deploymentInfo = deploymentInfo;
     }
 
+    @Override
     public TestRule createTestRule() {
       final TemporaryFolder tempFolder = new TemporaryFolder();
 
       return RuleChain.outerRule(tempFolder).around(new ExternalResource() {
 
-        final EmbeddedServerBootstrap bootstrap = new ResteasyUndertowServerBootstrap(deploymentInfo);
+        final AbstractServerBootstrap bootstrap = new ResteasyUndertowServerBootstrap(deploymentInfo);
 
+        @Override
         protected void before() {
           bootstrap.start();
         }
 
+        @Override
         protected void after() {
           bootstrap.stop();
         }

--- a/engine-rest/engine-rest/src/test/java-resteasy/org/camunda/bpm/engine/rest/util/container/ResteasyServerBootstrap.java
+++ b/engine-rest/engine-rest/src/test/java-resteasy/org/camunda/bpm/engine/rest/util/container/ResteasyServerBootstrap.java
@@ -17,29 +17,29 @@
 package org.camunda.bpm.engine.rest.util.container;
 
 import java.util.Properties;
-
 import javax.ws.rs.core.Application;
-
-import org.camunda.bpm.engine.rest.util.container.EmbeddedServerBootstrap;
 import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
 
 public class ResteasyServerBootstrap extends EmbeddedServerBootstrap {
 
-  private NettyJaxrsServer server;
+  protected NettyJaxrsServer server;
 
   public ResteasyServerBootstrap(Application application) {
-    setupServer(application);
+    super(application);
   }
 
-  public void start() {
-    server.start();
-  }
-
+  @Override
   public void stop() {
     server.stop();
   }
 
-  private void setupServer(Application application) {
+  @Override
+  protected void startServerInternal() {
+    server.start();
+  }
+
+  @Override
+  protected void setupServer(Application application) {
     Properties serverProperties = readProperties();
     int port = Integer.parseInt(serverProperties.getProperty(PORT_PROPERTY));
 

--- a/engine-rest/engine-rest/src/test/java-resteasy/org/camunda/bpm/engine/rest/util/container/ResteasyTomcatServerBootstrap.java
+++ b/engine-rest/engine-rest/src/test/java-resteasy/org/camunda/bpm/engine/rest/util/container/ResteasyTomcatServerBootstrap.java
@@ -16,7 +16,6 @@
  */
 package org.camunda.bpm.engine.rest.util.container;
 
-import org.camunda.bpm.engine.rest.util.container.TomcatServerBootstrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.PomEquippedResolveStage;
 import org.jboss.shrinkwrap.resolver.api.maven.ScopeType;

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/util/container/AbstractServerBootstrap.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/util/container/AbstractServerBootstrap.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.rest.util.container;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import org.camunda.bpm.engine.rest.AbstractRestServiceTest;
+
+public abstract class AbstractServerBootstrap {
+
+  protected static final String PORT_PROPERTY = "rest.http.port";
+  protected static final String ROOT_RESOURCE_PATH = "/rest-test";
+  protected static final String PROPERTIES_FILE = "/testconfig.properties";
+
+  protected static final int STARTUP_RETRIES = 3;
+
+  public abstract void stop();
+
+  public void start() {
+    startServer(STARTUP_RETRIES);
+  }
+
+  protected abstract void startServer(int startUpRetries);
+
+  protected Properties readProperties() {
+    InputStream propStream = null;
+    Properties properties = new Properties();
+
+    try {
+      propStream = AbstractRestServiceTest.class.getResourceAsStream(PROPERTIES_FILE);
+      properties.load(propStream);
+    } catch (IOException e) {
+      throw new ServerBootstrapException(e);
+    } finally {
+      try {
+        propStream.close();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    return properties;
+  }
+}

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/util/container/TomcatServerBootstrap.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/util/container/TomcatServerBootstrap.java
@@ -20,8 +20,8 @@ import java.io.File;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleState;
 import org.apache.catalina.startup.Tomcat;
 import org.camunda.bpm.engine.rest.spi.ProcessEngineProvider;
 import org.camunda.bpm.engine.rest.spi.impl.MockedProcessEngineProvider;
@@ -35,7 +35,9 @@ import org.jboss.shrinkwrap.resolver.api.maven.ScopeType;
 import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenDependencies;
 
 
-public abstract class TomcatServerBootstrap extends EmbeddedServerBootstrap {
+public abstract class TomcatServerBootstrap extends AbstractServerBootstrap {
+
+  protected static final int RETRIES = 3;
 
   private Tomcat tomcat;
   private String workingDir;
@@ -45,9 +47,29 @@ public abstract class TomcatServerBootstrap extends EmbeddedServerBootstrap {
     this.webXmlPath = webXmlPath;
   }
 
+  @Override
+  public void stop() {
+    try {
+      try {
+        tomcat.stop();
+      } catch (Exception e) {
+        Logger.getLogger(getClass().getName()).log(Level.WARNING, "Failed to stop tomcat instance", e);
+      }
 
+      try {
+        tomcat.destroy();
+      } catch (Exception e) {
+        Logger.getLogger(getClass().getName()).log(Level.WARNING, "Failed to destroy instance", e);
+      }
 
-  public void start() {
+      tomcat = null;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected void startServer(int startUpRetries) {
     Properties serverProperties = readProperties();
     int port = Integer.parseInt(serverProperties.getProperty(PORT_PROPERTY));
 
@@ -89,6 +111,14 @@ public abstract class TomcatServerBootstrap extends EmbeddedServerBootstrap {
 
     try {
       tomcat.start();
+      if (LifecycleState.FAILED.equals(tomcat.getConnector().getState())) {
+        stop();
+        try {
+          Thread.sleep(1500L);
+        } catch (Exception ex) {
+        }
+        startServer(--startUpRetries);
+      }
     } catch (LifecycleException e) {
       throw new RuntimeException(e);
     }
@@ -96,38 +126,18 @@ public abstract class TomcatServerBootstrap extends EmbeddedServerBootstrap {
 
   protected abstract void addRuntimeSpecificLibraries(WebArchive wa, PomEquippedResolveStage resolver);
 
-  private String getContextPath() {
+  protected String getContextPath() {
     return "rest-test";
   }
 
-  public void stop() {
-    try {
-      try {
-        tomcat.stop();
-      } catch (Exception e) {
-        Logger.getLogger(getClass().getName()).log(Level.WARNING, "Failed to stop tomcat instance", e);
-      }
-
-      try {
-        tomcat.destroy();
-      } catch (Exception e) {
-        Logger.getLogger(getClass().getName()).log(Level.WARNING, "Failed to destroy instance", e);
-      }
-
-      tomcat = null;
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  public String getWorkingDir() {
+  protected String getWorkingDir() {
     if (workingDir == null) {
       workingDir = System.getProperty("java.io.tmpdir");
     }
     return workingDir;
   }
 
-  public void setWorkingDir(String workingDir) {
+  protected void setWorkingDir(String workingDir) {
     this.workingDir = workingDir;
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/util/container/TomcatServerBootstrap.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/util/container/TomcatServerBootstrap.java
@@ -37,8 +37,6 @@ import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenDependencies;
 
 public abstract class TomcatServerBootstrap extends AbstractServerBootstrap {
 
-  protected static final int RETRIES = 3;
-
   private Tomcat tomcat;
   private String workingDir;
   private String webXmlPath;


### PR DESCRIPTION
* Supports retrying server startups when the address is still bound. Occasionally, the OS can take more time to release the port physically after we stop our test server instance. Before we start it again for the next test class, we might have to wait and retry.

related to https://github.com/camunda/camunda-bpm-platform/issues/3535