### PR TITLE
Avoid NPE in ExceptionUtil.checkVariableIntegrityViolation()

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/ExceptionUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/ExceptionUtil.java
@@ -219,7 +219,7 @@ public class ExceptionUtil {
     }
 
     String message = sqlException.getMessage().toLowerCase();
-    String sqlState = sqlException.getSQLState().toUpperCase();
+    String sqlState = sqlException.getSQLState();
     int errorCode = sqlException.getErrorCode();
 
     // MySQL & MariaDB


### PR DESCRIPTION
I can't describe the exact situation an NPE happened for me here, but it does happen at least on some databases that `SQLState` is `null`. As can be seen from the source code, `toUpperCase()` call is actually pointless in this function and is never important, so its only practical consequence was causing an NPE in certain situations.

related to https://github.com/camunda/camunda-bpm-platform/issues/3818