### PR TITLE
feat(engine): set removal time in chunks

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/history/SetRemovalTimeToHistoricProcessInstancesDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/history/SetRemovalTimeToHistoricProcessInstancesDto.ftl
@@ -22,9 +22,11 @@
   <@lib.property
       name = "updateInChunks"
       type = "boolean"
-      desc = "Processes removal time updates in chunks, taking into account defined limits.
-              This can lead to multiple executions of the resulting jobs and prevents the database
-              transaction from timing out by limiting the number of rows to update.
+      desc = "Handles removal time updates in chunks, taking into account the defined size in
+              `removalTimeUpdateChunkSize` in the process engine configuration. The size of the 
+              chunks can also be overridden per call with the `updateChunkSize` parameter.
+              Enabling this option can lead to multiple executions of the resulting jobs, preventing
+              the database transaction from timing out by limiting the number of rows to update.
               Value may only be `true`, as `false` is the default behavior."/>
 
   <@lib.property
@@ -33,8 +35,9 @@
       format = "int32"
       last = true
       desc = "Defines the size of the chunks in which removal time updates are processed.
-              The value must be a positive integer between `1` and `500`.
-              This only has an effect if `updateInChunks` is set to `true`."/>
+              The value must be a positive integer between `1` and `500`. This only has an 
+              effect if `updateInChunks` is set to `true`. If undefined, the operation uses the 
+              `removalTimeUpdateChunkSize` defined in the process engine configuration."/>
 
 </@lib.dto>
 </#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/history/SetRemovalTimeToHistoricProcessInstancesDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/history/SetRemovalTimeToHistoricProcessInstancesDto.ftl
@@ -16,9 +16,25 @@
   <@lib.property
       name = "hierarchical"
       type = "boolean"
-      last = true
       desc = "Sets the removal time to all historic process instances in the hierarchy.
               Value may only be `true`, as `false` is the default behavior."/>
+
+  <@lib.property
+      name = "updateInChunks"
+      type = "boolean"
+      desc = "Processes removal time updates in chunks, taking into account defined limits.
+              This can lead to multiple executions of the resulting jobs and prevents the database
+              transaction from timing out by limiting the number of rows to update.
+              Value may only be `true`, as `false` is the default behavior."/>
+
+  <@lib.property
+      name = "updateChunkSize"
+      type = "integer"
+      format = "int32"
+      last = true
+      desc = "Defines the size of the chunks in which removal time updates are processed.
+              The value must be a positive integer between `1` and `500`.
+              This only has an effect if `updateInChunks` is set to `true`."/>
 
 </@lib.dto>
 </#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/history/process-instance/set-removal-time/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/history/process-instance/set-removal-time/post.ftl
@@ -26,6 +26,22 @@
                                   "b4d2ad94-7240-11e9-98b7-be5e0f7575b7"
                                 ]
                               }
+                   }',
+                   '"example-2": {
+                     "summary": "POST `/history/process-instance/set-removal-time`",
+                     "value": {
+                                "absoluteRemovalTime": "2019-05-05T11:56:24.725+0200",
+                                "hierarchical": true,
+                                "updateInChunks": true,
+                                "updateChunkSize": 300,
+                                "historicProcessInstanceQuery": {
+                                  "unfinished": true
+                                },
+                                "historicProcessInstanceIds": [
+                                  "b4d2ad98-7240-11e9-98b7-be5e0f7575b7",
+                                  "b4d2ad94-7240-11e9-98b7-be5e0f7575b7"
+                                ]
+                              }
                    }'
                 ] />
   "responses" : {

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/batch/removaltime/SetRemovalTimeToHistoricProcessInstancesDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/batch/removaltime/SetRemovalTimeToHistoricProcessInstancesDto.java
@@ -26,6 +26,8 @@ public class SetRemovalTimeToHistoricProcessInstancesDto extends AbstractSetRemo
   protected String[] historicProcessInstanceIds;
   protected HistoricProcessInstanceQueryDto historicProcessInstanceQuery;
   protected boolean hierarchical;
+  protected boolean updateInChunks;
+  protected Integer updateChunkSize;
 
   public String[] getHistoricProcessInstanceIds() {
     return historicProcessInstanceIds;
@@ -51,4 +53,19 @@ public class SetRemovalTimeToHistoricProcessInstancesDto extends AbstractSetRemo
     this.hierarchical = hierarchical;
   }
 
+  public boolean isUpdateInChunks() {
+    return updateInChunks;
+  }
+
+  public void setUpdateInChunks(boolean updateInChunks) {
+    this.updateInChunks = updateInChunks;
+  }
+
+  public Integer getUpdateChunkSize() {
+    return updateChunkSize;
+  }
+
+  public void setUpdateChunkSize(Integer updateChunkSize) {
+    this.updateChunkSize = updateChunkSize;
+  }
 }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/impl/history/HistoricProcessInstanceRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/impl/history/HistoricProcessInstanceRestServiceImpl.java
@@ -194,6 +194,15 @@ import org.camunda.bpm.engine.rest.util.URLEncodingUtil;
 
     }
 
