### PR TITLE
chore(engine-rest, clients): Change sorting param

### DIFF
--- a/clients/java/client/src/main/java/org/camunda/bpm/client/topic/impl/dto/FetchAndLockRequestDto.java
+++ b/clients/java/client/src/main/java/org/camunda/bpm/client/topic/impl/dto/FetchAndLockRequestDto.java
@@ -32,7 +32,7 @@ public class FetchAndLockRequestDto extends RequestDto {
   protected boolean usePriority;
   protected Long asyncResponseTimeout;
   protected List<TopicRequestDto> topics;
-  protected List<SortingDto> sortings;
+  protected List<SortingDto> sorting;
 
   public FetchAndLockRequestDto(String workerId, int maxTasks, Long asyncResponseTimeout, List<TopicRequestDto> topics) {
     this(workerId, maxTasks, asyncResponseTimeout, topics, true);
@@ -50,7 +50,7 @@ public class FetchAndLockRequestDto extends RequestDto {
     this.usePriority = usePriority;
     this.asyncResponseTimeout = asyncResponseTimeout;
     this.topics = topics;
-    this.sortings = orderingConfig.toSortingDtos();
+    this.sorting = orderingConfig.toSortingDtos();
   }
 
   public int getMaxTasks() {
@@ -69,12 +69,12 @@ public class FetchAndLockRequestDto extends RequestDto {
     return asyncResponseTimeout;
   }
 
-  public List<SortingDto> getSortings() {
-    return sortings;
+  public List<SortingDto> getSorting() {
+    return sorting;
   }
 
-  public void setSortings(List<SortingDto> sortings) {
-    this.sortings = sortings;
+  public void setSorting(List<SortingDto> sorting) {
+    this.sorting = sorting;
   }
 
 }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/externaltask/FetchExternalTasksDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/externaltask/FetchExternalTasksDto.java
@@ -43,7 +43,7 @@ public class FetchExternalTasksDto {
   protected List<FetchExternalTaskTopicDto> topics;
   protected boolean includeExtensionProperties = false;
 
-  protected List<SortingDto> sortings;
+  protected List<SortingDto> sorting;
 
   public int getMaxTasks() {
     return maxTasks;
@@ -77,12 +77,12 @@ public class FetchExternalTasksDto {
     this.usePriority = usePriority;
   }
 
-  public void setSortings(List<SortingDto> sortings) {
-    this.sortings = sortings;
+  public void setSorting(List<SortingDto> sorting) {
+    this.sorting = sorting;
   }
 
-  public List<SortingDto> getSortings() {
-    return this.sortings;
+  public List<SortingDto> getSorting() {
+    return this.sorting;
   }
 
   public boolean isIncludeExtensionProperties() {
@@ -283,7 +283,7 @@ public class FetchExternalTasksDto {
         .maxTasks(maxTasks)
         .usePriority(usePriority);
 
-    SortMapper mapper = new SortMapper(sortings, builder);
+    SortMapper mapper = new SortMapper(sorting, builder);
 
     return mapper.getBuilderWithSortConfigs();
   }
@@ -306,11 +306,11 @@ public class FetchExternalTasksDto {
         "desc", FetchAndLockBuilder::desc
     );
 
-    protected final List<SortingDto> sortings;
+    protected final List<SortingDto> sorting;
     protected final FetchAndLockBuilder builder;
 
-    protected SortMapper(List<SortingDto> sortings, FetchAndLockBuilder builder) {
-      this.sortings = (sortings == null) ? Collections.emptyList() : sortings;
+    protected SortMapper(List<SortingDto> sorting, FetchAndLockBuilder builder) {
+      this.sorting = (sorting == null) ? Collections.emptyList() : sorting;
       this.builder = builder;
     }
 
@@ -318,7 +318,7 @@ public class FetchExternalTasksDto {
      * Applies the sorting field mappings to the builder and returns it.
      */
     protected FetchAndLockBuilder getBuilderWithSortConfigs() {
-      sortings.forEach(dto -> {
+      sorting.forEach(dto -> {
         fieldMappingKey(dto).ifPresent(key -> FIELD_MAPPINGS.get(key).accept(builder));
         orderMappingKey(dto).ifPresent(key -> ORDER_MAPPINGS.get(key).accept(builder));
       });

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ExternalTaskRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ExternalTaskRestServiceInteractionTest.java
@@ -360,7 +360,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     parameters.put("maxTasks", 5);
     parameters.put("workerId", "aWorkerId");
     parameters.put("usePriority", false);
-    parameters.put("sortings", List.of(create("createTime", "desc")));
+    parameters.put("sorting", List.of(create("createTime", "desc")));
 
     Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");
@@ -408,7 +408,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     parameters.put("maxTasks", 5);
     parameters.put("workerId", "aWorkerId");
     parameters.put("usePriority", false);
-    parameters.put("sortings", List.of(create("createTime", null)));
+    parameters.put("sorting", List.of(create("createTime", null)));
 
     Map<String, Object> topicParameter = new HashMap<>();
     topicParameter.put("topicName", "aTopicName");


### PR DESCRIPTION
Description: This commit renames the `sortings` parameter of the FetchAndLock API to `sorting` to match the existing convention of other similar APIs that involve sorting.

Related-to: #4018, #3896