### PR TITLE
chore(integration-tests-engine): Increase Max Job Wait Timeout

### DIFF
--- a/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/util/AbstractFoxPlatformIntegrationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/camunda/bpm/integrationtest/util/AbstractFoxPlatformIntegrationTest.java
@@ -45,6 +45,8 @@ import java.util.logging.Logger;
 
 public abstract class AbstractFoxPlatformIntegrationTest {
 
+  protected static final long JOBS_WAIT_TIMEOUT_MS = 20_000L;
+
   protected Logger logger = Logger.getLogger(AbstractFoxPlatformIntegrationTest.class.getName());
 
   protected ProcessEngineService processEngineService;
@@ -101,7 +103,7 @@ public abstract class AbstractFoxPlatformIntegrationTest {
   }
 
   public void waitForJobExecutorToProcessAllJobs() {
-    waitForJobExecutorToProcessAllJobs(12000);
+    waitForJobExecutorToProcessAllJobs(JOBS_WAIT_TIMEOUT_MS);
   }
 
   public void waitForJobExecutorToProcessAllJobs(long maxMillisToWait) {


### PR DESCRIPTION
Description: Increase max wait-time of all Jobs to finish of class `AbstractFoxPlatformIntegrationTest` from 12 to 20 seconds
Reason: Fix flaky tests which might have spawned jobs that take longer to finish in various Jenkins executions
Context: Wildfly Flakiness

Related-to: #3995