### PR TITLE
docs(engine): Adjust Docs for HistoryTimeToLive Update Actions

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/HistoryTimeToLiveDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/HistoryTimeToLiveDto.ftl
@@ -8,7 +8,7 @@
         minimum = 0
         last = true
         desc = "New value for historyTimeToLive field of the definition.
-                Can not be negative."/>
+                Cannot be negative."/>
 
 </@lib.dto>
 </#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/HistoryTimeToLiveDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/HistoryTimeToLiveDto.ftl
@@ -8,7 +8,7 @@
         minimum = 0
         last = true
         desc = "New value for historyTimeToLive field of the definition.
-                Can be `null`. Can not be negative."/>
+                Can not be negative."/>
 
 </@lib.dto>
 </#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/HistoryTimeToLiveDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/HistoryTimeToLiveDto.ftl
@@ -8,6 +8,7 @@
         minimum = 0
         last = true
         desc = "New value for historyTimeToLive field of the definition.
+                Can be `null` if `enforceHistoryTimeToLive` is configured to `true`.
                 Cannot be negative."/>
 
 </@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/HistoryTimeToLiveDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/HistoryTimeToLiveDto.ftl
@@ -8,7 +8,7 @@
         minimum = 0
         last = true
         desc = "New value for historyTimeToLive field of the definition.
-                Can be `null` if `enforceHistoryTimeToLive` is configured to `true`.
+                Can be `null` if `enforceHistoryTimeToLive` is configured to `false`.
                 Cannot be negative."/>
 
 </@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/decision-definition/key/{key}/tenant-id/{tenant-id}/history-time-to-live/put.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/decision-definition/key/{key}/tenant-id/{tenant-id}/history-time-to-live/put.ftl
@@ -6,7 +6,10 @@
       tag = "Decision Definition"
       summary = "Update History Time to Live By Key And Tenant"
       desc = "Updates the latest version of the decision definition for tenant.
-              The field is used within [History cleanup](${docsUrl}/user-guide/process-engine/history/#history-cleanup)." />
+              The field is used within [History cleanup](${docsUrl}/user-guide/process-engine/history/#history-cleanup).
+              The value of the update is mandatory by default and does not allow `null` values. To enable them, please
+              set the feature flag `enforceHistoryTimeToLive` to `false`. Read more in [Configuration Properties]
+              (${docsUrl}/reference/deployment-descriptors/tags/process-engine#configuration-properties)" />
 
   "parameters" : [
 

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/process-definition/key/{key}/history-time-to-live/put.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/process-definition/key/{key}/history-time-to-live/put.ftl
@@ -6,7 +6,10 @@
       tag = "Process Definition"
       summary = "Update History Time to Live"
       desc = "Updates history time to live for the latest version of the process definition which belongs to no tenant.
-              The field is used within [History cleanup](${docsUrl}/user-guide/process-engine/history/#history-cleanup)." />
+              The field is used within [History cleanup](${docsUrl}/user-guide/process-engine/history/#history-cleanup).
+              The value of the update is mandatory by default and does not allow `null` values. To enable them, please
+              set the feature flag `enforceHistoryTimeToLive` to `false`. Read more in [Configuration Properties]
+              (${docsUrl}/reference/deployment-descriptors/tags/process-engine#configuration-properties)" />
 
   "parameters" : [
 

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/process-definition/{id}/history-time-to-live/put.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/process-definition/{id}/history-time-to-live/put.ftl
@@ -6,7 +6,10 @@
       tag = "Process Definition"
       summary = "Update History Time to Live"
       desc = "Updates history time to live for process definition.
-              The field is used within [History cleanup](${docsUrl}/user-guide/process-engine/history/#history-cleanup)." />
+              The field is used within [History cleanup](${docsUrl}/user-guide/process-engine/history/#history-cleanup).
+              The value of the update is mandatory by default and does not allow `null` values. To enable them, please
+              set the feature flag `enforceHistoryTimeToLive` to `false`. Read more in [Configuration Properties]
+              (${docsUrl}/reference/deployment-descriptors/tags/process-engine#configuration-properties)" />
 
   "parameters" : [
 


### PR DESCRIPTION
Remove explicit `null` mention in **HistoryTimeToLiveDto**

Doc **Endpoints** Adjusted:

updateHistoryTimeToLiveByDecisionDefinitionKeyAndTenant
updateHistoryTimeToLiveByProcessDefinitionKey
updateHistoryTimeToLiveByProcessDefinitionId

Related to: #2994 