### PR TITLE
fix(engine-rest): typo fix. related to #3710

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/history/HistoricDecisionInstanceDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/history/HistoricDecisionInstanceDto.ftl
@@ -112,7 +112,7 @@
     />
     
     <@lib.property
-        name = "ouputs"
+        name = "outputs"
         type = "array"
         dto = "HistoricDecisionOutputInstanceDto"
         desc = "The list of decision output values. **Only exists** if `includeOutputs`


### PR DESCRIPTION
- fixed typo in /history/decision-instance response

related to #3710