### PR TITLE
avoid more potential NPE in ExceptionUtil

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/ExceptionUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/ExceptionUtil.java
@@ -144,13 +144,17 @@ public class ExceptionUtil {
 
   public static boolean checkValueTooLongException(SQLException sqlException) {
     String message = sqlException.getMessage();
+    if (message != null) {
+      message = message.toLowerCase();
+    } else {
+      return false;
+    }
     return message.contains("too long") ||
         message.contains("too large") ||
-        message.contains("TOO LARGE") ||
-        message.contains("ORA-01461") ||
-        message.contains("ORA-01401") ||
+        message.contains("ora-01461") ||
+        message.contains("ora-01401") ||
         message.contains("data would be truncated") ||
-        message.contains("SQLCODE=-302, SQLSTATE=22001");
+        message.contains("sqlcode=-302, sqlstate=22001");
   }
 
   public static boolean checkValueTooLongException(ProcessEngineException genericPersistenceException) {
@@ -171,11 +175,17 @@ public class ExceptionUtil {
     }
 
     String message = sqlException.getMessage();
+    if (message != null) {
+      message = message.toLowerCase();
+    } else {
+      return false;
+    }
+
     return message.contains("constraint") ||
         message.contains("violat") ||
-        message.toLowerCase().contains("duplicate") ||
-        message.contains("ORA-00001") ||
-        message.contains("SQLCODE=-803, SQLSTATE=23505");
+        message.contains("duplicate") ||
+        message.contains("ora-00001") ||
+        message.contains("sqlcode=-803, sqlstate=23505");
   }
 
   public static boolean checkForeignKeyConstraintViolation(PersistenceException persistenceException) {
@@ -189,7 +199,13 @@ public class ExceptionUtil {
   }
 
   public static boolean checkForeignKeyConstraintViolation(SQLException sqlException) {
-    String message = sqlException.getMessage().toLowerCase();
+    String message = sqlException.getMessage();
+    if (message != null) {
+      message = message.toLowerCase();
+    } else {
+      return false;
+    }
+
     String sqlState = sqlException.getSQLState();
     int errorCode = sqlException.getErrorCode();
 
@@ -218,7 +234,13 @@ public class ExceptionUtil {
       return false;
     }
 
-    String message = sqlException.getMessage().toLowerCase();
+    String message = sqlException.getMessage();
+    if (message != null) {
+      message = message.toLowerCase();
+    } else {
+      return false;
+    }
+
     String sqlState = sqlException.getSQLState();
     int errorCode = sqlException.getErrorCode();
 

--- a/engine/src/test/java/org/camunda/bpm/engine/impl/util/ExceptionUtilTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/impl/util/ExceptionUtilTest.java
@@ -27,9 +27,6 @@ import org.junit.Test;
 
 public class ExceptionUtilTest {
 
-  // Several tests here make sure there are no NPE because of null SQL state (already
-  // happened) or message (who knows?). This would only clobber the real problem.
-
   @Test
   public void checkValueTooLongException() {
     assertThat(ExceptionUtil.checkValueTooLongException(mock(SQLException.class))).isFalse();

--- a/engine/src/test/java/org/camunda/bpm/engine/impl/util/ExceptionUtilTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/impl/util/ExceptionUtilTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.sql.SQLException;
+import org.apache.ibatis.exceptions.PersistenceException;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.junit.Test;
+
+public class ExceptionUtilTest {
+
+  // Several tests here make sure there are no NPE because of null SQL state (already
+  // happened) or message (who knows?). This would only clobber the real problem.
+
+  @Test
+  public void checkValueTooLongException() {
+    assertThat(ExceptionUtil.checkValueTooLongException(mock(SQLException.class))).isFalse();
+
+    SQLException tooLong = mock(SQLException.class);
+    doReturn("too long").when(tooLong).getMessage();
+    assertThat(ExceptionUtil.checkValueTooLongException(tooLong)).isTrue();
+  }
+
+  @Test
+  public void checkConstraintViolationException() {
+    assertThat(ExceptionUtil.checkConstraintViolationException(new ProcessEngineException(new PersistenceException(mock(SQLException.class))))).isFalse();
+
+    SQLException constraintViolation = mock(SQLException.class);
+    doReturn("ora-00001").when(constraintViolation).getMessage();
+    assertThat(ExceptionUtil.checkConstraintViolationException(new ProcessEngineException(new PersistenceException(constraintViolation)))).isTrue();
+  }
+
+  @Test
+  public void checkForeignKeyConstraintViolation() {
+    assertThat(ExceptionUtil.checkForeignKeyConstraintViolation(mock(SQLException.class))).isFalse();
+
+    SQLException constraintViolation = mock(SQLException.class);
+    doReturn("integrity constraint").when(constraintViolation).getMessage();
+    assertThat(ExceptionUtil.checkForeignKeyConstraintViolation(constraintViolation)).isTrue();
+  }
+
+  @Test
+  public void checkVariableIntegrityViolation() {
+    assertThat(ExceptionUtil.checkVariableIntegrityViolation(new PersistenceException(mock(SQLException.class)))).isFalse();
+
+    SQLException integrityViolation = mock(SQLException.class);
+    doReturn("act_uniq_variable").when(integrityViolation).getMessage();
+    doReturn("23505").when(integrityViolation).getSQLState();
+    assertThat(ExceptionUtil.checkVariableIntegrityViolation(new PersistenceException(integrityViolation))).isTrue();
+  }
+
+  @Test
+  public void checkCrdbTransactionRetryException() {
+    assertThat(ExceptionUtil.checkCrdbTransactionRetryException(mock(SQLException.class))).isFalse();
+
+    SQLException retry = mock(SQLException.class);
+    doReturn("restart transaction").when(retry).getMessage();
+    doReturn(40001).when(retry).getErrorCode();
+    assertThat(ExceptionUtil.checkCrdbTransactionRetryException(retry)).isTrue();
+  }
+
+  @Test
+  public void checkDeadlockException() {
+    assertThat(ExceptionUtil.checkDeadlockException(mock(SQLException.class))).isFalse();
+
+    SQLException deadlock = mock(SQLException.class);
+    doReturn("40P01").when(deadlock).getSQLState();  // PostgreSQL
+    assertThat(ExceptionUtil.checkDeadlockException(deadlock)).isTrue();
+  }
+
+}


### PR DESCRIPTION
This commit

1) plugs _potential_ (I haven't observed them in reality) causes for NPEs in `ExceptionUtil`, similar to those in 660e7f1298;
2) adds several tests for the plugged methods that assert no NPEs and each check one (mocked) parameter set that causes the tested method to return true.

This was tentatively agreed on in #3818.