### PR TITLE
chore(.ci/config): Add jdk-11-latest to engine-rest unit tests

### DIFF
--- a/.ci/config/stage-types.yaml
+++ b/.ci/config/stage-types.yaml
@@ -90,6 +90,7 @@ engine-rest-unit-jersey-2:
   labels:
   - 'rest-api'
   nodeLabel: 'h2'
+  jdkVersion: 'openjdk-jdk-11-latest'
 engine-rest-unit-resteasy:
   directory: 'engine-rest/engine-rest'
   command: 'clean install -Presteasy'
@@ -98,6 +99,7 @@ engine-rest-unit-resteasy:
   labels:
   - 'rest-api'
   nodeLabel: 'h2'
+  jdkVersion: 'openjdk-jdk-11-latest'
 engine-rest-jakarta-unit-resteasy:
   directory: 'engine-rest/engine-rest-jakarta'
   command: 'clean install -Presteasy'
@@ -115,6 +117,7 @@ engine-rest-unit-compatibility-wildfly:
   labels:
   - 'rest-api'
   nodeLabel: 'h2'
+  jdkVersion: 'openjdk-jdk-11-latest'
 engine-rest-IT-embedded-wildfly26:
   directory: 'qa'
   command: 'clean install -Pwildfly26,h2,webapps-integration,embedded-engine-rest'

--- a/.ci/config/stage-types.yaml
+++ b/.ci/config/stage-types.yaml
@@ -90,7 +90,7 @@ engine-rest-unit-jersey-2:
   labels:
   - 'rest-api'
   nodeLabel: 'h2'
-  jdkVersion: 'openjdk-jdk-11-0-22'
+  jdkVersion: 'jdk-11-0-21'
 engine-rest-unit-resteasy:
   directory: 'engine-rest/engine-rest'
   command: 'clean install -Presteasy'
@@ -99,7 +99,7 @@ engine-rest-unit-resteasy:
   labels:
   - 'rest-api'
   nodeLabel: 'h2'
-  jdkVersion: 'openjdk-jdk-11-0-22'
+  jdkVersion: 'jdk-11-0-21'
 engine-rest-jakarta-unit-resteasy:
   directory: 'engine-rest/engine-rest-jakarta'
   command: 'clean install -Presteasy'
@@ -117,7 +117,7 @@ engine-rest-unit-compatibility-wildfly:
   labels:
   - 'rest-api'
   nodeLabel: 'h2'
-  jdkVersion: 'openjdk-jdk-11-0-22'
+  jdkVersion: 'jdk-11-0-21'
 engine-rest-IT-embedded-wildfly26:
   directory: 'qa'
   command: 'clean install -Pwildfly26,h2,webapps-integration,embedded-engine-rest'

--- a/.ci/config/stage-types.yaml
+++ b/.ci/config/stage-types.yaml
@@ -90,7 +90,7 @@ engine-rest-unit-jersey-2:
   labels:
   - 'rest-api'
   nodeLabel: 'h2'
-  jdkVersion: 'openjdk-jdk-11-latest'
+  jdkVersion: 'openjdk-jdk-11-0-22'
 engine-rest-unit-resteasy:
   directory: 'engine-rest/engine-rest'
   command: 'clean install -Presteasy'
@@ -99,7 +99,7 @@ engine-rest-unit-resteasy:
   labels:
   - 'rest-api'
   nodeLabel: 'h2'
-  jdkVersion: 'openjdk-jdk-11-latest'
+  jdkVersion: 'openjdk-jdk-11-0-22'
 engine-rest-jakarta-unit-resteasy:
   directory: 'engine-rest/engine-rest-jakarta'
   command: 'clean install -Presteasy'
@@ -117,7 +117,7 @@ engine-rest-unit-compatibility-wildfly:
   labels:
   - 'rest-api'
   nodeLabel: 'h2'
-  jdkVersion: 'openjdk-jdk-11-latest'
+  jdkVersion: 'openjdk-jdk-11-0-22'
 engine-rest-IT-embedded-wildfly26:
   directory: 'qa'
   command: 'clean install -Pwildfly26,h2,webapps-integration,embedded-engine-rest'

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -289,7 +289,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <runOrder>alphabetical</runOrder>
           <systemPropertyVariables>
             <restEasyVersion>${version.resteasy}</restEasyVersion>
           </systemPropertyVariables>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -289,6 +289,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <runOrder>alphabetical</runOrder>
           <systemPropertyVariables>
             <restEasyVersion>${version.resteasy}</restEasyVersion>
           </systemPropertyVariables>


### PR DESCRIPTION
engine-rest-unit-jersey-2
engine-rest-unit-resteasy
engine-rest-unit-compatibility-wildfly

Related-to: https://github.com/camunda/team-automation-platform/issues/114