### PR TITLE
fix(engine): fix resource leak when bootstrapping the engine

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -1812,8 +1812,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected String checkForCrdb(Connection connection) {
     try {
-      try (PreparedStatement preparedStatement = connection.prepareStatement("select version() as version;")) {
-        ResultSet result = preparedStatement.executeQuery();
+      try (PreparedStatement preparedStatement = connection.prepareStatement("select version() as version;");
+           ResultSet result = preparedStatement.executeQuery()) {
         if (result.next()) {
           String versionData = result.getString(1);
           if (versionData != null && versionData.toLowerCase().contains("cockroachdb")) {


### PR DESCRIPTION
`ResultSet` is a resource and must be closed correctly