### PR TITLE
chore(deps): bump up postgresql driver

### DIFF
--- a/database/pom.xml
+++ b/database/pom.xml
@@ -26,7 +26,7 @@
     <version.sqlserver>8.4.1.jre8</version.sqlserver>
     <version.db2-11.5>11.5.0.0</version.db2-11.5>
     <version.db2>${version.db2-11.5}</version.db2>
-    <version.postgresql>42.5.4</version.postgresql>
+    <version.postgresql>42.5.5</version.postgresql>
     <version.liquibase>4.8.0</version.liquibase>
 
     <!-- CockroachDB is compatible with PostgreSQL 9.5,


### PR DESCRIPTION
We have been alerted a critical vulnerability in prostgres driver version 42.5.4 from Github hence bumping it up to 42.5.5 
Advisory :
https://github.com/advisories/GHSA-xfg6-62px-cxc2

https://nvd.nist.gov/vuln/detail/CVE-2024-1597

related to https://github.com/camunda/camunda-bpm-platform/issues/4127