### PR TITLE
fix(engine): handle required field with default value

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/form/validator/RequiredValidator.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/form/validator/RequiredValidator.java
@@ -26,13 +26,31 @@ public class RequiredValidator implements FormFieldValidator {
 
   public boolean validate(Object submittedValue, FormFieldValidatorContext validatorContext) {
     if(submittedValue == null) {
-      TypedValue value = validatorContext.getVariableScope().getVariableTyped(validatorContext.getFormFieldHandler().getId());
-      return (value != null && value.getValue() != null);
+      var variableName = validatorContext.getFormFieldHandler().getId();
+      TypedValue value = validatorContext.getVariableScope().getVariableTyped(variableName);
+
+      if (value != null) {
+        return value.getValue() != null;
+      }
+
+      // check if there is a default value
+      var defaultValueExpression = validatorContext.getFormFieldHandler().getDefaultValueExpression();
+      if (defaultValueExpression != null) {
+        var variableValue = defaultValueExpression.getValue(validatorContext.getVariableScope());
+
+        if (variableValue != null) {
+          // set default value
+          validatorContext.getVariableScope().setVariable(variableName, variableValue);
+          return true;
+        }
+      }
+
+      return false;
     } else {
       if (submittedValue instanceof String) {
-        return submittedValue != null && !((String)submittedValue).isEmpty();
+        return !((String)submittedValue).isEmpty();
       } else {
-        return submittedValue != null;
+        return true;
       }
     }
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/form/BuiltInValidatorsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/form/BuiltInValidatorsTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.VariableScope;
 import org.camunda.bpm.engine.impl.ProcessEngineImpl;
+import org.camunda.bpm.engine.impl.el.FixedValue;
 import org.camunda.bpm.engine.impl.form.FormException;
 import org.camunda.bpm.engine.impl.form.handler.FormFieldHandler;
 import org.camunda.bpm.engine.impl.form.validator.FormFieldValidator;
@@ -72,7 +73,7 @@ public class BuiltInValidatorsTest extends PluggableProcessEngineTest {
     assertTrue(validator.validate(1, validatorContext));
     assertTrue(validator.validate(true, validatorContext));
 
-    // empty string and 'null' are invalid
+    // empty string and 'null' are invalid without default
     assertFalse(validator.validate("", validatorContext));
     assertFalse(validator.validate(null, validatorContext));
 
@@ -80,6 +81,12 @@ public class BuiltInValidatorsTest extends PluggableProcessEngineTest {
     validatorContext = new TestValidatorContext(null, "fieldName");
     validatorContext.getVariableScope().setVariable("fieldName", "existingValue");
     assertTrue(validator.validate(null, validatorContext));
+
+    // can submit null if a default value exists
+    validatorContext = new TestValidatorContext(null, "fieldName");
+    validatorContext.getFormFieldHandler().setDefaultValueExpression(new FixedValue("defaultValue"));
+    assertTrue(validator.validate(null, validatorContext));
+    assertEquals("defaultValue", validatorContext.getVariableScope().getVariable("fieldName"));
   }
 
   @Test


### PR DESCRIPTION
- RequiredValidator handles default value if present
- BuiltInValidatorsTest.testRequiredValidator covers handling of default value

related to #3950