### PR TITLE
chore(engine): Add Support for skipIoMappings

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/runtime/batch/DeleteProcessInstancesDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/runtime/batch/DeleteProcessInstancesDto.java
@@ -31,6 +31,7 @@ public class DeleteProcessInstancesDto {
   protected boolean skipCustomListeners;
   protected HistoricProcessInstanceQueryDto historicProcessInstanceQuery;
   protected boolean skipSubprocesses;
+  protected boolean skipIoMappings;
 
   public List<String> getProcessInstanceIds() {
     return processInstanceIds;
@@ -78,6 +79,14 @@ public class DeleteProcessInstancesDto {
 
   public void setSkipSubprocesses(Boolean skipSubprocesses) {
     this.skipSubprocesses = skipSubprocesses;
+  }
+
+  public boolean isSkipIoMappings() {
+    return skipIoMappings;
+  }
+
+  public void setSkipIoMappings(boolean skipIoMappings) {
+    this.skipIoMappings = skipIoMappings;
   }
 
 }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/impl/ProcessInstanceRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/impl/ProcessInstanceRestServiceImpl.java
@@ -164,12 +164,14 @@ public class ProcessInstanceRestServiceImpl extends AbstractRestProcessEngineAwa
 
     try {
       Batch batch = runtimeService.deleteProcessInstancesAsync(
-        deleteProcessInstancesDto.getProcessInstanceIds(),
-        null,
-        historicProcessInstanceQuery,
-        deleteProcessInstancesDto.getDeleteReason(),
-        deleteProcessInstancesDto.isSkipCustomListeners(),
-        deleteProcessInstancesDto.isSkipSubprocesses());
+          deleteProcessInstancesDto.getProcessInstanceIds(),
+          null,
+          historicProcessInstanceQuery,
+          deleteProcessInstancesDto.getDeleteReason(),
+          deleteProcessInstancesDto.isSkipCustomListeners(),
+          deleteProcessInstancesDto.isSkipSubprocesses(),
+          deleteProcessInstancesDto.isSkipIoMappings()
+      );
 
       return BatchDto.fromBatch(batch);
     } catch (BadUserRequestException e) {

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ProcessInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ProcessInstanceRestServiceInteractionTest.java
@@ -450,7 +450,9 @@ public class ProcessInstanceRestServiceInteractionTest extends
       any(),
       any(),
       anyBoolean(),
-      anyBoolean()))
+      anyBoolean(),
+      anyBoolean()
+    ))
     .thenReturn(new BatchEntity());
 
     HistoricProcessInstanceQuery mockedHistoricProcessInstanceQuery = mock(HistoricProcessInstanceQueryImpl.class);
@@ -472,7 +474,9 @@ public class ProcessInstanceRestServiceInteractionTest extends
         mockedHistoricProcessInstanceQuery,
         null,
         false,
-        false);
+        false,
+        false
+    );
   }
 
   @Test
@@ -483,7 +487,9 @@ public class ProcessInstanceRestServiceInteractionTest extends
       eq((HistoricProcessInstanceQuery)null),
       any(),
       anyBoolean(),
-      anyBoolean()))
+      anyBoolean(),
+      anyBoolean()
+    ))
     .thenReturn(new BatchEntity());
 
     DeleteProcessInstancesDto body = new DeleteProcessInstancesDto();
@@ -502,7 +508,9 @@ public class ProcessInstanceRestServiceInteractionTest extends
       null,
       null,
       false,
-      false);
+      false,
+      false
+    );
   }
 
   @Test
@@ -513,7 +521,9 @@ public class ProcessInstanceRestServiceInteractionTest extends
       any(),
       any(),
       anyBoolean(),
-      anyBoolean()))
+      anyBoolean(),
+      anyBoolean()
+    ))
     .thenReturn(new BatchEntity());
 
     HistoricProcessInstanceQuery mockedHistoricProcessInstanceQuery = mock(HistoricProcessInstanceQueryImpl.class);
@@ -536,7 +546,9 @@ public class ProcessInstanceRestServiceInteractionTest extends
       mockedHistoricProcessInstanceQuery,
       null,
       false,
