### PR TITLE
fix(engine): fire end event when inactive exec is canceled externally

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/ActivityCancellationCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/ActivityCancellationCmd.java
@@ -55,6 +55,7 @@ public class ActivityCancellationCmd extends AbstractProcessInstanceModification
     for (AbstractInstanceCancellationCmd cmd : commands) {
       cmd.setSkipCustomListeners(skipCustomListeners);
       cmd.setSkipIoMappings(skipIoMappings);
+      cmd.setExternallyTerminated(true);
       cmd.execute(commandContext);
     }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/PvmExecutionImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/pvm/runtime/PvmExecutionImpl.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
 import org.camunda.bpm.engine.ActivityTypes;
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.ProcessEngineLogger;
@@ -39,6 +38,7 @@ import org.camunda.bpm.engine.impl.core.variable.event.VariableEvent;
 import org.camunda.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
 import org.camunda.bpm.engine.impl.form.FormPropertyHelper;
 import org.camunda.bpm.engine.impl.history.HistoryLevel;
+import org.camunda.bpm.engine.impl.history.event.HistoricVariableUpdateEventEntity;
 import org.camunda.bpm.engine.impl.history.event.HistoryEvent;
 import org.camunda.bpm.engine.impl.history.event.HistoryEventProcessor;
 import org.camunda.bpm.engine.impl.history.event.HistoryEventTypes;
@@ -361,7 +361,7 @@ public abstract class PvmExecutionImpl extends CoreExecution implements
 
     // fire activity end on active activity
     PvmActivity activity = getActivity();
-    if (isActive && activity != null) {
+    if ((isActive || externallyTerminated) && activity != null) {
       // set activity instance state to cancel
       if (activityInstanceState != ENDING.getStateCode() || activityInstanceEndListenersFailed) {
         setCanceled(true);


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/3916