### PR TITLE
Update ClientAutoConfiguration.java

### DIFF
--- a/spring-boot-starter/starter-client/spring-boot/src/main/java/org/camunda/bpm/client/spring/boot/starter/impl/ClientAutoConfiguration.java
+++ b/spring-boot-starter/starter-client/spring-boot/src/main/java/org/camunda/bpm/client/spring/boot/starter/impl/ClientAutoConfiguration.java
@@ -20,6 +20,7 @@ import org.camunda.bpm.client.spring.boot.starter.ClientProperties;
 import org.camunda.bpm.client.spring.impl.client.ClientPostProcessor;
 import org.camunda.bpm.client.spring.impl.subscription.SubscriptionPostProcessor;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,11 +30,13 @@ import org.springframework.context.annotation.Configuration;
 public class ClientAutoConfiguration {
 
   @Bean
+  @ConditionalOnMissingBean
   public static SubscriptionPostProcessor subscriptionPostprocessor() {
     return new SubscriptionPostProcessor(PropertiesAwareSpringTopicSubscription.class);
   }
 
   @Bean
+  @ConditionalOnMissingBean
   public static ClientPostProcessor clientPostProcessor() {
     return new ClientPostProcessor(PropertiesAwareClientFactory.class);
   }


### PR DESCRIPTION
If I want to use the spring-boot-starter, but override some of the beans, they need to be conditional.

Otherwise, I would have to active allow-bean-definition-overriding