### PR TITLE
fix(webapps): correct loading path of legacy `requireJs` plugins

### DIFF
--- a/webapps/frontend/ui/admin/client/scripts/camunda-admin-bootstrap.js
+++ b/webapps/frontend/ui/admin/client/scripts/camunda-admin-bootstrap.js
@@ -150,7 +150,7 @@ define('camunda-admin-bootstrap', function() {
           });
 
           // configure RequireJS
-          requirejs.config(conf);
+          requirejs.config({baseUrl: '../', ...conf});
 
           // load the dependencies and bootstrap the AngularJS application
           requirejs(custom.deps || [], function() {

--- a/webapps/frontend/ui/cockpit/client/scripts/camunda-cockpit-bootstrap.js
+++ b/webapps/frontend/ui/cockpit/client/scripts/camunda-cockpit-bootstrap.js
@@ -266,7 +266,7 @@ define('camunda-cockpit-bootstrap', function() {
 
         function loadRequireJsDeps() {
           // configure RequireJS
-          requirejs.config(conf);
+          requirejs.config({baseUrl: '../', ...conf});
 
           // load the dependencies and bootstrap the AngularJS application
           requirejs(custom.deps || [], function() {

--- a/webapps/frontend/ui/common/scripts/services/plugins/loadPlugins.js
+++ b/webapps/frontend/ui/common/scripts/services/plugins/loadPlugins.js
@@ -46,15 +46,17 @@ module.exports = async function loadPlugins(config, appName) {
       !el.name.startsWith(`${appName}-plugin-legacy`)
   ).map(el => {
     addCssSource(`${el.location}/plugin.css?bust=${CAMUNDA_VERSION}`); // eslint-disable-line
-    return `${el.location}/${el.main}`;
+    return `${el.location}/${el.main}?bust=${CAMUNDA_VERSION}`; // eslint-disable-line
   });
 
   const baseImportPath = `${appRoot}/app/${appName}/`;
   const fetchers = customScripts.map(url =>
-    _import(baseImportPath + withSuffix(url, '.js')) // eslint-disable-line
-      .catch(
-        e => console.error(e) // eslint-disable-line
-      )
+    // eslint-disable-next-line
+    _import(
+      baseImportPath + withSuffix(url, '.js') + `?bust=${CAMUNDA_VERSION}` // eslint-disable-line
+    ).catch(
+      e => console.error(e) // eslint-disable-line
+    )
   );
 
   fetchers.push(

--- a/webapps/frontend/ui/tasklist/client/scripts/camunda-tasklist-bootstrap.js
+++ b/webapps/frontend/ui/tasklist/client/scripts/camunda-tasklist-bootstrap.js
@@ -154,7 +154,7 @@ define('camunda-tasklist-bootstrap', function() {
           });
 
           // configure RequireJS
-          requirejs.config(conf);
+          requirejs.config({baseUrl: '../', ...conf});
 
           // load the dependencies and bootstrap the AngularJS application
           requirejs(custom.deps || [], function() {

--- a/webapps/frontend/ui/welcome/client/scripts/camunda-welcome-bootstrap.js
+++ b/webapps/frontend/ui/welcome/client/scripts/camunda-welcome-bootstrap.js
@@ -151,7 +151,7 @@ define('camunda-welcome-bootstrap', function() {
           });
 
           // configure RequireJS
-          requirejs.config(conf);
+          requirejs.config({baseUrl: '../', ...conf});
 
           // load the dependencies and bootstrap the AngularJS application
           requirejs(custom.deps || [], function() {


### PR DESCRIPTION
related to camunda/camunda-bpm-platform#3701