### PR TITLE
chore(project): Upgrade to feel-engine 1.7.5

### DIFF
--- a/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/feel/BreakingScalaFeelBehaviorTest.java
+++ b/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/feel/BreakingScalaFeelBehaviorTest.java
@@ -110,7 +110,7 @@ public class BreakingScalaFeelBehaviorTest extends DmnEngineTest {
     // then
     thrown.expect(FeelException.class);
     thrown.expectMessage("FEEL/SCALA-01008 Error while evaluating expression: failed to parse expression ''Hello World'': "
-      + "Expected (negation | positiveUnaryTests | anyInput):1:1, found \"'Hello Wor\"");
+      + "Expected (start-of-input | negation | positiveUnaryTests | anyInput):1:1, found \"'Hello Wor\"");
 
     // when
     engine.evaluateDecision(decision, Variables.createVariables().putValue("input", "Hello World"));

--- a/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/feel/BreakingScalaFeelBehaviorTest.java
+++ b/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/feel/BreakingScalaFeelBehaviorTest.java
@@ -19,7 +19,6 @@ package org.camunda.bpm.dmn.engine.feel;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Date;
-
 import org.camunda.bpm.dmn.engine.DmnDecisionResult;
 import org.camunda.bpm.dmn.engine.DmnEngine;
 import org.camunda.bpm.dmn.engine.DmnEngineConfiguration;