-      false);
+      false,
+      false
+    );
   }
 
   @Test
@@ -547,6 +559,7 @@ public class ProcessInstanceRestServiceInteractionTest extends
         eq((ProcessInstanceQuery)null),
         eq((HistoricProcessInstanceQuery)null),
         any(),
+        anyBoolean(),
         anyBoolean(),
         anyBoolean());
 
@@ -563,7 +576,9 @@ public class ProcessInstanceRestServiceInteractionTest extends
         null,
         null,
         false,
-        false);
+        false,
+        false
+    );
   }
 
   @Test
@@ -574,7 +589,9 @@ public class ProcessInstanceRestServiceInteractionTest extends
       any(),
       any(),
       anyBoolean(),
-      anyBoolean()))
+      anyBoolean(),
+      anyBoolean()
+    ))
     .thenReturn(new BatchEntity());
 
     DeleteProcessInstancesDto body = new DeleteProcessInstancesDto();
@@ -593,7 +610,9 @@ public class ProcessInstanceRestServiceInteractionTest extends
         null,
         MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_DELETE_REASON,
         false,
-        false);
+        false,
+        false
+    );
   }
 
   @Test
@@ -604,7 +623,9 @@ public class ProcessInstanceRestServiceInteractionTest extends
       any(),
       any(),
       anyBoolean(),
-      anyBoolean()))
+      anyBoolean(),
+      anyBoolean()
+    ))
     .thenReturn(new BatchEntity());
 
     DeleteProcessInstancesDto body = new DeleteProcessInstancesDto();
@@ -623,7 +644,9 @@ public class ProcessInstanceRestServiceInteractionTest extends
       null,
       null,
       true,
-      false);
+      false,
+      false
+    );
   }
 
   @Test
@@ -634,7 +657,9 @@ public class ProcessInstanceRestServiceInteractionTest extends
       eq((HistoricProcessInstanceQuery)null),
       any(),
       anyBoolean(),
-      anyBoolean()))
+      anyBoolean(),
+      anyBoolean()
+    ))
     .thenReturn(new BatchEntity());
 
     DeleteProcessInstancesDto body = new DeleteProcessInstancesDto();
@@ -653,7 +678,9 @@ public class ProcessInstanceRestServiceInteractionTest extends
       null,
       null,
       false,
-      true);
+      true,
+      false
+    );
   }
 
   @Test

