### PR TITLE
fix(webapps): clear requirejs globals after bootstrapping

### DIFF
--- a/webapps/frontend/ui/admin/client/scripts/camunda-admin-bootstrap.js
+++ b/webapps/frontend/ui/admin/client/scripts/camunda-admin-bootstrap.js
@@ -159,6 +159,8 @@ define('camunda-admin-bootstrap', function() {
             // directives, controllers, services and all when loaded
             angular.module('cam.admin.custom', custom.ngDeps);
 
+            clearAmdGlobals();
+
             // now that we loaded the plugins and the additional modules, we can finally
             // initialize Admin
             camundaAdminUi.init(pluginDependencies);
@@ -175,8 +177,19 @@ define('camunda-admin-bootstrap', function() {
           // not have been defined yet. Placing a new require call here will put
           // the bootstrapping of the angular app at the end of the queue
           rjsrequire([], function() {
+            clearAmdGlobals();
             camundaAdminUi.init(pluginDependencies);
           });
+        }
+
+        /**
+         * Clearing AMD globals is necessary so third-party AMD scripts users
+         * register via script tag are prevented from registration via RequireJS
+         * and made global on the window object.
+         */
+        function clearAmdGlobals() {
+          window.define = undefined;
+          window.require = undefined;
         }
       });
     });

--- a/webapps/frontend/ui/cockpit/client/scripts/camunda-cockpit-bootstrap.js
+++ b/webapps/frontend/ui/cockpit/client/scripts/camunda-cockpit-bootstrap.js
@@ -280,6 +280,18 @@ define('camunda-cockpit-bootstrap', function() {
         }
 
         function initCockpitUi(pluginDependencies) {
+          /**
+           * Clearing AMD globals is necessary so third-party AMD scripts users
+           * register via script tag are prevented from registration via RequireJS
+           * and made global on the window object.
+           */
+          function clearAmdGlobals() {
+            window.define = undefined;
+            window.require = undefined;
+          }
+
+          clearAmdGlobals();
+
           // now that we loaded the plugins and the additional modules, we can finally
           // initialize Cockpit
           camundaCockpitUi.init(pluginDependencies);

--- a/webapps/frontend/ui/tasklist/client/scripts/camunda-tasklist-bootstrap.js
+++ b/webapps/frontend/ui/tasklist/client/scripts/camunda-tasklist-bootstrap.js
@@ -163,6 +163,8 @@ define('camunda-tasklist-bootstrap', function() {
             // directives, controllers, services and all when loaded
             angular.module('cam.tasklist.custom', custom.ngDeps);
 
+            clearAmdGlobals();
+
             // now that we loaded the plugins and the additional modules, we can finally
             // initialize the tasklist
             camundaTasklistUi.init(pluginDependencies);
@@ -179,8 +181,19 @@ define('camunda-tasklist-bootstrap', function() {
           // not have been defined yet. Placing a new require call here will put
           // the bootstrapping of the angular app at the end of the queue
           rjsrequire([], function() {
+            clearAmdGlobals();
             camundaTasklistUi.init(pluginDependencies);
           });
+        }
+
+        /**
+         * Clearing AMD globals is necessary so third-party AMD scripts users
+         * register via script tag are prevented from registration via RequireJS
+         * and made global on the window object.
+         */
+        function clearAmdGlobals() {
+          window.define = undefined;
+          window.require = undefined;
         }
       });
     });

--- a/webapps/frontend/ui/welcome/client/scripts/camunda-welcome-bootstrap.js
+++ b/webapps/frontend/ui/welcome/client/scripts/camunda-welcome-bootstrap.js
@@ -160,6 +160,8 @@ define('camunda-welcome-bootstrap', function() {
             // directives, controllers, services and all when loaded
             angular.module('cam.welcome.custom', custom.ngDeps);
 
+            clearAmdGlobals();
+
             // now that we loaded the plugins and the additional modules, we can finally
             // initialize Welcome
             camundaWelcomeUi.init(pluginDependencies);
@@ -176,8 +178,19 @@ define('camunda-welcome-bootstrap', function() {
           // not have been defined yet. Placing a new require call here will put
           // the bootstrapping of the angular app at the end of the queue
           rjsrequire([], function() {
+            clearAmdGlobals();
             camundaWelcomeUi.init(pluginDependencies);
           });
+        }
+
+        /**
+         * Clearing AMD globals is necessary so third-party AMD scripts users
+         * register via script tag are prevented from registration via RequireJS
+         * and made global on the window object.
+         */
+        function clearAmdGlobals() {
+          window.define = undefined;
+          window.require = undefined;
         }
       });
     });


### PR DESCRIPTION
related to camunda/camunda-bpm-platform#3796