### PR TITLE
chore(engine): Adjust Persistence Layer for CreateTime

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/externaltask/ExternalTask.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/externaltask/ExternalTask.java
@@ -51,6 +51,12 @@ public interface ExternalTask {
   Date getLockExpirationTime();
 
   /**
+   * @return the absolute time at which the task was created
+   * @return
+   */
+  Date getCreationDate();
+
+  /**
    * @return the id of the process instance the task exists in
    */
   String getProcessInstanceId();

--- a/engine/src/main/java/org/camunda/bpm/engine/externaltask/ExternalTask.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/externaltask/ExternalTask.java
@@ -54,7 +54,7 @@ public interface ExternalTask {
    * @return the absolute time at which the task was created
    * @return
    */
-  Date getCreationDate();
+  Date getCreateTime();
 
   /**
    * @return the id of the process instance the task exists in

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/history/producer/DefaultHistoryEventProducer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/history/producer/DefaultHistoryEventProducer.java
@@ -1226,7 +1226,8 @@ public class DefaultHistoryEventProducer implements HistoryEventProducer {
 
   protected HistoricExternalTaskLogEntity initHistoricExternalTaskLog(ExternalTaskEntity entity, ExternalTaskState state) {
     HistoricExternalTaskLogEntity event = new HistoricExternalTaskLogEntity();
-    event.setTimestamp(ClockUtil.getCurrentTime());
+
+    event.setTimestamp(getTimestamp(entity, state));
     event.setExternalTaskId(entity.getId());
     event.setTopicName(entity.getTopicName());
     event.setWorkerId(entity.getWorkerId());
@@ -1254,6 +1255,10 @@ public class DefaultHistoryEventProducer implements HistoryEventProducer {
     }
 
     return event;
+  }
+
+  protected Date getTimestamp(ExternalTaskEntity entity, ExternalTaskState state) {
+    return state == ExternalTaskState.CREATED ? entity.getCreationDate() : ClockUtil.getCurrentTime();
   }
 
   protected boolean isRootProcessInstance(HistoricProcessInstanceEventEntity evt) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/history/producer/DefaultHistoryEventProducer.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/history/producer/DefaultHistoryEventProducer.java
@@ -1258,7 +1258,7 @@ public class DefaultHistoryEventProducer implements HistoryEventProducer {
   }
 
   protected Date getTimestamp(ExternalTaskEntity entity, ExternalTaskState state) {
-    return state == ExternalTaskState.CREATED ? entity.getCreationDate() : ClockUtil.getCurrentTime();
+    return state == ExternalTaskState.CREATED ? entity.getCreateTime() : ClockUtil.getCurrentTime();
   }
 
   protected boolean isRootProcessInstance(HistoricProcessInstanceEventEntity evt) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExternalTaskEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExternalTaskEntity.java
@@ -72,6 +72,7 @@ public class ExternalTaskEntity implements ExternalTask, DbEntity,
   protected String topicName;
   protected String workerId;
   protected Date lockExpirationTime;
+  protected Date creationDate;
   protected Integer retries;
   protected String errorMessage;
 
@@ -123,9 +124,20 @@ public class ExternalTaskEntity implements ExternalTask, DbEntity,
   public Date getLockExpirationTime() {
     return lockExpirationTime;
   }
+
   public void setLockExpirationTime(Date lockExpirationTime) {
     this.lockExpirationTime = lockExpirationTime;
   }
+
+  @Override
+  public Date getCreationDate() {
+    return creationDate;
+  }
+
+  public void setCreationDate(Date creationDate) {
+    this.creationDate = creationDate;
+  }
+
   @Override
   public String getExecutionId() {
     return executionId;
@@ -564,6 +576,7 @@ public class ExternalTaskEntity implements ExternalTask, DbEntity,
     externalTask.setActivityInstanceId(execution.getActivityInstanceId());
     externalTask.setTenantId(execution.getTenantId());
     externalTask.setPriority(priority);
+    externalTask.setCreationDate(ClockUtil.getCurrentTime());
 
     ProcessDefinitionEntity processDefinition = execution.getProcessDefinition();
     externalTask.setProcessDefinitionKey(processDefinition.getKey());

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExternalTaskEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/ExternalTaskEntity.java
@@ -72,7 +72,7 @@ public class ExternalTaskEntity implements ExternalTask, DbEntity,
   protected String topicName;
   protected String workerId;
   protected Date lockExpirationTime;
-  protected Date creationDate;
+  protected Date createTime;
   protected Integer retries;
   protected String errorMessage;
 
@@ -130,12 +130,12 @@ public class ExternalTaskEntity implements ExternalTask, DbEntity,
   }
 
   @Override
-  public Date getCreationDate() {
-    return creationDate;
+  public Date getCreateTime() {
+    return createTime;
   }
 
-  public void setCreationDate(Date creationDate) {
-    this.creationDate = creationDate;
+  public void setCreateTime(Date createTime) {
+    this.createTime = createTime;
   }
 
   @Override
@@ -576,7 +576,7 @@ public class ExternalTaskEntity implements ExternalTask, DbEntity,
     externalTask.setActivityInstanceId(execution.getActivityInstanceId());
     externalTask.setTenantId(execution.getTenantId());
     externalTask.setPriority(priority);
-    externalTask.setCreationDate(ClockUtil.getCurrentTime());
+    externalTask.setCreateTime(ClockUtil.getCurrentTime());
 
     ProcessDefinitionEntity processDefinition = execution.getProcessDefinition();
     externalTask.setProcessDefinitionKey(processDefinition.getKey());

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ExternalTask.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ExternalTask.xml
@@ -31,7 +31,7 @@
     <result property="errorDetailsByteArrayId" column="ERROR_DETAILS_ID_" jdbcType="VARCHAR" />
 
     <result property="lockExpirationTime" column="LOCK_EXP_TIME_" jdbcType="TIMESTAMP"/>
-    <result property="creationDate" column="CREATION_DATE_" jdbcType="TIMESTAMP"/>
+    <result property="createTime" column="CREATE_TIME_" jdbcType="TIMESTAMP"/>
     <result property="suspensionState" column="SUSPENSION_STATE_" jdbcType="INTEGER" />
     <result property="executionId" column="EXECUTION_ID_" jdbcType="VARCHAR" />
     <result property="processInstanceId" column="PROC_INST_ID_" jdbcType="VARCHAR" />
@@ -58,7 +58,7 @@
       WORKER_ID_,
       TOPIC_NAME_,
       LOCK_EXP_TIME_,
-      CREATION_DATE_,
+      CREATE_TIME_,
       RETRIES_,
       ERROR_MSG_,
       ERROR_DETAILS_ID_,
@@ -78,7 +78,7 @@
       #{workerId, jdbcType=VARCHAR},
       #{topicName, jdbcType=VARCHAR},
       #{lockExpirationTime, jdbcType=TIMESTAMP},
-      #{creationDate, jdbcType=TIMESTAMP},
+      #{createTime, jdbcType=TIMESTAMP},
       #{retries, jdbcType=INTEGER},
       #{errorMessage, jdbcType=VARCHAR},
       #{errorDetailsByteArrayId, jdbcType=VARCHAR},
@@ -445,7 +445,7 @@
     RES.TOPIC_NAME_, 
     RES.WORKER_ID_, 
     RES.LOCK_EXP_TIME_,
-    RES.CREATION_DATE_,
+    RES.CREATE_TIME_,
     RES.RETRIES_,
     RES.ERROR_MSG_,
     RES.ERROR_DETAILS_ID_,

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ExternalTask.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ExternalTask.xml
@@ -31,6 +31,7 @@
     <result property="errorDetailsByteArrayId" column="ERROR_DETAILS_ID_" jdbcType="VARCHAR" />
 
     <result property="lockExpirationTime" column="LOCK_EXP_TIME_" jdbcType="TIMESTAMP"/>
+    <result property="creationDate" column="CREATION_DATE_" jdbcType="TIMESTAMP"/>
     <result property="suspensionState" column="SUSPENSION_STATE_" jdbcType="INTEGER" />
     <result property="executionId" column="EXECUTION_ID_" jdbcType="VARCHAR" />
     <result property="processInstanceId" column="PROC_INST_ID_" jdbcType="VARCHAR" />
@@ -57,6 +58,7 @@
       WORKER_ID_,
       TOPIC_NAME_,
       LOCK_EXP_TIME_,
+      CREATION_DATE_,
       RETRIES_,
       ERROR_MSG_,
       ERROR_DETAILS_ID_,
@@ -76,6 +78,7 @@
       #{workerId, jdbcType=VARCHAR},
       #{topicName, jdbcType=VARCHAR},
       #{lockExpirationTime, jdbcType=TIMESTAMP},
+      #{creationDate, jdbcType=TIMESTAMP},
       #{retries, jdbcType=INTEGER},
       #{errorMessage, jdbcType=VARCHAR},
       #{errorDetailsByteArrayId, jdbcType=VARCHAR},
@@ -442,6 +445,7 @@
     RES.TOPIC_NAME_, 
     RES.WORKER_ID_, 
     RES.LOCK_EXP_TIME_,
+    RES.CREATION_DATE_,
     RES.RETRIES_,
     RES.ERROR_MSG_,
     RES.ERROR_DETAILS_ID_,

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskQueryByCreateTimeTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskQueryByCreateTimeTest.java
@@ -42,7 +42,7 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
-public class ExternalTaskQueryByCreationDateTest {
+public class ExternalTaskQueryByCreateTimeTest {
 
   public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
   public ProcessEngineTestRule testHelper = new ProcessEngineTestRule(engineRule);
@@ -74,7 +74,7 @@ public class ExternalTaskQueryByCreationDateTest {
   }
 
   @Test
-  public void shouldHaveNonNullCreationDate() {
+  public void shouldHaveNonNullCreateTime() {
     // given
     runtimeService.startProcessInstanceByKey("process1");
 
@@ -85,11 +85,11 @@ public class ExternalTaskQueryByCreationDateTest {
 
     // then
     assertThat(result.size()).isEqualTo(1);
-    assertThat(result.get(0).getCreationDate()).isNotNull();
+    assertThat(result.get(0).getCreateTime()).isNotNull();
   }
 
   @Test
-  public void shouldProduceEventWithCreationDateValue() {
+  public void shouldProduceEventWithCreateTimeValue() {
     // given
     runtimeService.startProcessInstanceByKey("process1");
 
@@ -105,7 +105,7 @@ public class ExternalTaskQueryByCreationDateTest {
     var historyEventTimestamp = result.get(0).getTimestamp();
 
     // then
-    assertThat(extTask.getCreationDate()).isEqualTo(historyEventTimestamp);
+    assertThat(extTask.getCreateTime()).isEqualTo(historyEventTimestamp);
   }
 
   @Test
@@ -117,7 +117,7 @@ public class ExternalTaskQueryByCreationDateTest {
     var result = engineRule.getExternalTaskService()
         .createExternalTaskQuery()
         // when
-        .orderByCreationDate().desc()
+        .orderByCreateTime().desc()
         .list();
 
     assertThat(result.size()).isEqualTo(2);
@@ -126,8 +126,8 @@ public class ExternalTaskQueryByCreationDateTest {
     var extTask2 = result.get(1);
 
     // then
-    assertThat(extTask2.getCreationDate())
-        .isBefore(extTask1.getCreationDate());
+    assertThat(extTask2.getCreateTime())
+        .isBefore(extTask1.getCreateTime());
   }
 
   @Test
@@ -139,7 +139,7 @@ public class ExternalTaskQueryByCreationDateTest {
     var result = engineRule.getExternalTaskService()
         .createExternalTaskQuery()
         // when
-        .orderByCreationDate().asc()
+        .orderByCreateTime().asc()
         .list();
 
     assertThat(result.size()).isEqualTo(2);
@@ -148,14 +148,14 @@ public class ExternalTaskQueryByCreationDateTest {
     var extTask2 = result.get(1);
 
     // then
-    assertThat(extTask1.getCreationDate())
-        .isBefore(extTask2.getCreationDate());
+    assertThat(extTask1.getCreateTime())
+        .isBefore(extTask2.getCreateTime());
   }
 
-  // Multi-Level Sorting with CreationDate & Priority
+  // Multi-Level Sorting with CreateTime & Priority
 
   @Test
-  public void shouldReturnTasksInCreationDateAscOrderOnPriorityEquality() {
+  public void shouldReturnTasksInCreateTimeAscOrderOnPriorityEquality() {
     // given
     startProcessInstanceAfter("process1", 1);
     startProcessInstanceAfter("process2", 1);
@@ -166,7 +166,7 @@ public class ExternalTaskQueryByCreationDateTest {
         .createExternalTaskQuery()
         // when
         .orderByPriority().desc()
-        .orderByCreationDate().asc()
+        .orderByCreateTime().asc()
 
         .list();
 
@@ -180,7 +180,7 @@ public class ExternalTaskQueryByCreationDateTest {
   }
 
   @Test
-  public void shouldReturnTasksInCreationDateDescOrderOnPriorityEquality() {
+  public void shouldReturnTasksInCreateTimeDescOrderOnPriorityEquality() {
     // given
     startProcessInstanceAfter("process1", 1);
     startProcessInstanceAfter("process2", 1);
@@ -191,7 +191,7 @@ public class ExternalTaskQueryByCreationDateTest {
         .createExternalTaskQuery()
         // when
         .orderByPriority().desc()
-        .orderByCreationDate().desc()
+        .orderByCreateTime().desc()
 
         .list();
 
@@ -200,12 +200,12 @@ public class ExternalTaskQueryByCreationDateTest {
     // then
     assertThat(result.get(0).getActivityId()).isEqualTo("task1"); // due to priority DESC
     assertThat(result.get(1).getActivityId()).isEqualTo("task2");
-    assertThat(result.get(2).getActivityId()).isEqualTo("task4"); // due to creationDate DESC
+    assertThat(result.get(2).getActivityId()).isEqualTo("task4"); // due to CreateTime DESC
     assertThat(result.get(3).getActivityId()).isEqualTo("task3");
   }
 
   @Test
-  public void shouldReturnTasksInPriorityAscOnCreationDateEquality() {
+  public void shouldReturnTasksInPriorityAscOnCreateTimeEquality() {
     var now = ClockTestUtil.setClockToDateWithoutMilliseconds();
 
     // given
@@ -218,7 +218,7 @@ public class ExternalTaskQueryByCreationDateTest {
     var result = engineRule.getExternalTaskService()
         .createExternalTaskQuery()
         // when
-        .orderByCreationDate().asc()
+        .orderByCreateTime().asc()
         .orderByPriority().asc()
 
         .list();
@@ -226,7 +226,7 @@ public class ExternalTaskQueryByCreationDateTest {
     assertThat(result.size()).isEqualTo(4);
 
     // then
-    assertThat(result.get(0).getActivityId()).isEqualTo("task2"); // due to creationDate Equality, priority ASC
+    assertThat(result.get(0).getActivityId()).isEqualTo("task2"); // due to CreateTime Equality, priority ASC
     assertThat(result.get(1).getActivityId()).isEqualTo("task1");
 
     assertThat(result.get(2).getActivityId()).isEqualTo("task3");
@@ -234,7 +234,7 @@ public class ExternalTaskQueryByCreationDateTest {
   }
 
   @Test
-  public void shouldReturnTasksInPriorityDescOnCreationDateEquality() {
+  public void shouldReturnTasksInPriorityDescOnCreateTimeEquality() {
     var now = ClockTestUtil.setClockToDateWithoutMilliseconds();
 
     // given
@@ -247,7 +247,7 @@ public class ExternalTaskQueryByCreationDateTest {
     var result = engineRule.getExternalTaskService()
         .createExternalTaskQuery()
         // when
-        .orderByCreationDate().asc()
+        .orderByCreateTime().asc()
         .orderByPriority().desc()
 
         .list();
@@ -255,7 +255,7 @@ public class ExternalTaskQueryByCreationDateTest {
     assertThat(result.size()).isEqualTo(4);
 
     // then
-    assertThat(result.get(0).getActivityId()).isEqualTo("task1"); // due to creationDate equality, priority DESC
+    assertThat(result.get(0).getActivityId()).isEqualTo("task1"); // due to CreateTime equality, priority DESC
     assertThat(result.get(1).getActivityId()).isEqualTo("task2");
 
     assertThat(result.get(2).getActivityId()).isEqualTo("task3");

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskQueryByCreationDateTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/externaltask/ExternalTaskQueryByCreationDateTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.camunda.bpm.engine.test.api.externaltask;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.camunda.bpm.engine.CaseService;
+import org.camunda.bpm.engine.HistoryService;
+import org.camunda.bpm.engine.ManagementService;
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
+import org.camunda.bpm.engine.RepositoryService;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.RequiredHistoryLevel;
+import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
+import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+@RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+public class ExternalTaskQueryByCreationDateTest {
+
+  public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
+  public ProcessEngineTestRule testHelper = new ProcessEngineTestRule(engineRule);
+
+  @Rule
+  public RuleChain chain = RuleChain.outerRule(engineRule).around(testHelper);
+
+  protected ProcessEngine engine;
+
+  protected RepositoryService repositoryService;
+  protected RuntimeService runtimeService;
+  protected ManagementService managementService;
+  protected HistoryService historyService;
+  protected TaskService taskService;
+  protected CaseService caseService;
+
+  @Before
+  public void initServices() {
+    engine = engineRule.getProcessEngine();
+    repositoryService = engineRule.getRepositoryService();
+    runtimeService = engineRule.getRuntimeService();
+    managementService = engineRule.getManagementService();
+    historyService = engineRule.getHistoryService();
+    taskService = engineRule.getTaskService();
+    caseService = engineRule.getCaseService();
+
+    // given
+    deployProcessesWithExternalTasks();
+  }
+
+  @Test
+  public void shouldHaveNonNullCreationDate() {
+    // when
+    runtimeService.startProcessInstanceByKey("process1");
+
+    // then
+    var result = engineRule.getExternalTaskService()
+        .createExternalTaskQuery()
+        .list();
+
+    assertThat(result.size()).isEqualTo(1);
+    assertThat(result.get(0).getCreationDate()).isNotNull();
+  }
+
+  @Test
+  public void shouldProduceEventWithCreationDateValue() {
+    // when
+    runtimeService.startProcessInstanceByKey("process1");
+
+    var extTask = engineRule.getExternalTaskService()
+        .createExternalTaskQuery()
+        .singleResult();
+
+    var result = historyService.createHistoricExternalTaskLogQuery().list();
+
+    assertThat(result.size()).isEqualTo(1);
+
+    var historyEventTimestamp = result.get(0).getTimestamp();
+
+    // then
+    assertThat(extTask.getCreationDate()).isEqualTo(historyEventTimestamp);
+  }
+
+  @Test
+  public void shouldReturnTasksInDescOrder() {
+    // when
+    runtimeService.startProcessInstanceByKey("process1");
+    runtimeService.startProcessInstanceByKey("process2");
+
+    var result = engineRule.getExternalTaskService()
+        .createExternalTaskQuery()
+        .orderByCreationDate().desc()
+        .list();
+
+    assertThat(result.size()).isEqualTo(2);
+
+    var extTask1 = result.get(0);
+    var extTask2 = result.get(1);
+
+    // then
+    assertThat(extTask2.getCreationDate())
+        .isBefore(extTask1.getCreationDate());
+  }
+
+  @Test
+  public void shouldReturnTasksInAScOrder() {
+    // when
+    runtimeService.startProcessInstanceByKey("process1");
+    runtimeService.startProcessInstanceByKey("process2");
+
+    var result = engineRule.getExternalTaskService()
+        .createExternalTaskQuery()
+        .orderByCreationDate().asc()
+        .list();
+
+    assertThat(result.size()).isEqualTo(2);
+
+    var extTask1 = result.get(0);
+    var extTask2 = result.get(1);
+
+    // then
+    assertThat(extTask1.getCreationDate())
+        .isBefore(extTask2.getCreationDate());
+  }
+
+  private void deployProcessesWithExternalTasks() {
+    var processWithExtTask = Bpmn.createExecutableProcess("process1")
+        .startEvent()
+        .serviceTask().camundaExternalTask("external-task-topic1")
+        .endEvent()
+        .done();
+
+    var process2WithExtTask = Bpmn.createExecutableProcess("process2")
+        .startEvent()
+        .serviceTask().camundaExternalTask("external-task-topic2")
+        .endEvent()
+        .done();
+
+    testHelper.deploy(processWithExtTask);
+    testHelper.deploy(process2WithExtTask);
+  }
+}


### PR DESCRIPTION
- MyBatis Adjustments
- ExternalTask is saved & Create Time is persisted
- orderByCreateTime works with ASC & DESC Order
- HistoryExternalTaskLog uses CreateTime

Related-to: #3923, #3896 