### PR TITLE
Fix inconsistent order of task-listeners execution

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/TaskEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/TaskEntity.java
@@ -1047,7 +1047,16 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
         return resolvedTaskDefinition.getBuiltinTaskListeners(event);
       }
       else {
-        return resolvedTaskDefinition.getTaskListeners(event);
+        List<TaskListener> listeners = new ArrayList<>();
+        List<TaskListener> builtinTaskListeners = resolvedTaskDefinition.getBuiltinTaskListeners(event);
+        if (builtinTaskListeners != null) {
+          listeners.addAll(builtinTaskListeners);
+        }
+        List<TaskListener> taskListeners = resolvedTaskDefinition.getTaskListeners(event);
+        if (taskListeners != null) {
+          listeners.addAll(taskListeners);
+        }
+        return listeners;
       }
     }
     else {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/task/TaskDefinition.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/task/TaskDefinition.java
@@ -172,14 +172,6 @@ public class TaskDefinition {
   }
 
   public void addBuiltInTaskListener(String eventName, TaskListener taskListener) {
-    List<TaskListener> listeners = taskListeners.get(eventName);
-    if (listeners == null) {
-      listeners = new ArrayList<>();
-      taskListeners.put(eventName, listeners);
-    }
-
-    listeners.add(0, taskListener);
-
     CollectionUtil.addToMapOfLists(builtinTaskListeners, eventName, taskListener);
   }
 


### PR DESCRIPTION
**Problem:**

1. Add custom-task listener in parseUserTask of a customPreBPMNParseListener as builtin-tasklistener
1. Add custom-task listener in parseUserTask of a customPostBPMNParseListener as builtin-tasklistener
1. Listener added by customPostBPMNParseListener fires first
1. Listener added by customPreBPMNParseListener fires last

The order of events depends on whether it is a normal execution or on doing a token-jump execution.

**Hint:**

We need to run two task-listeners which are unskipable (builtin-tasklistener) in the order in which they are registered, regardless whether they are executed normal or by token-jump (and selecting "skip custom listeners" in Cockpit). We need them for a custom-tasklist application and also for aspect orientated coding.