--- a/engine/src/main/java/org/camunda/bpm/engine/RuntimeService.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/RuntimeService.java
@@ -670,6 +670,7 @@ public interface RuntimeService {
    * @param deleteReason reason for deleting, which will be stored in the history. Can be null.
    * @param skipCustomListeners skips custom execution listeners when removing instances
    * @param skipSubprocesses skips subprocesses when removing instances
+   * @param skipIoMappings specifies whether input/output mappings for tasks should be invoked
    *
    * @throws BadUserRequestException
    *          when no process instance is found with the given queries or ids.
@@ -682,7 +683,8 @@ public interface RuntimeService {
                                     HistoricProcessInstanceQuery historicProcessInstanceQuery,
                                     String deleteReason,
                                     boolean skipCustomListeners,
-                                    boolean skipSubprocesses);
+                                    boolean skipSubprocesses,
+                                    boolean skipIoMappings);
 
   /**
    * Delete an existing runtime process instances asynchronously using Batch operation.
@@ -799,7 +801,7 @@ public interface RuntimeService {
    * @param externallyTerminated indicator if deletion triggered from external context, for instance
    *                             REST API call
    * @param skipSubprocesses specifies whether subprocesses should be deleted
-   *
+   * @param skipIoMappings specifies whether input/output mappings for tasks should be invoked
    *
    * @throws BadUserRequestException
    *          when a processInstanceId is null.
@@ -810,7 +812,7 @@ public interface RuntimeService {
    *          or no {@link Permissions#DELETE_INSTANCE} permission on {@link Resources#PROCESS_DEFINITION}.
    */
   void deleteProcessInstances(List<String> processInstanceIds, String deleteReason, boolean skipCustomListeners, boolean externallyTerminated,
-  boolean skipSubprocesses);
+                              boolean skipSubprocesses, boolean skipIoMappings);
 
   /**
    * Delete existing runtime process instances.

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/RuntimeServiceImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/RuntimeServiceImpl.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.camunda.bpm.engine.BadUserRequestException;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.RuntimeService;
@@ -46,7 +45,6 @@ import org.camunda.bpm.engine.impl.cmd.ResolveIncidentCmd;
 import org.camunda.bpm.engine.impl.cmd.SetAnnotationForIncidentCmd;
 import org.camunda.bpm.engine.impl.cmd.SetExecutionVariablesCmd;
 import org.camunda.bpm.engine.impl.cmd.SignalCmd;
-import org.camunda.bpm.engine.impl.cmd.batch.CorrelateAllMessageBatchCmd;
 import org.camunda.bpm.engine.impl.cmd.batch.DeleteProcessInstanceBatchCmd;
 import org.camunda.bpm.engine.impl.cmd.batch.variables.SetVariablesToProcessInstancesBatchCmd;
 import org.camunda.bpm.engine.impl.migration.MigrationPlanBuilderImpl;
@@ -200,19 +198,38 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
   }
 
   @Override
-  public Batch deleteProcessInstancesAsync(List<String> processInstanceIds, ProcessInstanceQuery processInstanceQuery, String deleteReason, boolean skipCustomListeners, boolean skipSubprocesses) {
-    return commandExecutor.execute(new DeleteProcessInstanceBatchCmd(processInstanceIds,
-        processInstanceQuery, null, deleteReason, skipCustomListeners, skipSubprocesses));
+  public Batch deleteProcessInstancesAsync(List<String> processInstanceIds, ProcessInstanceQuery processInstanceQuery, String deleteReason,
+                                           boolean skipCustomListeners, boolean skipSubprocesses) {
+
+    return commandExecutor.execute(new DeleteProcessInstanceBatchCmd(
+        processInstanceIds,
+        processInstanceQuery,
+        null,
+        deleteReason,
+        skipCustomListeners,
+        skipSubprocesses,
+        false
+    ));
   }
 
   @Override
   public Batch deleteProcessInstancesAsync(List<String> processInstanceIds,
                                            ProcessInstanceQuery processInstanceQuery,
                                            HistoricProcessInstanceQuery historicProcessInstanceQuery,
-                                           String deleteReason, boolean skipCustomListeners, boolean skipSubprocesses) {
-    return commandExecutor.execute(new DeleteProcessInstanceBatchCmd(processInstanceIds,
-        processInstanceQuery, historicProcessInstanceQuery,
-        deleteReason, skipCustomListeners, skipSubprocesses));
+                                           String deleteReason,
+                                           boolean skipCustomListeners,
+                                           boolean skipSubprocesses,
+                                           boolean skipIoMappings
+  ) {
+    return commandExecutor.execute(new DeleteProcessInstanceBatchCmd(
+        processInstanceIds,
+        processInstanceQuery,
+        historicProcessInstanceQuery,
+        deleteReason,
+        skipCustomListeners,
+        skipSubprocesses,
+        skipIoMappings
+    ));
   }
 
   @Override
@@ -242,18 +259,17 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
 
   @Override
   public void deleteProcessInstances(List<String> processInstanceIds, String deleteReason, boolean skipCustomListeners, boolean externallyTerminated){
-    deleteProcessInstances(processInstanceIds, deleteReason, skipCustomListeners, externallyTerminated, false);
+    deleteProcessInstances(processInstanceIds, deleteReason, skipCustomListeners, externallyTerminated, false, false);
   }
 
   @Override
-  public void deleteProcessInstances(List<String> processInstanceIds, String deleteReason, boolean skipCustomListeners, boolean externallyTerminated, boolean skipSubprocesses){
-    commandExecutor.execute(new DeleteProcessInstancesCmd(processInstanceIds, deleteReason, skipCustomListeners, externallyTerminated, skipSubprocesses, true));
+  public void deleteProcessInstances(List<String> processInstanceIds, String deleteReason, boolean skipCustomListeners, boolean externallyTerminated, boolean skipSubprocesses, boolean skipIoMappings){
+    commandExecutor.execute(new DeleteProcessInstancesCmd(processInstanceIds, deleteReason, skipCustomListeners, externallyTerminated, skipSubprocesses, true, skipIoMappings));
   }
 
   @Override
-  public void deleteProcessInstancesIfExists(List<String> processInstanceIds, String deleteReason, boolean skipCustomListeners, boolean externallyTerminated,
-      boolean skipSubprocesses) {
-    commandExecutor.execute(new DeleteProcessInstancesCmd(processInstanceIds, deleteReason, skipCustomListeners, externallyTerminated, skipSubprocesses, false));
+  public void deleteProcessInstancesIfExists(List<String> processInstanceIds, String deleteReason, boolean skipCustomListeners, boolean externallyTerminated, boolean skipSubprocesses) {
+    commandExecutor.execute(new DeleteProcessInstancesCmd(processInstanceIds, deleteReason, skipCustomListeners, externallyTerminated, skipSubprocesses, false, false));
   }
 
   @Override

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/deletion/DeleteProcessInstanceBatchConfiguration.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/deletion/DeleteProcessInstanceBatchConfiguration.java
@@ -31,24 +31,28 @@ import org.camunda.bpm.engine.impl.batch.DeploymentMappings;
  * @see org.camunda.bpm.engine.impl.batch.deletion.DeleteProcessInstanceBatchConfigurationJsonConverter
  */
 public class DeleteProcessInstanceBatchConfiguration extends BatchConfiguration {
+
   protected String deleteReason;
   protected boolean skipCustomListeners;
   protected boolean skipSubprocesses;
+  protected boolean skipIoMappings;
 
   public DeleteProcessInstanceBatchConfiguration(List<String> ids, DeploymentMappings mappings, boolean skipCustomListeners, boolean skipSubprocesses) {
-    this(ids, mappings, null, skipCustomListeners, skipSubprocesses, true);
+    this(ids, mappings, null, skipCustomListeners, skipSubprocesses, true, false);
   }
 
   public DeleteProcessInstanceBatchConfiguration(List<String> ids, DeploymentMappings mappings, String deleteReason, boolean skipCustomListeners) {
-    this(ids, mappings, deleteReason, skipCustomListeners, true, true);
+    this(ids, mappings, deleteReason, skipCustomListeners, true, true, false);
   }
 
-  public DeleteProcessInstanceBatchConfiguration(List<String> ids, DeploymentMappings mappings, String deleteReason, boolean skipCustomListeners, boolean skipSubprocesses, boolean failIfNotExists) {
+  public DeleteProcessInstanceBatchConfiguration(List<String> ids, DeploymentMappings mappings, String deleteReason, boolean skipCustomListeners,
+                                                 boolean skipSubprocesses, boolean failIfNotExists, boolean skipIoMappings) {
     super(ids, mappings);
     this.deleteReason = deleteReason;
     this.skipCustomListeners = skipCustomListeners;
     this.skipSubprocesses = skipSubprocesses;
     this.failIfNotExists = failIfNotExists;
+    this.skipIoMappings = skipIoMappings;
   }
 
   public String getDeleteReason() {
@@ -69,6 +73,14 @@ public class DeleteProcessInstanceBatchConfiguration extends BatchConfiguration 
 
   public void setSkipSubprocesses(boolean skipSubprocesses) {
     this.skipSubprocesses = skipSubprocesses;
+  }
+
+  public boolean isSkipIoMappings() {
+    return skipIoMappings;
+  }
+
+  public void setSkipIoMappings(boolean skipIoMappings) {
+    this.skipIoMappings = skipIoMappings;
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/deletion/DeleteProcessInstanceBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/deletion/DeleteProcessInstanceBatchConfigurationJsonConverter.java
@@ -40,6 +40,8 @@ public class DeleteProcessInstanceBatchConfigurationJsonConverter
   public static final String PROCESS_INSTANCE_ID_MAPPINGS = "processInstanceIdMappings";
   public static final String SKIP_CUSTOM_LISTENERS = "skipCustomListeners";
   public static final String SKIP_SUBPROCESSES = "skipSubprocesses";
+  public static final String SKIP_IO_MAPPINGS = "skipIoMappings";
+
   public static final String FAIL_IF_NOT_EXISTS = "failIfNotExists";
 
   @Override
@@ -52,15 +54,22 @@ public class DeleteProcessInstanceBatchConfigurationJsonConverter
     JsonUtil.addField(json, SKIP_CUSTOM_LISTENERS, configuration.isSkipCustomListeners());
     JsonUtil.addField(json, SKIP_SUBPROCESSES, configuration.isSkipSubprocesses());
     JsonUtil.addField(json, FAIL_IF_NOT_EXISTS, configuration.isFailIfNotExists());
+    JsonUtil.addField(json, SKIP_IO_MAPPINGS, configuration.isSkipIoMappings());
+
     return json;
   }
 
   @Override
   public DeleteProcessInstanceBatchConfiguration readConfiguration(JsonObject json) {
-    DeleteProcessInstanceBatchConfiguration configuration =
-      new DeleteProcessInstanceBatchConfiguration(readProcessInstanceIds(json), readIdMappings(json), null,
-          JsonUtil.getBoolean(json, SKIP_CUSTOM_LISTENERS), JsonUtil.getBoolean(json, SKIP_SUBPROCESSES),
-          JsonUtil.getBoolean(json, FAIL_IF_NOT_EXISTS));
+    DeleteProcessInstanceBatchConfiguration configuration = new DeleteProcessInstanceBatchConfiguration(
+        readProcessInstanceIds(json),
+        readIdMappings(json),
+        null,
+        JsonUtil.getBoolean(json, SKIP_CUSTOM_LISTENERS),
+        JsonUtil.getBoolean(json, SKIP_SUBPROCESSES),
+        JsonUtil.getBoolean(json, FAIL_IF_NOT_EXISTS),
+        JsonUtil.getBoolean(json, SKIP_IO_MAPPINGS)
+    );
 
     String deleteReason = JsonUtil.getString(json, DELETE_REASON);
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/deletion/DeleteProcessInstancesJobHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/deletion/DeleteProcessInstancesJobHandler.java
@@ -18,14 +18,13 @@ package org.camunda.bpm.engine.impl.batch.deletion;
 
 import java.util.HashSet;
 import java.util.List;
-
 import org.camunda.bpm.engine.batch.Batch;
 import org.camunda.bpm.engine.impl.ProcessInstanceQueryImpl;
 import org.camunda.bpm.engine.impl.batch.AbstractBatchJobHandler;
+import org.camunda.bpm.engine.impl.batch.BatchElementConfiguration;
 import org.camunda.bpm.engine.impl.batch.BatchEntity;
 import org.camunda.bpm.engine.impl.batch.BatchJobContext;
 import org.camunda.bpm.engine.impl.batch.BatchJobDeclaration;
-import org.camunda.bpm.engine.impl.batch.BatchElementConfiguration;
 import org.camunda.bpm.engine.impl.cmd.DeleteProcessInstancesCmd;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.jobexecutor.JobDeclaration;
@@ -55,7 +54,15 @@ public class DeleteProcessInstancesJobHandler extends AbstractBatchJobHandler<De
 
   @Override
   protected DeleteProcessInstanceBatchConfiguration createJobConfiguration(DeleteProcessInstanceBatchConfiguration configuration, List<String> processIdsForJob) {
-    return new DeleteProcessInstanceBatchConfiguration(processIdsForJob, null, configuration.getDeleteReason(), configuration.isSkipCustomListeners(), configuration.isSkipSubprocesses(), configuration.isFailIfNotExists());
+    return new DeleteProcessInstanceBatchConfiguration(
+        processIdsForJob,
+        null,
+        configuration.getDeleteReason(),
+        configuration.isSkipCustomListeners(),
+        configuration.isSkipSubprocesses(),
+        configuration.isFailIfNotExists(),
+        configuration.isSkipIoMappings()
+    );
   }
 
   @Override
@@ -71,7 +78,9 @@ public class DeleteProcessInstancesJobHandler extends AbstractBatchJobHandler<De
             batchConfiguration.isSkipCustomListeners(),
             true,
             batchConfiguration.isSkipSubprocesses(),
-            batchConfiguration.isFailIfNotExists()));
+            batchConfiguration.isFailIfNotExists(),
+            batchConfiguration.isSkipIoMappings()
+        ));
   }
 
   @Override

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AbstractDeleteProcessInstanceCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AbstractDeleteProcessInstanceCmd.java
@@ -54,6 +54,7 @@ public abstract class AbstractDeleteProcessInstanceCmd {
   protected boolean skipCustomListeners;
   protected boolean skipSubprocesses;
   protected boolean failIfNotExists = true;
+  protected boolean skipIoMappings;
 
   protected void checkDeleteProcessInstance(ExecutionEntity execution, CommandContext commandContext) {
     for (CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
@@ -68,7 +69,8 @@ public abstract class AbstractDeleteProcessInstanceCmd {
       final boolean skipCustomListeners,
       final boolean externallyTerminated,
       final boolean skipIoMappings,
-      boolean skipSubprocesses) {
+      boolean skipSubprocesses
+  ) {
     ensureNotNull(BadUserRequestException.class, "processInstanceId is null", "processInstanceId", processInstanceId);
 
     // fetch process instance
@@ -87,7 +89,8 @@ public abstract class AbstractDeleteProcessInstanceCmd {
     // delete process instance
     commandContext
         .getExecutionManager()
-        .deleteProcessInstance(processInstanceId, deleteReason, false, skipCustomListeners, externallyTerminated, skipIoMappings, skipSubprocesses);
+        .deleteProcessInstance(processInstanceId, deleteReason, false, skipCustomListeners,
+            externallyTerminated, skipIoMappings, skipSubprocesses);
 
     if (skipSubprocesses) {
       List<ProcessInstance> superProcesslist = commandContext.getProcessEngineConfiguration().getRuntimeService().createProcessInstanceQuery()

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteProcessInstancesCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteProcessInstancesCmd.java
@@ -16,11 +16,10 @@
  */
 package org.camunda.bpm.engine.impl.cmd;
 
-import org.camunda.bpm.engine.impl.interceptor.Command;
-import org.camunda.bpm.engine.impl.interceptor.CommandContext;
-
 import java.io.Serializable;
 import java.util.List;
+import org.camunda.bpm.engine.impl.interceptor.Command;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 
 
 /**
@@ -31,8 +30,9 @@ public class DeleteProcessInstancesCmd extends AbstractDeleteProcessInstanceCmd 
   private static final long serialVersionUID = 1L;
   protected List<String> processInstanceIds;
 
-  public DeleteProcessInstancesCmd(List<String> processInstanceIds, String deleteReason, boolean skipCustomListeners, boolean externallyTerminated,
-      boolean skipSubprocesses, boolean failIfNotExists) {
+  public DeleteProcessInstancesCmd(List<String> processInstanceIds, String deleteReason, boolean skipCustomListeners,
+                                   boolean externallyTerminated, boolean skipSubprocesses, boolean failIfNotExists,
+                                   boolean skipIoMappings) {
 
     this.processInstanceIds = processInstanceIds;
     this.deleteReason = deleteReason;
@@ -40,11 +40,21 @@ public class DeleteProcessInstancesCmd extends AbstractDeleteProcessInstanceCmd 
     this.externallyTerminated = externallyTerminated;
     this.skipSubprocesses = skipSubprocesses;
     this.failIfNotExists = failIfNotExists;
+    this.skipIoMappings = skipIoMappings;
   }
 
   public Void execute(CommandContext commandContext) {
     for (String processInstanceId : this.processInstanceIds) {
-      deleteProcessInstance(commandContext, processInstanceId, deleteReason, skipCustomListeners, externallyTerminated, false, skipSubprocesses);
+
+      deleteProcessInstance(
+          commandContext,
+          processInstanceId,
+          deleteReason,
+          skipCustomListeners,
+          externallyTerminated,
+          skipIoMappings,
+          skipSubprocesses
+      );
     }
     return null;
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/batch/DeleteProcessInstanceBatchCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/batch/DeleteProcessInstanceBatchCmd.java
@@ -49,20 +49,24 @@ public class DeleteProcessInstanceBatchCmd implements Command<Batch> {
   protected HistoricProcessInstanceQuery historicProcessInstanceQuery;
   protected boolean skipCustomListeners;
   protected boolean skipSubprocesses;
+  protected boolean skipIoMappings;
 
   public DeleteProcessInstanceBatchCmd(List<String> processInstances,
                                        ProcessInstanceQuery processInstanceQuery,
                                        HistoricProcessInstanceQuery historicProcessInstanceQuery,
                                        String deleteReason,
                                        boolean skipCustomListeners,
-                                       boolean skipSubprocesses) {
+                                       boolean skipSubprocesses,
+                                       boolean skipIoMappings) {
     super();
+
     this.processInstanceIds = processInstances;
     this.processInstanceQuery = processInstanceQuery;
     this.historicProcessInstanceQuery = historicProcessInstanceQuery;
     this.deleteReason = deleteReason;
     this.skipCustomListeners = skipCustomListeners;
     this.skipSubprocesses = skipSubprocesses;
+    this.skipIoMappings = skipIoMappings;
   }
 
   @Override
@@ -124,7 +128,7 @@ public class DeleteProcessInstanceBatchCmd implements Command<Batch> {
 
   public BatchConfiguration getConfiguration(BatchElementConfiguration elementConfiguration) {
     return new DeleteProcessInstanceBatchConfiguration(elementConfiguration.getIds(), elementConfiguration.getMappings(),
-        deleteReason, skipCustomListeners, skipSubprocesses, false);
+        deleteReason, skipCustomListeners, skipSubprocesses, false, skipIoMappings);
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/RuntimeServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/RuntimeServiceAsyncOperationsTest.java
@@ -265,7 +265,7 @@ public class RuntimeServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
 
     // when
     Batch batch = runtimeService.deleteProcessInstancesAsync(null, null,
-        historicProcessInstanceQuery, "", false, false);
+        historicProcessInstanceQuery, "", false, false, false);
 
     completeSeedJobs(batch);
     executeBatchJobs(batch);
@@ -292,7 +292,7 @@ public class RuntimeServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
 
     // when
     Batch batch = runtimeService.deleteProcessInstancesAsync(null, processInstanceQuery,
-        historicProcessInstanceQuery, "", false, false);
+        historicProcessInstanceQuery, "", false, false, false);
 
     completeSeedJobs(batch);
     executeBatchJobs(batch);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/RuntimeServiceTest.java
@@ -531,7 +531,7 @@ public class RuntimeServiceTest {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
     try {
-      runtimeService.deleteProcessInstances(Arrays.asList(instance.getId(), "aFake"), "test", false, false, false);
+      runtimeService.deleteProcessInstances(Arrays.asList(instance.getId(), "aFake"), "test", false, false, false, false);
       fail("ProcessEngineException expected");
     }catch (ProcessEngineException e) {
       //expected
@@ -3255,7 +3255,7 @@ public class RuntimeServiceTest {
     subprocessList.addAll(runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance2.getId()).list());
 
     // when
-    runtimeService.deleteProcessInstances(Arrays.asList(processInstance.getId(), processInstance2.getId()), null, false, false, true);
+    runtimeService.deleteProcessInstances(Arrays.asList(processInstance.getId(), processInstance2.getId()), null, false, false, true, false);
 
     // then
     testRule.assertProcessEnded(processInstance.getId());
@@ -3281,7 +3281,7 @@ public class RuntimeServiceTest {
     subprocessList.addAll(runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance2.getId()).list());
 
     // when
-    runtimeService.deleteProcessInstances(Arrays.asList(processInstance.getId(), processInstance2.getId()), null, false, false, false);
+    runtimeService.deleteProcessInstances(Arrays.asList(processInstance.getId(), processInstance2.getId()), null, false, false, false, false);
 
     // then
     testRule.assertProcessEnded(processInstance.getId());


### PR DESCRIPTION
Parameter is added to

- deleteProcessInstances, deleteProcessInstancesAsync
- The respective DeleteBatch commands that the methods issue and their config