### PR TITLE
fix(engine/webapps/engine-rest/clients): tests fails when build runs on UTC timezone

### DIFF
--- a/clients/java/client/src/test/java/org/camunda/bpm/client/variable/DateValueMapperTest.java
+++ b/clients/java/client/src/test/java/org/camunda/bpm/client/variable/DateValueMapperTest.java
@@ -26,14 +26,17 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Date;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.text.SimpleDateFormat;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DateValueMapperTest {
 
   protected final static String DATE_FORMAT = "dd.MM.yyyy - HH:mm:ss.SSSZ";
-  protected static final Date VARIABLE_VALUE_DATE = new Date(1514790000000L);
-  protected static final String VARIABLE_VALUE_DATE_SERIALIZED = "01.01.2018 - 08:00:00.000+0100";
+  protected final Date VARIABLE_VALUE_DATE = new GregorianCalendar(2018, Calendar.JANUARY, 1, 8, 0, 0).getTime();
+  protected final String VARIABLE_VALUE_DATE_SERIALIZED = new SimpleDateFormat(DATE_FORMAT).format(VARIABLE_VALUE_DATE);
 
   protected DateValueMapper dateValueMapper;
 

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoryCleanupRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoryCleanupRestServiceInteractionTest.java
@@ -153,16 +153,16 @@ public class HistoryCleanupRestServiceInteractionTest extends AbstractRestServic
   @Test
   public void testHistoryConfigurationOutsideBatchWindow() throws ParseException {
     ProcessEngineConfigurationImpl processEngineConfigurationImplMock = mock(ProcessEngineConfigurationImpl.class);
-    Date startDate = HistoryCleanupHelper.parseTimeConfiguration("23:59+0200");
-    Date endDate = HistoryCleanupHelper.parseTimeConfiguration("00:00+0200");
+    Date startDate = HistoryCleanupHelper.parseTimeConfiguration("23:59");
+    Date endDate = HistoryCleanupHelper.parseTimeConfiguration("00:00");
     when(processEngine.getProcessEngineConfiguration()).thenReturn(processEngineConfigurationImplMock);
-    when(processEngineConfigurationImplMock.getHistoryCleanupBatchWindowStartTime()).thenReturn("23:59+0200");
-    when(processEngineConfigurationImplMock.getHistoryCleanupBatchWindowEndTime()).thenReturn("00:00+0200");
+    when(processEngineConfigurationImplMock.getHistoryCleanupBatchWindowStartTime()).thenReturn("23:59");
+    when(processEngineConfigurationImplMock.getHistoryCleanupBatchWindowEndTime()).thenReturn("00:00");
     when(processEngineConfigurationImplMock.getBatchWindowManager()).thenReturn(new DefaultBatchWindowManager());
     when(processEngineConfigurationImplMock.isHistoryCleanupEnabled()).thenReturn(true);
 
     SimpleDateFormat sdf = new SimpleDateFormat(JacksonConfigurator.dateFormatString);
-    Date now = sdf.parse("2017-09-01T22:00:00.000+0200");
+    Date now = sdf.parse("2017-09-01T22:00:00.000+0000");
 
     ClockUtil.setCurrentTime(now);
     Calendar today = Calendar.getInstance();

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/RemovalTimeStrategyEndTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/RemovalTimeStrategyEndTest.java
@@ -25,8 +25,10 @@ import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -116,7 +118,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     .endEvent().done();
 
   protected final Date START_DATE = new Date(1363607000000L);
-  protected final Date END_DATE = new Date(1363608000000L);
+  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   @Deployment(resources = {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/RemovalTimeStrategyStartTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/RemovalTimeStrategyStartTest.java
@@ -24,8 +24,10 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
 import java.io.ByteArrayInputStream;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -117,7 +119,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
         .calledElement(CALLED_PROCESS_KEY)
     .endEvent().done();
 
-  protected final Date START_DATE = new Date(1363608000000L);
+  protected final Date START_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   @Deployment(resources = {
@@ -934,7 +936,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
 
     testRule.deploy(CALLED_PROCESS);
 
-    repositoryService.suspendProcessDefinitionByKey(CALLED_PROCESS_KEY, true, new Date(1363608000000L));
+    repositoryService.suspendProcessDefinitionByKey(CALLED_PROCESS_KEY, true, new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime());
 
     String jobId = managementService.createJobQuery()
       .singleResult()
@@ -1033,7 +1035,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
 
     testRule.deploy(CALLED_PROCESS);
 
-    repositoryService.suspendProcessDefinitionByKey(CALLED_PROCESS_KEY, true, new Date(1363608000000L));
+    repositoryService.suspendProcessDefinitionByKey(CALLED_PROCESS_KEY, true, new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime());
 
     // when
     HistoricJobLog jobLog = historyService.createHistoricJobLogQuery().singleResult();
@@ -1303,7 +1305,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
 
     // assume
     assertThat(comment, notNullValue());
-    
+
     // then
     assertThat(comment.getRemovalTime(), nullValue());
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeInChunksTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeInChunksTest.java
@@ -23,7 +23,9 @@ import static org.camunda.bpm.engine.ProcessEngineConfiguration.HISTORY_FULL;
 import static org.camunda.bpm.engine.test.api.history.removaltime.batch.helper.BatchSetRemovalTimeRule.addDays;
 
 import java.io.ByteArrayInputStream;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
 import org.camunda.bpm.engine.AuthorizationService;
 import org.camunda.bpm.engine.BadUserRequestException;
@@ -94,7 +96,7 @@ public class BatchSetRemovalTimeInChunksTest {
 
   protected final Date REMOVAL_TIME = testRule.REMOVAL_TIME;
 
-  protected final Date CREATE_TIME = new Date(1363608000000L);
+  protected final Date CREATE_TIME = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   protected final Date CURRENT_DATE = testRule.CURRENT_DATE;
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeNonHierarchicalTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeNonHierarchicalTest.java
@@ -21,10 +21,11 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.camunda.bpm.engine.ProcessEngineConfiguration.HISTORY_FULL;
 
 import java.io.ByteArrayInputStream;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
-
 import org.camunda.bpm.engine.AuthorizationService;
 import org.camunda.bpm.engine.DecisionService;
 import org.camunda.bpm.engine.ExternalTaskService;
@@ -94,7 +95,7 @@ public class BatchSetRemovalTimeNonHierarchicalTest {
 
   protected final Date REMOVAL_TIME = testRule.REMOVAL_TIME;
 
-  protected final Date CREATE_TIME = new Date(1363608000000L);
+  protected final Date CREATE_TIME = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   protected RuntimeService runtimeService;
   protected DecisionService decisionService;

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/batch/helper/BatchSetRemovalTimeRule.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/batch/helper/BatchSetRemovalTimeRule.java
@@ -18,6 +18,7 @@ package org.camunda.bpm.engine.test.api.history.removaltime.batch.helper;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.Map;
 import org.camunda.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
@@ -44,7 +45,7 @@ import org.junit.runner.Description;
  */
 public class BatchSetRemovalTimeRule extends BatchRule {
 
-  public final Date CURRENT_DATE = new Date(1363608000000L);
+  public final Date CURRENT_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
   public final Date REMOVAL_TIME = new Date(1363609000000L);
 
   public BatchSetRemovalTimeRule(ProcessEngineRule engineRule, ProcessEngineTestRule engineTestRule) {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/AbstractHistoryCleanupSchedulerTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/AbstractHistoryCleanupSchedulerTest.java
@@ -22,12 +22,13 @@ import static org.camunda.bpm.engine.ProcessEngineConfiguration.HISTORY_CLEANUP_
 import static org.camunda.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_END;
 import static org.camunda.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupHandler.MAX_BATCH_SIZE;
 
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import org.camunda.bpm.engine.HistoryService;
 import org.camunda.bpm.engine.ManagementService;
 import org.camunda.bpm.engine.ProcessEngineConfiguration;
@@ -60,7 +61,7 @@ public abstract class AbstractHistoryCleanupSchedulerTest {
   protected HistoryService historyService;
   protected ManagementService managementService;
 
-  protected final Date END_DATE = new Date(1363608000000L);
+  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   public void initEngineConfiguration(ProcessEngineConfigurationImpl engineConfiguration) {
     engineConfiguration

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
@@ -30,14 +30,15 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
 import org.camunda.bpm.engine.AuthorizationService;
 import org.camunda.bpm.engine.DecisionService;
 import org.camunda.bpm.engine.ExternalTaskService;
@@ -262,7 +263,7 @@ public class HistoryCleanupRemovalTimeTest {
         .camundaDecisionRef("dish-decision")
     .endEvent().done();
 
-  protected final Date END_DATE = new Date(1363608000000L);
+  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   @Deployment(resources = {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerAttachmentsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerAttachmentsTest.java
@@ -21,8 +21,9 @@ import static org.apache.commons.lang3.time.DateUtils.addSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupJobHandlerConfiguration.START_DELAY;
 
+import java.util.Calendar;
 import java.util.Date;
-
+import java.util.GregorianCalendar;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
@@ -74,7 +75,7 @@ public class HistoryCleanupSchedulerAttachmentsTest extends AbstractHistoryClean
       .userTask("userTask").name("userTask")
     .endEvent().done();
 
-  protected final Date END_DATE = new Date(1363608000000L);
+  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   public void shouldScheduleToNow() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerAuthorizationsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerAuthorizationsTest.java
@@ -21,9 +21,10 @@ import static org.apache.commons.lang3.time.DateUtils.addSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupJobHandlerConfiguration.START_DELAY;
 
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
-
 import org.camunda.bpm.engine.AuthorizationService;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
@@ -82,7 +83,7 @@ public class HistoryCleanupSchedulerAuthorizationsTest extends AbstractHistoryCl
         .multiInstanceDone()
     .endEvent().done();
 
-  protected final Date END_DATE = new Date(1363608000000L);
+  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   public void shouldScheduleToNow() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerBatchesTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerBatchesTest.java
@@ -21,10 +21,11 @@ import static org.apache.commons.lang3.time.DateUtils.addSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupJobHandlerConfiguration.START_DELAY;
 
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
-
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.impl.history.event.HistoryEventTypes;
@@ -87,7 +88,7 @@ public class HistoryCleanupSchedulerBatchesTest extends AbstractHistoryCleanupSc
           .multiInstanceDone()
     .endEvent().done();
 
-  protected final Date END_DATE = new Date(1363608000000L);
+  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   public void shouldScheduleToNow() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerDecisionsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerDecisionsTest.java
@@ -21,8 +21,9 @@ import static org.apache.commons.lang3.time.DateUtils.addSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupJobHandlerConfiguration.START_DELAY;
 
+import java.util.Calendar;
 import java.util.Date;
-
+import java.util.GregorianCalendar;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.impl.history.event.HistoryEventTypes;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
@@ -79,7 +80,7 @@ public class HistoryCleanupSchedulerDecisionsTest extends AbstractHistoryCleanup
         .multiInstanceDone()
     .endEvent().done();
 
-  protected final Date END_DATE = new Date(1363608000000L);
+  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   @Deployment(resources = {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerProcessInstancesTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerProcessInstancesTest.java
@@ -21,8 +21,9 @@ import static org.apache.commons.lang3.time.DateUtils.addSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupJobHandlerConfiguration.START_DELAY;
 
+import java.util.Calendar;
 import java.util.Date;
-
+import java.util.GregorianCalendar;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.impl.history.event.HistoryEventTypes;
@@ -75,7 +76,7 @@ public class HistoryCleanupSchedulerProcessInstancesTest extends AbstractHistory
       .userTask("userTask").name("userTask")
     .endEvent().done();
 
-  protected final Date END_DATE = new Date(1363608000000L);
+  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   public void shouldScheduleToNow() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerTaskInstancesTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerTaskInstancesTest.java
@@ -21,9 +21,10 @@ import static org.apache.commons.lang3.time.DateUtils.addSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupJobHandlerConfiguration.START_DELAY;
 
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
-
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.impl.history.event.HistoryEventTypes;
@@ -80,7 +81,7 @@ public class HistoryCleanupSchedulerTaskInstancesTest extends AbstractHistoryCle
         .multiInstanceDone()
     .endEvent().done();
 
-  protected final Date END_DATE = new Date(1363608000000L);
+  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   public void shouldScheduleToNow() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerTaskMetricsTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerTaskMetricsTest.java
@@ -21,7 +21,9 @@ import static org.apache.commons.lang3.time.DateUtils.addSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupJobHandlerConfiguration.START_DELAY;
 
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
@@ -69,7 +71,7 @@ public class HistoryCleanupSchedulerTaskMetricsTest extends AbstractHistoryClean
       .userTask()
     .endEvent().done();
 
-  protected final Date END_DATE = new Date(1363608000000L);
+  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   public void shouldScheduleToNow() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerVariableInstancesTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerVariableInstancesTest.java
@@ -21,8 +21,9 @@ import static org.apache.commons.lang3.time.DateUtils.addSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupJobHandlerConfiguration.START_DELAY;
 
+import java.util.Calendar;
 import java.util.Date;
-
+import java.util.GregorianCalendar;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.impl.history.event.HistoryEventTypes;
@@ -75,7 +76,7 @@ public class HistoryCleanupSchedulerVariableInstancesTest extends AbstractHistor
       .userTask()
     .endEvent().done();
 
-  protected final Date END_DATE = new Date(1363608000000L);
+  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   public void shouldScheduleToNow() {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/timer/StartTimerEventTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/bpmn/event/timer/StartTimerEventTest.java
@@ -28,12 +28,13 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
 import org.camunda.bpm.engine.impl.cmd.DeleteJobsCmd;
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
@@ -66,6 +67,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
 
   protected static final long ONE_HOUR = TimeUnit.HOURS.toMillis(1L);
   protected static final long TWO_HOURS = TimeUnit.HOURS.toMillis(2L);
+  private static final Date START_DATE = new GregorianCalendar(2023, Calendar.AUGUST, 18, 8, 0, 0).getTime();
 
   protected boolean reevaluateTimeCycleWhenDue;
 
@@ -1725,7 +1727,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
   @Test
   public void shouldReevaluateCronTimerCycleWhenDue() throws Exception {
     // given
-    ClockUtil.setCurrentTime(new Date(1692338400000l)); //"2023/8/18 8:00:00"
+    ClockUtil.setCurrentTime(START_DATE);
     MyCycleTimerBean myCycleTimerBean = new MyCycleTimerBean("0 0 * ? * * *"); // every hour
     processEngineConfiguration.getBeans().put("myCycleTimerBean", myCycleTimerBean);
     processEngineConfiguration.setReevaluateTimeCycleWhenDue(true);
@@ -1747,7 +1749,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
   @Test
   public void shouldReevaluateRepeatingToCronTimerCycle() throws Exception {
     // given
-    ClockUtil.setCurrentTime(new Date(1692338400000l)); // "2023/8/18 8:00:00"
+    ClockUtil.setCurrentTime(START_DATE);
     MyCycleTimerBean myCycleTimerBean = new MyCycleTimerBean("R2/PT1H");
     processEngineConfiguration.getBeans().put("myCycleTimerBean", myCycleTimerBean);
     processEngineConfiguration.setReevaluateTimeCycleWhenDue(true);
@@ -1768,7 +1770,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
   @Test
   public void shouldReevaluateCronToRepeatingTimerCycle() throws Exception {
     // given
-    ClockUtil.setCurrentTime(new Date(1692338400000l)); //"2023/8/18 8:00:00"
+    ClockUtil.setCurrentTime(START_DATE);
     MyCycleTimerBean myCycleTimerBean = new MyCycleTimerBean("0 0 * ? * * *"); // every hour
     processEngineConfiguration.getBeans().put("myCycleTimerBean", myCycleTimerBean);
     processEngineConfiguration.setReevaluateTimeCycleWhenDue(true);
@@ -1803,7 +1805,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
   @Test
   public void shouldReevaluateCronToRepeatingTimerCycleWithDate() throws Exception {
     // given
-    ClockUtil.setCurrentTime(new Date(1692338400000l)); //"2023/8/18 8:00:00"
+    ClockUtil.setCurrentTime(START_DATE);
     MyCycleTimerBean myCycleTimerBean = new MyCycleTimerBean("0 0 * ? * * *"); // every hour
     processEngineConfiguration.getBeans().put("myCycleTimerBean", myCycleTimerBean);
     processEngineConfiguration.setReevaluateTimeCycleWhenDue(true);
@@ -1838,7 +1840,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
   @Test
   public void shouldReevaluateRepeatingTimerCycleWithDate() throws Exception {
     // given
-    ClockUtil.setCurrentTime(new Date(1692338400000l)); //"2023/8/18 8:00:00"
+    ClockUtil.setCurrentTime(START_DATE);
     MyCycleTimerBean myCycleTimerBean = new MyCycleTimerBean("R3/2023-08-18T8:00/PT1H"); // every hour
     processEngineConfiguration.getBeans().put("myCycleTimerBean", myCycleTimerBean);
     processEngineConfiguration.setReevaluateTimeCycleWhenDue(true);
@@ -1873,7 +1875,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
   @Test
   public void shouldReevaluateRepeatingTimerCycleToTimerCycleWithDate() throws Exception {
     // given
-    ClockUtil.setCurrentTime(new Date(1692338400000l)); //"2023/8/18 8:00:00"
+    ClockUtil.setCurrentTime(START_DATE);
     MyCycleTimerBean myCycleTimerBean = new MyCycleTimerBean("R3/PT1H"); // every hour
     processEngineConfiguration.getBeans().put("myCycleTimerBean", myCycleTimerBean);
     processEngineConfiguration.setReevaluateTimeCycleWhenDue(true);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/CompetingHistoryCleanupAcquisitionTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/concurrency/CompetingHistoryCleanupAcquisitionTest.java
@@ -21,9 +21,10 @@ import static org.apache.commons.lang3.time.DateUtils.addSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupJobHandlerConfiguration.START_DELAY;
 
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
-
+import java.util.GregorianCalendar;
 import org.camunda.bpm.engine.HistoryService;
 import org.camunda.bpm.engine.ManagementService;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -58,7 +59,7 @@ public class CompetingHistoryCleanupAcquisitionTest extends ConcurrencyTestHelpe
   protected HistoryService historyService;
   protected ManagementService managementService;
 
-  protected final Date CURRENT_DATE = new Date(1363608000000L);
+  protected final Date CURRENT_DATE = new GregorianCalendar(2023, Calendar.MARCH, 18, 12, 0, 0).getTime();
 
   protected static ThreadControl cleanupThread = null;
 
@@ -214,7 +215,7 @@ public class CompetingHistoryCleanupAcquisitionTest extends ConcurrencyTestHelpe
       syncBeforeFlush.set(true);
 
       managementService.executeJob(jobId);
-      
+
       return null;
     }
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/useroperationlog/UserOperationLogAnnotationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/useroperationlog/UserOperationLogAnnotationTest.java
@@ -20,9 +20,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.camunda.bpm.engine.ProcessEngineConfiguration.HISTORY_FULL;
 
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
-
 import org.camunda.bpm.engine.BadUserRequestException;
 import org.camunda.bpm.engine.EntityTypes;
 import org.camunda.bpm.engine.HistoryService;
@@ -48,7 +49,7 @@ public class UserOperationLogAnnotationTest {
   protected static final String ANNOTATION = "anAnnotation";
   protected static final String TASK_NAME = "aTaskName";
   protected static final String OPERATION_ID = "operationId";
-  protected final Date CREATE_TIME = new Date(1363608000000L);
+  protected final Date CREATE_TIME = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   protected ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
   protected ProcessEngineTestRule engineTestRule = new ProcessEngineTestRule(engineRule);

--- a/engine/src/test/java/org/camunda/bpm/engine/test/util/ClockTestUtil.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/util/ClockTestUtil.java
@@ -16,8 +16,9 @@
  */
 package org.camunda.bpm.engine.test.util;
 
+import java.util.Calendar;
 import java.util.Date;
-
+import java.util.GregorianCalendar;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 
 public final class ClockTestUtil {
@@ -42,7 +43,7 @@ public final class ClockTestUtil {
    * @return the new current time
    */
   public static Date setClockToDateWithoutMilliseconds() {
-    ClockUtil.setCurrentTime(new Date(1363608000000L));
+    ClockUtil.setCurrentTime(new GregorianCalendar(2023, Calendar.AUGUST, 18, 8, 0, 0).getTime());
     return ClockUtil.getCurrentTime();
   }
 

--- a/webapps/assembly/src/test/java/org/camunda/bpm/admin/plugin/base/MetricsRestServiceTest.java
+++ b/webapps/assembly/src/test/java/org/camunda/bpm/admin/plugin/base/MetricsRestServiceTest.java
@@ -105,7 +105,7 @@ public class MetricsRestServiceTest extends AbstractAdminPluginTest {
   @Test
   public void shouldThrowExceptionWhenSubscriptionStartDateNotInPast() {
     // given
-    queryParameters.add("subscriptionStartDate", "2100-01-31");
+    queryParameters.add("subscriptionStartDate", new DateTime().withYear(2100).withMonthOfYear(1).withDayOfMonth(31).toString());
     queryParameters.add("groupBy", "month");
 
     // when
@@ -196,7 +196,7 @@ public class MetricsRestServiceTest extends AbstractAdminPluginTest {
   @Test
   public void shouldReturnAggregatedMetricsFilteredByMetricsParameter() {
     // given
-    queryParameters.add("subscriptionStartDate", "2020-01-01");
+    queryParameters.add("subscriptionStartDate", new DateTime().withYear(2020).withMonthOfYear(1).withDayOfMonth(1).toString());
     queryParameters.add("groupBy", "year");
     queryParameters.add("metrics", String.format("%s,%s", Metrics.PROCESS_INSTANCES, Metrics.FLOW_NODE_INSTANCES));
 
@@ -219,7 +219,7 @@ public class MetricsRestServiceTest extends AbstractAdminPluginTest {
   @Test
   public void shouldReturnAggregatedMetricsFilteredByStartDateParameter() {
     // given
-    queryParameters.add("subscriptionStartDate", "2020-01-01");
+    queryParameters.add("subscriptionStartDate", new DateTime().withYear(2020).withMonthOfYear(1).withDayOfMonth(1).toString());
     queryParameters.add("groupBy", "year");
     queryParameters.add("startDate", "2022-01-01");
     queryParameters.add("metrics", Metrics.PROCESS_INSTANCES);
@@ -246,7 +246,7 @@ public class MetricsRestServiceTest extends AbstractAdminPluginTest {
   @Test
   public void shouldReturnAggregatedMetricsFilteredByEndDateParameter() {
     // given
-    queryParameters.add("subscriptionStartDate", "2020-01-01");
+    queryParameters.add("subscriptionStartDate", new DateTime().withYear(2020).withMonthOfYear(1).withDayOfMonth(1).toString());
     queryParameters.add("groupBy", "year");
     queryParameters.add("endDate", "2022-01-01");
     queryParameters.add("metrics", Metrics.PROCESS_INSTANCES);
@@ -273,7 +273,7 @@ public class MetricsRestServiceTest extends AbstractAdminPluginTest {
   @Test
   public void shouldReturnAggregatedMetricsGroupedByMonth() {
     // given
-    queryParameters.add("subscriptionStartDate", "2020-04-15");
+    queryParameters.add("subscriptionStartDate", new DateTime().withYear(2020).withMonthOfYear(4).withDayOfMonth(15).toString());
     queryParameters.add("groupBy", "month");
     queryParameters.add("metrics", Metrics.PROCESS_INSTANCES);
 
@@ -306,7 +306,7 @@ public class MetricsRestServiceTest extends AbstractAdminPluginTest {
   @Test
   public void shouldReturnAggregatedMetricsGroupedByYear() {
     // given
-    queryParameters.add("subscriptionStartDate", "2020-04-15");
+    queryParameters.add("subscriptionStartDate", new DateTime().withYear(2020).withMonthOfYear(4).withDayOfMonth(15).toString());
     queryParameters.add("groupBy", "year");
     queryParameters.add("metrics", Metrics.PROCESS_INSTANCES);
 
@@ -339,7 +339,7 @@ public class MetricsRestServiceTest extends AbstractAdminPluginTest {
   @Test
   public void shouldReturnAnnualAggregatedMetricsForTU() {
     // given
-    queryParameters.add("subscriptionStartDate", "2020-01-01");
+    queryParameters.add("subscriptionStartDate", new DateTime().withYear(2020).withMonthOfYear(1).withDayOfMonth(1).toString());
     queryParameters.add("groupBy", "year");
     queryParameters.add("metrics", Metrics.TASK_USERS);
 
@@ -364,7 +364,7 @@ public class MetricsRestServiceTest extends AbstractAdminPluginTest {
   @Test
   public void shouldReturnMonthlyAggregatedMetricsForTU() {
     // given
-    queryParameters.add("subscriptionStartDate", "2020-01-01");
+    queryParameters.add("subscriptionStartDate", new DateTime().withYear(2020).withMonthOfYear(1).withDayOfMonth(1).toString());
     queryParameters.add("startDate", "2023-01-01");
     queryParameters.add("groupBy", "month");
     queryParameters.add("metrics", Metrics.TASK_USERS);
@@ -426,7 +426,7 @@ public class MetricsRestServiceTest extends AbstractAdminPluginTest {
   @Test
   public void shouldReturnAggregatedMetricsByYear() {
     // given
-    queryParameters.add("subscriptionStartDate", "2020-01-01");
+    queryParameters.add("subscriptionStartDate", new DateTime().withYear(2020).withMonthOfYear(1).withDayOfMonth(1).toString());
     queryParameters.add("groupBy", "year");
 
     // generate metrics for last 5 days & last 3 years
@@ -457,7 +457,7 @@ public class MetricsRestServiceTest extends AbstractAdminPluginTest {
   @Test
   public void shouldReturnAggregatedMetricsByMonth() {
     // given
-    queryParameters.add("subscriptionStartDate", "2020-01-01");
+    queryParameters.add("subscriptionStartDate", new DateTime().withYear(2020).withMonthOfYear(1).withDayOfMonth(1).toString());
     queryParameters.add("groupBy", "month");
 
     // generate metrics for last 5 days & last 3 years


### PR DESCRIPTION
The bug is they used Epoch millisecond based on CET instead of UTC timezone. There are other places that its being used but aren't affecting tests. I just fixed the failed ones. I used GregorianCalendar Calendar instead of Julian since its widely used to create Date and also I think its more readable than that putting an Epoch millisecond.


_The fix should work on any timezone that the tests are being run_
Example to run engine (other modules can be run the same way) tests in a specific timezone from a root folder:
**mvn clean install -pl engine Duser.timezone=UTC
mvn clean install -pl engine -Duser.timezone=MST**


-Duser.timezone --> sets VM time which takes precedence over OS time.

https://github.com/camunda/camunda-bpm-platform/issues/2604