### PR TITLE
fix(spring): Fix Unchecked cast to the SQLException

### DIFF
--- a/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringTransactionInterceptor.java
+++ b/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringTransactionInterceptor.java
@@ -73,9 +73,9 @@ public class SpringTransactionInterceptor extends CommandInterceptor {
       Throwable cause = ex.getCause();
 
       if (cause != null && cause instanceof SQLException) {
-          handleCrdbConcurrencyError((SQLException) cause);
+        handleCrdbConcurrencyError((SQLException) cause);
       } else {
-          throw ex;
+        throw ex;
       }
     }
   }

--- a/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringTransactionInterceptor.java
+++ b/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringTransactionInterceptor.java
@@ -73,7 +73,7 @@ public class SpringTransactionInterceptor extends CommandInterceptor {
       Throwable cause = ex.getCause();
 
       if (cause != null && cause instanceof SQLException) {
-        handleCrdbConcurrencyError((SQLException) cause);
+        handleCrdbConcurrencyError((SQLException) cause, ex);
       } else {
         throw ex;
       }
@@ -85,11 +85,11 @@ public class SpringTransactionInterceptor extends CommandInterceptor {
     * To ensure that these errors are still detected as OLEs, we must catch them and wrap
     * them in a CrdbTransactionRetryException
     */
-  private void handleCrdbConcurrencyError(SQLException sqlException)
+  private void handleCrdbConcurrencyError(SQLException sqlException, TransactionSystemException cause)
     if (processEngineConfiguration != null
         && DbSqlSession.isCrdbConcurrencyConflictOnCommit(sqlException, processEngineConfiguration)) {
 
-      throw ProcessEngineLogger.PERSISTENCE_LOGGER.crdbTransactionRetryExceptionOnCommit(ex);
+      throw ProcessEngineLogger.PERSISTENCE_LOGGER.crdbTransactionRetryExceptionOnCommit(cause);
     }
   }
 }

--- a/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringTransactionInterceptor.java
+++ b/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringTransactionInterceptor.java
@@ -70,13 +70,6 @@ public class SpringTransactionInterceptor extends CommandInterceptor {
       // don't use lambdas here => CAM-12810
       return (T) transactionTemplate.execute((TransactionCallback) status -> next.execute(command));
     } catch (TransactionSystemException ex) {
-      public <T> T execute(final Command<T> command) {
-    TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
-    transactionTemplate.setPropagationBehavior(transactionPropagation);
-    try {
-      // don't use lambdas here => CAM-12810
-      return (T) transactionTemplate.execute((TransactionCallback) status -> next.execute(command));
-    } catch (TransactionSystemException ex) {
       Throwable cause = ex.getCause();
        
       if (cause != null && cause instanceof SQLException) {

--- a/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringTransactionInterceptor.java
+++ b/engine-spring/core/src/main/java/org/camunda/bpm/engine/spring/SpringTransactionInterceptor.java
@@ -71,23 +71,25 @@ public class SpringTransactionInterceptor extends CommandInterceptor {
       return (T) transactionTemplate.execute((TransactionCallback) status -> next.execute(command));
     } catch (TransactionSystemException ex) {
       Throwable cause = ex.getCause();
-       
+
       if (cause != null && cause instanceof SQLException) {
-        handleCrdbConcurrencyError((SQLException) cause);
+          handleCrdbConcurrencyError((SQLException) cause);
       } else {
-        throw ex;
+          throw ex;
       }
     }
+  }
     
-    /**
-      * When CockroachDB is used, a CRDB concurrency error may occur on transaction commit.
-      * To ensure that these errors are still detected as OLEs, we must catch them and wrap
-      * them in a CrdbTransactionRetryException
-      */  
-    private void handleCrdbConcurrencyError(SQLException sqlException) 
-      if (processEngineConfiguration != null
-          && DbSqlSession.isCrdbConcurrencyConflictOnCommit(sqlException, processEngineConfiguration)) {
-        throw ProcessEngineLogger.PERSISTENCE_LOGGER.crdbTransactionRetryExceptionOnCommit(ex);
-      }
+  /**
+    * When CockroachDB is used, a CRDB concurrency error may occur on transaction commit.
+    * To ensure that these errors are still detected as OLEs, we must catch them and wrap
+    * them in a CrdbTransactionRetryException
+    */
+  private void handleCrdbConcurrencyError(SQLException sqlException)
+    if (processEngineConfiguration != null
+        && DbSqlSession.isCrdbConcurrencyConflictOnCommit(sqlException, processEngineConfiguration)) {
+
+      throw ProcessEngineLogger.PERSISTENCE_LOGGER.crdbTransactionRetryExceptionOnCommit(ex);
     }
+  }
 }


### PR DESCRIPTION
related to camunda/camunda-bpm-platform#3712


I’ve encountered a bug in the implementation of org.camunda.bpm.engine.spring.SpringTransactionInterceptor

My Delegate code results in a Rollback Exception. The Interceptor, in an attempt to handle commit retry for CockroachDB casts RollbackException to the SQLException. We use Spring Data JPA (Hibernate) on our end to communicate with DB

I didn’t find any mention of such behaviour from this class

Spring Boot: 2.7.10
Camunda Version: 7.19.0
DBMS: PostgreSQL

Without digging depper I can understand that the matter can be fixed with a single `instanceof`

My changes changes are covered in this PR. I found it more productive to submit PR, because my topic on the forum (https://forum.camunda.io/t/java-lang-classcastexception-class-javax-persistence-rollbackexception-cannot-be-cast-to-class-java-sql-sqlexception/46433) did not get any attention

If I need to add testcases or format this PR more carefully, I'm open to contribution

Thank you.