### PR TITLE
fix camunda-engine-rest-core (-jakarta) dependencies.

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -75,17 +75,12 @@
       </dependency>
       <dependency>
         <groupId>org.camunda.bpm</groupId>
-        <artifactId>camunda-engine-rest</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.camunda.bpm</groupId>
-        <artifactId>camunda-engine-rest-jakarta</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.camunda.bpm</groupId>
         <artifactId>camunda-engine-rest-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.camunda.bpm</groupId>
+        <artifactId>camunda-engine-rest-core-jakarta</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
### Provide actual camunda-engine-rest-core(-jakarta) dependencies in BOM

Fix #3789.