### PR TITLE
fix(db2): Reduce batch execution time by filtering out queried byte arrays

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/db/sql/DbSqlSessionFactory.java
@@ -675,6 +675,7 @@ public class DbSqlSessionFactory implements SessionFactory {
     addDatabaseSpecificStatement(DB2, "deleteHistoricBatchesByRemovalTime", "deleteHistoricBatchesByRemovalTime_postgres_or_db2");
     addDatabaseSpecificStatement(DB2, "deleteAuthorizationsByRemovalTime", "deleteAuthorizationsByRemovalTime_postgres_or_db2");
     addDatabaseSpecificStatement(DB2, "deleteTaskMetricsByRemovalTime", "deleteTaskMetricsByRemovalTime_postgres_or_db2");
+    addDatabaseSpecificStatement(DB2, "updateByteArraysByBatchId", "updateByteArraysByBatchId_db2");
 
     constants = new HashMap<>();
     constants.put("constant.event", "'event'");

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/VariableInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/VariableInstance.xml
@@ -1226,6 +1226,17 @@
       )
   </update>
 
+  <update id="updateByteArraysByBatchId_db2"
+          parameterType="java.util.Map">
+      UPDATE ${prefix}ACT_GE_BYTEARRAY
+      SET REMOVAL_TIME_ = #{removalTime, jdbcType=TIMESTAMP}
+      WHERE NAME_ = 'job.exceptionByteArray' AND ID_ IN (
+          SELECT JOB_EXCEPTION_STACK_ID_
+          FROM ${prefix}ACT_HI_JOB_LOG
+          WHERE JOB_DEF_CONFIGURATION_ = #{batchId, jdbcType=VARCHAR}
+      )
+  </update>
+
   <update id="updateByteArraysByBatchId_mssql"
           parameterType="java.util.Map">
     update RES set


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/4067