@@ -72,32 +71,27 @@ public class BreakingScalaFeelBehaviorTest extends DmnEngineTest {
   @Test
   @DecisionResource(resource = "breaking_compare_date_with_time_zone_untyped.dmn")
   public void shouldEvaluateTimezoneComparisonWithTypedValue() {
-    // given
+    // given a date typed value
     variables.putValue("date1", Variables.dateValue(new Date()));
 
-    // then
-    thrown.expect(FeelException.class);
-    thrown.expectMessage("can not be compared to ValDateTime(2019-09-12T13:00+02:00[Europe/Berlin])");
+    // when it is compared against timezone
+    var evaluationResult = evaluateDecisionTable(dmnEngine);
 
-    // when
-    assertThatDecisionTableResult()
-      .hasSingleResult()
-      .hasSingleEntryTyped(Variables.stringValue("foo"));
+    // then the evaluation is handled gracefully and empty results are returned despite the type mismatch
+    assertThat(evaluationResult).isEmpty();
   }
 
   @Test
   @DecisionResource(resource = "breaking_compare_date_with_time_zone_untyped.dmn")
   public void shouldEvaluateTimezoneComparisonWithDate() {
+    // given a date
     variables.putValue("date1", new Date());
 
-    // then
-    thrown.expect(FeelException.class);
-    thrown.expectMessage("can not be compared to ValDateTime(2019-09-12T13:00+02:00[Europe/Berlin])");
+    // when it is compared against timezone
+    var evaluationResult = evaluateDecisionTable(dmnEngine);
 
-    // when
-    assertThatDecisionTableResult()
-      .hasSingleResult()
-      .hasSingleEntryTyped(Variables.stringValue("foo"));
+    // then the evaluation is handled gracefully and empty results are returned despite the type mismatch
+    assertThat(evaluationResult).isEmpty();
   }
 
   @Test

--- a/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/feel/FeelBehavior.java
+++ b/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/feel/FeelBehavior.java
@@ -184,27 +184,6 @@ public abstract class FeelBehavior extends DmnEngineTest {
     assertThat(foo).isEqualTo("bar");
   }
 
-  /**
-   * For expression languages, so-called context functions can be used [1].
-   *
-   * This test ensures that context functions cannot be called in the
-   * juel as well as the scala-based implementation.
-   *
-   * [1] https://docs.camunda.org/manual/7.12/user-guide/process-engine/expression-language/#internal-context-functions
-   */
-  @Test
-  @DecisionResource(resource = "context_function.dmn")
-  public void shouldFailOnInternalContextFunctions() {
-    // given
-    getVariables().putValue("myDate", new Date());
-
-    // then
-    thrown.expect(FeelException.class);
-
-    // when
-    evaluateDecision().getSingleEntry();
-  }
-
   @Test
   @DecisionResource(resource = "input_date_typed.dmn")
   public void shouldThrowExceptionWhenEvaluateJodaDate_Typed() {

--- a/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/feel/JuelFeelBehaviorTest.java
+++ b/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/feel/JuelFeelBehaviorTest.java
@@ -16,9 +16,13 @@
  */
 package org.camunda.bpm.dmn.engine.feel;
 
+import java.util.Date;
 import org.camunda.bpm.dmn.engine.DmnEngineConfiguration;
 import org.camunda.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
+import org.camunda.bpm.dmn.engine.test.DecisionResource;
+import org.camunda.bpm.dmn.feel.impl.FeelException;
 import org.camunda.bpm.dmn.feel.impl.juel.FeelEngineFactoryImpl;
+import org.junit.Test;
 
 public class JuelFeelBehaviorTest extends FeelBehavior {
 
@@ -28,6 +32,27 @@ public class JuelFeelBehaviorTest extends FeelBehavior {
     configuration.setFeelEngineFactory(new FeelEngineFactoryImpl());
     configuration.init();
     return configuration;
+  }
+
+  /**
+   * For expression languages, so-called context functions can be used [1].
+   *
+   * This test ensures that context functions cannot be called in the
+   * juel as well as the scala-based implementation.
+   *
+   * [1] https://docs.camunda.org/manual/7.12/user-guide/process-engine/expression-language/#internal-context-functions
+   */
+  @Test
+  @DecisionResource(resource = "context_function.dmn")
+  public void shouldFailOnInternalContextFunctions() {
+    // given
+    getVariables().putValue("myDate", new Date());
+
+    // then
+    thrown.expect(FeelException.class);
+
+    // when
+    evaluateDecision().getSingleEntry();
   }
 
 }

--- a/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/feel/ScalaFeelBehaviorTest.java
+++ b/engine-dmn/engine/src/test/java/org/camunda/bpm/dmn/engine/feel/ScalaFeelBehaviorTest.java
@@ -16,9 +16,16 @@
  */
 package org.camunda.bpm.dmn.engine.feel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+import org.camunda.bpm.dmn.engine.DmnDecisionResult;
+import org.camunda.bpm.dmn.engine.DmnDecisionResultEntries;
 import org.camunda.bpm.dmn.engine.DmnEngineConfiguration;
 import org.camunda.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
+import org.camunda.bpm.dmn.engine.test.DecisionResource;
 import org.camunda.bpm.dmn.feel.impl.scala.ScalaFeelEngineFactory;
+import org.junit.Test;
 
 public class ScalaFeelBehaviorTest extends FeelBehavior {
 
@@ -28,6 +35,30 @@ public class ScalaFeelBehaviorTest extends FeelBehavior {
     configuration.setFeelEngineFactory(new ScalaFeelEngineFactory());
     configuration.init();
     return configuration;
+  }
+
+  /**
+   * For expression languages, so-called context functions can be used [1].
+   *
+   * This test ensures that context functions cannot be called in the
+   * juel as well as the scala-based implementation.
+   *
+   * [1] https://docs.camunda.org/manual/7.12/user-guide/process-engine/expression-language/#internal-context-functions
+   */
+  @Test
+  @DecisionResource(resource = "context_function.dmn")
+  public void shouldReturnNullOnInternalContextFunctions() {
+    // given
+    getVariables().putValue("myDate", new Date());
+
+    // when
+    DmnDecisionResult result = evaluateDecision();
+    DmnDecisionResultEntries firstResult = result.getFirstResult();
+
+    assertThat(firstResult)
+      .hasSize(1)
+      .containsKey(null)
+      .containsValue("foo");
   }
 
 }

--- a/engine-dmn/feel-scala/src/test/java/org/camunda/bpm/dmn/engine/feel/function/CustomFunctionTest.java
+++ b/engine-dmn/feel-scala/src/test/java/org/camunda/bpm/dmn/engine/feel/function/CustomFunctionTest.java
@@ -16,6 +16,16 @@
  */
 package org.camunda.bpm.dmn.engine.feel.function;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import org.camunda.bpm.dmn.engine.feel.function.helper.FunctionProvider;
 import org.camunda.bpm.dmn.engine.feel.function.helper.MyPojo;
 import org.camunda.bpm.dmn.engine.feel.helper.FeelRule;
@@ -27,17 +37,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.RuleChain;
-
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
 
 public class CustomFunctionTest {
 
@@ -494,12 +493,11 @@ public class CustomFunctionTest {
 
     functionProvider.register("myFunction", myFunction);
 
-    // then
-    thrown.expect(FeelException.class);
-    thrown.expectMessage("no function found with name 'myFunction' and 3 parameters");
-
     // when
-    feelRule.evaluateExpression("myFunction(\"foo\", \"bar\", \"baz\")");
+    var result = feelRule.evaluateExpression("myFunction(\"foo\", \"bar\", \"baz\")");
+
+    // then
+    assertThat(result).isNull();
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <version.camunda.connect>1.6.0</version.camunda.connect>
     <version.camunda.spin>1.22.0</version.camunda.spin>
     <version.camunda.freemarker.template.engine>2.2.0</version.camunda.freemarker.template.engine>
-    <version.feel-scala>1.16.2</version.feel-scala>
+    <version.feel-scala>1.17.5</version.feel-scala>
   </properties>
 
   <build>


### PR DESCRIPTION
Notable points of this change:

**Changes in feel-scala:**
- `1.6.2` **legacy behaviour**: when disabling the var-args evaluation and a given function with arguments that do not exist throws an Exception
- `1.7.5` **new behaviour**: The above returns successfully and the answer contains suppressed failures.
- `FeelEngine#evalExpression` are deprecated and changed to the new `FeelEngineApi#evaluateExpression`. They also contain breaking changes in behaviour.

**Change Reason:**
- Adapt the behaviour of ScalaFeelEngine appropriately so that the legacy behaviour of `ScalaFeelEngine` is retained.

**Breaking change:**
- `FeelExceptions` with "no function found" messages now start with a capital letter.
- This is accepted as a small change to make the proxy code as simple as possible

Related-to: https://github.com/camunda/camunda-bpm-platform/issues/4100