+    if (dto.isUpdateInChunks()) {
+      builder.updateInChunks();
+    }
+
+    Integer chunkSize = dto.getUpdateChunkSize();
+    if (chunkSize != null) {
+      builder.chunkSize(chunkSize);
+    }
+
     Batch batch = builder.executeAsync();
     return BatchDto.fromBatch(batch);
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/history/SetRemovalTimeToHistoricProcessInstancesBuilder.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/history/SetRemovalTimeToHistoricProcessInstancesBuilder.java
@@ -61,9 +61,12 @@ public interface SetRemovalTimeToHistoricProcessInstancesBuilder {
   SetRemovalTimeToHistoricProcessInstancesBuilder hierarchical();
 
   /**
-   * Processes removal time updates in chunks, taking into account defined limits. This
-   * can lead to multiple executions of the job to keep the transaction from timing out
-   * due to too many rows that would need to be updated within one transaction.
+   * Handles removal time updates in chunks, taking into account the defined
+   * size in {@code removalTimeUpdateChunkSize} in the process engine
+   * configuration. The size of the chunks can also be overridden per call with
+   * the {@link #chunkSize(int)} option. Enabling this option can lead to
+   * multiple executions of the resulting jobs, preventing the database
+   * transaction from timing out by limiting the number of rows to update.
    *
    * @since 7.20
    *
@@ -75,8 +78,11 @@ public interface SetRemovalTimeToHistoricProcessInstancesBuilder {
    * Defines the size of the chunks in which removal time updates are processed.
    * The value must be a positive integer value that doesn't exceed the
    * {@link ProcessSetRemovalTimeJobHandler#MAX_CHUNK_SIZE}.
-   *
+   * 
    * Only has an effect if {@link #updateInChunks()} is invoked as well.
+   * 
+   * If undefined, the operation uses the `removalTimeUpdateChunkSize` defined
+   * in the process engine configuration.
    *
    * @since 7.20
    *

--- a/engine/src/main/java/org/camunda/bpm/engine/history/SetRemovalTimeToHistoricProcessInstancesBuilder.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/history/SetRemovalTimeToHistoricProcessInstancesBuilder.java
@@ -22,6 +22,7 @@ import org.camunda.bpm.engine.authorization.BatchPermissions;
 import org.camunda.bpm.engine.authorization.Permissions;
 import org.camunda.bpm.engine.authorization.Resources;
 import org.camunda.bpm.engine.batch.Batch;
+import org.camunda.bpm.engine.impl.batch.removaltime.ProcessSetRemovalTimeJobHandler;
 
 /**
  * Fluent builder to set the removal time to historic process instances and
@@ -58,6 +59,30 @@ public interface SetRemovalTimeToHistoricProcessInstancesBuilder {
    * @return the builder.
    */
   SetRemovalTimeToHistoricProcessInstancesBuilder hierarchical();
+
+  /**
+   * Processes removal time updates in chunks, taking into account defined limits. This
+   * can lead to multiple executions of the job to keep the transaction from timing out
+   * due to too many rows that would need to be updated within one transaction.
+   *
+   * @since 7.20
+   *
+   * @return the builder.
+   */
+  SetRemovalTimeToHistoricProcessInstancesBuilder updateInChunks();
+
+  /**
+   * Defines the size of the chunks in which removal time updates are processed.
+   * The value must be a positive integer value that doesn't exceed the
+   * {@link ProcessSetRemovalTimeJobHandler#MAX_CHUNK_SIZE}.
+   *
+   * Only has an effect if {@link #updateInChunks()} is invoked as well.
+   *
+   * @since 7.20
+   *
+   * @return the builder.
+   */
+  SetRemovalTimeToHistoricProcessInstancesBuilder chunkSize(int chunkSize);
 
   /**
    * Sets the removal time asynchronously as batch. The returned batch can be used to

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/BatchJobDeclaration.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/BatchJobDeclaration.java
@@ -51,10 +51,17 @@ public class BatchJobDeclaration extends JobDeclaration<BatchJobContext, Message
     return context.getBatch().getBatchJobDefinitionId();
   }
 
+  @Override
   public ParameterValueProvider getJobPriorityProvider() {
     long batchJobPriority = Context.getProcessEngineConfiguration()
         .getBatchJobPriority();
     return new ConstantValueProvider(batchJobPriority);
   }
 
+  @Override
+  public MessageEntity reconfigure(BatchJobContext context, MessageEntity job) {
+    super.reconfigure(context, job);
+    job.setJobHandlerConfiguration(new BatchJobConfiguration(context.getConfiguration().getId()));
+    return job;
+  }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/BatchJobHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/BatchJobHandler.java
@@ -66,4 +66,17 @@ public interface BatchJobHandler<T> extends JobHandler<BatchJobConfiguration> {
    */
   void deleteJobs(BatchEntity batch);
 
+  /**
+   * Determine the number of invocations ber patch job. This can be defined by
+   * the related batch job handler specifically or otherwise taken from the
+   * engine configuration.
+   *
+   * @param batchType
+   *          the batch's type to help determine any engine configuration
+   *          related to it
+   * @param configuration
+   *          the configuration object
+   * @return the number of invocations ber patch job
+   */
+  int calculateInvocationsPerBatchJob(String batchType, T configuration);
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/builder/BatchBuilder.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/builder/BatchBuilder.java
@@ -16,6 +16,8 @@
  */
 package org.camunda.bpm.engine.impl.batch.builder;
 
+import java.util.List;
+import java.util.Map;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.authorization.Permission;
 import org.camunda.bpm.engine.batch.Batch;
@@ -26,9 +28,6 @@ import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.jobexecutor.JobHandler;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
-
-import java.util.List;
-import java.util.Map;
 
 public class BatchBuilder {
 
@@ -130,7 +129,7 @@ public class BatchBuilder {
     String type = jobHandler.getType();
     batch.setType(type);
 
-    int invocationPerBatchJobCount = calculateInvocationsPerBatchJob(type);
+    int invocationPerBatchJobCount = jobHandler.calculateInvocationsPerBatchJob(type, config);
     batch.setInvocationsPerBatchJob(invocationPerBatchJobCount);
 
     batch.setTenantId(tenantId);
@@ -205,23 +204,6 @@ public class BatchBuilder {
     }
 
     return (instanceCount / invocationPerBatchJobCount) + 1;
-  }
-
-  protected int calculateInvocationsPerBatchJob(String batchType) {
-    ProcessEngineConfigurationImpl engineConfig = commandContext.getProcessEngineConfiguration();
-
-    Map<String, Integer> invocationsPerBatchJobByBatchType =
-        engineConfig.getInvocationsPerBatchJobByBatchType();
-
-    Integer invocationCount = invocationsPerBatchJobByBatchType.get(batchType);
-
-    if (invocationCount != null) {
-      return invocationCount;
-
-    } else {
-      return engineConfig.getInvocationsPerBatchJob();
-
-    }
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/removaltime/ProcessSetRemovalTimeJobHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/removaltime/ProcessSetRemovalTimeJobHandler.java
@@ -16,11 +16,24 @@
  */
 package org.camunda.bpm.engine.impl.batch.removaltime;
 
+import static org.camunda.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_END;
+import static org.camunda.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_START;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.camunda.bpm.engine.batch.Batch;
 import org.camunda.bpm.engine.impl.batch.AbstractBatchJobHandler;
 import org.camunda.bpm.engine.impl.batch.BatchJobContext;
 import org.camunda.bpm.engine.impl.batch.BatchJobDeclaration;
+import org.camunda.bpm.engine.impl.cfg.TransactionListener;
+import org.camunda.bpm.engine.impl.cfg.TransactionState;
+import org.camunda.bpm.engine.impl.db.DbEntity;
+import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 import org.camunda.bpm.engine.impl.jobexecutor.JobDeclaration;
 import org.camunda.bpm.engine.impl.persistence.entity.ByteArrayEntity;
 import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
@@ -28,80 +41,95 @@ import org.camunda.bpm.engine.impl.persistence.entity.HistoricProcessInstanceEnt
 import org.camunda.bpm.engine.impl.persistence.entity.MessageEntity;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
 
-import java.util.Date;
-import java.util.List;
-
-import static org.camunda.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_END;
-import static org.camunda.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_START;
-
 /**
  * @author Tassilo Weidner
  */
 public class ProcessSetRemovalTimeJobHandler extends AbstractBatchJobHandler<SetRemovalTimeBatchConfiguration> {
 
   public static final BatchJobDeclaration JOB_DECLARATION = new BatchJobDeclaration(Batch.TYPE_PROCESS_SET_REMOVAL_TIME);
+  public static final int MAX_CHUNK_SIZE = 500;
 
-  public void executeHandler(SetRemovalTimeBatchConfiguration batchConfiguration,
+  @Override
+  public void executeHandler(SetRemovalTimeBatchConfiguration configuration,
                              ExecutionEntity execution,
                              CommandContext commandContext,
                              String tenantId) {
+    if (configuration.isUpdateInChunks()) {
+      // only one instance allowed if enabled, see #calculateInvocationsPerBatchJob
+      String instanceId = configuration.getIds().get(0);
+      Set<String> entities = configuration.getEntities();
+      Integer chunkSize = getUpdateChunkSize(configuration, commandContext);
+      Map<Class<? extends DbEntity>, DbOperation> operations = addRemovalTimeToInstance(instanceId, configuration,
+          chunkSize, entities, commandContext);
+      MessageEntity currentJob = (MessageEntity) commandContext.getCurrentJob();
+      registerTransactionHandler(configuration, operations, chunkSize, currentJob, commandContext);
+      currentJob.setRepeat("true");
+    } else {
+      configuration.getIds().forEach(id ->
+        addRemovalTimeToInstance(id, configuration, null, Collections.emptySet(), commandContext));
+    }
+  }
 
-    for (String instanceId : batchConfiguration.getIds()) {
-
-      HistoricProcessInstanceEntity instance = findProcessInstanceById(instanceId, commandContext);
-
-      if (instance != null) {
-        if (batchConfiguration.isHierarchical() && hasHierarchy(instance)) {
-          String rootProcessInstanceId = instance.getRootProcessInstanceId();
-
-          HistoricProcessInstanceEntity rootInstance = findProcessInstanceById(rootProcessInstanceId, commandContext);
-          Date removalTime = getOrCalculateRemovalTime(batchConfiguration, rootInstance, commandContext);
-
-          addRemovalTimeToHierarchy(rootProcessInstanceId, removalTime, commandContext);
-
-        } else {
-          Date removalTime = getOrCalculateRemovalTime(batchConfiguration, instance, commandContext);
-
-          if (removalTime != instance.getRemovalTime()) {
-            addRemovalTime(instanceId, removalTime, commandContext);
-
-          }
+  protected Map<Class<? extends DbEntity>, DbOperation> addRemovalTimeToInstance(String instanceId,
+      SetRemovalTimeBatchConfiguration configuration,
+      Integer batchSize,
+      Set<String> entities,
+      CommandContext commandContext) {
+    HistoricProcessInstanceEntity instance = findProcessInstanceById(instanceId, commandContext);
+    if (instance != null) {
+      if (configuration.isHierarchical() && hasHierarchy(instance)) {
+        String rootProcessInstanceId = instance.getRootProcessInstanceId();
+        HistoricProcessInstanceEntity rootInstance = findProcessInstanceById(rootProcessInstanceId, commandContext);
+        Date removalTime = getOrCalculateRemovalTime(configuration, rootInstance, commandContext);
+        return addRemovalTimeToHierarchy(rootProcessInstanceId, removalTime, batchSize, entities, commandContext);
+      } else {
+        Date removalTime = getOrCalculateRemovalTime(configuration, instance, commandContext);
+        if (removalTime != instance.getRemovalTime()) {
+          return addRemovalTime(instanceId, removalTime, batchSize, entities, commandContext);
         }
       }
     }
+    return null;
   }
 
-  protected Date getOrCalculateRemovalTime(SetRemovalTimeBatchConfiguration batchConfiguration, HistoricProcessInstanceEntity instance, CommandContext commandContext) {
-    if (batchConfiguration.hasRemovalTime()) {
-      return batchConfiguration.getRemovalTime();
-
+  protected Date getOrCalculateRemovalTime(SetRemovalTimeBatchConfiguration configuration,
+      HistoricProcessInstanceEntity instance,
+      CommandContext commandContext) {
+    if (configuration.hasRemovalTime()) {
+      return configuration.getRemovalTime();
     } else if (hasBaseTime(instance, commandContext)) {
       return calculateRemovalTime(instance, commandContext);
-
     } else {
       return null;
-
     }
   }
 
-  protected void addRemovalTimeToHierarchy(String rootProcessInstanceId, Date removalTime, CommandContext commandContext) {
-    commandContext.getHistoricProcessInstanceManager()
-      .addRemovalTimeToProcessInstancesByRootProcessInstanceId(rootProcessInstanceId, removalTime);
-
+  protected Map<Class<? extends DbEntity>, DbOperation> addRemovalTimeToHierarchy(String rootProcessInstanceId,
+      Date removalTime,
+      Integer batchSize,
+      Set<String> entities,
+      CommandContext commandContext) {
+    Map<Class<? extends DbEntity>, DbOperation> operations = commandContext.getHistoricProcessInstanceManager()
+        .addRemovalTimeToProcessInstancesByRootProcessInstanceId(rootProcessInstanceId, removalTime, batchSize, entities);
     if (isDmnEnabled(commandContext)) {
-      commandContext.getHistoricDecisionInstanceManager()
-        .addRemovalTimeToDecisionsByRootProcessInstanceId(rootProcessInstanceId, removalTime);
+      operations.putAll(commandContext.getHistoricDecisionInstanceManager()
+        .addRemovalTimeToDecisionsByRootProcessInstanceId(rootProcessInstanceId, removalTime, batchSize, entities));
     }
+    return operations;
   }
 
-  protected void addRemovalTime(String instanceId, Date removalTime, CommandContext commandContext) {
-    commandContext.getHistoricProcessInstanceManager()
-      .addRemovalTimeById(instanceId, removalTime);
-
+  protected Map<Class<? extends DbEntity>, DbOperation> addRemovalTime(String instanceId,
+      Date removalTime,
+      Integer batchSize,
+      Set<String> entities,
+      CommandContext commandContext) {
+    Map<Class<? extends DbEntity>, DbOperation> operations = commandContext.getHistoricProcessInstanceManager()
+      .addRemovalTimeById(instanceId, removalTime, batchSize, entities);
     if (isDmnEnabled(commandContext)) {
-      commandContext.getHistoricDecisionInstanceManager()
-        .addRemovalTimeToDecisionsByProcessInstanceId(instanceId, removalTime);
+      operations.putAll(commandContext.getHistoricDecisionInstanceManager()
+        .addRemovalTimeToDecisionsByProcessInstanceId(instanceId, removalTime, batchSize, entities));
     }
+    return operations;
   }
 
   protected boolean hasBaseTime(HistoricProcessInstanceEntity instance, CommandContext commandContext) {
@@ -157,23 +185,63 @@ public class ProcessSetRemovalTimeJobHandler extends AbstractBatchJobHandler<Set
       .findHistoricProcessInstance(instanceId);
   }
 
+  protected void registerTransactionHandler(SetRemovalTimeBatchConfiguration configuration,
+      Map<Class<? extends DbEntity>, DbOperation> operations,
+      Integer chunkSize,
+      MessageEntity currentJob,
+      CommandContext commandContext) {
+    CommandExecutor newCommandExecutor = commandContext.getProcessEngineConfiguration().getCommandExecutorTxRequiresNew();
+    TransactionListener transactionResulthandler = createTransactionHandler(configuration, operations, chunkSize,
+        currentJob, newCommandExecutor);
+    commandContext.getTransactionContext().addTransactionListener(TransactionState.COMMITTED, transactionResulthandler);
+  }
+
+  protected int getUpdateChunkSize(SetRemovalTimeBatchConfiguration configuration, CommandContext commandContext) {
+    return configuration.getChunkSize() == null
+        ? commandContext.getProcessEngineConfiguration().getRemovalTimeUpdateChunkSize()
+        : configuration.getChunkSize();
+  }
+
+  protected TransactionListener createTransactionHandler(SetRemovalTimeBatchConfiguration configuration,
+      Map<Class<? extends DbEntity>, DbOperation> operations,
+      Integer chunkSize,
+      MessageEntity currentJob,
+      CommandExecutor newCommandExecutor) {
+    return new ProcessSetRemovalTimeResultHandler(configuration, chunkSize, newCommandExecutor, this,
+        currentJob.getId(), operations);
+  }
+
+  @Override
   public JobDeclaration<BatchJobContext, MessageEntity> getJobDeclaration() {
     return JOB_DECLARATION;
   }
 
-  protected SetRemovalTimeBatchConfiguration createJobConfiguration(SetRemovalTimeBatchConfiguration configuration, List<String> processInstanceIds) {
+  @Override
+  protected SetRemovalTimeBatchConfiguration createJobConfiguration(SetRemovalTimeBatchConfiguration configuration,
+      List<String> processInstanceIds) {
     return new SetRemovalTimeBatchConfiguration(processInstanceIds)
       .setRemovalTime(configuration.getRemovalTime())
       .setHasRemovalTime(configuration.hasRemovalTime())
-      .setHierarchical(configuration.isHierarchical());
+      .setHierarchical(configuration.isHierarchical())
+      .setUpdateInChunks(configuration.isUpdateInChunks())
+      .setChunkSize(configuration.getChunkSize());
   }
 
+  @Override
   protected SetRemovalTimeJsonConverter getJsonConverterInstance() {
     return SetRemovalTimeJsonConverter.INSTANCE;
   }
 
+  @Override
+  public int calculateInvocationsPerBatchJob(String batchType, SetRemovalTimeBatchConfiguration configuration) {
+    if (configuration.isUpdateInChunks()) {
+      return 1;
+    }
+    return super.calculateInvocationsPerBatchJob(batchType, configuration);
+  }
+
+  @Override
   public String getType() {
     return Batch.TYPE_PROCESS_SET_REMOVAL_TIME;
   }
-
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/removaltime/ProcessSetRemovalTimeResultHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/removaltime/ProcessSetRemovalTimeResultHandler.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.batch.removaltime;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.camunda.bpm.engine.impl.batch.BatchJobContext;
+import org.camunda.bpm.engine.impl.cfg.TransactionListener;
+import org.camunda.bpm.engine.impl.db.DbEntity;
+import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
+import org.camunda.bpm.engine.impl.history.event.HistoricProcessInstanceEventEntity;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
+import org.camunda.bpm.engine.impl.persistence.entity.ByteArrayEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.MessageEntity;
+import org.camunda.bpm.engine.impl.util.ClockUtil;
+
+public class ProcessSetRemovalTimeResultHandler implements TransactionListener {
+
+  protected SetRemovalTimeBatchConfiguration batchJobConfiguration;
+  protected Integer chunkSize;
+  protected CommandExecutor commandExecutor;
+  protected ProcessSetRemovalTimeJobHandler jobHandler;
+  protected String jobId;
+  protected Map<Class<? extends DbEntity>, DbOperation> operations;
+
+  public ProcessSetRemovalTimeResultHandler(SetRemovalTimeBatchConfiguration batchJobConfiguration,
+      Integer chunkSize,
+      CommandExecutor commandExecutor,
+      ProcessSetRemovalTimeJobHandler jobHandler,
+      String jobId,
+      Map<Class<? extends DbEntity>, DbOperation> operations) {
+    this.batchJobConfiguration = batchJobConfiguration;
+    this.chunkSize = chunkSize;
+    this.commandExecutor = commandExecutor;
+    this.jobHandler = jobHandler;
+    this.jobId = jobId;
+    this.operations = operations;
+  }
+
+  @Override
+  public void execute(CommandContext commandContext) {
+    // use the new command executor since the command context might already have been closed/finished
+    commandExecutor.execute(context -> {
+        JobEntity job = context.getJobManager().findJobById(jobId);
+        Set<String> entitiesToUpdate = getEntitiesToUpdate(operations, chunkSize, commandContext);
+        if (entitiesToUpdate.isEmpty() && !operations.containsKey(HistoricProcessInstanceEventEntity.class)) {
+          // update the process instance last to avoid orphans
+          entitiesToUpdate = new HashSet<>();
+          entitiesToUpdate.add(HistoricProcessInstanceEventEntity.class.getName());
+        }
+        if (entitiesToUpdate.isEmpty()) {
+          job.delete(true);
+        } else {
+          // save batch job configuration
+          batchJobConfiguration.setEntities(entitiesToUpdate);
+          ByteArrayEntity newConfiguration = saveConfiguration(batchJobConfiguration, context);
+          BatchJobContext newBatchContext = new BatchJobContext(null, newConfiguration);
+          ProcessSetRemovalTimeJobHandler.JOB_DECLARATION.reconfigure(newBatchContext, (MessageEntity) job);
+          // reschedule job
+          context.getJobManager().reschedule(job, ClockUtil.getCurrentTime());
+        }
+        return null;
+    });
+  }
+
+  protected ByteArrayEntity saveConfiguration(SetRemovalTimeBatchConfiguration configuration, CommandContext context) {
+    ByteArrayEntity configurationEntity = new ByteArrayEntity();
+    configurationEntity.setBytes(jobHandler.writeConfiguration(configuration));
+    context.getByteArrayManager().insert(configurationEntity);
+    return configurationEntity;
+  }
+
+  protected static Set<String> getEntitiesToUpdate(Map<Class<? extends DbEntity>, DbOperation> operations,
+      int chunkSize,
+      CommandContext commandContext) {
+    return operations.entrySet().stream()
+        .filter(op -> op.getValue().getRowsAffected() == chunkSize)
+        .map(e -> e.getKey().getName())
+        .collect(Collectors.toSet());
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/removaltime/ProcessSetRemovalTimeResultHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/removaltime/ProcessSetRemovalTimeResultHandler.java
@@ -60,7 +60,7 @@ public class ProcessSetRemovalTimeResultHandler implements TransactionListener {
     // use the new command executor since the command context might already have been closed/finished
     commandExecutor.execute(context -> {
         JobEntity job = context.getJobManager().findJobById(jobId);
-        Set<String> entitiesToUpdate = getEntitiesToUpdate(operations, chunkSize, commandContext);
+        Set<String> entitiesToUpdate = getEntitiesToUpdate(operations, chunkSize);
         if (entitiesToUpdate.isEmpty() && !operations.containsKey(HistoricProcessInstanceEventEntity.class)) {
           // update the process instance last to avoid orphans
           entitiesToUpdate = new HashSet<>();
@@ -88,12 +88,10 @@ public class ProcessSetRemovalTimeResultHandler implements TransactionListener {
     return configurationEntity;
   }
 
-  protected static Set<String> getEntitiesToUpdate(Map<Class<? extends DbEntity>, DbOperation> operations,
-      int chunkSize,
-      CommandContext commandContext) {
+  protected static Set<String> getEntitiesToUpdate(Map<Class<? extends DbEntity>, DbOperation> operations, int chunkSize) {
     return operations.entrySet().stream()
         .filter(op -> op.getValue().getRowsAffected() == chunkSize)
-        .map(e -> e.getKey().getName())
+        .map(op -> op.getKey().getName())
         .collect(Collectors.toSet());
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/removaltime/SetRemovalTimeBatchConfiguration.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/removaltime/SetRemovalTimeBatchConfiguration.java
@@ -18,7 +18,7 @@ package org.camunda.bpm.engine.impl.batch.removaltime;
 
 import java.util.Date;
 import java.util.List;
-
+import java.util.Set;
 import org.camunda.bpm.engine.impl.batch.BatchConfiguration;
 import org.camunda.bpm.engine.impl.batch.DeploymentMappings;
 
@@ -30,6 +30,9 @@ public class SetRemovalTimeBatchConfiguration extends BatchConfiguration {
   protected Date removalTime;
   protected boolean hasRemovalTime;
   protected boolean isHierarchical;
+  protected boolean updateInChunks;
+  protected Integer chunkSize;
+  protected Set<String> entities;
 
   public SetRemovalTimeBatchConfiguration(List<String> ids) {
     this(ids, null);
@@ -63,6 +66,33 @@ public class SetRemovalTimeBatchConfiguration extends BatchConfiguration {
 
   public SetRemovalTimeBatchConfiguration setHierarchical(boolean hierarchical) {
     isHierarchical = hierarchical;
+    return this;
+  }
+
+  public boolean isUpdateInChunks() {
+    return updateInChunks;
+  }
+
+  public SetRemovalTimeBatchConfiguration setUpdateInChunks(boolean updateInChunks) {
+    this.updateInChunks = updateInChunks;
+    return this;
+  }
+
+  public Integer getChunkSize() {
+    return chunkSize;
+  }
+
+  public SetRemovalTimeBatchConfiguration setChunkSize(Integer chunkSize) {
+    this.chunkSize = chunkSize;
+    return this;
+  }
+
+  public Set<String> getEntities() {
+    return entities;
+  }
+
+  public SetRemovalTimeBatchConfiguration setEntities(Set<String> entities) {
+    this.entities = entities;
     return this;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -1064,6 +1064,11 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected boolean reevaluateTimeCycleWhenDue = false;
 
   /**
+   * Size of batch in which removal time data will be updated. {@link ProcessSetRemovalTimeJobHandler#MAX_CHUNK_SIZE} must be respected.
+   */
+  protected int removalTimeUpdateChunkSize = 500;
+
+  /**
    * @return {@code true} if the exception code feature is disabled and vice-versa.
    */
   public boolean isDisableExceptionCode() {
@@ -1475,7 +1480,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   // batch ///////////////////////////////////////////////////////////////////////
 
-  protected void initBatchHandlers() {
+  public void initBatchHandlers() {
     if (batchHandlers == null) {
       batchHandlers = new HashMap<>();
 
@@ -1526,6 +1531,11 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       for (BatchJobHandler<?> customBatchJobHandler : customBatchJobHandlers) {
         batchHandlers.put(customBatchJobHandler.getType(), customBatchJobHandler);
       }
+    }
+
+    if (removalTimeUpdateChunkSize > ProcessSetRemovalTimeJobHandler.MAX_CHUNK_SIZE || removalTimeUpdateChunkSize <= 0) {
+      throw LOG.invalidPropertyValue("removalTimeUpdateChunkSize", String.valueOf(removalTimeUpdateChunkSize),
+          String.format("value for chunk size should be between 1 and %s", ProcessSetRemovalTimeJobHandler.MAX_CHUNK_SIZE));
     }
   }
 
@@ -1894,6 +1904,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       properties.put("limitBeforeNativeQuery", DbSqlSessionFactory.databaseSpecificLimitBeforeNativeQueryStatements.get(databaseType));
       properties.put("distinct", DbSqlSessionFactory.databaseSpecificDistinct.get(databaseType));
       properties.put("numericCast", DbSqlSessionFactory.databaseSpecificNumericCast.get(databaseType));
+
+      properties.put("limitBeforeInUpdate", DbSqlSessionFactory.databaseSpecificLimitBeforeInUpdate.get(databaseType));
+      properties.put("limitAfterInUpdate", DbSqlSessionFactory.databaseSpecificLimitAfterInUpdate.get(databaseType));
 
       properties.put("countDistinctBeforeStart", DbSqlSessionFactory.databaseSpecificCountDistinctBeforeStart.get(databaseType));
       properties.put("countDistinctBeforeEnd", DbSqlSessionFactory.databaseSpecificCountDistinctBeforeEnd.get(databaseType));
@@ -5348,6 +5361,15 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public ProcessEngineConfigurationImpl setReevaluateTimeCycleWhenDue(boolean reevaluateTimeCycleWhenDue) {
     this.reevaluateTimeCycleWhenDue = reevaluateTimeCycleWhenDue;
+    return this;
+  }
+
+  public int getRemovalTimeUpdateChunkSize() {
+    return removalTimeUpdateChunkSize;
+  }
+
+  public ProcessEngineConfigurationImpl setRemovalTimeUpdateChunkSize(int removalTimeUpdateChunkSize) {
+    this.removalTimeUpdateChunkSize = removalTimeUpdateChunkSize;
     return this;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/entitymanager/DbEntityManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/entitymanager/DbEntityManager.java
@@ -583,8 +583,8 @@ public class DbEntityManager implements Session, EntityLoadListener {
    * @param statement
    * @param parameter
    */
-  public void updatePreserveOrder(Class<? extends DbEntity> entityType, String statement, Object parameter) {
-    performBulkOperationPreserveOrder(entityType, statement, parameter, UPDATE_BULK);
+  public DbOperation updatePreserveOrder(Class<? extends DbEntity> entityType, String statement, Object parameter) {
+    return performBulkOperationPreserveOrder(entityType, statement, parameter, UPDATE_BULK);
   }
 
   public void delete(Class<? extends DbEntity> entityType, String statement, Object parameter) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/history/event/HistoricDecisionInstanceManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/history/event/HistoricDecisionInstanceManager.java
@@ -16,23 +16,6 @@
  */
 package org.camunda.bpm.engine.impl.history.event;
 
-import org.camunda.bpm.engine.authorization.Resources;
-import org.camunda.bpm.engine.history.HistoricDecisionInputInstance;
-import org.camunda.bpm.engine.history.HistoricDecisionInstance;
-import org.camunda.bpm.engine.history.HistoricDecisionOutputInstance;
-import org.camunda.bpm.engine.history.CleanableHistoricDecisionInstanceReportResult;
-import org.camunda.bpm.engine.impl.CleanableHistoricDecisionInstanceReportImpl;
-import org.camunda.bpm.engine.impl.HistoricDecisionInstanceQueryImpl;
-import org.camunda.bpm.engine.impl.Page;
-import org.camunda.bpm.engine.impl.db.DbEntity;
-import org.camunda.bpm.engine.impl.db.ListQueryParameterObject;
-import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
-import org.camunda.bpm.engine.impl.persistence.AbstractHistoricManager;
-import org.camunda.bpm.engine.impl.persistence.entity.ByteArrayEntity;
-import org.camunda.bpm.engine.impl.util.ClockUtil;
-import org.camunda.bpm.engine.impl.util.ImmutablePair;
-import org.camunda.bpm.engine.impl.variable.serializer.AbstractTypedValueSerializer;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -41,6 +24,23 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.camunda.bpm.engine.authorization.Resources;
+import org.camunda.bpm.engine.history.CleanableHistoricDecisionInstanceReportResult;
+import org.camunda.bpm.engine.history.HistoricDecisionInputInstance;
+import org.camunda.bpm.engine.history.HistoricDecisionInstance;
+import org.camunda.bpm.engine.history.HistoricDecisionOutputInstance;
+import org.camunda.bpm.engine.impl.CleanableHistoricDecisionInstanceReportImpl;
+import org.camunda.bpm.engine.impl.HistoricDecisionInstanceQueryImpl;
+import org.camunda.bpm.engine.impl.Page;
+import org.camunda.bpm.engine.impl.context.Context;
+import org.camunda.bpm.engine.impl.db.DbEntity;
+import org.camunda.bpm.engine.impl.db.ListQueryParameterObject;
+import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
+import org.camunda.bpm.engine.impl.persistence.AbstractHistoricManager;
+import org.camunda.bpm.engine.impl.persistence.entity.ByteArrayEntity;
+import org.camunda.bpm.engine.impl.util.ClockUtil;
+import org.camunda.bpm.engine.impl.util.ImmutablePair;
+import org.camunda.bpm.engine.impl.variable.serializer.AbstractTypedValueSerializer;
 
 /**
  * Data base operations for {@link HistoricDecisionInstanceEntity}.
@@ -169,7 +169,7 @@ public class HistoricDecisionInstanceManager extends AbstractHistoricManager {
       parameters.put("minuteTo", minuteTo);
     }
     ListQueryParameterObject parameterObject = new ListQueryParameterObject(parameters, 0, batchSize);
-    return (List<String>) getDbEntityManager().selectList("selectHistoricDecisionInstanceIdsForCleanup", parameterObject);
+    return getDbEntityManager().selectList("selectHistoricDecisionInstanceIdsForCleanup", parameterObject);
   }
 
   protected void appendHistoricDecisionInputInstances(Map<String, HistoricDecisionInstanceEntity> decisionInstancesById, HistoricDecisionInstanceQueryImpl query) {
@@ -304,33 +304,69 @@ public class HistoricDecisionInstanceManager extends AbstractHistoricManager {
   }
 
   public void addRemovalTimeToDecisionsByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("rootProcessInstanceId", rootProcessInstanceId);
-    parameters.put("removalTime", removalTime);
+    addRemovalTimeToDecisionsByRootProcessInstanceId(rootProcessInstanceId, removalTime, null, Collections.emptySet());
+  }
 
-    getDbEntityManager()
-      .updatePreserveOrder(HistoricDecisionInstanceEntity.class, "updateHistoricDecisionInstancesByRootProcessInstanceId", parameters);
+  public Map<Class<? extends DbEntity>, DbOperation> addRemovalTimeToDecisionsByRootProcessInstanceId(String rootProcessInstanceId,
+      Date removalTime,
+      Integer batchSize,
+      Set<String> entities) {
+    Map<Class<? extends DbEntity>, DbOperation> updateOperations = new HashMap<>();
 
-    getDbEntityManager()
-      .updatePreserveOrder(HistoricDecisionInputInstanceEntity.class, "updateHistoricDecisionInputInstancesByRootProcessInstanceId", parameters);
+    if (entities == null || entities.isEmpty()
+        || entities.contains(HistoricDecisionInstanceEntity.class.getName())
+        || entities.contains(HistoricDecisionInputInstanceEntity.class.getName())
+        || entities.contains(HistoricDecisionOutputInstanceEntity.class.getName())) {
 
-    getDbEntityManager()
-      .updatePreserveOrder(HistoricDecisionOutputInstanceEntity.class, "updateHistoricDecisionOutputInstancesByRootProcessInstanceId", parameters);
+      Map<String, Object> parameters = new HashMap<>();
+      parameters.put("rootProcessInstanceId", rootProcessInstanceId);
+      parameters.put("removalTime", removalTime);
+      parameters.put("maxResults", batchSize);
+
+      addOperation(getDbEntityManager().updatePreserveOrder(HistoricDecisionInstanceEntity.class,
+          "updateHistoricDecisionInstancesByRootProcessInstanceId", parameters), updateOperations);
+
+      addOperation(getDbEntityManager().updatePreserveOrder(HistoricDecisionInputInstanceEntity.class,
+          "updateHistoricDecisionInputInstancesByRootProcessInstanceId", parameters), updateOperations);
+
+      addOperation(getDbEntityManager().updatePreserveOrder(HistoricDecisionOutputInstanceEntity.class,
+          "updateHistoricDecisionOutputInstancesByRootProcessInstanceId", parameters), updateOperations);
+    }
+
+    return updateOperations;
   }
 
   public void addRemovalTimeToDecisionsByProcessInstanceId(String processInstanceId, Date removalTime) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("removalTime", removalTime);
+    addRemovalTimeToDecisionsByProcessInstanceId(processInstanceId, removalTime, null, Collections.emptySet());
+  }
 
-    getDbEntityManager()
-      .updatePreserveOrder(HistoricDecisionInstanceEntity.class, "updateHistoricDecisionInstancesByProcessInstanceId", parameters);
+  public Map<Class<? extends DbEntity>, DbOperation> addRemovalTimeToDecisionsByProcessInstanceId(String processInstanceId,
+      Date removalTime,
+      Integer batchSize,
+      Set<String> entities) {
+    Map<Class<? extends DbEntity>, DbOperation> updateOperations = new HashMap<>();
 
-    getDbEntityManager()
-      .updatePreserveOrder(HistoricDecisionInputInstanceEntity.class, "updateHistoricDecisionInputInstancesByProcessInstanceId", parameters);
+    if (entities == null || entities.isEmpty()
+        || entities.contains(HistoricDecisionInstanceEntity.class.getName())
+        || entities.contains(HistoricDecisionInputInstanceEntity.class.getName())
+        || entities.contains(HistoricDecisionOutputInstanceEntity.class.getName())) {
 
-    getDbEntityManager()
-      .updatePreserveOrder(HistoricDecisionOutputInstanceEntity.class, "updateHistoricDecisionOutputInstancesByProcessInstanceId", parameters);
+      Map<String, Object> parameters = new HashMap<>();
+      parameters.put("processInstanceId", processInstanceId);
+      parameters.put("removalTime", removalTime);
+      parameters.put("maxResults", batchSize);
+
+      addOperation(getDbEntityManager().updatePreserveOrder(HistoricDecisionInstanceEntity.class,
+          "updateHistoricDecisionInstancesByProcessInstanceId", parameters), updateOperations);
+
+      addOperation(getDbEntityManager().updatePreserveOrder(HistoricDecisionInputInstanceEntity.class,
+          "updateHistoricDecisionInputInstancesByProcessInstanceId", parameters), updateOperations);
+
+      addOperation(getDbEntityManager().updatePreserveOrder(HistoricDecisionOutputInstanceEntity.class,
+          "updateHistoricDecisionOutputInstancesByProcessInstanceId", parameters), updateOperations);
+    }
+
+    return updateOperations;
   }
 
   public void addRemovalTimeToDecisionsByRootDecisionInstanceId(String rootInstanceId, Date removalTime) {
@@ -408,6 +444,15 @@ public class HistoricDecisionInstanceManager extends AbstractHistoricManager {
     deleteOperations.put(HistoricDecisionInstanceEntity.class, deleteDecisionInstances);
 
     return deleteOperations;
+  }
+
+  protected static void addOperation(DbOperation operation, Map<Class<? extends DbEntity>, DbOperation> operations) {
+    operations.put(operation.getEntityType(), operation);
+  }
+
+  protected static boolean isEnableHistoricInstancePermissions() {
+    return Context.getProcessEngineConfiguration()
+        .isEnableHistoricInstancePermissions();
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/history/event/HistoricDecisionInstanceManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/history/event/HistoricDecisionInstanceManager.java
@@ -313,22 +313,22 @@ public class HistoricDecisionInstanceManager extends AbstractHistoricManager {
       Set<String> entities) {
     Map<Class<? extends DbEntity>, DbOperation> updateOperations = new HashMap<>();
 
-    if (entities == null || entities.isEmpty()
-        || entities.contains(HistoricDecisionInstanceEntity.class.getName())
-        || entities.contains(HistoricDecisionInputInstanceEntity.class.getName())
-        || entities.contains(HistoricDecisionOutputInstanceEntity.class.getName())) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("rootProcessInstanceId", rootProcessInstanceId);
+    parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-      Map<String, Object> parameters = new HashMap<>();
-      parameters.put("rootProcessInstanceId", rootProcessInstanceId);
-      parameters.put("removalTime", removalTime);
-      parameters.put("maxResults", batchSize);
-
+    if (isPerformUpdate(entities, HistoricDecisionInstanceEntity.class)) {
       addOperation(getDbEntityManager().updatePreserveOrder(HistoricDecisionInstanceEntity.class,
           "updateHistoricDecisionInstancesByRootProcessInstanceId", parameters), updateOperations);
+    }
 
+    if (isPerformUpdate(entities, HistoricDecisionInputInstanceEntity.class)) {
       addOperation(getDbEntityManager().updatePreserveOrder(HistoricDecisionInputInstanceEntity.class,
           "updateHistoricDecisionInputInstancesByRootProcessInstanceId", parameters), updateOperations);
+    }
 
+    if (isPerformUpdate(entities, HistoricDecisionOutputInstanceEntity.class)) {
       addOperation(getDbEntityManager().updatePreserveOrder(HistoricDecisionOutputInstanceEntity.class,
           "updateHistoricDecisionOutputInstancesByRootProcessInstanceId", parameters), updateOperations);
     }
@@ -346,22 +346,22 @@ public class HistoricDecisionInstanceManager extends AbstractHistoricManager {
       Set<String> entities) {
     Map<Class<? extends DbEntity>, DbOperation> updateOperations = new HashMap<>();
 
-    if (entities == null || entities.isEmpty()
-        || entities.contains(HistoricDecisionInstanceEntity.class.getName())
-        || entities.contains(HistoricDecisionInputInstanceEntity.class.getName())
-        || entities.contains(HistoricDecisionOutputInstanceEntity.class.getName())) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("processInstanceId", processInstanceId);
+    parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-      Map<String, Object> parameters = new HashMap<>();
-      parameters.put("processInstanceId", processInstanceId);
-      parameters.put("removalTime", removalTime);
-      parameters.put("maxResults", batchSize);
-
+    if (isPerformUpdate(entities, HistoricDecisionInstanceEntity.class)) {
       addOperation(getDbEntityManager().updatePreserveOrder(HistoricDecisionInstanceEntity.class,
           "updateHistoricDecisionInstancesByProcessInstanceId", parameters), updateOperations);
+    }
 
+    if (isPerformUpdate(entities, HistoricDecisionInputInstanceEntity.class)) {
       addOperation(getDbEntityManager().updatePreserveOrder(HistoricDecisionInputInstanceEntity.class,
           "updateHistoricDecisionInputInstancesByProcessInstanceId", parameters), updateOperations);
+    }
 
+    if (isPerformUpdate(entities, HistoricDecisionOutputInstanceEntity.class)) {
       addOperation(getDbEntityManager().updatePreserveOrder(HistoricDecisionOutputInstanceEntity.class,
           "updateHistoricDecisionOutputInstancesByProcessInstanceId", parameters), updateOperations);
     }
@@ -444,10 +444,6 @@ public class HistoricDecisionInstanceManager extends AbstractHistoricManager {
     deleteOperations.put(HistoricDecisionInstanceEntity.class, deleteDecisionInstances);
 
     return deleteOperations;
-  }
-
-  protected static void addOperation(DbOperation operation, Map<Class<? extends DbEntity>, DbOperation> operations) {
-    operations.put(operation.getEntityType(), operation);
   }
 
   protected static boolean isEnableHistoricInstancePermissions() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/history/event/HistoricDecisionInstanceManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/history/event/HistoricDecisionInstanceManager.java
@@ -32,7 +32,6 @@ import org.camunda.bpm.engine.history.HistoricDecisionOutputInstance;
 import org.camunda.bpm.engine.impl.CleanableHistoricDecisionInstanceReportImpl;
 import org.camunda.bpm.engine.impl.HistoricDecisionInstanceQueryImpl;
 import org.camunda.bpm.engine.impl.Page;
-import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.db.DbEntity;
 import org.camunda.bpm.engine.impl.db.ListQueryParameterObject;
 import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
@@ -444,11 +443,6 @@ public class HistoricDecisionInstanceManager extends AbstractHistoricManager {
     deleteOperations.put(HistoricDecisionInstanceEntity.class, deleteDecisionInstances);
 
     return deleteOperations;
-  }
-
-  protected static boolean isEnableHistoricInstancePermissions() {
-    return Context.getProcessEngineConfiguration()
-        .isEnableHistoricInstancePermissions();
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/AbstractHistoricManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/AbstractHistoricManager.java
@@ -16,9 +16,14 @@
  */
 package org.camunda.bpm.engine.impl.persistence;
 
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.context.Context;
+import org.camunda.bpm.engine.impl.db.DbEntity;
 import org.camunda.bpm.engine.impl.db.EnginePersistenceLogger;
+import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
 import org.camunda.bpm.engine.impl.history.HistoryLevel;
 
 
@@ -46,5 +51,21 @@ public class AbstractHistoricManager extends AbstractManager {
 
   public boolean isHistoryLevelFullEnabled() {
     return isHistoryLevelFullEnabled;
+  }
+
+  protected static boolean isPerformUpdate(Set<String> entities, Class<?> entityClass) {
+    return entities == null || entities.isEmpty() || entities.contains(entityClass.getName());
+  }
+
+  protected static boolean isPerformUpdateOnly(Set<String> entities, Class<?> entityClass) {
+    return entities != null && entities.size() == 1 && entities.contains(entityClass.getName());
+  }
+
+  protected static void addOperation(DbOperation operation, Map<Class<? extends DbEntity>, DbOperation> operations) {
+    operations.put(operation.getEntityType(), operation);
+  }
+
+  protected static void addOperation(Collection<DbOperation> newOperations, Map<Class<? extends DbEntity>, DbOperation> operations) {
+    newOperations.forEach(operation -> operations.put(operation.getEntityType(), operation));
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/AttachmentManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/AttachmentManager.java
@@ -20,7 +20,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.camunda.bpm.engine.impl.db.ListQueryParameterObject;
 import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
 import org.camunda.bpm.engine.impl.persistence.AbstractHistoricManager;
@@ -44,21 +43,23 @@ public class AttachmentManager extends AbstractHistoricManager {
     return getDbEntityManager().selectList("selectAttachmentsByTaskId", taskId);
   }
 
-  public void addRemovalTimeToAttachmentsByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToAttachmentsByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("rootProcessInstanceId", rootProcessInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(AttachmentEntity.class, "updateAttachmentsByRootProcessInstanceId", parameters);
   }
 
-  public void addRemovalTimeToAttachmentsByProcessInstanceId(String processInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToAttachmentsByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("processInstanceId", processInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(AttachmentEntity.class, "updateAttachmentsByProcessInstanceId", parameters);
 
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/AuthorizationManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/AuthorizationManager.java
@@ -25,17 +25,18 @@ import static org.camunda.bpm.engine.authorization.Permissions.READ_TASK;
 import static org.camunda.bpm.engine.authorization.Permissions.UPDATE;
 import static org.camunda.bpm.engine.authorization.Permissions.UPDATE_INSTANCE;
 import static org.camunda.bpm.engine.authorization.ProcessDefinitionPermissions.READ_INSTANCE_VARIABLE;
-import static org.camunda.bpm.engine.authorization.Resources.HISTORIC_PROCESS_INSTANCE;
-import static org.camunda.bpm.engine.authorization.Resources.HISTORIC_TASK;
-import static org.camunda.bpm.engine.authorization.TaskPermissions.READ_VARIABLE;
 import static org.camunda.bpm.engine.authorization.Resources.AUTHORIZATION;
 import static org.camunda.bpm.engine.authorization.Resources.BATCH;
 import static org.camunda.bpm.engine.authorization.Resources.DECISION_DEFINITION;
 import static org.camunda.bpm.engine.authorization.Resources.DECISION_REQUIREMENTS_DEFINITION;
 import static org.camunda.bpm.engine.authorization.Resources.DEPLOYMENT;
+import static org.camunda.bpm.engine.authorization.Resources.HISTORIC_PROCESS_INSTANCE;
+import static org.camunda.bpm.engine.authorization.Resources.HISTORIC_TASK;
 import static org.camunda.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.camunda.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 import static org.camunda.bpm.engine.authorization.Resources.TASK;
+import static org.camunda.bpm.engine.authorization.TaskPermissions.READ_VARIABLE;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -46,7 +47,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
-
 import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.authorization.Authorization;
@@ -84,7 +84,6 @@ import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.TaskQueryImpl;
 import org.camunda.bpm.engine.impl.UserOperationLogQueryImpl;
 import org.camunda.bpm.engine.impl.VariableInstanceQueryImpl;
-
 import org.camunda.bpm.engine.impl.batch.BatchQueryImpl;
 import org.camunda.bpm.engine.impl.batch.BatchStatisticsQueryImpl;
 import org.camunda.bpm.engine.impl.batch.history.HistoricBatchQueryImpl;
@@ -1167,24 +1166,26 @@ public class AuthorizationManager extends AbstractManager {
     return Context.getProcessEngineConfiguration().isEnableHistoricInstancePermissions();
   }
 
-  public void addRemovalTimeToAuthorizationsByRootProcessInstanceId(String rootProcessInstanceId,
-                                                                    Date removalTime) {
+  public DbOperation addRemovalTimeToAuthorizationsByRootProcessInstanceId(String rootProcessInstanceId,
+                                                                    Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("rootProcessInstanceId", rootProcessInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
         .updatePreserveOrder(AuthorizationEntity.class,
             "updateAuthorizationsByRootProcessInstanceId", parameters);
   }
 
-  public void addRemovalTimeToAuthorizationsByProcessInstanceId(String processInstanceId,
-                                                                Date removalTime) {
+  public DbOperation addRemovalTimeToAuthorizationsByProcessInstanceId(String processInstanceId,
+                                                                Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("processInstanceId", processInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
         .updatePreserveOrder(AuthorizationEntity.class,
             "updateAuthorizationsByProcessInstanceId", parameters);
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/CommentManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/CommentManager.java
@@ -20,12 +20,11 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.camunda.bpm.engine.impl.Direction;
 import org.camunda.bpm.engine.impl.QueryOrderingProperty;
 import org.camunda.bpm.engine.impl.QueryPropertyImpl;
-import org.camunda.bpm.engine.impl.db.ListQueryParameterObject;
 import org.camunda.bpm.engine.impl.db.DbEntity;
+import org.camunda.bpm.engine.impl.db.ListQueryParameterObject;
 import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
 import org.camunda.bpm.engine.impl.persistence.AbstractHistoricManager;
 import org.camunda.bpm.engine.task.Comment;
@@ -37,11 +36,13 @@ import org.camunda.bpm.engine.task.Event;
  */
 public class CommentManager extends AbstractHistoricManager {
 
+  @Override
   public void delete(DbEntity dbEntity) {
     checkHistoryEnabled();
     super.delete(dbEntity);
   }
 
+  @Override
   public void insert(DbEntity dbEntity) {
     checkHistoryEnabled();
     super.insert(dbEntity);
@@ -107,21 +108,23 @@ public class CommentManager extends AbstractHistoricManager {
     return (CommentEntity) getDbEntityManager().selectOne("selectCommentByTaskIdAndCommentId", parameters);
   }
 
-  public void addRemovalTimeToCommentsByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToCommentsByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("rootProcessInstanceId", rootProcessInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(CommentEntity.class, "updateCommentsByRootProcessInstanceId", parameters);
   }
 
-  public void addRemovalTimeToCommentsByProcessInstanceId(String processInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToCommentsByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("processInstanceId", processInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(CommentEntity.class, "updateCommentsByProcessInstanceId", parameters);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/EverLivingJobEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/EverLivingJobEntity.java
@@ -19,8 +19,6 @@ package org.camunda.bpm.engine.impl.persistence.entity;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 import org.camunda.bpm.engine.impl.db.EnginePersistenceLogger;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
-import org.camunda.bpm.engine.impl.jobexecutor.JobHandler;
-import org.camunda.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupHelper;
 
 /**
  * JobEntity for ever living job, which can be rescheduled and executed again.
@@ -35,6 +33,7 @@ public class EverLivingJobEntity extends JobEntity {
 
   public static final String TYPE = "ever-living";
 
+  @Override
   public String getType() {
     return TYPE;
   }
@@ -42,36 +41,13 @@ public class EverLivingJobEntity extends JobEntity {
   @Override
   protected void postExecute(CommandContext commandContext) {
     LOG.debugJobExecuted(this);
-    init(commandContext);
+    init(commandContext, false, true);
     commandContext.getHistoricJobLogManager().fireJobSuccessfulEvent(this);
   }
 
   @Override
   public void init(CommandContext commandContext) {
-    init(commandContext, false);
-  }
-
-  public void init(CommandContext commandContext, boolean shouldResetLock) {
-    // clean additional data related to this job
-    JobHandler jobHandler = getJobHandler();
-    if (jobHandler != null) {
-      jobHandler.onDelete(getJobHandlerConfiguration(), this);
-    }
-
-    //cancel the retries -> will resolve job incident if present
-    int retries = HistoryCleanupHelper.getMaxRetries();
-    setRetries(retries);
-
-    //delete the job's exception byte array and exception message
-    if (exceptionByteArrayId != null) {
-      clearFailedJobException();
-    }
-
-    //clean the lock information
-    if (shouldResetLock) {
-      setLockOwner(null);
-      setLockExpirationTime(null);
-    }
+    init(commandContext, false, false);
   }
 
   @Override

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/EverLivingJobEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/EverLivingJobEntity.java
@@ -41,13 +41,13 @@ public class EverLivingJobEntity extends JobEntity {
   @Override
   protected void postExecute(CommandContext commandContext) {
     LOG.debugJobExecuted(this);
-    init(commandContext, false, true);
+    init(commandContext);
     commandContext.getHistoricJobLogManager().fireJobSuccessfulEvent(this);
   }
 
   @Override
   public void init(CommandContext commandContext) {
-    init(commandContext, false, false);
+    init(commandContext, false, true);
   }
 
   @Override

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricActivityInstanceManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricActivityInstanceManager.java
@@ -20,7 +20,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.camunda.bpm.engine.history.HistoricActivityInstance;
 import org.camunda.bpm.engine.impl.HistoricActivityInstanceQueryImpl;
 import org.camunda.bpm.engine.impl.Page;
@@ -76,21 +75,23 @@ public class HistoricActivityInstanceManager extends AbstractHistoricManager {
     getTenantManager().configureQuery(query);
   }
 
-  public void addRemovalTimeToActivityInstancesByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToActivityInstancesByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("rootProcessInstanceId", rootProcessInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(HistoricActivityInstanceEventEntity.class, "updateHistoricActivityInstancesByRootProcessInstanceId", parameters);
   }
 
-  public void addRemovalTimeToActivityInstancesByProcessInstanceId(String processInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToActivityInstancesByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("processInstanceId", processInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(HistoricActivityInstanceEventEntity.class, "updateHistoricActivityInstancesByProcessInstanceId", parameters);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricDetailManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricDetailManager.java
@@ -20,7 +20,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.camunda.bpm.engine.history.HistoricDetail;
 import org.camunda.bpm.engine.impl.HistoricDetailQueryImpl;
 import org.camunda.bpm.engine.impl.Page;
@@ -57,7 +56,7 @@ public class HistoricDetailManager extends AbstractHistoricManager {
     parameters.put("taskCaseInstanceIds", historicCaseInstanceIds);
     deleteHistoricDetails(parameters);
   }
-  
+
   public void deleteHistoricDetailsByVariableInstanceId(String historicVariableInstanceId) {
     Map<String, Object> parameters = new HashMap<String, Object>();
     parameters.put("variableInstanceId", historicVariableInstanceId);
@@ -111,21 +110,23 @@ public class HistoricDetailManager extends AbstractHistoricManager {
     getTenantManager().configureQuery(query);
   }
 
-  public void addRemovalTimeToDetailsByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToDetailsByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("rootProcessInstanceId", rootProcessInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(HistoricDetailEventEntity.class, "updateHistoricDetailsByRootProcessInstanceId", parameters);
   }
 
-  public void addRemovalTimeToDetailsByProcessInstanceId(String processInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToDetailsByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("processInstanceId", processInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(HistoricDetailEventEntity.class, "updateHistoricDetailsByProcessInstanceId", parameters);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricExternalTaskLogManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricExternalTaskLogManager.java
@@ -16,6 +16,10 @@
  */
 package org.camunda.bpm.engine.impl.persistence.entity;
 
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.camunda.bpm.engine.externaltask.ExternalTask;
 import org.camunda.bpm.engine.history.HistoricExternalTaskLog;
 import org.camunda.bpm.engine.impl.HistoricExternalTaskLogQueryImpl;
@@ -25,15 +29,14 @@ import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.db.ListQueryParameterObject;
 import org.camunda.bpm.engine.impl.db.entitymanager.operation.DbOperation;
 import org.camunda.bpm.engine.impl.history.HistoryLevel;
-import org.camunda.bpm.engine.impl.history.event.*;
+import org.camunda.bpm.engine.impl.history.event.HistoricExternalTaskLogEntity;
+import org.camunda.bpm.engine.impl.history.event.HistoryEvent;
+import org.camunda.bpm.engine.impl.history.event.HistoryEventProcessor;
+import org.camunda.bpm.engine.impl.history.event.HistoryEventType;
+import org.camunda.bpm.engine.impl.history.event.HistoryEventTypes;
 import org.camunda.bpm.engine.impl.history.producer.HistoryEventProducer;
 import org.camunda.bpm.engine.impl.persistence.AbstractManager;
 import org.camunda.bpm.engine.impl.util.EnsureUtil;
-
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 
 public class HistoricExternalTaskLogManager extends AbstractManager {
@@ -57,21 +60,23 @@ public class HistoricExternalTaskLogManager extends AbstractManager {
 
   // update ///////////////////////////////////////////////////////////////////
 
-  public void addRemovalTimeToExternalTaskLogByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToExternalTaskLogByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("rootProcessInstanceId", rootProcessInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(HistoricExternalTaskLogEntity.class, "updateExternalTaskLogByRootProcessInstanceId", parameters);
   }
 
-  public void addRemovalTimeToExternalTaskLogByProcessInstanceId(String processInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToExternalTaskLogByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("processInstanceId", processInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(HistoricExternalTaskLogEntity.class, "updateExternalTaskLogByProcessInstanceId", parameters);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricIdentityLinkLogManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricIdentityLinkLogManager.java
@@ -20,7 +20,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.camunda.bpm.engine.history.HistoricIdentityLinkLog;
 import org.camunda.bpm.engine.impl.HistoricIdentityLinkLogQueryImpl;
 import org.camunda.bpm.engine.impl.Page;
@@ -49,21 +48,23 @@ public class HistoricIdentityLinkLogManager extends AbstractHistoricManager {
     return getDbEntityManager().selectList("selectHistoricIdentityLinkByQueryCriteria", query, page);
   }
 
-  public void addRemovalTimeToIdentityLinkLogByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToIdentityLinkLogByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("rootProcessInstanceId", rootProcessInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(HistoricIdentityLinkLogEventEntity.class, "updateIdentityLinkLogByRootProcessInstanceId", parameters);
   }
 
-  public void addRemovalTimeToIdentityLinkLogByProcessInstanceId(String processInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToIdentityLinkLogByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("processInstanceId", processInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(HistoricIdentityLinkLogEventEntity.class, "updateIdentityLinkLogByProcessInstanceId", parameters);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricIncidentManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricIncidentManager.java
@@ -20,7 +20,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.camunda.bpm.engine.history.HistoricIncident;
 import org.camunda.bpm.engine.impl.HistoricIncidentQueryImpl;
 import org.camunda.bpm.engine.impl.Page;
@@ -53,21 +52,23 @@ public class HistoricIncidentManager extends AbstractHistoricManager {
     return getDbEntityManager().selectList("selectHistoricIncidentByQueryCriteria", query, page);
   }
 
-  public void addRemovalTimeToIncidentsByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToIncidentsByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("rootProcessInstanceId", rootProcessInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(HistoricIncidentEventEntity.class, "updateHistoricIncidentsByRootProcessInstanceId", parameters);
   }
 
-  public void addRemovalTimeToIncidentsByProcessInstanceId(String processInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToIncidentsByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("processInstanceId", processInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(HistoricIncidentEventEntity.class, "updateHistoricIncidentsByProcessInstanceId", parameters);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricJobLogManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricJobLogManager.java
@@ -20,7 +20,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.camunda.bpm.engine.history.HistoricJobLog;
 import org.camunda.bpm.engine.impl.HistoricJobLogQueryImpl;
 import org.camunda.bpm.engine.impl.Page;
@@ -68,21 +67,23 @@ public class HistoricJobLogManager extends AbstractHistoricManager {
 
   // update ///////////////////////////////////////////////////////////////////
 
-  public void addRemovalTimeToJobLogByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToJobLogByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("rootProcessInstanceId", rootProcessInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(HistoricJobLogEventEntity.class, "updateJobLogByRootProcessInstanceId", parameters);
   }
 
-  public void addRemovalTimeToJobLogByProcessInstanceId(String processInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToJobLogByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("processInstanceId", processInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(HistoricJobLogEventEntity.class, "updateJobLogByProcessInstanceId", parameters);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricProcessInstanceManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricProcessInstanceManager.java
@@ -16,7 +16,6 @@
  */
 package org.camunda.bpm.engine.impl.persistence.entity;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -469,21 +468,5 @@ public class HistoricProcessInstanceManager extends AbstractHistoricManager {
   protected static boolean isEnableHistoricInstancePermissions() {
     return Context.getProcessEngineConfiguration()
         .isEnableHistoricInstancePermissions();
-  }
-
-  protected static void addOperation(DbOperation operation, Map<Class<? extends DbEntity>, DbOperation> operations) {
-    operations.put(operation.getEntityType(), operation);
-  }
-
-  protected static void addOperation(Collection<DbOperation> newOperations, Map<Class<? extends DbEntity>, DbOperation> operations) {
-    newOperations.forEach(operation -> operations.put(operation.getEntityType(), operation));
-  }
-
-  protected static boolean isPerformUpdate(Set<String> entities, Class<?> entityClass) {
-    return entities == null || entities.isEmpty() || entities.contains(entityClass.getName());
-  }
-
-  protected static boolean isPerformUpdateOnly(Set<String> entities, Class<?> entityClass) {
-    return entities != null && entities.size() == 1 && entities.contains(entityClass.getName());
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricTaskInstanceManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricTaskInstanceManager.java
@@ -23,7 +23,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.camunda.bpm.engine.authorization.Resources;
 import org.camunda.bpm.engine.history.HistoricTaskInstance;
 import org.camunda.bpm.engine.impl.HistoricTaskInstanceQueryImpl;
@@ -184,21 +183,23 @@ public class HistoricTaskInstanceManager extends AbstractHistoricManager {
     }
   }
 
-  public void addRemovalTimeToTaskInstancesByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToTaskInstancesByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("rootProcessInstanceId", rootProcessInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(HistoricTaskInstanceEventEntity.class, "updateHistoricTaskInstancesByRootProcessInstanceId", parameters);
   }
 
-  public void addRemovalTimeToTaskInstancesByProcessInstanceId(String processInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToTaskInstancesByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("processInstanceId", processInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(HistoricTaskInstanceEventEntity.class, "updateHistoricTaskInstancesByProcessInstanceId", parameters);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricVariableInstanceManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricVariableInstanceManager.java
@@ -22,7 +22,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.camunda.bpm.engine.history.HistoricVariableInstance;
 import org.camunda.bpm.engine.history.HistoricVariableInstanceQuery;
 import org.camunda.bpm.engine.impl.HistoricVariableInstanceQueryImpl;
@@ -45,7 +44,7 @@ public class HistoricVariableInstanceManager extends AbstractHistoricManager {
       }
     }
   }
-  
+
   public void deleteHistoricVariableInstanceByProcessInstanceIds(List<String> historicProcessInstanceIds) {
     Map<String, Object> parameters = new HashMap<String, Object>();
     parameters.put("processInstanceIds", historicProcessInstanceIds);
@@ -137,21 +136,23 @@ public class HistoricVariableInstanceManager extends AbstractHistoricManager {
     }
   }
 
-  public void addRemovalTimeToVariableInstancesByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToVariableInstancesByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("rootProcessInstanceId", rootProcessInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(HistoricVariableInstanceEntity.class, "updateHistoricVariableInstancesByRootProcessInstanceId", parameters);
   }
 
-  public void addRemovalTimeToVariableInstancesByProcessInstanceId(String processInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToVariableInstancesByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("processInstanceId", processInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(HistoricVariableInstanceEntity.class, "updateHistoricVariableInstancesByProcessInstanceId", parameters);
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/JobManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/JobManager.java
@@ -27,7 +27,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.camunda.bpm.engine.impl.Direction;
 import org.camunda.bpm.engine.impl.JobQueryImpl;
 import org.camunda.bpm.engine.impl.JobQueryProperty;
@@ -116,10 +115,12 @@ public class JobManager extends AbstractManager {
   }
 
   public void reschedule(JobEntity jobEntity, Date newDuedate) {
-    ((EverLivingJobEntity)jobEntity).init(Context.getCommandContext(), true);
-    jobEntity.setSuspensionState(SuspensionState.ACTIVE.getStateCode());
-    jobEntity.setDuedate(newDuedate);
-    hintJobExecutorIfNeeded(jobEntity, newDuedate);
+    if (jobEntity instanceof EverLivingJobEntity || jobEntity instanceof MessageEntity) {
+      jobEntity.init(Context.getCommandContext(), true, false);
+      jobEntity.setSuspensionState(SuspensionState.ACTIVE.getStateCode());
+      jobEntity.setDuedate(newDuedate);
+      hintJobExecutorIfNeeded(jobEntity, newDuedate);
+    }
   }
 
   private void hintJobExecutorIfNeeded(JobEntity jobEntity, Date duedate) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/MessageEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/MessageEntity.java
@@ -23,7 +23,7 @@ import org.camunda.bpm.engine.impl.jobexecutor.MessageJobDeclaration;
 
 
 /**
- * NOTE: instances of Messge Entity should be created via {@link MessageJobDeclaration}.
+ * NOTE: instances of Message Entity should be created via {@link MessageJobDeclaration}.
  *
  * @author Tom Baeyens
  */

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/MessageEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/MessageEntity.java
@@ -16,6 +16,9 @@
  */
 package org.camunda.bpm.engine.impl.persistence.entity;
 
+import org.camunda.bpm.engine.impl.ProcessEngineLogger;
+import org.camunda.bpm.engine.impl.db.EnginePersistenceLogger;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.jobexecutor.MessageJobDeclaration;
 
 
@@ -30,6 +33,8 @@ public class MessageEntity extends JobEntity {
 
   private static final long serialVersionUID = 1L;
 
+  private final static EnginePersistenceLogger LOG = ProcessEngineLogger.PERSISTENCE_LOGGER;
+
   private String repeat = null;
 
   public String getRepeat() {
@@ -39,8 +44,26 @@ public class MessageEntity extends JobEntity {
     this.repeat = repeat;
   }
 
+  @Override
   public String getType() {
     return TYPE;
+  }
+
+  @Override
+  protected void postExecute(CommandContext commandContext) {
+    LOG.debugJobExecuted(this);
+    if (repeat != null && !repeat.isEmpty()) {
+      init(commandContext, false, true);
+    } else {
+      delete(true);
+    }
+    commandContext.getHistoricJobLogManager().fireJobSuccessfulEvent(this);
+  }
+
+  @Override
+  public void init(CommandContext commandContext, boolean shouldResetLock, boolean shouldCallDeleteHandler) {
+    super.init(commandContext, shouldResetLock, shouldCallDeleteHandler);
+    repeat = null;
   }
 
   @Override

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/UserOperationLogManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/UserOperationLogManager.java
@@ -23,7 +23,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.camunda.bpm.engine.EntityTypes;
 import org.camunda.bpm.engine.authorization.Permission;
 import org.camunda.bpm.engine.authorization.Permissions;
@@ -80,21 +79,23 @@ public class UserOperationLogManager extends AbstractHistoricManager {
     return getDbEntityManager().selectList("selectUserOperationLogEntriesByQueryCriteria", query, page);
   }
 
-  public void addRemovalTimeToUserOperationLogByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToUserOperationLogByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("rootProcessInstanceId", rootProcessInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(UserOperationLogEntryEventEntity.class, "updateUserOperationLogByRootProcessInstanceId", parameters);
   }
 
-  public void addRemovalTimeToUserOperationLogByProcessInstanceId(String processInstanceId, Date removalTime) {
+  public DbOperation addRemovalTimeToUserOperationLogByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("processInstanceId", processInstanceId);
     parameters.put("removalTime", removalTime);
+    parameters.put("maxResults", batchSize);
 
-    getDbEntityManager()
+    return getDbEntityManager()
       .updatePreserveOrder(UserOperationLogEntryEventEntity.class, "updateUserOperationLogByProcessInstanceId", parameters);
   }
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Attachment.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Attachment.xml
@@ -45,7 +45,8 @@
   <!-- ATTACHMENT UPDATE -->
 
   <update id="updateAttachment" parameterType="org.camunda.bpm.engine.impl.persistence.entity.AttachmentEntity">
-    update ${prefix}ACT_HI_ATTACHMENT 
+    update
+    ${prefix}ACT_HI_ATTACHMENT 
     set
       REV_ = #{revisionNext, jdbcType=INTEGER},
       NAME_ = #{name, jdbcType=VARCHAR},
@@ -56,43 +57,153 @@
 
   <update id="updateAttachmentsByRootProcessInstanceId"
           parameterType="java.util.Map">
-      update ${prefix}ACT_HI_ATTACHMENT set
+      update
+      <if test="maxResults != null">
+        ${limitBeforeWithoutOffset}
+      </if>
+      ${prefix}ACT_HI_ATTACHMENT set
       REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
       where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateAttachmentsByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_HI_ATTACHMENT set
+      REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_ATTACHMENT
+      </if>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateAttachmentsByRootProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_HI_ATTACHMENT
+      <choose>
+      <when test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_ATTACHMENT
+      </when>
+      <otherwise>
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </otherwise>
+      </choose>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateAttachmentsByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_ATTACHMENT RES WITH (FORCESEEK)
     where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
   </update>
 
   <update id="updateAttachmentsByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_ATTACHMENT
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_ATTACHMENT
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
-      where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      where (PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
         or TASK_ID_ in (
           SELECT ID_
           FROM ${prefix}ACT_HI_TASKINST
           WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
-        )
+        ))
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateAttachmentsByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_ATTACHMENT
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_ATTACHMENT
+      </if>
+      where (PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+        or TASK_ID_ in (
+          SELECT ID_
+          FROM ${prefix}ACT_HI_TASKINST
+          WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+        ))
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateAttachmentsByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_ATTACHMENT
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_ATTACHMENT
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+      where (PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+        or TASK_ID_ in (
+          SELECT ID_
+          FROM ${prefix}ACT_HI_TASKINST
+          WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+        ))
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateAttachmentsByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
       RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       FROM ${prefix}ACT_HI_ATTACHMENT RES WITH (FORCESEEK)
-      where RES.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      where (RES.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
         or RES.TASK_ID_ in (
           SELECT ID_
           FROM ${prefix}ACT_HI_TASKINST
           WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
-        )
+        ))
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <!-- ATTACHMENT DELETE -->

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Authorization.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Authorization.xml
@@ -68,50 +68,168 @@
 
   <update id="updateAuthorizationsByRootProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_RU_AUTHORIZATION set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_RU_AUTHORIZATION set
     REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
     where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
+  </update>
+
+  <update id="updateAuthorizationsByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_RU_AUTHORIZATION set
+    REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+    <if test="maxResults != null">
+      ${limitBeforeInUpdate} ${prefix}ACT_RU_AUTHORIZATION
+    </if>
+
+    where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterInUpdate}
+    </if>
+  </update>
+
+  <update id="updateAuthorizationsByRootProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_RU_AUTHORIZATION
+    <choose>
+      <when test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_RU_AUTHORIZATION
+      </when>
+      <otherwise>
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </otherwise>
+    </choose>
+
+    where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterInUpdate}
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+    </if>
   </update>
 
   <update id="updateAuthorizationsByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_RU_AUTHORIZATION RES WITH (FORCESEEK)
     where RES.ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
   </update>
 
   <update id="updateAuthorizationsByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_RU_AUTHORIZATION set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_RU_AUTHORIZATION set
     REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
     where
       <!-- task instances -->
-      RESOURCE_ID_ IN (
+      (RESOURCE_ID_ IN (
         SELECT ID_
         FROM ${prefix}ACT_HI_TASKINST
         WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
       <!-- process instances -->
-      or RESOURCE_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      or RESOURCE_ID_ = #{processInstanceId, jdbcType=VARCHAR})
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateAuthorizationsByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_RU_AUTHORIZATION set
+    REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+    <if test="maxResults != null">
+      ${limitBeforeInUpdate} ${prefix}ACT_RU_AUTHORIZATION
+    </if>
+
+    where
+      <!-- task instances -->
+      (RESOURCE_ID_ IN (
+        SELECT ID_
+        FROM ${prefix}ACT_HI_TASKINST
+        WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      )
+      <!-- process instances -->
+      or RESOURCE_ID_ = #{processInstanceId, jdbcType=VARCHAR})
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateAuthorizationsByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_RU_AUTHORIZATION
+    <choose>
+      <when test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_RU_AUTHORIZATION
+      </when>
+      <otherwise>
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </otherwise>
+    </choose>
+
+    where
+      <!-- task instances -->
+      (RESOURCE_ID_ IN (
+        SELECT ID_
+        FROM ${prefix}ACT_HI_TASKINST
+        WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      )
+      <!-- process instances -->
+      or RESOURCE_ID_ = #{processInstanceId, jdbcType=VARCHAR})
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateAuthorizationsByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_RU_AUTHORIZATION RES WITH (FORCESEEK)
     where
       <!-- task instances -->
-      RES.RESOURCE_ID_ IN (
+      (RES.RESOURCE_ID_ IN (
         SELECT ID_
         FROM ${prefix}ACT_HI_TASKINST
         WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
       <!-- process instances -->
-      or RES.RESOURCE_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      or RES.RESOURCE_ID_ = #{processInstanceId, jdbcType=VARCHAR})
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <!-- AUTHORIZATION DELETE -->

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Comment.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Comment.xml
@@ -62,43 +62,153 @@
   <!-- UPDATE -->
   <update id="updateCommentsByRootProcessInstanceId"
           parameterType="java.util.Map">
-      update ${prefix}ACT_HI_COMMENT set
+      update
+      <if test="maxResults != null">
+        ${limitBeforeWithoutOffset}
+      </if>
+      ${prefix}ACT_HI_COMMENT set
       REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
       where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateCommentsByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_HI_COMMENT set
+      REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_COMMENT
+      </if>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateCommentsByRootProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_HI_COMMENT
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_COMMENT
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateCommentsByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_COMMENT RES WITH (FORCESEEK)
     where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
   </update>
 
   <update id="updateCommentsByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_COMMENT
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_COMMENT
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
-      where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      where (PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
         or TASK_ID_ in (
           SELECT ID_
           FROM ${prefix}ACT_HI_TASKINST
           WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
-        )
+        ))
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateCommentsByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_COMMENT
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_COMMENT
+      </if>
+      where (PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+        or TASK_ID_ in (
+          SELECT ID_
+          FROM ${prefix}ACT_HI_TASKINST
+          WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+        ))
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateCommentsByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_COMMENT
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_COMMENT
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+      where (PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+        or TASK_ID_ in (
+          SELECT ID_
+          FROM ${prefix}ACT_HI_TASKINST
+          WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+        ))
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateCommentsByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
       RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       FROM ${prefix}ACT_HI_COMMENT RES WITH (FORCESEEK)
-      where RES.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      where (RES.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
         or RES.TASK_ID_ in (
           SELECT ID_
           FROM ${prefix}ACT_HI_TASKINST
           WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
-        )
+        ))
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <!-- COMMENT DELETE -->

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricActivityInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricActivityInstance.xml
@@ -102,33 +102,132 @@
 
   <update id="updateHistoricActivityInstancesByRootProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_ACTINST set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_ACTINST set
     REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
     where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
+  </update>
+  
+  <update id="updateHistoricActivityInstancesByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_ACTINST set
+    REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+    <if test="maxResults != null">
+      ${limitBeforeInUpdate} ${prefix}ACT_HI_ACTINST
+    </if>
+    where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterInUpdate}
+    </if>
+  </update>
+  
+  <update id="updateHistoricActivityInstancesByRootProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_ACTINST
+    <choose>
+      <when test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_ACTINST
+      </when>
+      <otherwise>
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </otherwise>
+    </choose>
+    where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterInUpdate}
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+    </if>
+    
   </update>
 
   <update id="updateHistoricActivityInstancesByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_ACTINST RES WITH (FORCESEEK)
     where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
   </update>
 
   <update id="updateHistoricActivityInstancesByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_ACTINST
+    update 
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_ACTINST
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+  
+  <update id="updateHistoricActivityInstancesByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_ACTINST 
+    set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+    <if test="maxResults != null">
+      ${limitBeforeInUpdate} ${prefix}ACT_HI_ACTINST
+    </if>
+    where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterInUpdate}
+    </if>
+  </update>
+  
+  <update id="updateHistoricActivityInstancesByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_ACTINST 
+    <choose>
+      <when test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_ACTINST
+      </when>
+      <otherwise>
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </otherwise>
+    </choose>
+    where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterInUpdate}
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+    </if>
   </update>
 
   <update id="updateHistoricActivityInstancesByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update 
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_ACTINST RES WITH (FORCESEEK)
     where RES.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
   </update>
 
   <!-- HISTORIC ACTIVITY INSTANCE SELECT -->

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricDecisionInputInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricDecisionInputInstance.xml
@@ -60,34 +60,138 @@
   <!-- update -->
   <update id="updateHistoricDecisionInputInstancesByRootProcessInstanceId"
           parameterType="java.util.Map">
-      update ${prefix}ACT_HI_DEC_IN set
+      update
+      <if test="maxResults != null">
+        ${limitBeforeWithoutOffset}
+      </if>
+      ${prefix}ACT_HI_DEC_IN set
       REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
       where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateHistoricDecisionInputInstancesByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_HI_DEC_IN set
+      REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_DEC_IN
+      </if>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateHistoricDecisionInputInstancesByRootProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_HI_DEC_IN
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_DEC_IN
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateHistoricDecisionInputInstancesByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_DEC_IN RES WITH (FORCESEEK)
     where RES.ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
   </update>
 
   <update id="updateHistoricDecisionInputInstancesByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_DEC_IN
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_DEC_IN
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where DEC_INST_ID_ IN (
         SELECT ID_
         FROM ${prefix}ACT_HI_DECINST
         WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=TIMESTAMP}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateHistoricDecisionInputInstancesByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_DEC_IN
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_DEC_IN
+      </if>
+      where DEC_INST_ID_ IN (
+        SELECT ID_
+        FROM ${prefix}ACT_HI_DECINST
+        WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=TIMESTAMP}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateHistoricDecisionInputInstancesByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_DEC_IN
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_DEC_IN
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+      where DEC_INST_ID_ IN (
+        SELECT ID_
+        FROM ${prefix}ACT_HI_DECINST
+        WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=TIMESTAMP}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateHistoricDecisionInputInstancesByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
       RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       from ${prefix}ACT_HI_DEC_IN RES WITH (FORCESEEK)
       where RES.DEC_INST_ID_ IN (
@@ -95,6 +199,10 @@
         FROM ${prefix}ACT_HI_DECINST
         WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=TIMESTAMP}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateHistoricDecisionInputInstancesByRootDecisionInstanceId"

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricDecisionInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricDecisionInstance.xml
@@ -85,33 +85,133 @@
 
   <update id="updateHistoricDecisionInstancesByRootProcessInstanceId"
           parameterType="java.util.Map">
-      update ${prefix}ACT_HI_DECINST set
+      update
+      <if test="maxResults != null">
+        ${limitBeforeWithoutOffset}
+      </if>
+      ${prefix}ACT_HI_DECINST set
       REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
       where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateHistoricDecisionInstancesByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_HI_DECINST set
+      REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_DECINST
+      </if>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateHistoricDecisionInstancesByRootProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_HI_DECINST
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_DECINST
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateHistoricDecisionInstancesByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_DECINST RES WITH (FORCESEEK)
     where RES.ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
   </update>
 
   <update id="updateHistoricDecisionInstancesByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_DECINST
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_DECINST
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateHistoricDecisionInstancesByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_DECINST
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_DECINST
+      </if>
+      where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateHistoricDecisionInstancesByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_DECINST
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_DECINST
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+      where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateHistoricDecisionInstancesByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES
     set RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_DECINST RES WITH (FORCESEEK)
     where RES.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
   </update>
 
   <update id="updateHistoricDecisionInstancesByRootDecisionInstanceId"

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricDecisionOutputInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricDecisionOutputInstance.xml
@@ -67,34 +67,138 @@
 
   <update id="updateHistoricDecisionOutputInstancesByRootProcessInstanceId"
           parameterType="java.util.Map">
-      update ${prefix}ACT_HI_DEC_OUT set
+      update
+      <if test="maxResults != null">
+        ${limitBeforeWithoutOffset}
+      </if>
+      ${prefix}ACT_HI_DEC_OUT set
       REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
       where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateHistoricDecisionOutputInstancesByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_HI_DEC_OUT set
+      REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_DEC_OUT
+      </if>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateHistoricDecisionOutputInstancesByRootProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_HI_DEC_OUT
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_DEC_OUT
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateHistoricDecisionOutputInstancesByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-      update RES set
+      update
+      <if test="maxResults != null">
+        ${limitBeforeWithoutOffset}
+      </if>
+      RES set
       RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       FROM ${prefix}ACT_HI_DEC_OUT RES WITH (FORCESEEK)
       where RES.ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateHistoricDecisionOutputInstancesByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_DEC_OUT
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_DEC_OUT
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where DEC_INST_ID_ IN (
         SELECT ID_
         FROM ${prefix}ACT_HI_DECINST
         WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=TIMESTAMP}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateHistoricDecisionOutputInstancesByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_DEC_OUT
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_DEC_OUT
+      </if>
+      where DEC_INST_ID_ IN (
+        SELECT ID_
+        FROM ${prefix}ACT_HI_DECINST
+        WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=TIMESTAMP}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateHistoricDecisionOutputInstancesByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_DEC_OUT
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_DEC_OUT
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+      where DEC_INST_ID_ IN (
+        SELECT ID_
+        FROM ${prefix}ACT_HI_DECINST
+        WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=TIMESTAMP}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateHistoricDecisionOutputInstancesByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
       RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       FROM ${prefix}ACT_HI_DEC_OUT RES WITH (FORCESEEK)
       where RES.DEC_INST_ID_ IN (
@@ -102,6 +206,10 @@
         FROM ${prefix}ACT_HI_DECINST
         WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=TIMESTAMP}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateHistoricDecisionOutputInstancesByRootDecisionInstanceId"

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricDetail.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricDetail.xml
@@ -132,33 +132,133 @@
 
   <update id="updateHistoricDetailsByRootProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_DETAIL set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_DETAIL set
     REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
     where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
+  </update>
+
+  <update id="updateHistoricDetailsByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_DETAIL set
+    REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+    <if test="maxResults != null">
+      ${limitBeforeInUpdate} ${prefix}ACT_HI_DETAIL
+    </if>
+
+    where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterInUpdate}
+    </if>
+  </update>
+
+  <update id="updateHistoricDetailsByRootProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_DETAIL
+    <choose>
+      <when test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_DETAIL
+      </when>
+      <otherwise>
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </otherwise>
+    </choose>
+
+    where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterInUpdate}
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+    </if>
   </update>
 
   <update id="updateHistoricDetailsByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_DETAIL RES WITH (FORCESEEK)
     where RES.ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
   </update>
 
   <update id="updateHistoricDetailsByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_DETAIL
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_DETAIL
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateHistoricDetailsByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_DETAIL
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_DETAIL
+      </if>
+      where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateHistoricDetailsByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_DETAIL
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_DETAIL
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+      where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateHistoricDetailsByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_DETAIL RES WITH (FORCESEEK)
     where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
   </update>
 
   <!-- HISTORIC DETAILS DELETE -->

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricExternalTaskLog.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricExternalTaskLog.xml
@@ -71,50 +71,137 @@
 
   <update id="updateExternalTaskLogByRootProcessInstanceId"
           parameterType="java.util.Map">
-      update ${prefix}ACT_HI_EXT_TASK_LOG set
+      update
+      <if test="maxResults != null">
+        ${limitBeforeWithoutOffset}
+      </if>
+      ${prefix}ACT_HI_EXT_TASK_LOG set
       REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
       where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateExternalTaskLogByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_HI_EXT_TASK_LOG set
+      REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_EXT_TASK_LOG
+      </if>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
   </update>
 
   <update id="updateExternalTaskLogByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-      update RES set
+      update
+      <if test="maxResults != null">
+        ${limitBeforeWithoutOffset}
+      </if>
+      RES set
       RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       FROM ${prefix}ACT_HI_EXT_TASK_LOG RES WITH (FORCESEEK)
       where RES.ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateExternalTaskLogByRootProcessInstanceId_mysql"
           parameterType="java.util.Map">
-      update ${prefix}ACT_HI_EXT_TASK_LOG set
-      REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
-      TIMESTAMP_ = TIMESTAMP_
+      update ${prefix}ACT_HI_EXT_TASK_LOG
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_EXT_TASK_LOG
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
+              TIMESTAMP_ = TIMESTAMP_
+        </otherwise>
+      </choose>
 
       where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
+            TIMESTAMP_ = TIMESTAMP_
+      </if>
   </update>
 
   <update id="updateExternalTaskLogByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_EXT_TASK_LOG
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_EXT_TASK_LOG
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateExternalTaskLogByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_EXT_TASK_LOG
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_EXT_TASK_LOG
+      </if>
+      where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
   </update>
 
   <update id="updateExternalTaskLogByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
       RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       FROM ${prefix}ACT_HI_EXT_TASK_LOG RES WITH (FORCESEEK)
       where RES.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateExternalTaskLogByProcessInstanceId_mysql"
           parameterType="java.util.Map">
     update ${prefix}ACT_HI_EXT_TASK_LOG
-      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
-          TIMESTAMP_ = TIMESTAMP_
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_EXT_TASK_LOG
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
+              TIMESTAMP_ = TIMESTAMP_
+        </otherwise>
+      </choose>
       where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
+            TIMESTAMP_ = TIMESTAMP_
+      </if>
   </update>
 
   <!-- DELETE -->

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricIdentityLinkLog.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricIdentityLinkLog.xml
@@ -58,43 +58,117 @@
 
   <update id="updateIdentityLinkLogByRootProcessInstanceId"
           parameterType="java.util.Map">
-      update ${prefix}ACT_HI_IDENTITYLINK set
+      update
+      <if test="maxResults != null">
+        ${limitBeforeWithoutOffset}
+      </if>
+      ${prefix}ACT_HI_IDENTITYLINK set
       REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
       where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateIdentityLinkLogByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_HI_IDENTITYLINK set
+      REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_IDENTITYLINK
+      </if>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
   </update>
 
   <update id="updateIdentityLinkLogByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-      update RES set
+      update
+      <if test="maxResults != null">
+        ${limitBeforeWithoutOffset}
+      </if>
+      RES set
       RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       FROM ${prefix}ACT_HI_IDENTITYLINK RES WITH (FORCESEEK)
       where RES.ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateIdentityLinkLogByRootProcessInstanceId_mysql"
           parameterType="java.util.Map">
-      update ${prefix}ACT_HI_IDENTITYLINK set
-      REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
-      TIMESTAMP_ = TIMESTAMP_
+      update ${prefix}ACT_HI_IDENTITYLINK
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_IDENTITYLINK
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
+              TIMESTAMP_ = TIMESTAMP_
+        </otherwise>
+      </choose>
 
       where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
+            TIMESTAMP_ = TIMESTAMP_
+      </if>
   </update>
 
   <update id="updateIdentityLinkLogByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_IDENTITYLINK
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_IDENTITYLINK
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where TASK_ID_ IN (
         SELECT ID_
         FROM ${prefix}ACT_HI_TASKINST
         WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateIdentityLinkLogByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_IDENTITYLINK
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_IDENTITYLINK
+      </if>
+      where TASK_ID_ IN (
+        SELECT ID_
+        FROM ${prefix}ACT_HI_TASKINST
+        WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
   </update>
 
   <update id="updateIdentityLinkLogByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
       RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       FROM ${prefix}ACT_HI_IDENTITYLINK RES WITH (FORCESEEK)
       where RES.TASK_ID_ IN (
@@ -102,18 +176,35 @@
         FROM ${prefix}ACT_HI_TASKINST
         WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateIdentityLinkLogByProcessInstanceId_mysql"
           parameterType="java.util.Map">
     update ${prefix}ACT_HI_IDENTITYLINK
-      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
-          TIMESTAMP_ = TIMESTAMP_
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_IDENTITYLINK
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
+              TIMESTAMP_ = TIMESTAMP_
+        </otherwise>
+      </choose>
       where TASK_ID_ IN (
         SELECT ID_
         FROM ${prefix}ACT_HI_TASKINST
         WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
+            TIMESTAMP_ = TIMESTAMP_
+      </if>
   </update>
   
   <!-- HISTORIC IDENTITY LINK DELETE -->

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricIncident.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricIncident.xml
@@ -107,50 +107,137 @@
   
   <update id="updateHistoricIncidentsByRootProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_INCIDENT set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_INCIDENT set
     REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
     where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
+  </update>
+  
+  <update id="updateHistoricIncidentsByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_INCIDENT set
+    REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+    <if test="maxResults != null">
+      ${limitBeforeInUpdate} ${prefix}ACT_HI_INCIDENT
+    </if>
+
+    where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterInUpdate}
+    </if>
   </update>
 
   <update id="updateHistoricIncidentsByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_INCIDENT RES WITH (FORCESEEK)
     where RES.ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
   </update>
 
   <update id="updateHistoricIncidentsByRootProcessInstanceId_mysql"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_INCIDENT set
-    REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
-    CREATE_TIME_ = CREATE_TIME_
+    update ${prefix}ACT_HI_INCIDENT
+    <choose>
+      <when test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_INCIDENT
+      </when>
+      <otherwise>
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
+            CREATE_TIME_ = CREATE_TIME_
+      </otherwise>
+    </choose>
 
     where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterInUpdate}
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
+          CREATE_TIME_ = CREATE_TIME_
+    </if>
   </update>
 
   <update id="updateHistoricIncidentsByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_INCIDENT
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_INCIDENT
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateHistoricIncidentsByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_INCIDENT
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_INCIDENT
+      </if>
+      where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
   </update>
 
   <update id="updateHistoricIncidentsByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update 
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_INCIDENT RES WITH (FORCESEEK)
     where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
   </update>
 
   <update id="updateHistoricIncidentsByProcessInstanceId_mysql"
           parameterType="java.util.Map">
     update ${prefix}ACT_HI_INCIDENT
-      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
-          CREATE_TIME_ = CREATE_TIME_
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_INCIDENT
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
+              CREATE_TIME_ = CREATE_TIME_
+        </otherwise>
+      </choose>
       where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
+            CREATE_TIME_ = CREATE_TIME_
+      </if>
   </update>
 
   <update id="updateHistoricIncidentsByBatchId"

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricJobLog.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricJobLog.xml
@@ -81,33 +81,133 @@
 
   <update id="updateJobLogByRootProcessInstanceId"
           parameterType="java.util.Map">
-      update ${prefix}ACT_HI_JOB_LOG set
+      update
+      <if test="maxResults != null">
+        ${limitBeforeWithoutOffset}
+      </if>
+      ${prefix}ACT_HI_JOB_LOG set
       REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
       where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateJobLogByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_HI_JOB_LOG set
+      REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_JOB_LOG
+      </if>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateJobLogByRootProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_HI_JOB_LOG
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_JOB_LOG
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateJobLogByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-      update RES set
+      update
+      <if test="maxResults != null">
+        ${limitBeforeWithoutOffset}
+      </if>
+      RES set
       RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       FROM ${prefix}ACT_HI_JOB_LOG RES WITH (FORCESEEK)
       where RES.ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateJobLogByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_JOB_LOG
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_JOB_LOG
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where PROCESS_INSTANCE_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateJobLogByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_JOB_LOG
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_JOB_LOG
+      </if>
+      where PROCESS_INSTANCE_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateJobLogByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_JOB_LOG
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_JOB_LOG
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+      where PROCESS_INSTANCE_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateJobLogByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
       RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       FROM ${prefix}ACT_HI_JOB_LOG RES WITH (FORCESEEK)
       where RES.PROCESS_INSTANCE_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateJobLogByBatchId"

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
@@ -106,33 +106,131 @@
 
   <update id="updateHistoricProcessInstanceEventsByRootProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_PROCINST set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_PROCINST set
     REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
     where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
+  </update>
+
+  <update id="updateHistoricProcessInstanceEventsByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_PROCINST set
+    REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+    <if test="maxResults != null">
+      ${limitBeforeInUpdate} ${prefix}ACT_HI_PROCINST
+    </if>
+    where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterInUpdate}
+    </if>
+  </update>
+
+  <update id="updateHistoricProcessInstanceEventsByRootProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_PROCINST
+    <choose>
+      <when test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_PROCINST
+      </when>
+      <otherwise>
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </otherwise>
+    </choose>
+    where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterInUpdate}
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+    </if>
   </update>
 
   <update id="updateHistoricProcessInstanceEventsByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_PROCINST RES WITH (FORCESEEK)
     where RES.ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
   </update>
 
   <update id="updateHistoricProcessInstanceByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_PROCINST
+    update 
+      <if test="maxResults != null">
+        ${limitBeforeWithoutOffset}
+      </if>
+      ${prefix}ACT_HI_PROCINST
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateHistoricProcessInstanceByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_PROCINST
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_PROCINST
+      </if>
+      where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateHistoricProcessInstanceByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_PROCINST
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_PROCINST
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+      where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateHistoricProcessInstanceByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_PROCINST RES WITH (FORCESEEK)
     where RES.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
   </update>
 
   <!-- HISTORIC PROCESS INSTANCE SELECT -->

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
@@ -110,33 +110,133 @@
 
   <update id="updateHistoricTaskInstancesByRootProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_TASKINST set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_TASKINST set
     REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
     where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
+  </update>
+
+  <update id="updateHistoricTaskInstancesByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_TASKINST set
+    REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+    <if test="maxResults != null">
+      ${limitBeforeInUpdate} ${prefix}ACT_HI_TASKINST
+    </if>
+
+    where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterInUpdate}
+    </if>
+  </update>
+
+  <update id="updateHistoricTaskInstancesByRootProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_TASKINST
+    <choose>
+      <when test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_TASKINST
+      </when>
+      <otherwise>
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </otherwise>
+    </choose>
+
+    where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterInUpdate}
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+    </if>
   </update>
 
   <update id="updateHistoricTaskInstancesByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_TASKINST RES WITH (FORCESEEK)
     where RES.ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
   </update>
 
   <update id="updateHistoricTaskInstancesByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_TASKINST
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_TASKINST
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateHistoricTaskInstancesByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_TASKINST
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_TASKINST
+      </if>
+      where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateHistoricTaskInstancesByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_TASKINST
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_TASKINST
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+      where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateHistoricTaskInstancesByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_TASKINST RES WITH (FORCESEEK)
       where RES.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <!-- HISTORIC TASK INSTANCE SELECT -->

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricVariableInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricVariableInstance.xml
@@ -98,33 +98,133 @@
 
   <update id="updateHistoricVariableInstancesByRootProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_VARINST set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_VARINST set
     REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
     where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
+  </update>
+  
+  <update id="updateHistoricVariableInstancesByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_VARINST set
+    REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+    <if test="maxResults != null">
+      ${limitBeforeInUpdate} ${prefix}ACT_HI_VARINST
+    </if>
+
+    where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterInUpdate}
+    </if>
+  </update>
+  
+  <update id="updateHistoricVariableInstancesByRootProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_VARINST
+    <choose>
+      <when test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_VARINST
+      </when>
+      <otherwise>
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </otherwise>
+    </choose>
+
+    where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterInUpdate}
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+    </if>
   </update>
 
   <update id="updateHistoricVariableInstancesByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_VARINST RES WITH (FORCESEEK)
     where RES.ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+    <if test="maxResults != null">
+      and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+      ${limitAfterWithoutOffset}
+    </if>
   </update>
 
   <update id="updateHistoricVariableInstancesByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_VARINST
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_VARINST
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+  
+  <update id="updateHistoricVariableInstancesByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_VARINST
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_VARINST
+      </if>
+      where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+  
+  <update id="updateHistoricVariableInstancesByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_VARINST
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_VARINST
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+      where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateHistoricVariableInstancesByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_VARINST RES WITH (FORCESEEK)
       where RES.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <!-- HISTORIC PROCESS VARIABLE DELETE -->

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/UserOperationLogEntry.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/UserOperationLogEntry.xml
@@ -87,50 +87,137 @@
 
   <update id="updateUserOperationLogByRootProcessInstanceId"
           parameterType="java.util.Map">
-      update ${prefix}ACT_HI_OP_LOG set
+      update
+      <if test="maxResults != null">
+        ${limitBeforeWithoutOffset}
+      </if>
+      ${prefix}ACT_HI_OP_LOG set
       REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
       where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateUserOperationLogByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_HI_OP_LOG set
+      REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_OP_LOG
+      </if>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
   </update>
 
   <update id="updateUserOperationLogByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-      update RES set
-    RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
-    FROM ${prefix}ACT_HI_OP_LOG RES WITH (FORCESEEK)
+      update
+      <if test="maxResults != null">
+        ${limitBeforeWithoutOffset}
+      </if>
+      RES set
+      RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      FROM ${prefix}ACT_HI_OP_LOG RES WITH (FORCESEEK)
       where RES.ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateUserOperationLogByRootProcessInstanceId_mysql"
           parameterType="java.util.Map">
-      update ${prefix}ACT_HI_OP_LOG set
-      REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
-      TIMESTAMP_ = TIMESTAMP_
+      update ${prefix}ACT_HI_OP_LOG
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_OP_LOG
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
+              TIMESTAMP_ = TIMESTAMP_
+        </otherwise>
+      </choose>
 
       where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
+            TIMESTAMP_ = TIMESTAMP_
+      </if>
   </update>
 
   <update id="updateUserOperationLogByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_HI_OP_LOG
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_HI_OP_LOG
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateUserOperationLogByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_HI_OP_LOG
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_HI_OP_LOG
+      </if>
+      where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
   </update>
 
   <update id="updateUserOperationLogByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_HI_OP_LOG RES WITH (FORCESEEK)
       where RES.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateUserOperationLogByProcessInstanceId_mysql"
           parameterType="java.util.Map">
     update ${prefix}ACT_HI_OP_LOG
-      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
-          TIMESTAMP_ = TIMESTAMP_
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_HI_OP_LOG
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
+              TIMESTAMP_ = TIMESTAMP_
+        </otherwise>
+      </choose>
       where PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP},
+            TIMESTAMP_ = TIMESTAMP_
+      </if>
   </update>
 
   <update id="updateOperationLogAnnotationByOperationId"

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/VariableInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/VariableInstance.xml
@@ -501,23 +501,78 @@
 
   <update id="updateByteArraysByRootProcessInstanceId"
           parameterType="java.util.Map">
-      update ${prefix}ACT_GE_BYTEARRAY set
+      update
+      <if test="maxResults != null">
+        ${limitBeforeWithoutOffset}
+      </if>
+      ${prefix}ACT_GE_BYTEARRAY set
       REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
 
       where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateByteArraysByRootProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_GE_BYTEARRAY set
+      REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_GE_BYTEARRAY
+      </if>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateByteArraysByRootProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+      update ${prefix}ACT_GE_BYTEARRAY 
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_GE_BYTEARRAY
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+
+      where ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateByteArraysByRootProcessInstanceId_mssql"
           parameterType="java.util.Map">
-      update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_GE_BYTEARRAY RES WITH (FORCESEEK)
       where RES.ROOT_PROC_INST_ID_ = #{rootProcessInstanceId, jdbcType=VARCHAR}
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateVariableByteArraysByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_GE_BYTEARRAY
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_GE_BYTEARRAY
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where ID_ IN (
         <!-- variables -->
@@ -525,11 +580,62 @@
         FROM ${prefix}ACT_HI_VARINST
         WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateVariableByteArraysByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_GE_BYTEARRAY
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_GE_BYTEARRAY
+      </if>
+      where ID_ IN (
+        <!-- variables -->
+        SELECT BYTEARRAY_ID_
+        FROM ${prefix}ACT_HI_VARINST
+        WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateVariableByteArraysByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_GE_BYTEARRAY
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_GE_BYTEARRAY
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+      where ID_ IN (
+        <!-- variables -->
+        SELECT BYTEARRAY_ID_
+        FROM ${prefix}ACT_HI_VARINST
+        WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateVariableByteArraysByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_GE_BYTEARRAY RES WITH (FORCESEEK)
       where RES.ID_ IN (
@@ -538,11 +644,19 @@
         FROM ${prefix}ACT_HI_VARINST
         WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateDecisionInputsByteArraysByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_GE_BYTEARRAY
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_GE_BYTEARRAY
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where ID_ IN (
         <!-- decision inputs -->
@@ -552,11 +666,66 @@
         ON I.DEC_INST_ID_ = D.ID_
         WHERE D.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateDecisionInputsByteArraysByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_GE_BYTEARRAY
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_GE_BYTEARRAY
+      </if>
+      where ID_ IN (
+        <!-- decision inputs -->
+        SELECT BYTEARRAY_ID_
+        FROM ${prefix}ACT_HI_DEC_IN I
+        INNER JOIN ${prefix}ACT_HI_DECINST D
+        ON I.DEC_INST_ID_ = D.ID_
+        WHERE D.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateDecisionInputsByteArraysByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_GE_BYTEARRAY
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_GE_BYTEARRAY
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+      where ID_ IN (
+        <!-- decision inputs -->
+        SELECT BYTEARRAY_ID_
+        FROM ${prefix}ACT_HI_DEC_IN I
+        INNER JOIN ${prefix}ACT_HI_DECINST D
+        ON I.DEC_INST_ID_ = D.ID_
+        WHERE D.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateDecisionInputsByteArraysByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_GE_BYTEARRAY RES WITH (FORCESEEK)
       where RES.ID_ IN (
@@ -567,11 +736,19 @@
         ON I.DEC_INST_ID_ = D.ID_
         WHERE D.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateDecisionOutputsByteArraysByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_GE_BYTEARRAY
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_GE_BYTEARRAY
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where ID_ IN (
         <!-- decision outputs -->
@@ -581,11 +758,66 @@
         ON O.DEC_INST_ID_ = D.ID_
         WHERE D.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateDecisionOutputsByteArraysByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_GE_BYTEARRAY
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_GE_BYTEARRAY
+      </if>
+      where ID_ IN (
+        <!-- decision outputs -->
+        SELECT BYTEARRAY_ID_
+        FROM ${prefix}ACT_HI_DEC_OUT O
+        INNER JOIN ${prefix}ACT_HI_DECINST D
+        ON O.DEC_INST_ID_ = D.ID_
+        WHERE D.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateDecisionOutputsByteArraysByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_GE_BYTEARRAY
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_GE_BYTEARRAY
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+      where ID_ IN (
+        <!-- decision outputs -->
+        SELECT BYTEARRAY_ID_
+        FROM ${prefix}ACT_HI_DEC_OUT O
+        INNER JOIN ${prefix}ACT_HI_DECINST D
+        ON O.DEC_INST_ID_ = D.ID_
+        WHERE D.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateDecisionOutputsByteArraysByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_GE_BYTEARRAY RES WITH (FORCESEEK)
       where RES.ID_ IN (
@@ -596,11 +828,19 @@
         ON O.DEC_INST_ID_ = D.ID_
         WHERE D.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateJobLogByteArraysByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_GE_BYTEARRAY
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_GE_BYTEARRAY
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where ID_ IN (
         <!-- job log -->
@@ -608,11 +848,62 @@
         FROM ${prefix}ACT_HI_JOB_LOG
         WHERE PROCESS_INSTANCE_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateJobLogByteArraysByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_GE_BYTEARRAY
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_GE_BYTEARRAY
+      </if>
+      where ID_ IN (
+        <!-- job log -->
+        SELECT JOB_EXCEPTION_STACK_ID_
+        FROM ${prefix}ACT_HI_JOB_LOG
+        WHERE PROCESS_INSTANCE_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateJobLogByteArraysByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_GE_BYTEARRAY
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_GE_BYTEARRAY
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+      where ID_ IN (
+        <!-- job log -->
+        SELECT JOB_EXCEPTION_STACK_ID_
+        FROM ${prefix}ACT_HI_JOB_LOG
+        WHERE PROCESS_INSTANCE_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateJobLogByteArraysByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_GE_BYTEARRAY RES WITH (FORCESEEK)
       where RES.ID_ IN (
@@ -621,11 +912,19 @@
         FROM ${prefix}ACT_HI_JOB_LOG
         WHERE PROCESS_INSTANCE_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateExternalTaskLogByteArraysByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_GE_BYTEARRAY
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_GE_BYTEARRAY
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where ID_ IN (
         <!-- external task log -->
@@ -633,11 +932,62 @@
         FROM ${prefix}ACT_HI_EXT_TASK_LOG
         WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateExternalTaskLogByteArraysByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_GE_BYTEARRAY
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_GE_BYTEARRAY
+      </if>
+      where ID_ IN (
+        <!-- external task log -->
+        SELECT ERROR_DETAILS_ID_
+        FROM ${prefix}ACT_HI_EXT_TASK_LOG
+        WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateExternalTaskLogByteArraysByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_GE_BYTEARRAY
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_GE_BYTEARRAY
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+      where ID_ IN (
+        <!-- external task log -->
+        SELECT ERROR_DETAILS_ID_
+        FROM ${prefix}ACT_HI_EXT_TASK_LOG
+        WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateExternalTaskLogByteArraysByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_GE_BYTEARRAY RES WITH (FORCESEEK)
       where RES.ID_ IN (
@@ -646,11 +996,19 @@
         FROM ${prefix}ACT_HI_EXT_TASK_LOG
         WHERE PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateAttachmentByteArraysByProcessInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_GE_BYTEARRAY
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    ${prefix}ACT_GE_BYTEARRAY
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where ID_ IN (
         <!-- attachment -->
@@ -660,11 +1018,66 @@
         WHERE A.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
           OR T.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
+  </update>
+
+  <update id="updateAttachmentByteArraysByProcessInstanceId_postgres"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_GE_BYTEARRAY
+      set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      <if test="maxResults != null">
+        ${limitBeforeInUpdate} ${prefix}ACT_GE_BYTEARRAY
+      </if>
+      where ID_ IN (
+        <!-- attachment -->
+        SELECT CONTENT_ID_
+        FROM ${prefix}ACT_HI_ATTACHMENT A
+        LEFT JOIN ${prefix}ACT_HI_TASKINST T ON A.TASK_ID_ = T.ID_
+        WHERE A.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+          OR T.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+      </if>
+  </update>
+
+  <update id="updateAttachmentByteArraysByProcessInstanceId_mysql"
+          parameterType="java.util.Map">
+    update ${prefix}ACT_GE_BYTEARRAY
+      <choose>
+        <when test="maxResults != null">
+          ${limitBeforeInUpdate} ${prefix}ACT_GE_BYTEARRAY
+        </when>
+        <otherwise>
+          set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+        </otherwise>
+      </choose>
+      where ID_ IN (
+        <!-- attachment -->
+        SELECT CONTENT_ID_
+        FROM ${prefix}ACT_HI_ATTACHMENT A
+        LEFT JOIN ${prefix}ACT_HI_TASKINST T ON A.TASK_ID_ = T.ID_
+        WHERE A.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+          OR T.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
+      )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterInUpdate}
+        set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      </if>
   </update>
 
   <update id="updateAttachmentByteArraysByProcessInstanceId_mssql"
           parameterType="java.util.Map">
-    update RES set
+    update
+    <if test="maxResults != null">
+      ${limitBeforeWithoutOffset}
+    </if>
+    RES set
     RES.REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
     FROM ${prefix}ACT_GE_BYTEARRAY RES WITH (FORCESEEK)
       where RES.ID_ IN (
@@ -675,11 +1088,16 @@
         WHERE A.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
           OR T.PROC_INST_ID_ = #{processInstanceId, jdbcType=VARCHAR}
       )
+      <if test="maxResults != null">
+        and (REMOVAL_TIME_ is null or REMOVAL_TIME_ != #{removalTime, jdbcType=TIMESTAMP})
+        ${limitAfterWithoutOffset}
+      </if>
   </update>
 
   <update id="updateDecisionInputByteArraysByRootDecisionInstanceId"
           parameterType="java.util.Map">
-    update ${prefix}ACT_GE_BYTEARRAY
+    update
+    ${prefix}ACT_GE_BYTEARRAY
       set REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
       where ID_ IN (
         <!-- decision inputs -->

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeInChunksTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeInChunksTest.java
@@ -1,0 +1,2574 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.api.history.removaltime.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.camunda.bpm.engine.ProcessEngineConfiguration.HISTORY_FULL;
+import static org.camunda.bpm.engine.test.api.history.removaltime.batch.helper.BatchSetRemovalTimeRule.addDays;
+
+import java.io.ByteArrayInputStream;
+import java.util.Date;
+import java.util.List;
+import org.camunda.bpm.engine.AuthorizationService;
+import org.camunda.bpm.engine.BadUserRequestException;
+import org.camunda.bpm.engine.DecisionService;
+import org.camunda.bpm.engine.ExternalTaskService;
+import org.camunda.bpm.engine.HistoryService;
+import org.camunda.bpm.engine.IdentityService;
+import org.camunda.bpm.engine.ManagementService;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.authorization.Authorization;
+import org.camunda.bpm.engine.authorization.AuthorizationQuery;
+import org.camunda.bpm.engine.authorization.Resources;
+import org.camunda.bpm.engine.batch.Batch;
+import org.camunda.bpm.engine.history.HistoricActivityInstance;
+import org.camunda.bpm.engine.history.HistoricDecisionInputInstance;
+import org.camunda.bpm.engine.history.HistoricDecisionInstance;
+import org.camunda.bpm.engine.history.HistoricDecisionOutputInstance;
+import org.camunda.bpm.engine.history.HistoricDetail;
+import org.camunda.bpm.engine.history.HistoricExternalTaskLog;
+import org.camunda.bpm.engine.history.HistoricIdentityLinkLog;
+import org.camunda.bpm.engine.history.HistoricIncident;
+import org.camunda.bpm.engine.history.HistoricJobLog;
+import org.camunda.bpm.engine.history.HistoricProcessInstance;
+import org.camunda.bpm.engine.history.HistoricProcessInstanceQuery;
+import org.camunda.bpm.engine.history.HistoricTaskInstance;
+import org.camunda.bpm.engine.history.HistoricVariableInstance;
+import org.camunda.bpm.engine.history.SetRemovalTimeSelectModeForHistoricProcessInstancesBuilder;
+import org.camunda.bpm.engine.history.UserOperationLogEntry;
+import org.camunda.bpm.engine.impl.batch.removaltime.ProcessSetRemovalTimeJobHandler;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.engine.impl.history.event.HistoricDecisionInputInstanceEntity;
+import org.camunda.bpm.engine.impl.history.event.HistoricDecisionOutputInstanceEntity;
+import org.camunda.bpm.engine.impl.history.event.HistoricExternalTaskLogEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.AttachmentEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.ByteArrayEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricJobLogEventEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
+import org.camunda.bpm.engine.impl.util.ClockUtil;
+import org.camunda.bpm.engine.task.Attachment;
+import org.camunda.bpm.engine.task.Comment;
+import org.camunda.bpm.engine.task.Task;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.RequiredHistoryLevel;
+import org.camunda.bpm.engine.test.api.history.removaltime.batch.helper.BatchSetRemovalTimeRule;
+import org.camunda.bpm.engine.test.api.history.removaltime.batch.helper.BatchSetRemovalTimeRule.TestProcessBuilder;
+import org.camunda.bpm.engine.test.dmn.businessruletask.TestPojo;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.engine.variable.Variables;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+@RequiredHistoryLevel(HISTORY_FULL)
+public class BatchSetRemovalTimeInChunksTest {
+
+  protected ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
+  protected ProcessEngineTestRule engineTestRule = new ProcessEngineTestRule(engineRule);
+  protected BatchSetRemovalTimeRule testRule = new BatchSetRemovalTimeRule(engineRule, engineTestRule);
+
+  @Rule
+  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(engineTestRule).around(testRule);
+
+  protected final Date REMOVAL_TIME = testRule.REMOVAL_TIME;
+
+  protected final Date CREATE_TIME = new Date(1363608000000L);
+
+  protected final Date CURRENT_DATE = testRule.CURRENT_DATE;
+
+  protected ProcessEngineConfigurationImpl engineConfiguration;
+  protected RuntimeService runtimeService;
+  protected DecisionService decisionService;
+  protected HistoryService historyService;
+  protected ManagementService managementService;
+  protected TaskService taskService;
+  protected IdentityService identityService;
+  protected ExternalTaskService externalTaskService;
+  protected AuthorizationService authorizationService;
+  protected int defaultMaxUpdateRows;
+  protected int defaultInvocationsPerBatchJob;
+
+  @Before
+  public void setup() {
+    engineConfiguration = engineRule.getProcessEngineConfiguration();
+
+    defaultMaxUpdateRows = engineConfiguration.getRemovalTimeUpdateChunkSize();
+    defaultInvocationsPerBatchJob = engineConfiguration.getInvocationsPerBatchJob();
+    engineConfiguration.setRemovalTimeUpdateChunkSize(1);
+
+    runtimeService = engineRule.getRuntimeService();
+    decisionService = engineRule.getDecisionService();
+    historyService = engineRule.getHistoryService();
+    managementService = engineRule.getManagementService();
+    taskService = engineRule.getTaskService();
+    identityService = engineRule.getIdentityService();
+    externalTaskService = engineRule.getExternalTaskService();
+    authorizationService = engineRule.getAuthorizationService();
+  }
+
+  @After
+  public void tearDown() {
+    engineConfiguration.setRemovalTimeUpdateChunkSize(defaultMaxUpdateRows);
+    engineConfiguration.setInvocationsPerBatchJob(defaultInvocationsPerBatchJob);
+  }
+
+  @Test
+  public void shouldRescheduleRemovalTimeJob() {
+    // given
+    testRule.process().serviceTask().serviceTask().userTask().deploy().start();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    Batch batch = historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync();
+    testRule.executeSeedJobs(batch, true);
+    // first execution updating one row per table
+    testRule.getExecutionJobs(batch).forEach(job -> managementService.executeJob(job.getId()));
+
+    // when second execution updating one row per table
+    testRule.getExecutionJobs(batch).forEach(job -> managementService.executeJob(job.getId()));
+
+    // then more executions exist
+    assertThat(testRule.getExecutionJobs(batch)).isNotEmpty();
+  }
+
+  @Test
+  public void shouldUseCustomChunkSize() {
+    // given
+    testRule.process().serviceTask().serviceTask().userTask().deploy().start();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    Batch batch = historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .chunkSize(100) // data updated in one chunk
+        .executeAsync();
+    testRule.executeSeedJobs(batch, true);
+    // first execution updating all but the process instance
+    testRule.getExecutionJobs(batch).forEach(job -> managementService.executeJob(job.getId()));
+
+    // when second execution updating process instance
+    testRule.getExecutionJobs(batch).forEach(job -> managementService.executeJob(job.getId()));
+
+    // then no more jobs exist
+    assertThat(testRule.getExecutionJobs(batch)).isEmpty();
+  }
+
+  @Test
+  public void shouldUpdateProcessInstanceLast() {
+    // given
+    testRule.process().serviceTask().serviceTask().userTask().deploy().start();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    Batch batch = historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .chunkSize(100) // most data updated in one chunk
+        .executeAsync();
+    testRule.executeSeedJobs(batch, true);
+    // first execution updating all but the process instance
+    testRule.getExecutionJobs(batch).forEach(job -> managementService.executeJob(job.getId()));
+
+    HistoricProcessInstance historicProcessInstance = query.singleResult();
+
+    // assume
+    assertThat(historicProcessInstance.getRemovalTime()).isNull();
+
+    // when second execution updating process instance
+    testRule.getExecutionJobs(batch).forEach(job -> managementService.executeJob(job.getId()));
+
+    // then
+    historicProcessInstance = query.singleResult();
+
+    assertThat(testRule.getExecutionJobs(batch)).isEmpty();
+    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldUpdateProcessInstanceLast_Hierarchical() {
+    // given
+    testRule.process().call().userTask().deploy().start();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    Batch batch = historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .chunkSize(100) // most data updated in one chunk
+        .executeAsync();
+    testRule.executeSeedJobs(batch, true);
+    // first execution updating all but the process instance
+    testRule.getExecutionJobs(batch).forEach(job -> managementService.executeJob(job.getId()));
+
+    List<HistoricProcessInstance> historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
+
+    // assume
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isNull();
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isNull();
+
+    // when second execution updating process instance
+    testRule.getExecutionJobs(batch).forEach(job -> managementService.executeJob(job.getId()));
+
+    // then
+    historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
+
+    assertThat(testRule.getExecutionJobs(batch)).isEmpty();
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldCreateOneRemovalTimeJobPerProcessInstance() {
+    // given
+    engineConfiguration.setInvocationsPerBatchJob(3);
+
+    TestProcessBuilder process = testRule.process().userTask().deploy();
+    process.start();
+    process.start();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    Batch batch = historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync();
+
+    // when
+    testRule.executeSeedJobs(batch, true);
+
+    // then
+    assertThat(testRule.getExecutionJobs(batch)).hasSize(2);
+  }
+
+  @Test
+  public void shouldRejectChunkSize_Zero() {
+    // given
+    engineConfiguration.setRemovalTimeUpdateChunkSize(0);
+
+    // when
+    assertThatThrownBy(() -> engineConfiguration.initBatchHandlers())
+
+    // then
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("chunk size should be between 1 and");
+  }
+
+  @Test
+  public void shouldRejectChunkSize_Negative() {
+    // given
+    engineConfiguration.setRemovalTimeUpdateChunkSize(-5);
+
+    // when
+    assertThatThrownBy(() -> engineConfiguration.initBatchHandlers())
+
+    // then
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("chunk size should be between 1 and");
+  }
+
+  @Test
+  public void shouldRejectChunkSize_ExceedingLimit() {
+    // given
+    engineConfiguration.setRemovalTimeUpdateChunkSize(ProcessSetRemovalTimeJobHandler.MAX_CHUNK_SIZE + 5);
+
+    // when
+    assertThatThrownBy(() -> engineConfiguration.initBatchHandlers())
+
+    // then
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("chunk size should be between 1 and");
+  }
+
+  @Test
+  public void shouldRejectCustomChunkSize_Zero() {
+    // given
+    final SetRemovalTimeSelectModeForHistoricProcessInstancesBuilder builder =
+        historyService.setRemovalTimeToHistoricProcessInstances();
+
+    // when
+    assertThatThrownBy(() -> builder.chunkSize(0))
+
+    // then
+      .isInstanceOf(BadUserRequestException.class)
+      .hasMessageContaining("chunk size should be between 1 and");
+  }
+
+  @Test
+  public void shouldRejectCustomChunkSize_Negative() {
+    // given
+    final SetRemovalTimeSelectModeForHistoricProcessInstancesBuilder builder =
+        historyService.setRemovalTimeToHistoricProcessInstances();
+
+    // when
+    assertThatThrownBy(() -> builder.chunkSize(-3))
+
+    // then
+      .isInstanceOf(BadUserRequestException.class)
+      .hasMessageContaining("chunk size should be between 1 and");
+  }
+
+  @Test
+  public void shouldRejectCustomChunkSize_ExceedingLimit() {
+    // given
+    final SetRemovalTimeSelectModeForHistoricProcessInstancesBuilder builder =
+        historyService.setRemovalTimeToHistoricProcessInstances();
+
+    // when
+    assertThatThrownBy(() -> builder.chunkSize(ProcessSetRemovalTimeJobHandler.MAX_CHUNK_SIZE + 1))
+
+    // then
+      .isInstanceOf(BadUserRequestException.class)
+      .hasMessageContaining("chunk size should be between 1 and");
+  }
+
+  // NON-HIERARCHICAL TEST CASES
+
+  @Test
+  @Deployment(resources = {
+    "org/camunda/bpm/engine/test/dmn/deployment/drdDish.dmn11.xml"
+  })
+  public void shouldSetRemovalTime_DecisionInstance() {
+    // given
+    testRule.process().ruleTask("dish-decision").deploy().startWithVariables(
+      Variables.createVariables()
+      .putValue("temperature", 32)
+      .putValue("dayType", "Weekend")
+    );
+
+    List<HistoricDecisionInstance> historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
+
+    // then
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isNull();
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isNull();
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
+
+    // then
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  @Deployment(resources = {
+    "org/camunda/bpm/engine/test/dmn/deployment/drdDish.dmn11.xml"
+  })
+  public void shouldSetRemovalTime_DecisionInputInstance() {
+    // given
+    testRule.process().ruleTask("dish-decision").deploy().startWithVariables(
+      Variables.createVariables()
+      .putValue("temperature", 32)
+      .putValue("dayType", "Weekend")
+    );
+
+    HistoricDecisionInstance historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery()
+      .rootDecisionInstancesOnly()
+      .includeInputs()
+      .singleResult();
+
+    List<HistoricDecisionInputInstance> historicDecisionInputInstances = historicDecisionInstance.getInputs();
+
+    // then
+    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isNull();
+    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery()
+      .rootDecisionInstancesOnly()
+      .includeInputs()
+      .singleResult();
+
+    historicDecisionInputInstances = historicDecisionInstance.getInputs();
+
+    // then
+    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  @Deployment(resources = {
+    "org/camunda/bpm/engine/test/dmn/deployment/drdDish.dmn11.xml"
+  })
+  public void shouldSetRemovalTime_DecisionOutputInstance() {
+    // given
+    testRule.process().ruleTask("dish-decision").deploy().startWithVariables(
+      Variables.createVariables()
+      .putValue("temperature", 32)
+      .putValue("dayType", "Weekend")
+    );
+
+    HistoricDecisionInstance historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery()
+      .rootDecisionInstancesOnly()
+      .includeOutputs()
+      .singleResult();
+
+    List<HistoricDecisionOutputInstance> historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
+
+    // then
+    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery()
+      .rootDecisionInstancesOnly()
+      .includeOutputs()
+      .singleResult();
+
+    historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
+
+    // then
+    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_ProcessInstance() {
+    // given
+    testRule.process().userTask().deploy().start();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
+
+    // assume
+    assertThat(historicProcessInstance.getRemovalTime()).isNull();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
+
+    // then
+    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_ActivityInstance() {
+    // given
+    testRule.process().userTask().deploy().start();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery()
+      .activityName("userTask")
+      .singleResult();
+
+    // then
+    assertThat(historicActivityInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_TaskInstance() {
+    // given
+    testRule.process().userTask().deploy().start();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
+
+    // then
+    assertThat(historicTaskInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_HistoricTaskInstanceAuthorization() {
+    // given
+    testRule.getProcessEngineConfiguration()
+        .setEnableHistoricInstancePermissions(true);
+
+    testRule.enableAuth();
+    testRule.process().userTask().deploy().start();
+    testRule.disableAuth();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    Authorization authorization =
+        authorizationService.createAuthorizationQuery()
+            .resourceType(Resources.HISTORIC_TASK)
+            .singleResult();
+
+    // then
+    assertThat(authorization.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldNotSetRemovalTime_HistoricTaskInstancePermissionsDisabled() {
+    // given
+    testRule.getProcessEngineConfiguration()
+        .setEnableHistoricInstancePermissions(true);
+
+    testRule.enableAuth();
+    testRule.process().userTask().deploy().start();
+    testRule.disableAuth();
+
+    testRule.getProcessEngineConfiguration()
+        .setEnableHistoricInstancePermissions(false);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    Authorization authorization =
+        authorizationService.createAuthorizationQuery()
+            .resourceType(Resources.HISTORIC_TASK)
+            .singleResult();
+
+    // then
+    assertThat(authorization.getRemovalTime()).isNull();
+  }
+
+  @Test
+  public void shouldSetRemovalTime_HistoricProcessInstanceAuthorization() {
+    // given
+    testRule.getProcessEngineConfiguration()
+        .setEnableHistoricInstancePermissions(true);
+
+    String processInstanceId = testRule.process().userTask().deploy().start();
+
+    Authorization authorization =
+        authorizationService.createNewAuthorization(Authorization.AUTH_TYPE_GRANT);
+    authorization.setResource(Resources.HISTORIC_PROCESS_INSTANCE);
+    authorization.setResourceId(processInstanceId);
+    authorization.setUserId("foo");
+
+    authorizationService.saveAuthorization(authorization);
+
+    // assume
+    AuthorizationQuery authQuery = authorizationService.createAuthorizationQuery()
+        .resourceType(Resources.HISTORIC_PROCESS_INSTANCE);
+
+    assertThat(authQuery.list())
+        .extracting("removalTime", "resourceId", "rootProcessInstanceId")
+        .containsExactly(tuple(null, processInstanceId, processInstanceId));
+
+    // when
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    testRule.syncExec(
+        historyService.setRemovalTimeToHistoricProcessInstances()
+            .absoluteRemovalTime(REMOVAL_TIME)
+            .byQuery(query)
+            .updateInChunks()
+            .executeAsync()
+    );
+
+    // then
+    authQuery = authorizationService.createAuthorizationQuery()
+        .resourceType(Resources.HISTORIC_PROCESS_INSTANCE);
+
+    assertThat(authQuery.list())
+        .extracting("removalTime", "resourceId", "rootProcessInstanceId")
+        .containsExactly(tuple(REMOVAL_TIME, processInstanceId, processInstanceId));
+  }
+
+  @Test
+  public void shouldNotSetRemovalTime_HistoricProcessInstancePermissionsDisabled() {
+    // given
+    testRule.getProcessEngineConfiguration()
+        .setEnableHistoricInstancePermissions(false);
+
+    String processInstanceId = testRule.process().userTask().deploy().start();
+
+    Authorization authorization =
+        authorizationService.createNewAuthorization(Authorization.AUTH_TYPE_GRANT);
+    authorization.setResource(Resources.HISTORIC_PROCESS_INSTANCE);
+    authorization.setResourceId(processInstanceId);
+    authorization.setUserId("foo");
+
+    authorizationService.saveAuthorization(authorization);
+
+    // assume
+    AuthorizationQuery authQuery = authorizationService.createAuthorizationQuery()
+        .resourceType(Resources.HISTORIC_PROCESS_INSTANCE);
+
+    assertThat(authQuery.list())
+        .extracting("removalTime", "resourceId", "rootProcessInstanceId")
+        .containsExactly(tuple(null, processInstanceId, processInstanceId));
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+        historyService.setRemovalTimeToHistoricProcessInstances()
+            .absoluteRemovalTime(REMOVAL_TIME)
+            .byQuery(query)
+            .updateInChunks()
+            .executeAsync()
+    );
+
+    // then
+    authQuery = authorizationService.createAuthorizationQuery()
+        .resourceType(Resources.HISTORIC_PROCESS_INSTANCE);
+
+    assertThat(authQuery.list())
+        .extracting("removalTime", "resourceId", "rootProcessInstanceId")
+        .containsExactly(tuple(null, processInstanceId, processInstanceId));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_VariableInstance() {
+    // given
+    testRule.process().userTask().deploy()
+      .startWithVariables(
+        Variables.createVariables()
+          .putValue("aVariableName", "aVariableValue"));
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery().singleResult();
+
+    // then
+    assertThat(historicVariableInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_Detail() {
+    // given
+    testRule.process().userTask().deploy()
+      .startWithVariables(
+        Variables.createVariables()
+          .putValue("aVariableName", "aVariableValue"));
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    HistoricDetail historicDetail = historyService.createHistoricDetailQuery().singleResult();
+
+    // then
+    assertThat(historicDetail.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_ExternalTaskLog() {
+    // given
+    testRule.process().externalTask().deploy().start();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    HistoricExternalTaskLog historicExternalTaskLog = historyService.createHistoricExternalTaskLogQuery().singleResult();
+
+    // assume
+    assertThat(historicExternalTaskLog.getRemovalTime()).isNull();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicExternalTaskLog = historyService.createHistoricExternalTaskLogQuery().singleResult();
+
+    // then
+    assertThat(historicExternalTaskLog.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  /**
+   * See https://app.camunda.com/jira/browse/CAM-10172
+   */
+  @Test
+  public void shouldSetRemovalTime_ExternalTaskLog_WithPreservedCreateTime() {
+    // given
+    ClockUtil.setCurrentTime(CREATE_TIME);
+
+    testRule.process().externalTask().deploy().start();
+
+    HistoricExternalTaskLog historicExternalTaskLog = historyService.createHistoricExternalTaskLogQuery().singleResult();
+
+    // assume
+    assertThat(historicExternalTaskLog.getTimestamp()).isEqualTo(CREATE_TIME);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicExternalTaskLog = historyService.createHistoricExternalTaskLogQuery().singleResult();
+
+    // then
+    assertThat(historicExternalTaskLog.getTimestamp()).isEqualTo(CREATE_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_JobLog() {
+    // given
+    String processInstanceId = testRule.process().async().userTask().deploy().start();
+
+    HistoricJobLog job = historyService.createHistoricJobLogQuery()
+      .processInstanceId(processInstanceId)
+      .singleResult();
+
+    // assume
+    assertThat(job.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    job = historyService.createHistoricJobLogQuery()
+      .processInstanceId(processInstanceId)
+      .singleResult();
+
+    // then
+    assertThat(job.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_Incident() {
+    // given
+    testRule.process().async().userTask().deploy().start();
+
+    String jobId = managementService.createJobQuery().singleResult().getId();
+
+    managementService.setJobRetries(jobId, 0);
+
+    HistoricIncident historicIncident = historyService.createHistoricIncidentQuery().singleResult();
+
+    // assume
+    assertThat(historicIncident.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicIncident = historyService.createHistoricIncidentQuery().singleResult();
+
+    // then
+    assertThat(historicIncident.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  /**
+   * See https://app.camunda.com/jira/browse/CAM-10172
+   */
+  @Test
+  public void shouldSetRemovalTime_Incident_WithPreservedCreateTime() {
+    // given
+    ClockUtil.setCurrentTime(CREATE_TIME);
+
+    testRule.process().async().userTask().deploy().start();
+
+    String jobId = managementService.createJobQuery().singleResult().getId();
+
+    managementService.setJobRetries(jobId, 0);
+
+    HistoricIncident historicIncident = historyService.createHistoricIncidentQuery().singleResult();
+
+    // assume
+    assertThat(historicIncident.getCreateTime()).isEqualTo(CREATE_TIME);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicIncident = historyService.createHistoricIncidentQuery().singleResult();
+
+    // then
+    assertThat(historicIncident.getCreateTime()).isEqualTo(CREATE_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_OperationLog() {
+    // given
+    String processInstanceId = testRule.process().async().userTask().deploy().start();
+
+    identityService.setAuthenticatedUserId("aUserId");
+    runtimeService.suspendProcessInstanceById(processInstanceId);
+    identityService.clearAuthentication();
+
+    UserOperationLogEntry userOperationLog = historyService.createUserOperationLogQuery().singleResult();
+
+    // assume
+    assertThat(userOperationLog.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    userOperationLog = historyService.createUserOperationLogQuery().singleResult();
+
+    // then
+    assertThat(userOperationLog.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  /**
+   * See https://app.camunda.com/jira/browse/CAM-10172
+   */
+  @Test
+  public void shouldSetRemovalTime_OperationLog_WithPreservedTimestamp() {
+    // given
+    ClockUtil.setCurrentTime(CREATE_TIME);
+
+    String processInstanceId = testRule.process().async().userTask().deploy().start();
+
+    identityService.setAuthenticatedUserId("aUserId");
+    runtimeService.suspendProcessInstanceById(processInstanceId);
+    identityService.clearAuthentication();
+
+    UserOperationLogEntry userOperationLog = historyService.createUserOperationLogQuery().singleResult();
+
+    // assume
+    assertThat(userOperationLog.getTimestamp()).isEqualTo(CREATE_TIME);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    userOperationLog = historyService.createUserOperationLogQuery().singleResult();
+
+    // then
+    assertThat(userOperationLog.getTimestamp()).isEqualTo(CREATE_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_IdentityLinkLog() {
+    // given
+    testRule.process().userTask().deploy().start();
+
+    HistoricIdentityLinkLog identityLinkLog = historyService.createHistoricIdentityLinkLogQuery().singleResult();
+
+    // assume
+    assertThat(identityLinkLog.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    identityLinkLog = historyService.createHistoricIdentityLinkLogQuery().singleResult();
+
+    // then
+    assertThat(identityLinkLog.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  /**
+   * See https://app.camunda.com/jira/browse/CAM-10172
+   */
+  @Test
+  public void shouldSetRemovalTime_IdentityLinkLog_WithPreservedTime() {
+    // given
+    ClockUtil.setCurrentTime(CREATE_TIME);
+
+    testRule.process().userTask().deploy().start();
+
+    HistoricIdentityLinkLog identityLinkLog = historyService.createHistoricIdentityLinkLogQuery().singleResult();
+
+    // assume
+    assertThat(identityLinkLog.getTime()).isEqualTo(CREATE_TIME);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    identityLinkLog = historyService.createHistoricIdentityLinkLogQuery().singleResult();
+
+    // then
+    assertThat(identityLinkLog.getTime()).isEqualTo(CREATE_TIME);
+  }
+
+  @Test
+  public void shouldNotSetUnaffectedRemovalTime_IdentityLinkLog() {
+    // given
+    TestProcessBuilder testProcessBuilder = testRule.process().userTask().deploy();
+
+    String instance1 = testProcessBuilder.start();
+    String instance2 = testProcessBuilder.start();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query.processInstanceId(instance1))
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    Task task2 = taskService.createTaskQuery().processInstanceId(instance2).singleResult();
+
+    HistoricIdentityLinkLog identityLinkLog = historyService.createHistoricIdentityLinkLogQuery()
+        .taskId(task2.getId()).singleResult();
+
+    // then
+    assertThat(identityLinkLog.getRemovalTime()).isNull();
+  }
+
+  @Test
+  public void shouldSetRemovalTime_CommentByTaskId() {
+    // given
+    testRule.process().userTask().deploy().start();
+
+    String taskId = historyService.createHistoricTaskInstanceQuery()
+      .taskName("userTask")
+      .singleResult()
+      .getId();
+
+    taskService.createComment(taskId, null, "aComment");
+
+    Comment comment = taskService.getTaskComments(taskId).get(0);
+
+    // assume
+    assertThat(comment.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    comment = taskService.getTaskComments(taskId).get(0);
+
+    // then
+    assertThat(comment.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_CommentByProcessInstanceId() {
+    // given
+    String processInstanceId = testRule.process().userTask().deploy().start();
+
+    taskService.createComment(null, processInstanceId, "aComment");
+
+    Comment comment = taskService.getProcessInstanceComments(processInstanceId).get(0);
+
+    // assume
+    assertThat(comment.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    comment = taskService.getProcessInstanceComments(processInstanceId).get(0);
+
+    // then
+    assertThat(comment.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_AttachmentByTaskId() {
+    // given
+    testRule.process().userTask().deploy().start();
+
+    String taskId = historyService.createHistoricTaskInstanceQuery()
+      .taskName("userTask")
+      .singleResult()
+      .getId();
+
+    Attachment attachment = taskService.createAttachment(null, taskId,
+      null, null, null, "http://camunda.com");
+
+    // assume
+    assertThat(attachment.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    attachment = taskService.getTaskAttachments(taskId).get(0);
+
+    // then
+    assertThat(attachment.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_AttachmentByProcessInstanceId() {
+    // given
+    String processInstanceId = testRule.process().userTask().deploy().start();
+
+    Attachment attachment = taskService.createAttachment(null, null,
+      processInstanceId, null, null, "http://camunda.com");
+
+    // assume
+    assertThat(attachment.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    attachment = taskService.getProcessInstanceAttachments(processInstanceId).get(0);
+
+    // then
+    assertThat(attachment.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_ByteArray_AttachmentByTaskId() {
+    // given
+    testRule.process().userTask().deploy().start();
+
+    String taskId = historyService.createHistoricTaskInstanceQuery()
+      .taskName("userTask")
+      .singleResult()
+      .getId();
+
+    AttachmentEntity attachment = (AttachmentEntity) taskService.createAttachment(null, taskId,
+      null, null, null, new ByteArrayInputStream("".getBytes()));
+
+    ByteArrayEntity byteArrayEntity = testRule.findByteArrayById(attachment.getContentId());
+
+    // assume
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    byteArrayEntity = testRule.findByteArrayById(attachment.getContentId());
+
+    // then
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_ByteArray_AttachmentByProcessInstanceId() {
+    // given
+    String processInstanceId = testRule.process().userTask().deploy().start();
+
+    AttachmentEntity attachment = (AttachmentEntity) taskService.createAttachment(null, null,
+      processInstanceId, null, null, new ByteArrayInputStream("".getBytes()));
+
+    String byteArrayId = attachment.getContentId();
+
+    ByteArrayEntity byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // assume
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // then
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_ByteArray_Variable() {
+    // given
+    testRule.process().userTask().deploy()
+      .startWithVariables(
+        Variables.createVariables()
+          .putValue("aVariableName",
+            Variables.fileValue("file.xml")
+              .file("<root />".getBytes())));
+
+    HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery().singleResult();
+
+    String byteArrayId = ((HistoricVariableInstanceEntity) historicVariableInstance).getByteArrayId();
+
+    ByteArrayEntity byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // assume
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // then
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_ByteArray_JobLog() {
+    // given
+    testRule.process().async().scriptTask().deploy().start();
+
+    String jobId = managementService.createJobQuery().singleResult().getId();
+
+    try {
+      managementService.executeJob(jobId);
+
+    } catch (Exception ignored) { }
+
+    HistoricJobLog historicJobLog = historyService.createHistoricJobLogQuery()
+      .failureLog()
+      .singleResult();
+
+    String byteArrayId = ((HistoricJobLogEventEntity) historicJobLog).getExceptionByteArrayId();
+
+    ByteArrayEntity byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // assume
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // then
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  public void shouldSetRemovalTime_ByteArray_ExternalTaskLog() {
+    // given
+    testRule.process().externalTask().deploy().start();
+
+    String externalTaskId = externalTaskService.fetchAndLock(1, "aWorkerId")
+      .topic("aTopicName", Integer.MAX_VALUE)
+      .execute()
+      .get(0)
+      .getId();
+
+    externalTaskService.handleFailure(externalTaskId, "aWorkerId",
+      null, "errorDetails", 5, 3000L);
+
+    HistoricExternalTaskLog externalTaskLog = historyService.createHistoricExternalTaskLogQuery()
+      .failureLog()
+      .singleResult();
+
+    String byteArrayId = ((HistoricExternalTaskLogEntity) externalTaskLog).getErrorDetailsByteArrayId();
+
+    ByteArrayEntity byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // assume
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // then
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  @Deployment(resources = {
+    "org/camunda/bpm/engine/test/api/history/testDmnWithPojo.dmn11.xml"
+  })
+  public void shouldSetRemovalTime_ByteArray_DecisionInputInstance() {
+    // given
+    testRule.process().ruleTask("testDecision").deploy().startWithVariables(
+      Variables.createVariables()
+        .putValue("pojo", new TestPojo("okay", 13.37))
+    );
+
+    HistoricDecisionInstance historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery()
+      .rootDecisionInstancesOnly()
+      .includeInputs()
+      .singleResult();
+
+    String byteArrayId = ((HistoricDecisionInputInstanceEntity) historicDecisionInstance.getInputs().get(0))
+      .getByteArrayValueId();
+
+    ByteArrayEntity byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // assume
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // then
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  @Test
+  @Deployment(resources = {
+    "org/camunda/bpm/engine/test/api/history/testDmnWithPojo.dmn11.xml"
+  })
+  public void shouldSetRemovalTime_ByteArray_DecisionOutputInstance() {
+    // given
+    testRule.process().ruleTask("testDecision").deploy().startWithVariables(
+      Variables.createVariables()
+        .putValue("pojo", new TestPojo("okay", 13.37))
+    );
+
+    HistoricDecisionInstance historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery()
+      .rootDecisionInstancesOnly()
+      .includeOutputs()
+      .singleResult();
+
+    String byteArrayId = ((HistoricDecisionOutputInstanceEntity) historicDecisionInstance.getOutputs().get(0))
+      .getByteArrayValueId();
+
+    ByteArrayEntity byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // assume
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .absoluteRemovalTime(REMOVAL_TIME)
+        .byQuery(query)
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // then
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+  }
+
+  // HIERARCHICAL TEST CASES
+
+  @Test
+  @Deployment(resources = {
+    "org/camunda/bpm/engine/test/dmn/deployment/drdDish.dmn11.xml"
+  })
+  public void shouldSetRemovalTime_DecisionInstance_Hierarchical() {
+    // given
+    testRule.process()
+      .call()
+        .passVars("temperature", "dayType")
+      .ruleTask("dish-decision")
+      .userTask()
+      .deploy()
+      .startWithVariables(
+        Variables.createVariables()
+          .putValue("temperature", 32)
+          .putValue("dayType", "Weekend")
+      );
+
+    List<HistoricDecisionInstance> historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
+
+    // assume
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isNull();
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isNull();
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
+
+    // then
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  @Deployment(resources = {
+    "org/camunda/bpm/engine/test/dmn/deployment/drdDish.dmn11.xml"
+  })
+  public void shouldSetRemovalTime_DecisionInputInstance_Hierarchical() {
+    // given
+    testRule.process()
+      .call()
+        .passVars("temperature", "dayType")
+      .ruleTask("dish-decision")
+      .userTask()
+      .deploy()
+      .startWithVariables(
+        Variables.createVariables()
+        .putValue("temperature", 32)
+        .putValue("dayType", "Weekend")
+      );
+
+    HistoricDecisionInstance historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery()
+      .rootDecisionInstancesOnly()
+      .includeInputs()
+      .singleResult();
+
+    List<HistoricDecisionInputInstance> historicDecisionInputInstances = historicDecisionInstance.getInputs();
+
+    // assume
+    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isNull();
+    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery()
+      .rootDecisionInstancesOnly()
+      .includeInputs()
+      .singleResult();
+
+    historicDecisionInputInstances = historicDecisionInstance.getInputs();
+
+    // then
+    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  @Deployment(resources = {
+    "org/camunda/bpm/engine/test/dmn/deployment/drdDish.dmn11.xml"
+  })
+  public void shouldSetRemovalTime_DecisionOutputInstance_Hierarchical() {
+    // given
+    testRule.process()
+      .call()
+        .passVars("temperature", "dayType")
+      .ruleTask("dish-decision")
+      .userTask()
+      .deploy()
+      .startWithVariables(
+        Variables.createVariables()
+        .putValue("temperature", 32)
+        .putValue("dayType", "Weekend")
+      );
+
+    HistoricDecisionInstance historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery()
+      .rootDecisionInstancesOnly()
+      .includeOutputs()
+      .singleResult();
+
+    List<HistoricDecisionOutputInstance> historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
+
+    // assume
+    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery()
+      .rootDecisionInstancesOnly()
+      .includeOutputs()
+      .singleResult();
+
+    historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
+
+    // then
+    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_ProcessInstance_Hierarchical() {
+    // given
+    testRule.process().call().userTask().deploy().start();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    List<HistoricProcessInstance> historicProcessInstances = historyService.createHistoricProcessInstanceQuery().rootProcessInstances().list();
+
+    // assume
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
+
+    // then
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_ActivityInstance_Hierarchical() {
+    // given
+    testRule.process().call().userTask().deploy().start();
+
+    HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery()
+      .activityName("userTask")
+      .singleResult();
+
+    // assume
+    assertThat(historicActivityInstance.getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicActivityInstance = historyService.createHistoricActivityInstanceQuery()
+      .activityName("userTask")
+      .singleResult();
+
+    // then
+    assertThat(historicActivityInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_TaskInstance_Hierarchical() {
+    // given
+    testRule.process().call().userTask().deploy().start();
+
+    HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
+
+    // assume
+    assertThat(historicTaskInstance.getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
+
+    // then
+    assertThat(historicTaskInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_HistoricTaskInstanceAuthorization_Hierarchical() {
+    // given
+    testRule.getProcessEngineConfiguration()
+        .setEnableHistoricInstancePermissions(true);
+
+    testRule.enableAuth();
+    testRule.process().call().userTask().deploy().start();
+    testRule.disableAuth();
+
+    HistoricTaskInstance historicTaskInstance =
+        historyService.createHistoricTaskInstanceQuery().singleResult();
+
+    // assume
+    assertThat(historicTaskInstance.getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query =
+        historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    Authorization authorization =
+        authorizationService.createAuthorizationQuery()
+            .resourceType(Resources.HISTORIC_TASK)
+            .singleResult();
+
+    // then
+    assertThat(authorization.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldNotSetRemovalTime_HistoricTaskInstancePermissionsDisabled_Hierarchical() {
+    // given
+    testRule.getProcessEngineConfiguration()
+        .setEnableHistoricInstancePermissions(true);
+
+    testRule.enableAuth();
+    testRule.process().call().userTask().deploy().start();
+    testRule.disableAuth();
+
+    testRule.getProcessEngineConfiguration()
+        .setEnableHistoricInstancePermissions(false);
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query =
+        historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    Authorization authorization =
+        authorizationService.createAuthorizationQuery()
+            .resourceType(Resources.HISTORIC_TASK)
+            .singleResult();
+
+    // then
+    assertThat(authorization.getRemovalTime()).isNull();
+  }
+
+  @Test
+  public void shouldSetRemovalTime_HistoricProcessInstanceAuthorization_Hierarchical() {
+    // given
+    testRule.getProcessEngineConfiguration()
+        .setEnableHistoricInstancePermissions(true);
+
+    String rootProcessInstanceId = testRule.process().call().userTask().deploy().start();
+
+    Authorization authorization =
+        authorizationService.createNewAuthorization(Authorization.AUTH_TYPE_GRANT);
+    authorization.setResource(Resources.HISTORIC_PROCESS_INSTANCE);
+
+    String processInstanceId = historyService.createHistoricProcessInstanceQuery()
+        .activeActivityIdIn("userTask")
+        .singleResult()
+        .getId();
+
+    authorization.setResourceId(processInstanceId);
+    authorization.setUserId("foo");
+
+    authorizationService.saveAuthorization(authorization);
+
+    // assume
+    AuthorizationQuery authQuery = authorizationService.createAuthorizationQuery()
+        .resourceType(Resources.HISTORIC_PROCESS_INSTANCE);
+
+    assertThat(authQuery.list())
+        .extracting("removalTime", "resourceId", "rootProcessInstanceId")
+        .containsExactly(tuple(null, processInstanceId, rootProcessInstanceId));
+
+    // when
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query =
+        historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    testRule.syncExec(
+        historyService.setRemovalTimeToHistoricProcessInstances()
+            .calculatedRemovalTime()
+            .byQuery(query)
+            .hierarchical()
+            .updateInChunks()
+            .executeAsync()
+    );
+
+    // then
+    authQuery = authorizationService.createAuthorizationQuery()
+        .resourceType(Resources.HISTORIC_PROCESS_INSTANCE);
+
+    Date removalTime = addDays(CURRENT_DATE, 5);
+    assertThat(authQuery.list())
+        .extracting("removalTime", "resourceId", "rootProcessInstanceId")
+        .containsExactly(tuple(removalTime, processInstanceId, rootProcessInstanceId));
+  }
+
+  @Test
+  public void shouldNotSetRemovalTime_HistoricProcessInstancePermissionsDisabled_Hierarchical() {
+    // given
+    testRule.getProcessEngineConfiguration()
+        .setEnableHistoricInstancePermissions(false);
+
+    String rootProcessInstanceId = testRule.process().call().userTask().deploy().start();
+
+    Authorization authorization =
+        authorizationService.createNewAuthorization(Authorization.AUTH_TYPE_GRANT);
+    authorization.setResource(Resources.HISTORIC_PROCESS_INSTANCE);
+
+    String processInstanceId = historyService.createHistoricProcessInstanceQuery()
+        .activeActivityIdIn("userTask")
+        .singleResult()
+        .getId();
+
+    authorization.setResourceId(processInstanceId);
+    authorization.setUserId("foo");
+
+    authorizationService.saveAuthorization(authorization);
+
+    // assume
+    AuthorizationQuery authQuery = authorizationService.createAuthorizationQuery()
+        .resourceType(Resources.HISTORIC_PROCESS_INSTANCE);
+
+    assertThat(authQuery.list())
+        .extracting("removalTime", "resourceId", "rootProcessInstanceId")
+        .containsExactly(tuple(null, processInstanceId, rootProcessInstanceId));
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    // when
+    HistoricProcessInstanceQuery query =
+        historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    testRule.syncExec(
+        historyService.setRemovalTimeToHistoricProcessInstances()
+            .calculatedRemovalTime()
+            .byQuery(query)
+            .hierarchical()
+            .updateInChunks()
+            .executeAsync()
+    );
+
+    // then
+    authQuery = authorizationService.createAuthorizationQuery()
+        .resourceType(Resources.HISTORIC_PROCESS_INSTANCE);
+
+    assertThat(authQuery.list())
+        .extracting("removalTime", "resourceId", "rootProcessInstanceId")
+        .containsExactly(tuple(null, processInstanceId, rootProcessInstanceId));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_VariableInstance_Hierarchical() {
+    // given
+    testRule.process().call().userTask().deploy()
+      .startWithVariables(
+        Variables.createVariables()
+          .putValue("aVariableName", "aVariableValue"));
+
+    HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery().singleResult();
+
+    // assume
+    assertThat(historicVariableInstance.getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicVariableInstance = historyService.createHistoricVariableInstanceQuery().singleResult();
+
+    // then
+    assertThat(historicVariableInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_Detail_Hierarchical() {
+    // given
+    testRule.process().call().userTask().deploy()
+      .startWithVariables(
+        Variables.createVariables()
+          .putValue("aVariableName", "aVariableValue"));
+
+    HistoricDetail historicDetail = historyService.createHistoricDetailQuery().singleResult();
+
+    // assume
+    assertThat(historicDetail.getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicDetail = historyService.createHistoricDetailQuery().singleResult();
+
+    // then
+    assertThat(historicDetail.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_ExternalTaskLog_Hierarchical() {
+    // given
+    testRule.process().call().externalTask().deploy().start();
+
+    HistoricExternalTaskLog historicExternalTaskLog = historyService.createHistoricExternalTaskLogQuery().singleResult();
+
+    // assume
+    assertThat(historicExternalTaskLog.getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicExternalTaskLog = historyService.createHistoricExternalTaskLogQuery().singleResult();
+
+    // then
+    assertThat(historicExternalTaskLog.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_JobLog_Hierarchical() {
+    // given
+    testRule.process().call().async().userTask().deploy().start();
+
+    HistoricJobLog job = historyService.createHistoricJobLogQuery()
+      .processDefinitionKey("process")
+      .singleResult();
+
+    // assume
+    assertThat(job.getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    job = historyService.createHistoricJobLogQuery()
+      .processDefinitionKey("process")
+      .singleResult();
+
+    // then
+    assertThat(job.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_Incident_Hierarchical() {
+    // given
+    String rootProcessInstanceId = testRule.process().call().async().userTask().deploy().start();
+
+    String jobId = managementService.createJobQuery().singleResult().getId();
+
+    managementService.setJobRetries(jobId, 0);
+
+    String leafProcessInstanceId = historyService.createHistoricProcessInstanceQuery()
+      .superProcessInstanceId(rootProcessInstanceId)
+      .singleResult()
+      .getId();
+
+    HistoricIncident historicIncident = historyService.createHistoricIncidentQuery()
+      .processInstanceId(leafProcessInstanceId)
+      .singleResult();
+
+    // assume
+    assertThat(historicIncident.getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    historicIncident = historyService.createHistoricIncidentQuery()
+      .processInstanceId(leafProcessInstanceId)
+      .singleResult();
+
+    // then
+    assertThat(historicIncident.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_OperationLog_Hierarchical() {
+    // given
+    String processInstanceId = testRule.process().call().async().userTask().deploy().start();
+
+    identityService.setAuthenticatedUserId("aUserId");
+    runtimeService.suspendProcessInstanceById(processInstanceId);
+    identityService.clearAuthentication();
+
+    UserOperationLogEntry userOperationLog = historyService.createUserOperationLogQuery().singleResult();
+
+    // assume
+    assertThat(userOperationLog.getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    userOperationLog = historyService.createUserOperationLogQuery().singleResult();
+
+    // then
+    assertThat(userOperationLog.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_IdentityLinkLog_Hierarchical() {
+    // given
+    testRule.process().call().userTask().deploy().start();
+
+    HistoricIdentityLinkLog identityLinkLog = historyService.createHistoricIdentityLinkLogQuery().singleResult();
+
+    // assume
+    assertThat(identityLinkLog.getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    identityLinkLog = historyService.createHistoricIdentityLinkLogQuery().singleResult();
+
+    // then
+    assertThat(identityLinkLog.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_CommentByTaskId_Hierarchical() {
+    // given
+    testRule.process().call().userTask().deploy().start();
+
+    String taskId = historyService.createHistoricTaskInstanceQuery()
+      .taskName("userTask")
+      .singleResult()
+      .getId();
+
+    taskService.createComment(taskId, null, "aComment");
+
+    Comment comment = taskService.getTaskComments(taskId).get(0);
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    // assume
+    assertThat(comment.getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    comment = taskService.getTaskComments(taskId).get(0);
+
+    // then
+    assertThat(comment.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_CommentByProcessInstanceId_Hierarchical() {
+    // given
+    String processInstanceId = testRule.process().call().userTask().deploy().start();
+
+    taskService.createComment(null, processInstanceId, "aComment");
+
+    Comment comment = taskService.getProcessInstanceComments(processInstanceId).get(0);
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    // assume
+    assertThat(comment.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    comment = taskService.getProcessInstanceComments(processInstanceId).get(0);
+
+    // then
+    assertThat(comment.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_AttachmentByTaskId_Hierarchical() {
+    // given
+    testRule.process().call().userTask().deploy().start();
+
+    String taskId = historyService.createHistoricTaskInstanceQuery()
+      .taskName("userTask")
+      .singleResult()
+      .getId();
+
+    Attachment attachment = taskService.createAttachment(null, taskId,
+      null, null, null, "http://camunda.com");
+
+    // assume
+    assertThat(attachment.getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    attachment = taskService.getTaskAttachments(taskId).get(0);
+
+    // then
+    assertThat(attachment.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_AttachmentByProcessInstanceId_Hierarchical() {
+    // given
+    String processInstanceId = testRule.process().call().userTask().deploy().start();
+
+    Attachment attachment = taskService.createAttachment(null, null,
+      processInstanceId, null, null, "http://camunda.com");
+
+    // assume
+    assertThat(attachment.getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    attachment = taskService.getProcessInstanceAttachments(processInstanceId).get(0);
+
+    // then
+    assertThat(attachment.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_ByteArray_AttachmentByTaskId_Hierarchical() {
+    // given
+    testRule.process().call().userTask().deploy().start();
+
+    String taskId = historyService.createHistoricTaskInstanceQuery()
+      .taskName("userTask")
+      .singleResult()
+      .getId();
+
+    AttachmentEntity attachment = (AttachmentEntity) taskService.createAttachment(null, taskId,
+      null, null, null, new ByteArrayInputStream("".getBytes()));
+
+    ByteArrayEntity byteArrayEntity = testRule.findByteArrayById(attachment.getContentId());
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    // assume
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    byteArrayEntity = testRule.findByteArrayById(attachment.getContentId());
+
+    // then
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_ByteArray_AttachmentByProcessInstanceId_Hierarchical() {
+    // given
+    String processInstanceId = testRule.process().call().userTask().deploy().start();
+
+    AttachmentEntity attachment = (AttachmentEntity) taskService.createAttachment(null, null,
+      processInstanceId, null, null, new ByteArrayInputStream("".getBytes()));
+
+    String byteArrayId = attachment.getContentId();
+
+    ByteArrayEntity byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    // assume
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // then
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_ByteArray_Variable_Hierarchical() {
+    // given
+    testRule.process().call().userTask().deploy()
+      .startWithVariables(
+        Variables.createVariables()
+          .putValue("aVariableName",
+            Variables.fileValue("file.xml")
+              .file("<root />".getBytes())));
+
+    HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery().singleResult();
+
+    String byteArrayId = ((HistoricVariableInstanceEntity) historicVariableInstance).getByteArrayId();
+
+    ByteArrayEntity byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // assume
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // then
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_ByteArray_JobLog_Hierarchical() {
+    // given
+    testRule.process().call().async().scriptTask().deploy().start();
+
+    String jobId = managementService.createJobQuery().singleResult().getId();
+
+    try {
+      managementService.executeJob(jobId);
+
+    } catch (Exception ignored) { }
+
+    HistoricJobLog historicJobLog = historyService.createHistoricJobLogQuery()
+      .failureLog()
+      .singleResult();
+
+    String byteArrayId = ((HistoricJobLogEventEntity) historicJobLog).getExceptionByteArrayId();
+
+    ByteArrayEntity byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // assume
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // then
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  public void shouldSetRemovalTime_ByteArray_ExternalTaskLog_Hierarchical() {
+    // given
+    testRule.process().call().externalTask().deploy().start();
+
+    String externalTaskId = externalTaskService.fetchAndLock(1, "aWorkerId")
+      .topic("aTopicName", Integer.MAX_VALUE)
+      .execute()
+      .get(0)
+      .getId();
+
+    externalTaskService.handleFailure(externalTaskId, "aWorkerId",
+      null, "errorDetails", 5, 3000L);
+
+    HistoricExternalTaskLog externalTaskLog = historyService.createHistoricExternalTaskLogQuery()
+      .failureLog()
+      .singleResult();
+
+    String byteArrayId = ((HistoricExternalTaskLogEntity) externalTaskLog).getErrorDetailsByteArrayId();
+
+    ByteArrayEntity byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    // assume
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // then
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  @Deployment(resources = {
+    "org/camunda/bpm/engine/test/api/history/testDmnWithPojo.dmn11.xml"
+  })
+  public void shouldSetRemovalTime_ByteArray_DecisionInputInstance_Hierarchical() {
+    // given
+    testRule.process()
+      .call()
+        .passVars("pojo")
+      .ruleTask("testDecision")
+      .userTask()
+      .deploy()
+      .startWithVariables(
+        Variables.createVariables()
+          .putValue("pojo", new TestPojo("okay", 13.37))
+      );
+
+    HistoricDecisionInstance historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery()
+      .rootDecisionInstancesOnly()
+      .includeInputs()
+      .singleResult();
+
+    String byteArrayId = ((HistoricDecisionInputInstanceEntity) historicDecisionInstance.getInputs().get(0))
+      .getByteArrayValueId();
+
+    ByteArrayEntity byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    // assume
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // then
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+
+  @Test
+  @Deployment(resources = {
+    "org/camunda/bpm/engine/test/api/history/testDmnWithPojo.dmn11.xml"
+  })
+  public void shouldSetRemovalTime_ByteArray_DecisionOutputInstance_Hierarchical() {
+    // given
+    testRule.process()
+      .call()
+        .passVars("pojo")
+      .ruleTask("testDecision")
+      .userTask()
+      .deploy()
+      .startWithVariables(
+        Variables.createVariables()
+          .putValue("pojo", new TestPojo("okay", 13.37))
+      );
+
+    HistoricDecisionInstance historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery()
+      .rootDecisionInstancesOnly()
+      .includeOutputs()
+      .singleResult();
+
+    String byteArrayId = ((HistoricDecisionOutputInstanceEntity) historicDecisionInstance.getOutputs().get(0))
+      .getByteArrayValueId();
+
+    ByteArrayEntity byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // assume
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
+
+    testRule.updateHistoryTimeToLive("rootProcess", 5);
+
+    HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
+
+    // when
+    testRule.syncExec(
+      historyService.setRemovalTimeToHistoricProcessInstances()
+        .calculatedRemovalTime()
+        .byQuery(query)
+        .hierarchical()
+        .updateInChunks()
+        .executeAsync()
+    );
+
+    byteArrayEntity = testRule.findByteArrayById(byteArrayId);
+
+    // then
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+  }
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeTest.java
@@ -30,7 +30,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.camunda.bpm.engine.BadUserRequestException;
 import org.camunda.bpm.engine.DecisionService;
 import org.camunda.bpm.engine.HistoryService;
@@ -389,10 +388,10 @@ public class BatchSetRemovalTimeTest {
       .setInvocationsPerBatchJob(2);
 
     String processInstanceIdOne = testRule.process().userTask().deploy().start();
-    Batch batchOne = historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceIdOne), "");
+    historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceIdOne), "");
 
     String processInstanceIdTwo = testRule.process().userTask().deploy().start();
-    Batch batchTwo = historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceIdTwo), "");
+    historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceIdTwo), "");
 
     List<HistoricBatch> historicBatches = historyService.createHistoricBatchQuery()
       .type(Batch.TYPE_HISTORIC_PROCESS_INSTANCE_DELETION)
@@ -501,10 +500,10 @@ public class BatchSetRemovalTimeTest {
       .setInvocationsPerBatchJob(1);
 
     String processInstanceIdOne = testRule.process().userTask().deploy().start();
-    Batch batchOne = historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceIdOne), "");
+    historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceIdOne), "");
 
     String processInstanceIdTwo = testRule.process().userTask().deploy().start();
-    Batch batchTwo = historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceIdTwo), "");
+    historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceIdTwo), "");
 
     List<HistoricBatch> historicBatches = historyService.createHistoricBatchQuery()
       .type(Batch.TYPE_HISTORIC_PROCESS_INSTANCE_DELETION)
@@ -1007,7 +1006,7 @@ public class BatchSetRemovalTimeTest {
   public void shouldSetRemovalTimeForBatch_BaseTimeStart() {
     // given
     String processInstanceId = testRule.process().serviceTask().deploy().start();
-    Batch batch = historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceId), "");
+    historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceId), "");
 
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery()
       .type(Batch.TYPE_HISTORIC_PROCESS_INSTANCE_DELETION)
@@ -1188,7 +1187,7 @@ public class BatchSetRemovalTimeTest {
       .setHistoryRemovalTimeStrategy(HISTORY_REMOVAL_TIME_STRATEGY_END);
 
     String processInstanceId = testRule.process().serviceTask().deploy().start();
-    Batch batch = historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceId), "");
+    historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceId), "");
 
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery()
       .type(Batch.TYPE_HISTORIC_PROCESS_INSTANCE_DELETION)
@@ -1227,7 +1226,7 @@ public class BatchSetRemovalTimeTest {
     configuration.initHistoryCleanup();
 
     String processInstanceId = testRule.process().serviceTask().deploy().start();
-    Batch batch = historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceId), "");
+    historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceId), "");
 
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery()
       .type(Batch.TYPE_HISTORIC_PROCESS_INSTANCE_DELETION)
@@ -1602,7 +1601,7 @@ public class BatchSetRemovalTimeTest {
     configuration.initHistoryCleanup();
 
     String processInstanceId = testRule.process().serviceTask().deploy().start();
-    Batch batch = historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceId), "");
+    historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceId), "");
 
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery()
       .type(Batch.TYPE_HISTORIC_PROCESS_INSTANCE_DELETION)
@@ -1778,7 +1777,7 @@ public class BatchSetRemovalTimeTest {
   public void shouldSetRemovalTimeForBatch_Absolute() {
     // given
     String processInstanceId = testRule.process().serviceTask().deploy().start();
-    Batch batch = historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceId), "");
+    historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceId), "");
 
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery()
       .type(Batch.TYPE_HISTORIC_PROCESS_INSTANCE_DELETION)
@@ -2059,8 +2058,8 @@ public class BatchSetRemovalTimeTest {
     // given
     String processInstanceId = testRule.process().serviceTask().deploy().start();
 
-    Batch batchOne = historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceId), "");
-    Batch batchTwo = historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceId), "");
+    historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceId), "");
+    historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceId), "");
 
     List<HistoricBatch> historicBatches = historyService.createHistoricBatchQuery()
       .type(Batch.TYPE_HISTORIC_PROCESS_INSTANCE_DELETION)

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/batch/helper/BatchSetRemovalTimeRule.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/batch/helper/BatchSetRemovalTimeRule.java
@@ -16,22 +16,16 @@
  */
 package org.camunda.bpm.engine.test.api.history.removaltime.batch.helper;
 
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
-
 import org.camunda.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
-import org.camunda.bpm.engine.batch.Batch;
-import org.camunda.bpm.engine.batch.history.HistoricBatch;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.history.DefaultHistoryRemovalTimeProvider;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 import org.camunda.bpm.engine.impl.persistence.entity.ByteArrayEntity;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
-import org.camunda.bpm.engine.runtime.Job;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.api.resources.GetByteArrayCommand;
 import org.camunda.bpm.engine.test.bpmn.async.FailingExecutionListener;
@@ -43,7 +37,6 @@ import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.camunda.bpm.model.bpmn.builder.CallActivityBuilder;
 import org.camunda.bpm.model.bpmn.builder.ProcessBuilder;
 import org.camunda.bpm.model.bpmn.builder.StartEventBuilder;
-import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 /**
@@ -58,6 +51,7 @@ public class BatchSetRemovalTimeRule extends BatchRule {
     super(engineRule, engineTestRule);
   }
 
+  @Override
   protected void starting(Description description) {
     getProcessEngineConfiguration()
       .setHistoryRemovalTimeProvider(new DefaultHistoryRemovalTimeProvider())
@@ -76,6 +70,7 @@ public class BatchSetRemovalTimeRule extends BatchRule {
     super.starting(description);
   }
 
+  @Override
   protected void finished(Description description) {
     super.finished(description);
 
@@ -106,6 +101,7 @@ public class BatchSetRemovalTimeRule extends BatchRule {
     getProcessEngineConfiguration().setAuthorizationEnabled(false);
   }
 
+  @Override
   public void clearDatabase() {
     super.clearDatabase();
     clearAuthorization();

--- a/qa/test-db-instance-migration/test-fixture-719/src/main/java/org/camunda/bpm/qa/upgrade/TestFixture.java
+++ b/qa/test-db-instance-migration/test-fixture-719/src/main/java/org/camunda/bpm/qa/upgrade/TestFixture.java
@@ -19,6 +19,7 @@ package org.camunda.bpm.qa.upgrade;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.camunda.bpm.qa.upgrade.batch.SetRemovalTimeToProcessInstanceScenario;
 import org.camunda.bpm.qa.upgrade.httl.EnforceHistoryTimeToLiveScenario;
 import org.camunda.bpm.qa.upgrade.variables.JpaVariableScenario;
 
@@ -40,6 +41,7 @@ public class TestFixture {
     // example scenario setup
     runner.setupScenarios(JpaVariableScenario.class);
     runner.setupScenarios(EnforceHistoryTimeToLiveScenario.class);
+    runner.setupScenarios(SetRemovalTimeToProcessInstanceScenario.class);
 
     processEngine.close();
   }

--- a/qa/test-db-instance-migration/test-fixture-719/src/main/java/org/camunda/bpm/qa/upgrade/batch/SetRemovalTimeToProcessInstanceScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-719/src/main/java/org/camunda/bpm/qa/upgrade/batch/SetRemovalTimeToProcessInstanceScenario.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.qa.upgrade.batch;
+
+import java.util.Date;
+import org.camunda.bpm.engine.HistoryService;
+import org.camunda.bpm.engine.ManagementService;
+import org.camunda.bpm.engine.RepositoryService;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.batch.Batch;
+import org.camunda.bpm.engine.repository.ProcessDefinition;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.qa.upgrade.DescribesScenario;
+import org.camunda.bpm.qa.upgrade.ScenarioSetup;
+
+public class SetRemovalTimeToProcessInstanceScenario {
+
+  @Deployment
+  public static String deployOneTask() {
+    return "org/camunda/bpm/qa/upgrade/batch/SetRemovalTimeToProcessInstanceScenario.oneTaskProcess.bpmn20.xml";
+  }
+
+  @DescribesScenario("createSetRetriesBatch")
+  public static ScenarioSetup createSetRemovalTimeBatch() {
+    return (engine, scenarioName) -> {
+      // services
+      RuntimeService runtimeService = engine.getRuntimeService();
+      HistoryService historyService = engine.getHistoryService();
+      RepositoryService repositoryService = engine.getRepositoryService();
+      ManagementService managementService = engine.getManagementService();
+
+      // definition
+      ProcessDefinition definition = repositoryService.createProcessDefinitionQuery()
+          .processDefinitionKey("createProcessForSetRemovalTimeBatch_719").singleResult();
+
+      // create set removal time batch
+      Date removalTime = new Date(1363609000000L);
+      String processInstanceId = runtimeService.startProcessInstanceByKey(definition.getKey()).getId();
+      Batch batch = historyService.setRemovalTimeToHistoricProcessInstances().absoluteRemovalTime(removalTime).byIds(processInstanceId).executeAsync();
+      managementService.setProperty("SetRemovalTimeToProcessInstanceTest.batchId", batch.getId());
+      managementService.setProperty("SetRemovalTimeToProcessInstanceTest.processInstanceId", processInstanceId);
+    };
+  }
+}

--- a/qa/test-db-instance-migration/test-fixture-719/src/main/resources/org/camunda/bpm/qa/upgrade/batch/SetRemovalTimeToProcessInstanceScenario.oneTaskProcess.bpmn20.xml
+++ b/qa/test-db-instance-migration/test-fixture-719/src/main/resources/org/camunda/bpm/qa/upgrade/batch/SetRemovalTimeToProcessInstanceScenario.oneTaskProcess.bpmn20.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  targetNamespace="org.camunda.bpm.engine.test.enginge.test.api.mgmt">
+
+  <process id="createProcessForSetRemovalTimeBatch_719" isExecutable="true">
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="userTask" />
+    <userTask id="userTask" name="First line support" />
+    <sequenceFlow id="flow2" sourceRef="userTask" targetRef="normalEnd" />
+    <endEvent id="normalEnd" />
+    <boundaryEvent id="escalationTimer" cancelActivity="true" attachedToRef="userTask">
+      <timerEventDefinition>
+        <timeDuration>PT4H</timeDuration>
+      </timerEventDefinition>
+    </boundaryEvent>
+    <sequenceFlow id="flow3" sourceRef="escalationTimer" targetRef="escalatedEnd" />
+    <endEvent id="escalatedEnd" />
+  </process>
+  <message id="message" name="message" />
+</definitions>

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7200/batch/SetRemovalTimeToProcessInstanceTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7200/batch/SetRemovalTimeToProcessInstanceTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.qa.upgrade.scenarios7200.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import org.camunda.bpm.engine.HistoryService;
+import org.camunda.bpm.engine.ManagementService;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.batch.Batch;
+import org.camunda.bpm.engine.history.HistoricActivityInstance;
+import org.camunda.bpm.engine.runtime.Job;
+import org.camunda.bpm.qa.upgrade.Origin;
+import org.camunda.bpm.qa.upgrade.ScenarioUnderTest;
+import org.camunda.bpm.qa.upgrade.UpgradeTestRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ScenarioUnderTest("SetRemovalTimeToProcessInstanceScenario")
+@Origin("7.19.0")
+public class SetRemovalTimeToProcessInstanceTest {
+
+  Logger LOG = LoggerFactory.getLogger(SetRemovalTimeToProcessInstanceTest.class);
+
+  @Rule
+  public UpgradeTestRule engineRule = new UpgradeTestRule();
+
+  HistoryService historyService;
+  ManagementService managementService;
+  RuntimeService runtimeService;
+
+  @Before
+  public void assignServices() {
+    historyService = engineRule.getHistoryService();
+    managementService = engineRule.getManagementService();
+    runtimeService = engineRule.getRuntimeService();
+  }
+
+  @Test
+  @ScenarioUnderTest("runBatchJob.1")
+  public void shouldRunBatchJobOnce() {
+    // given
+    Map<String, String> properties = managementService.getProperties();
+    String batchId = properties.get("SetRemovalTimeToProcessInstanceTest.batchId");
+    String processInstanceId = properties.get("SetRemovalTimeToProcessInstanceTest.processInstanceId");
+    Date removalTime = new Date(1363609000000L);
+
+    Batch batch = managementService.createBatchQuery().batchId(batchId).singleResult();
+    String seedJobDefinitionId = batch.getSeedJobDefinitionId();
+    Job seedJob = managementService.createJobQuery().jobDefinitionId(seedJobDefinitionId).singleResult();
+
+    managementService.executeJob(seedJob.getId());
+    List<Job> batchJobs = managementService.createJobQuery()
+        .jobDefinitionId(batch.getBatchJobDefinitionId())
+        .list();
+
+    // when
+    batchJobs.forEach(job -> managementService.executeJob(job.getId()));
+
+    // then
+    HistoricActivityInstance historicActivityInstance = historyService.createHistoricActivityInstanceQuery()
+        .activityId("userTask")
+        .processInstanceId(processInstanceId)
+        .singleResult();
+    assertThat(historicActivityInstance.getRemovalTime()).isEqualTo(removalTime);
+
+    assertThat(managementService.createJobQuery().jobDefinitionId(batch.getBatchJobDefinitionId()).count()).isEqualTo(0);
+  }
+
+}

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7200/variables/JPAVariableTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/camunda/bpm/qa/upgrade/scenarios7200/variables/JPAVariableTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.camunda.bpm.qa.upgrade.scenarios7190.variables;
+package org.camunda.bpm.qa.upgrade.scenarios7200.variables;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/camunda/bpm/qa/rolling/update/TestFixture.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/camunda/bpm/qa/rolling/update/TestFixture.java
@@ -22,6 +22,7 @@ import org.camunda.bpm.engine.ProcessEngineConfiguration;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.qa.rolling.update.scenarios.DeploymentWhichShouldBeDeletedScenario;
 import org.camunda.bpm.qa.rolling.update.scenarios.authorization.AuthorizationScenario;
+import org.camunda.bpm.qa.rolling.update.scenarios.batch.SetRemovalTimeToProcessInstanceScenario;
 import org.camunda.bpm.qa.rolling.update.scenarios.callactivity.ProcessWithCallActivityScenario;
 import org.camunda.bpm.qa.rolling.update.scenarios.cleanup.HistoryCleanupScenario;
 import org.camunda.bpm.qa.rolling.update.scenarios.eventSubProcess.ProcessWithEventSubProcessScenario;
@@ -82,6 +83,7 @@ public class TestFixture {
     if (RollingUpdateConstants.NEW_ENGINE_TAG.equals(currentFixtureTag)) { // create data with new engine
       runner.setupScenarios(HistoryCleanupScenario.class);
       runner.setupScenarios(EmptyStringVariableScenario.class);
+      runner.setupScenarios(SetRemovalTimeToProcessInstanceScenario.class);
     }
 
     processEngine.close();

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/camunda/bpm/qa/rolling/update/scenarios/batch/SetRemovalTimeToProcessInstanceScenario.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/camunda/bpm/qa/rolling/update/scenarios/batch/SetRemovalTimeToProcessInstanceScenario.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.qa.rolling.update.scenarios.batch;
+
+import java.util.Date;
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.batch.Batch;
+import org.camunda.bpm.engine.runtime.Job;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.qa.upgrade.DescribesScenario;
+import org.camunda.bpm.qa.upgrade.ScenarioSetup;
+import org.camunda.bpm.qa.upgrade.Times;
+
+public class SetRemovalTimeToProcessInstanceScenario {
+
+  public static final String PROCESS_DEF_KEY = "oneTaskProcess";
+
+  @Deployment
+  public static String deploy() {
+    return "org/camunda/bpm/qa/rolling/update/oneTaskProcess.bpmn20.xml";
+  }
+
+  @DescribesScenario("createSetRemovalTimeToProcessInstanceBatch")
+  @Times(1)
+  public static ScenarioSetup createBatch() {
+    return new ScenarioSetup() {
+      @Override
+      public void execute(ProcessEngine engine, String scenarioName) {
+        Date removalTime = new Date(1363609000000L);
+        String processInstanceId = engine.getRuntimeService().startProcessInstanceByKey(PROCESS_DEF_KEY, "SetRemovalTimeToProcessInstance.batch").getId();
+        Batch batch = engine.getHistoryService().setRemovalTimeToHistoricProcessInstances().absoluteRemovalTime(removalTime).byIds(processInstanceId).executeAsync();
+        engine.getManagementService().setProperty("SetRemovalTimeToProcessInstance.batch.batchId", batch.getId());
+      }
+    };
+  }
+
+  @DescribesScenario("createSetRemovalTimeToProcessInstanceBatchJob")
+  @Times(1)
+  public static ScenarioSetup createBatchJob() {
+    return new ScenarioSetup() {
+      @Override
+      public void execute(ProcessEngine engine, String scenarioName) {
+        Date removalTime = new Date(1363609000000L);
+        String processInstanceId = engine.getRuntimeService().startProcessInstanceByKey(PROCESS_DEF_KEY, "SetRemovalTimeToProcessInstance.batchJob").getId();
+        Batch batch = engine.getHistoryService().setRemovalTimeToHistoricProcessInstances().absoluteRemovalTime(removalTime).byIds(processInstanceId).executeAsync();
+        String seedJobDefinitionId = batch.getSeedJobDefinitionId();
+        Job seedJob = engine.getManagementService().createJobQuery().jobDefinitionId(seedJobDefinitionId).singleResult();
+
+        engine.getManagementService().executeJob(seedJob.getId());
+        engine.getManagementService().setProperty("SetRemovalTimeToProcessInstance.batchJob.batchId", batch.getId());
+      }
+    };
+  }
+
+}

--- a/qa/test-db-rolling-update/test-old-engine/src/test/java/org/camunda/bpm/qa/rolling/update/batch/SetRemovalTimeToProcessInstanceTest.java
+++ b/qa/test-db-rolling-update/test-old-engine/src/test/java/org/camunda/bpm/qa/rolling/update/batch/SetRemovalTimeToProcessInstanceTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.qa.rolling.update.batch;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Date;
+import java.util.List;
+import org.camunda.bpm.engine.ManagementService;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.batch.Batch;
+import org.camunda.bpm.engine.history.HistoricActivityInstance;
+import org.camunda.bpm.engine.runtime.Job;
+import org.camunda.bpm.qa.rolling.update.AbstractRollingUpdateTestCase;
+import org.camunda.bpm.qa.rolling.update.RollingUpdateConstants;
+import org.camunda.bpm.qa.upgrade.ScenarioUnderTest;
+import org.junit.Before;
+import org.junit.Test;
+
+@ScenarioUnderTest("SetRemovalTimeToProcessInstanceScenario")
+public class SetRemovalTimeToProcessInstanceTest extends AbstractRollingUpdateTestCase {
+
+  protected ManagementService managementService;
+  protected RuntimeService runtimeService;
+
+  @Before
+  public void setUp() {
+    managementService = rule.getManagementService();
+    runtimeService = rule.getRuntimeService();
+  }
+
+  @Test
+  @ScenarioUnderTest("createSetRemovalTimeToProcessInstanceBatch.1")
+  public void shouldCompleteBatch() {
+    if (RollingUpdateConstants.OLD_ENGINE_TAG.equals(rule.getTag())) { // test cleanup with old engine
+      Date removalTime = new Date(1363609000000L);
+
+      String processInstanceId = runtimeService.createProcessInstanceQuery().processInstanceBusinessKey("SetRemovalTimeToProcessInstance.batch").singleResult().getId();
+      String batchId = managementService.getProperties().get("SetRemovalTimeToProcessInstance.batch.batchId");
+      Batch batch = managementService.createBatchQuery().batchId(batchId).singleResult();
+      String seedJobDefinitionId = batch.getSeedJobDefinitionId();
+      Job seedJob = managementService.createJobQuery().jobDefinitionId(seedJobDefinitionId).singleResult();
+
+      managementService.executeJob(seedJob.getId());
+      List<Job> batchJobs = managementService.createJobQuery()
+          .jobDefinitionId(batch.getBatchJobDefinitionId())
+          .list();
+
+      // when
+      batchJobs.forEach(job -> managementService.executeJob(job.getId()));
+
+      // then
+      HistoricActivityInstance historicActivityInstance = rule.getHistoryService().createHistoricActivityInstanceQuery()
+          .activityId("theTask")
+          .processInstanceId(processInstanceId)
+          .singleResult();
+      assertEquals(removalTime, historicActivityInstance.getRemovalTime());
+
+      assertEquals(0, managementService.createJobQuery().jobDefinitionId(batch.getBatchJobDefinitionId()).count());
+    }
+  }
+
+  @Test
+  @ScenarioUnderTest("createSetRemovalTimeToProcessInstanceBatchJob.1")
+  public void testCompleteBatchKJob() {
+    if (RollingUpdateConstants.OLD_ENGINE_TAG.equals(rule.getTag())) { // test cleanup with old engine
+      Date removalTime = new Date(1363609000000L);
+
+      String processInstanceId = runtimeService.createProcessInstanceQuery().processInstanceBusinessKey("SetRemovalTimeToProcessInstance.batchJob").singleResult().getId();
+      String batchId = managementService.getProperties().get("SetRemovalTimeToProcessInstance.batchJob.batchId");
+      Batch batch = managementService.createBatchQuery().batchId(batchId).singleResult();
+      List<Job> batchJobs = managementService.createJobQuery()
+          .jobDefinitionId(batch.getBatchJobDefinitionId())
+          .list();
+
+      // when
+      batchJobs.forEach(job -> managementService.executeJob(job.getId()));
+
+      // then
+      HistoricActivityInstance historicActivityInstance = rule.getHistoryService().createHistoricActivityInstanceQuery()
+          .activityId("theTask")
+          .processInstanceId(processInstanceId)
+          .singleResult();
+      assertEquals(removalTime, historicActivityInstance.getRemovalTime());
+
+      assertEquals(0, managementService.createJobQuery().jobDefinitionId(batch.getBatchJobDefinitionId()).count());
+    }
+  }
+
+}


### PR DESCRIPTION
* Makes the set removal time batch job repeatable, so it can run multiple
  times to update in chunks, keeping updates to a defined limit of rows.
* This has to be enabled specifically per batch execution to avoid more
  complex update queries running by default on all databases.
* The new flag is `updateInChunks` which can be set via Java and REST API.
  In combination with it, the `chunkSize` can also be defined dynamically,
  falling back to a defined default that is also configurable in the engine.

related to https://github.com/camunda/camunda-bpm-platform/issues/3064