### PR TITLE
chore(engine): adjust TTL warnings

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoryTimeToLiveParser.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoryTimeToLiveParser.java
@@ -110,7 +110,7 @@ public class HistoryTimeToLiveParser {
       }
 
       if (result.hasLongerModelValueThanGlobalConfig()) {
-        LOG.logModelHTTLLongerThanGlobalConfiguration(definitionKey, result.value);
+        LOG.logModelHTTLLongerThanGlobalConfiguration(definitionKey);
       }
     }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoryTimeToLiveParser.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoryTimeToLiveParser.java
@@ -25,7 +25,6 @@ import org.camunda.bpm.engine.exception.NotValidException;
 import org.camunda.bpm.engine.impl.cfg.ConfigurationLogger;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.context.Context;
-import org.camunda.bpm.engine.impl.dmn.entity.repository.DecisionRequirementsDefinitionEntity;
 import org.camunda.bpm.engine.impl.interceptor.CommandContext;
 import org.camunda.bpm.engine.impl.util.ParseUtil;
 import org.camunda.bpm.engine.impl.util.xml.Element;
@@ -118,6 +117,9 @@ public class HistoryTimeToLiveParser {
       if (result.shouldBeLogged()) {
         LOG.logHistoryTimeToLiveDefaultValueWarning(definitionKey);
       }
+      if (result.hasLongerModelValueThanGlobalConfig()) {
+        LOG.logModelHTTLLongerThanGlobalCongig(result.value);
+      }
     }
 
     return result.valueAsInteger;
