### PR TITLE
Fix inconsistent order of task-listeners execution

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/task/TaskDefinition.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/task/TaskDefinition.java
@@ -177,10 +177,14 @@ public class TaskDefinition {
       listeners = new ArrayList<>();
       taskListeners.put(eventName, listeners);
     }
-
     listeners.add(0, taskListener);
 
-    CollectionUtil.addToMapOfLists(builtinTaskListeners, eventName, taskListener);
+    List<TaskListener> builtins = builtinTaskListeners.get(eventName);
+    if (builtins == null) {
+      builtins = new ArrayList<>();
+      builtinTaskListeners.put(eventName, builtins);
+    }
+    builtins.add(0, taskListener);
   }
 
   public void addTimeoutTaskListener(String timeoutId, TaskListener taskListener) {


### PR DESCRIPTION
**Problem:**

1. Add custom-task listener in parseUserTask of a customPreBPMNParseListener as builtin-tasklistener
1. Add custom-task listener in parseUserTask of a customPostBPMNParseListener as builtin-tasklistener
1. Listener added by customPostBPMNParseListener fires first
1. Listener added by customPreBPMNParseListener fires last

The order of events depends on whether it is a normal execution or on doing a process-instance modification execution.

**Since this reversal of the order is already in place since years and some users' applications might rely on that behavior this pull request simply aligns the order of execution in case of a process-instance modification.** This PR replaces the former PR https://github.com/camunda/camunda-bpm-platform/pull/4025 in which the order of listeners was changed for common executions.

**Hint:**

We need to run two task-listeners which are unskipable (builtin-tasklistener) in the order in which they are registered, regardless whether they are executed normal or by token-jump (and selecting "skip custom listeners" in Cockpit). We need them for a custom-tasklist application and also for aspect orientated coding.
