### PR TITLE
fix(spring-boot): avoid logging admin user on `INFO`

### DIFF
--- a/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/configuration/impl/custom/CreateAdminUserConfiguration.java
+++ b/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/configuration/impl/custom/CreateAdminUserConfiguration.java
@@ -105,8 +105,4 @@ public class CreateAdminUserConfiguration extends AbstractCamundaConfiguration {
     return newUser;
   }
 
-  @Override
-  public String toString() {
-    return createToString(Collections.singletonMap("adminUser", adminUser));
-  }
 }

--- a/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/util/SpringBootProcessEngineLogger.java
+++ b/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/util/SpringBootProcessEngineLogger.java
@@ -35,11 +35,11 @@ public class SpringBootProcessEngineLogger extends BaseLogger {
   public static final SpringBootProcessEngineLogger LOG = createLogger(SpringBootProcessEngineLogger.class, PROJECT_CODE, PACKAGE, PROJECT_ID);
 
   public void creatingInitialAdminUser(User adminUser) {
-    logInfo("010", "Creating initial Admin User: {}", adminUser);
+    logDebug("010", "Creating initial Admin User: {}", adminUser);
   }
 
   public void skipAdminUserCreation(User existingUser) {
-    logInfo("011", "Skip creating initial Admin User, user does exist: {}", existingUser);
+    logDebug("011", "Skip creating initial Admin User, user does exist: {}", existingUser);
   }
 
   public void createInitialFilter(Filter filter) {


### PR DESCRIPTION
Logs admin user on `DEBUG`.

related to camunda/camunda-bpm-platform#3956