@@ -143,6 +145,12 @@ public class HistoryTimeToLiveParser {
       return !systemDefaultConfigWillBeUsed // only values originating from models make sense to be logged
           && valueAsInteger != null
           && valueAsInteger == CAMUNDA_MODELER_TTL_DEFAULT_VALUE;
+    }
+
+    protected boolean hasLongerModelValueThanGlobalConfig() {
+      return !systemDefaultConfigWillBeUsed // only values originating from models make sense to be logged
+          && valueAsInteger != null
+          && valueAsInteger > CAMUNDA_MODELER_TTL_DEFAULT_VALUE;
     }
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoryTimeToLiveParser.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoryTimeToLiveParser.java
@@ -33,15 +33,10 @@ import org.camunda.bpm.model.dmn.instance.Decision;
 
 /**
  * Class that encapsulates the business logic of parsing HistoryTimeToLive of different deployable resources (process, definition, case).
- * <p>
- * Furthermore, it considers notifying the users with a logging message when parsing historyTimeToLive values that are
- * the same with the default camunda modeler TTL value (see {@code CAMUNDA_MODELER_TTL_DEFAULT_VALUE}).
  */
 public class HistoryTimeToLiveParser {
 
   protected static final ConfigurationLogger LOG = ConfigurationLogger.CONFIG_LOGGER;
-
-  protected static final int CAMUNDA_MODELER_TTL_DEFAULT_VALUE = 180; // This value is hardcoded into camunda modeler
 
   protected final boolean enforceNonNullValue;
   protected final String httlConfigValue;
@@ -111,11 +106,7 @@ public class HistoryTimeToLiveParser {
 
     if (!skipEnforceTtl) {
       if (result.isInValidAgainstConfig()) {
-        throw new NotValidException("History Time To Live cannot be null");
-      }
-
-      if (result.shouldBeLogged()) {
-        LOG.logHistoryTimeToLiveDefaultValueWarning(definitionKey);
+        throw LOG.logErrorNoTTLConfigured();
       }
 
       if (result.hasLongerModelValueThanGlobalConfig()) {
@@ -142,16 +133,11 @@ public class HistoryTimeToLiveParser {
       return enforceNonNullValue && (valueAsInteger == null);
     }
 
-    protected boolean shouldBeLogged() {
-      return !systemDefaultConfigWillBeUsed // only values originating from models make sense to be logged
-          && valueAsInteger != null
-          && valueAsInteger == CAMUNDA_MODELER_TTL_DEFAULT_VALUE;
-    }
-
     protected boolean hasLongerModelValueThanGlobalConfig() {
       return !systemDefaultConfigWillBeUsed // only values originating from models make sense to be logged
           && valueAsInteger != null
-          && valueAsInteger > CAMUNDA_MODELER_TTL_DEFAULT_VALUE;
+          && httlConfigValue != null && !httlConfigValue.isEmpty()
+          && valueAsInteger > ParseUtil.parseHistoryTimeToLive(httlConfigValue);
     }
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoryTimeToLiveParser.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoryTimeToLiveParser.java
@@ -117,8 +117,9 @@ public class HistoryTimeToLiveParser {
       if (result.shouldBeLogged()) {
         LOG.logHistoryTimeToLiveDefaultValueWarning(definitionKey);
       }
+
       if (result.hasLongerModelValueThanGlobalConfig()) {
-        LOG.logModelHTTLLongerThanGlobalCongig(result.value);
+        LOG.logModelHTTLLongerThanGlobalConfiguration(definitionKey, result.value);
       }
     }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ConfigurationLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ConfigurationLogger.java
@@ -115,21 +115,26 @@ public class ConfigurationLogger extends ProcessEngineLogger {
   }
 
   /**
-   * Method for logging message when model history TTL longer than global TTL.
+   * Method for logging message when model TTL longer than global TTL.
    *
    * @param definitionKey the correlated definition key with which history TTL is related to.
    *                      For processes related to httl, that is the processDefinitionKey, for cases the case definition key
    *                      whereas for decisions is the decision definition key.
    */
-  public void logModelHTTLLongerThanGlobalConfiguration(String definitionKey, String ttl) {
+  public void logModelHTTLLongerThanGlobalConfiguration(String definitionKey) {
     logWarn(
         "017", "definitionKey: {}; "
-            + "The specified TTL (Time To Live) in the model is longer than the global (180 days) TTL configuration: {} days",
-            definitionKey, ttl);
+            + "The specified Time To Live (TTL) in the model is longer than the global TTL configuration. "
+            + "The historic data related to this model will be cleaned up at later point comparing to the other processes.",
+            definitionKey);
   }
 
   public NotValidException logErrorNoTTLConfigured() {
     return new NotValidException(exceptionMessage("018",
-        "History Time To Live cannot be null. You can set a default historyTimeToLive as a global process engine configuration."));
+        "History Time To Live (TTL) cannot be null. "
+        + "TTL is necessary for the History Cleanup to work. The following options are possible:\n"
+        + "* Set historyTimeToLive in the model\n"
+        + "* Set a default historyTimeToLive as a global process engine configuration\n"
+        + "* (Not recommended) Deactivate the enforceTTL config to disable this check"));
   }
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ConfigurationLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ConfigurationLogger.java
@@ -18,6 +18,7 @@ package org.camunda.bpm.engine.impl.cfg;
 
 import javax.naming.NamingException;
 import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.exception.NotValidException;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
 
 /**
@@ -114,18 +115,12 @@ public class ConfigurationLogger extends ProcessEngineLogger {
   }
 
   /**
-   * Method for logging message when default history time to live is configured.
+   * Method for logging message when model history TTL longer than global TTL.
    *
-   * @param definitionKey the correlated definition key with which history time to live is related to.
+   * @param definitionKey the correlated definition key with which history TTL is related to.
    *                      For processes related to httl, that is the processDefinitionKey, for cases the case definition key
    *                      whereas for decisions is the decision definition key.
    */
-  public void logHistoryTimeToLiveDefaultValueWarning(String definitionKey) {
-    String message = formatHTTLDefaultValueMessage(definitionKey);
-
-    logWarn("016", message);
-  }
-
   public void logModelHTTLLongerThanGlobalConfiguration(String definitionKey, String ttl) {
     logWarn(
         "017", "definitionKey: {}; "
@@ -133,17 +128,8 @@ public class ConfigurationLogger extends ProcessEngineLogger {
             definitionKey, ttl);
   }
 
-  protected String formatHTTLDefaultValueMessage(String definitionKey) {
-    String result = "You are using the default TTL (Time To Live) of 180 days (six months); "
-        + "the history clean-up feature will delete your data after six months. "
-        + "We recommend adjusting the TTL configuration property aligned with your specific requirements. "
-        + "You can set a custom historyTimeToLive as a global process engine configuration.";
-
-    if (definitionKey != null) {
-      result = "definitionKey: " + definitionKey + "; " + result;
-    }
-
-    return result;
+  public NotValidException logErrorNoTTLConfigured() {
+    return new NotValidException(exceptionMessage("018",
+        "History Time To Live cannot be null. You can set a default historyTimeToLive as a global process engine configuration."));
   }
-
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ConfigurationLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ConfigurationLogger.java
@@ -126,16 +126,18 @@ public class ConfigurationLogger extends ProcessEngineLogger {
     logWarn("016", message);
   }
 
-  public void logModelHTTLLongerThanGlobalCongig(String ttl) {
+  public void logModelHTTLLongerThanGlobalConfiguration(String definitionKey, String ttl) {
     logWarn(
-        "017", "Specified TTL (Time To Live) longer than the global (180 days) TTL configuration: {} ", ttl);
+        "017", "definitionKey: {}; "
+            + "The specified TTL (Time To Live) in the model is longer than the global (180 days) TTL configuration: {} days",
+            definitionKey, ttl);
   }
 
   protected String formatHTTLDefaultValueMessage(String definitionKey) {
     String result = "You are using the default TTL (Time To Live) of 180 days (six months); "
         + "the history clean-up feature will delete your data after six months. "
         + "We recommend adjusting the TTL configuration property aligned with your specific requirements. "
-        + "You can set a custom historyTimeToLive as a global process engine configuration";
+        + "You can set a custom historyTimeToLive as a global process engine configuration.";
 
     if (definitionKey != null) {
       result = "definitionKey: " + definitionKey + "; " + result;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ConfigurationLogger.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ConfigurationLogger.java
@@ -126,10 +126,16 @@ public class ConfigurationLogger extends ProcessEngineLogger {
     logWarn("016", message);
   }
 
+  public void logModelHTTLLongerThanGlobalCongig(String ttl) {
+    logWarn(
+        "017", "Specified TTL (Time To Live) longer than the global (180 days) TTL configuration: {} ", ttl);
+  }
+
   protected String formatHTTLDefaultValueMessage(String definitionKey) {
     String result = "You are using the default TTL (Time To Live) of 180 days (six months); "
         + "the history clean-up feature will delete your data after six months. "
-        + "We recommend adjusting the TTL configuration property aligned with your specific requirements.";
+        + "We recommend adjusting the TTL configuration property aligned with your specific requirements. "
+        + "You can set a custom historyTimeToLive as a global process engine configuration";
 
     if (definitionKey != null) {
       result = "definitionKey: " + definitionKey + "; " + result;

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/HistoryTimeToLiveDeploymentTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/HistoryTimeToLiveDeploymentTest.java
@@ -35,6 +35,7 @@ import org.camunda.bpm.engine.repository.DeploymentWithDefinitions;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
 import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.commons.testing.ProcessEngineLoggingRule;
 import org.junit.After;
 import org.junit.Before;
@@ -49,7 +50,11 @@ public class HistoryTimeToLiveDeploymentTest {
   protected static final String EXPECTED_DEFAULT_CONFIG_MSG =
       "You are using the default TTL (Time To Live) of 180 days (six months); "
       + "the history clean-up feature will delete your data after six months. "
-      + "We recommend adjusting the TTL configuration property aligned with your specific requirements.";
+      + "We recommend adjusting the TTL configuration property aligned with your specific requirements. "
+      + "You can set a custom historyTimeToLive as a global process engine configuration.";
+
+  protected static final String EXPECTED_LONGER_TTL_MSG =
+      "The specified TTL (Time To Live) in the model is longer than the global (180 days) TTL configuration:";
 
   protected static final String DEFAULT_HTTL_CONFIG_VALUE = "180";
 
@@ -295,6 +300,57 @@ public class HistoryTimeToLiveDeploymentTest {
     processEngineConfiguration.setEnforceHistoryTimeToLive(true);
     processEngineConfiguration.getDeploymentCache().purgeCache();
     repositoryService.getCaseDefinition(definitions.getDeployedCaseDefinitions().get(0).getId());
+  }
+
+  @Test
+  public void shouldLogMessageOnLongerTTLInProcessModel() {
+    // given
+    String nonDefaultValue = "179";
+    processEngineConfiguration.setHistoryTimeToLive(nonDefaultValue);
+
+    // when
+    deployProcessDefinitions();
+
+    // then
+    assertThat(loggingRule.getFilteredLog("definitionKey: process; " + EXPECTED_LONGER_TTL_MSG)).hasSize(1);
+  }
+
+  @Test
+  public void shouldLogMessageOnLongerTTLInfCaseModel() {
+    // given
+    String nonDefaultValue = "179";
+    processEngineConfiguration.setHistoryTimeToLive(nonDefaultValue);
+
+    // when
+    testRule.deploy(repositoryService.createDeployment()
+        .addClasspathResource("org/camunda/bpm/engine/test/api/repository/case_with_365_httl.cmmn"));
+
+    // then
+    assertThat(loggingRule.getFilteredLog("definitionKey: testCase; " + EXPECTED_LONGER_TTL_MSG)).hasSize(1);
+  }
+
+  @Test
+  public void shouldLogMessageOnLongerTTLInDecisionModel() {
+    // given
+    String nonDefaultValue = "179";
+    processEngineConfiguration.setHistoryTimeToLive(nonDefaultValue);
+
+    // when
+    testRule.deploy(repositoryService.createDeployment()
+        .addClasspathResource("org/camunda/bpm/engine/test/api/repository/decision_with_365_httl.dmn"));
+
+    // then
+    assertThat(loggingRule.getFilteredLog("definitionKey: testDecision; " + EXPECTED_LONGER_TTL_MSG)).hasSize(1);
+  }
+
+  protected void deployProcessDefinitions() {
+    testRule.deploy(
+      Bpmn.createExecutableProcess("process")
+        .camundaHistoryTimeToLive(365)
+        .startEvent()
+        .userTask()
+        .endEvent()
+        .done());
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/HistoryTimeToLiveDeploymentTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/HistoryTimeToLiveDeploymentTest.java
@@ -103,7 +103,7 @@ public class HistoryTimeToLiveDeploymentTest {
 
         // then
         .isInstanceOf(ParseException.class)
-        .hasMessageContaining("History Time To Live cannot be null");
+        .hasMessageContaining("History Time To Live cannot be null. You can set a default historyTimeToLive as a global process engine configuration");
   }
 
   @Test
@@ -208,10 +208,10 @@ public class HistoryTimeToLiveDeploymentTest {
 
     // when
     testRule.deploy(repositoryService.createDeployment()
-        .addClasspathResource("org/camunda/bpm/engine/test/api/repository/version3.bpmn20.xml"));
+        .addClasspathResource("org/camunda/bpm/engine/test/api/repository/version2.bpmn20.xml"));
 
     // then
-    assertThat(loggingRule.getFilteredLog("definitionKey: process; " + EXPECTED_DEFAULT_CONFIG_MSG)).hasSize(1);
+    assertThat(loggingRule.getFilteredLog("History Time To Live cannot be null. You can set a default historyTimeToLive as a global process engine configuration")).hasSize(1);
   }
 
   @Test

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/HistoryTimeToLiveDeploymentTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/repository/HistoryTimeToLiveDeploymentTest.java
@@ -47,16 +47,12 @@ public class HistoryTimeToLiveDeploymentTest {
 
   protected static final String CONFIG_LOGGER = "org.camunda.bpm.engine.cfg";
 
-  protected static final String EXPECTED_DEFAULT_CONFIG_MSG =
-      "You are using the default TTL (Time To Live) of 180 days (six months); "
-      + "the history clean-up feature will delete your data after six months. "
-      + "We recommend adjusting the TTL configuration property aligned with your specific requirements. "
-      + "You can set a custom historyTimeToLive as a global process engine configuration.";
+  protected static final String EXPECTED_DEFAULT_CONFIG_MSG = "History Time To Live (TTL) cannot be null. ";
 
-  protected static final String EXPECTED_LONGER_TTL_MSG =
-      "The specified TTL (Time To Live) in the model is longer than the global (180 days) TTL configuration:";
+  protected static final String EXPECTED_LONGER_TTL_MSG = "The specified Time To Live (TTL) in the model is longer than the global TTL configuration. "
+      + "The historic data related to this model will be cleaned up at later point comparing to the other processes.";
 
-  protected static final String DEFAULT_HTTL_CONFIG_VALUE = "180";
+  protected static final String HTTL_CONFIG_VALUE = "180";
 
   protected ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
   protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
@@ -103,7 +99,11 @@ public class HistoryTimeToLiveDeploymentTest {
 
         // then
         .isInstanceOf(ParseException.class)
-        .hasMessageContaining("History Time To Live cannot be null. You can set a default historyTimeToLive as a global process engine configuration");
+        .hasMessageContaining(EXPECTED_DEFAULT_CONFIG_MSG)
+        .hasMessageContaining("TTL is necessary for the History Cleanup to work. The following options are possible:")
+        .hasMessageContaining("* Set historyTimeToLive in the model")
+        .hasMessageContaining("* Set a default historyTimeToLive as a global process engine configuration")
+        .hasMessageContaining("* (Not recommended) Deactivate the enforceTTL config to disable this check");
   }
 
   @Test
@@ -142,7 +142,7 @@ public class HistoryTimeToLiveDeploymentTest {
         // then
         .isInstanceOf(ProcessEngineException.class)
         .hasCauseInstanceOf(NotValidException.class)
-        .hasStackTraceContaining("History Time To Live cannot be null");
+        .hasStackTraceContaining(EXPECTED_DEFAULT_CONFIG_MSG);
   }
 
   @Test
@@ -169,7 +169,7 @@ public class HistoryTimeToLiveDeploymentTest {
         // then
         .isInstanceOf(ProcessEngineException.class)
         .hasCauseInstanceOf(DmnTransformException.class)
-        .hasStackTraceContaining("History Time To Live cannot be null");
+        .hasStackTraceContaining(EXPECTED_DEFAULT_CONFIG_MSG);
   }
 
   @Test
@@ -190,64 +190,7 @@ public class HistoryTimeToLiveDeploymentTest {
   @Test
   public void shouldNotLogMessageOnDefaultConfigOriginatingFromConfig() {
     // given
-    processEngineConfiguration.setHistoryTimeToLive(DEFAULT_HTTL_CONFIG_VALUE);
-
-    // when
-    testRule.deploy(repositoryService.createDeployment()
-        .addClasspathResource("org/camunda/bpm/engine/test/api/repository/version1.bpmn20.xml"));
-
-    // then
-    assertThat(loggingRule.getFilteredLog(EXPECTED_DEFAULT_CONFIG_MSG)).hasSize(0);
-  }
-
-  @Test
-  public void shouldLogMessageOnDefaultValueOfProcessModel() {
-    // given
-    String nonDefaultValue = "179";
-    processEngineConfiguration.setHistoryTimeToLive(nonDefaultValue);
-
-    // when
-    testRule.deploy(repositoryService.createDeployment()
-        .addClasspathResource("org/camunda/bpm/engine/test/api/repository/version2.bpmn20.xml"));
-
-    // then
-    assertThat(loggingRule.getFilteredLog("History Time To Live cannot be null. You can set a default historyTimeToLive as a global process engine configuration")).hasSize(1);
-  }
-
-  @Test
-  public void shouldLogMessageOnDefaultValueOfCaseModel() {
-    // given
-    String nonDefaultValue = "179";
-    processEngineConfiguration.setHistoryTimeToLive(nonDefaultValue);
-
-    // when
-    testRule.deploy(repositoryService.createDeployment()
-        .addClasspathResource("org/camunda/bpm/engine/test/api/repository/case_with_180_httl.cmmn"));
-
-    // then
-    assertThat(loggingRule.getFilteredLog("definitionKey: testCase; " + EXPECTED_DEFAULT_CONFIG_MSG)).hasSize(1);
-  }
-
-  @Test
-  public void shouldLogMessageOnDefaultValueOfDecisionModel() {
-    // given
-    String nonDefaultValue = "179";
-    processEngineConfiguration.setHistoryTimeToLive(nonDefaultValue);
-
-    // when
-    testRule.deploy(repositoryService.createDeployment()
-        .addClasspathResource("org/camunda/bpm/engine/test/api/repository/decision_with_180_httl.dmn"));
-
-    // then
-    assertThat(loggingRule.getFilteredLog("definitionKey: testDecision; " + EXPECTED_DEFAULT_CONFIG_MSG)).hasSize(1);
-  }
-
-  @Test
-  public void shouldNotLogAnyMessageOnNonDefaultConfig() {
-    String nonDefaultValue = "179";
-
-    // given
-    processEngineConfiguration.setHistoryTimeToLive(nonDefaultValue);
+    processEngineConfiguration.setHistoryTimeToLive(HTTL_CONFIG_VALUE);
 
     // when
     testRule.deploy(repositoryService.createDeployment()

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/repository/case_with_365_httl.cmmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/repository/case_with_365_httl.cmmn
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?>
+<definitions id="_7f0c94c0-2a22-445d-b4b7-4fd181e08248"
+             xmlns="http://www.omg.org/spec/CMMN/20151109/MODEL"
+             xmlns:camunda="http://camunda.org/schema/1.0/cmmn"
+             targetNamespace="Examples">
+  <case id="testCase" name="One Task Case" camunda:historyTimeToLive="365">
+
+    <casePlanModel id="CasePlanModel_1">
+      <planItem id="PI_HumanTask_1" definitionRef="HumanTask_1" />
+      <humanTask id="HumanTask_1" name="A HumanTask" />
+    </casePlanModel>
+  </case>
+
+</definitions>

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/repository/decision_with_365_httl.dmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/repository/decision_with_365_httl.dmn
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+             xmlns:camunda="http://camunda.org/schema/1.0/dmn"
+             id="definitions"
+             name="definitions"
+             namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="testDecision" name="Check Order" camunda:historyTimeToLive="365">
+    <decisionTable id="decisionTable">
+      <input id="input1" label="Customer Status">
+        <inputExpression id="inputExpression1" typeRef="string">
+          <text>status</text>
+        </inputExpression>
+        <inputValues id="inputValues">
+          <text>"bronze","silver","gold"</text>
+        </inputValues>
+      </input>
+      <input id="input2" label="Order Sum">
+        <inputExpression id="inputExpression2" typeRef="double">
+          <text>sum</text>
+        </inputExpression>
+      </input>
+      <output id="output1" label="Check Result" name="result" typeRef="string">
+        <outputValues id="outputValues">
+          <text>"ok","notok"</text>
+        </outputValues>
+      </output>
+      <output id="output2" label="Reason" name="reason" typeRef="string" />
+      <rule id="rule1">
+        <inputEntry id="inputEntry1">
+          <text>"bronze"</text>
+        </inputEntry>
+        <inputEntry id="inputEntry2">
+          <text/>
+        </inputEntry>
+        <outputEntry id="outputEntry1">
+          <text>"notok"</text>
+        </outputEntry>
+        <outputEntry id="outputEntry2">
+          <text><![CDATA["work on your status first, as bronze you're not going to get anything"]]></text>
+        </outputEntry>
+      </rule>
+      <rule id="rule2">
+        <inputEntry id="inputEntry3">
+          <text>"silver"</text>
+        </inputEntry>
+        <inputEntry id="inputEntry4">
+          <text><![CDATA[< 1000]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry3">
+          <text>"ok"</text>
+        </outputEntry>
+        <outputEntry id="outputEntry4">
+          <text>"you little fish will get what you want"</text>
+        </outputEntry>
+      </rule>
+      <rule id="rule3">
+        <inputEntry id="inputEntry5">
+          <text>"silver"</text>
+        </inputEntry>
+        <inputEntry id="inputEntry6">
+          <text><![CDATA[>= 1000]]></text>
+        </inputEntry>
+        <outputEntry id="outputEntry5">
+          <text>"notok"</text>
+        </outputEntry>
+        <outputEntry id="outputEntry6">
+          <text>"you took too much man, you took too much!"</text>
+        </outputEntry>
+      </rule>
+      <rule id="rule4">
+        <inputEntry id="inputEntry7">
+          <text>"gold"</text>
+        </inputEntry>
+        <inputEntry id="inputEntry8">
+          <text/>
+        </inputEntry>
+        <outputEntry id="outputEntry7">
+          <text>"ok"</text>
+        </outputEntry>
+        <outputEntry id="outputEntry8">
+          <text>"you get anything you want"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>


### PR DESCRIPTION
https://github.com/camunda/camunda-bpm-platform/issues/4031

```[tasklist]
### Tasks
- [x] warning/error messages agreed with Tobi
- [x] adjust tests remove 180 constant
- [x] do we want to do any refactoring/simplification of HistoryTimeToLiveParser - no
```