### PR TITLE
feat(client): Enable Extension of TopicSubscriptionManager for custom task polling

### DIFF
--- a/clients/java/client/src/main/java/org/camunda/bpm/client/ExternalTaskClientBuilder.java
+++ b/clients/java/client/src/main/java/org/camunda/bpm/client/ExternalTaskClientBuilder.java
@@ -20,6 +20,7 @@ import org.camunda.bpm.client.backoff.BackoffStrategy;
 import org.camunda.bpm.client.backoff.ExponentialBackoffStrategy;
 import org.camunda.bpm.client.exception.ExternalTaskClientException;
 import org.camunda.bpm.client.interceptor.ClientRequestInterceptor;
+import org.camunda.bpm.client.topic.impl.TopicSubscriptionManager;
 
 /**
  * <p>A fluent builder to configure the Camunda client</p>
@@ -140,6 +141,8 @@ public interface ExternalTaskClientBuilder {
    * @return the builder
    */
   ExternalTaskClientBuilder disableBackoffStrategy();
+
+  ExternalTaskClientBuilder topicSubscriptionManager(TopicSubscriptionManager topicSubscriptionManager);
 
   /**
    * Bootstraps the Camunda client

--- a/clients/java/client/src/main/java/org/camunda/bpm/client/impl/ExternalTaskClientBuilderImpl.java
+++ b/clients/java/client/src/main/java/org/camunda/bpm/client/impl/ExternalTaskClientBuilderImpl.java
@@ -35,6 +35,7 @@ import org.camunda.bpm.client.interceptor.impl.RequestInterceptorHandler;
 import org.camunda.bpm.client.spi.DataFormat;
 import org.camunda.bpm.client.spi.DataFormatConfigurator;
 import org.camunda.bpm.client.spi.DataFormatProvider;
+import org.camunda.bpm.client.task.impl.ExternalTaskServiceImpl;
 import org.camunda.bpm.client.topic.impl.TopicSubscriptionManager;
 import org.camunda.bpm.client.variable.impl.DefaultValueMappers;
 import org.camunda.bpm.client.variable.impl.TypedValues;
@@ -146,6 +147,11 @@ public class ExternalTaskClientBuilderImpl implements ExternalTaskClientBuilder 
 
   public ExternalTaskClientBuilder disableBackoffStrategy() {
     this.isBackoffStrategyDisabled = true;
+    return this;
+  }
+
+  public ExternalTaskClientBuilder topicSubscriptionManager(TopicSubscriptionManager topicSubscriptionManager) {
+    this.topicSubscriptionManager = topicSubscriptionManager;
     return this;
   }
 
@@ -267,7 +273,14 @@ public class ExternalTaskClientBuilderImpl implements ExternalTaskClientBuilder 
   }
 
   protected void initTopicSubscriptionManager() {
-    topicSubscriptionManager = new TopicSubscriptionManager(engineClient, typedValues, lockDuration);
+    if (topicSubscriptionManager!=null){
+      topicSubscriptionManager.setClientLockDuration(lockDuration);
+      topicSubscriptionManager.setEngineClient(engineClient);
+      topicSubscriptionManager.setTypedValues(typedValues);
+      topicSubscriptionManager.setExternalTaskService(new ExternalTaskServiceImpl(engineClient));
+    }else {
+      topicSubscriptionManager = new TopicSubscriptionManager(engineClient, typedValues, lockDuration);
+    }
     topicSubscriptionManager.setBackoffStrategy(getBackoffStrategy());
 
     if (isBackoffStrategyDisabled) {

--- a/clients/java/client/src/main/java/org/camunda/bpm/client/topic/impl/TopicSubscriptionManager.java
+++ b/clients/java/client/src/main/java/org/camunda/bpm/client/topic/impl/TopicSubscriptionManager.java
@@ -71,6 +71,13 @@ public class TopicSubscriptionManager implements Runnable {
 
   protected long clientLockDuration;
 
+  public TopicSubscriptionManager(){
+    this.subscriptions = new CopyOnWriteArrayList<>();
+    this.taskTopicRequests = new ArrayList<>();
+    this.externalTaskHandlers = new HashMap<>();
+    this.isBackoffStrategyDisabled = new AtomicBoolean(false);
+  }
+
   public TopicSubscriptionManager(EngineClient engineClient, TypedValues typedValues, long clientLockDuration) {
     this.engineClient = engineClient;
     this.subscriptions = new CopyOnWriteArrayList<>();
@@ -207,6 +214,22 @@ public class TopicSubscriptionManager implements Runnable {
 
   public void setBackoffStrategy(BackoffStrategy backOffStrategy) {
     this.backoffStrategy = backOffStrategy;
+  }
+
+  public void setEngineClient(EngineClient engineClient) {
+    this.engineClient = engineClient;
+  }
+
+  public void setTypedValues(TypedValues typedValues) {
+    this.typedValues = typedValues;
+  }
+
+  public void setClientLockDuration(long clientLockDuration) {
+    this.clientLockDuration = clientLockDuration;
+  }
+
+  public void setExternalTaskService(ExternalTaskServiceImpl externalTaskService) {
+    this.externalTaskService = externalTaskService;
   }
 
   protected void runBackoffStrategy(FetchAndLockResponseDto fetchAndLockResponse) {

--- a/spring-boot-starter/starter-client/spring/src/main/java/org/camunda/bpm/client/spring/impl/client/ClientFactory.java
+++ b/spring-boot-starter/starter-client/spring/src/main/java/org/camunda/bpm/client/spring/impl/client/ClientFactory.java
@@ -25,6 +25,7 @@ import org.camunda.bpm.client.backoff.BackoffStrategy;
 import org.camunda.bpm.client.interceptor.ClientRequestInterceptor;
 
 import org.camunda.bpm.client.spring.impl.client.util.ClientLoggerUtil;
+import org.camunda.bpm.client.topic.impl.TopicSubscriptionManager;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +42,7 @@ public class ClientFactory
   protected ClientConfiguration clientConfiguration;
 
   protected BackoffStrategy backoffStrategy;
+  protected TopicSubscriptionManager topicSubscriptionManager;
   protected List<ClientRequestInterceptor> requestInterceptors = new ArrayList<>();
 
   protected ExternalTaskClient client;
@@ -89,6 +91,9 @@ public class ClientFactory
       if (backoffStrategy != null) {
         clientBuilder.backoffStrategy(backoffStrategy);
       }
+      if (topicSubscriptionManager!=null){
+        clientBuilder.topicSubscriptionManager(topicSubscriptionManager);
+      }
       client = clientBuilder.build();
     }
 
@@ -113,6 +118,12 @@ public class ClientFactory
   public void setClientBackoffStrategy(BackoffStrategy backoffStrategy) {
     this.backoffStrategy = backoffStrategy;
     LOG.backoffStrategyFound();
+  }
+
+  @Autowired(required = false)
+  public void setClientTopicSubscriptionManager(TopicSubscriptionManager topicSubscriptionManager){
+    this.topicSubscriptionManager = topicSubscriptionManager;
+    LOG.topicSubscriptionManagerFound();
   }
 
   @Override

--- a/spring-boot-starter/starter-client/spring/src/main/java/org/camunda/bpm/client/spring/impl/client/util/ClientLoggerUtil.java
+++ b/spring-boot-starter/starter-client/spring/src/main/java/org/camunda/bpm/client/spring/impl/client/util/ClientLoggerUtil.java
@@ -55,4 +55,8 @@ public class ClientLoggerUtil extends LoggerUtil {
             "when only one matching client annotation was expected."));
   }
 
+  public void topicSubscriptionManagerFound(){
+    logDebug("008", "Client topic subscription manager found");
+  }
+
 }


### PR DESCRIPTION
This pull request addresses Part 1 of the enhancement to enable custom task polling in the TopicSubscriptionManager class. The changes introduced in this pull request allow users to extend the TopicSubscriptionManager and override the task polling logic with their custom implementation, so if there was a Bean with their implementation, the client use their custom implementation.

Related to #3962 