### PR TITLE
fix(engine): Skip ByteArray Deletion when Updating Var

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
@@ -157,7 +157,7 @@ public class VariableInstanceEntity implements VariableInstance, CoreVariableIns
     }
 
     // clear value
-    clearValueFields();
+    clearValueFields(true);
 
     if (!isTransient) {
       // delete variable
@@ -280,19 +280,19 @@ public class VariableInstanceEntity implements VariableInstance, CoreVariableIns
 
   public void setValue(TypedValue value) {
     // clear value fields
-    clearValueFields();
+    clearValueFields(false);
 
     typedValueField.setValue(value);
   }
 
-  public void clearValueFields() {
+  public void clearValueFields(boolean deleteVariable) {
     this.longValue = null;
     this.doubleValue = null;
     this.textValue = null;
     this.textValue2 = null;
     typedValueField.clear();
 
-    if(byteArrayField.getByteArrayId() != null) {
+    if(deleteVariable && byteArrayField.getByteArrayId() != null) {
       deleteByteArrayValue();
       setByteArrayValueId(null);
     }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/VariableInstanceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/VariableInstanceTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.api.runtime;
+
+import org.camunda.bpm.engine.impl.persistence.entity.VariableInstanceEntity;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.util.PluggableProcessEngineTest;
+import org.camunda.bpm.engine.variable.VariableMap;
+import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.engine.variable.value.ObjectValue;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VariableInstanceTest extends PluggableProcessEngineTest {
+
+    @Test
+    @Deployment(resources = {"org/camunda/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+    public void shouldUpdateVariableStateOnVariableTypeChangeObjectToLong() {
+        // given
+
+        var processInstance = startProcessInstanceWithObjectVariable("oneTaskProcess",
+                "variableA", "43");
+
+        VariableInstanceEntity variable = (VariableInstanceEntity) runtimeService.createVariableInstanceQuery()
+                .processInstanceIdIn(processInstance.getId())
+                .singleResult();
+
+        // Object variables will populate the byte array fields
+        assertThat(variable.getByteArrayValue()).isNotNull();
+        assertThat(variable.getByteArrayValueId()).isNotNull();
+
+        // The other type fields will be null
+        assertThat(variable.getDoubleValue()).isNull();
+        assertThat(variable.getLongValue()).isNull();
+        assertThat(variable.getTextValue()).isNull();
+        assertThat(variable.getTextValue2()).isEqualTo("java.lang.String");
+
+        // when the type is updated from object to integer
+        runtimeService.setVariable(processInstance.getId(), "variableA", 43);
+
+        variable = (VariableInstanceEntity) runtimeService.createVariableInstanceQuery()
+                .processInstanceIdIn(processInstance.getId())
+                .singleResult();
+
+        // then the changed integer type should be reflected in the variable entity row appropriately
+        assertThat(variable.getByteArrayValue()).isNull();  // byte array fields should not exist for an integer field
+        assertThat(variable.getByteArrayValueId()).isNull();
+
+        assertThat(variable.getDoubleValue()).isNull();
+        assertThat(variable.getLongValue()).isEqualTo(43L);
+        assertThat(variable.getTextValue()).isEqualTo("43");
+        assertThat(variable.getTextValue2()).isNull();
+    }
+
+    @Test
+    @Deployment(resources = {"org/camunda/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+    public void shouldUpdateVariableStateOnVariableTypeChangeDoubleToObject() {
+        // given
+        var processInstance = startProcessInstanceWithVariable("oneTaskProcess",
+                "variableA", 43.0);
+
+        VariableInstanceEntity variable = (VariableInstanceEntity) runtimeService.createVariableInstanceQuery()
+                .processInstanceIdIn(processInstance.getId())
+                .singleResult();
+
+        // Double variable state is populated
+        assertThat(variable.getDoubleValue()).isEqualTo(43.0);
+        assertThat(variable.getLongValue()).isNull();
+        assertThat(variable.getTextValue()).isNull();
+        assertThat(variable.getTextValue2()).isNull();
+        assertThat(variable.getValue()).isEqualTo(43.0);
+
+        // The other type fields will be null
+        assertThat(variable.getByteArrayValue()).isNull();
+        assertThat(variable.getByteArrayValueId()).isNull();
+
+        // when the type is updated from double to object
+        setVariableWithObjectValue(processInstance.getId(), "variableA", "43.0"); // object value
+
+        variable = (VariableInstanceEntity) runtimeService.createVariableInstanceQuery()
+                .processInstanceIdIn(processInstance.getId())
+                .singleResult();
+
+        // then the changed object type should be reflected in the variable entity row appropriately
+        assertThat(variable.getByteArrayValue()).isNotNull();  // byte array fields should note exist for an integer field
+        assertThat(variable.getByteArrayValueId()).isNotNull();
+
+        assertThat(variable.getDoubleValue()).isNull();
+        assertThat(variable.getLongValue()).isNull();
+        assertThat(variable.getTextValue()).isNull();
+        assertThat(variable.getTextValue2()).isEqualTo("java.lang.String");
+    }
+
+    @Test
+    @Deployment(resources = {"org/camunda/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
+    public void shouldUpdateVariableStateOnVariableTypeChangeStringToObject() {
+        // given
+        var processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess",
+                "variableA", Map.of("variableA", "This is a string value")
+        );
+
+        VariableInstanceEntity variable = (VariableInstanceEntity) runtimeService.createVariableInstanceQuery()
+                .processInstanceIdIn(processInstance.getId())
+                .singleResult();
+
+        // Double variable state is populated
+        assertThat(variable.getDoubleValue()).isNull();
+        assertThat(variable.getLongValue()).isNull();
+        assertThat(variable.getTextValue()).isEqualTo("This is a string value");
+        assertThat(variable.getTextValue2()).isNull();
+        assertThat(variable.getValue()).isEqualTo("This is a string value");
+
+        // The other type fields will be null
+        assertThat(variable.getByteArrayValue()).isNull();
+        assertThat(variable.getByteArrayValueId()).isNull();
+
+        // when the type is updated from double to object
+        setVariableWithObjectValue(processInstance.getId(), "variableA", "43.0"); // object value
+
+        variable = (VariableInstanceEntity) runtimeService.createVariableInstanceQuery()
+                .processInstanceIdIn(processInstance.getId())
+                .singleResult();
+
+        // then the changed object type should be reflected in the variable entity row appropriately
+        assertThat(variable.getByteArrayValue()).isNotNull();  // byte array fields should note exist for an integer field
+        assertThat(variable.getByteArrayValueId()).isNotNull();
+
+        assertThat(variable.getDoubleValue()).isNull();
+        assertThat(variable.getLongValue()).isNull();
+        assertThat(variable.getTextValue()).isNull();
+        assertThat(variable.getTextValue2()).isEqualTo("java.lang.String");
+    }
+
+    private ProcessInstance startProcessInstanceWithVariable(String processDefinitionKey, String variableName, Object variableValue) {
+        VariableMap variables = Variables.createVariables()
+                .putValue(variableName, variableValue);
+
+        String businessKey = processDefinitionKey; // for simplicity’s sake, same businessKey with processDefinitionKey
+        return runtimeService.startProcessInstanceByKey(processDefinitionKey, businessKey, variables);
+    }
+
+    private ProcessInstance startProcessInstanceWithObjectVariable(String processDefinitionKey, String variableName, Object variableValue) {
+        ObjectValue value = Variables.objectValue(variableValue)
+                .serializationDataFormat(Variables.SerializationDataFormats.JAVA)
+                .create();
+
+        VariableMap variables = Variables.createVariables()
+                .putValue(variableName, value);
+
+        String businessKey = processDefinitionKey; // for simplicity’s sake, same businessKey with processDefinitionKey
+        return runtimeService.startProcessInstanceByKey(processDefinitionKey, businessKey, variables);
+    }
+
+    private void setVariableWithObjectValue(String executionId, String variableName, Object variableValue) {
+        ObjectValue value = Variables.objectValue(variableValue)
+                .serializationDataFormat(Variables.SerializationDataFormats.JAVA)
+                .create();
+
+        runtimeService.setVariable(executionId, variableName, value);
+    }
+}


### PR DESCRIPTION
**Problem Description:** During Set Variable and Read Variable operations, the following partial ORM operations can occur in a problematic sequence:

- Thread A reads an Object Variable, thus associated with a byte array value
- Thread B reads the same Object Variable and updates its value to the db
- Now Thread A has a leaking byte array reference that is null

**Solution:** Instead of deleting an updating the byte array value, during the update, the deletion is simply skipped.
The fix was verified with the customer.

The above behaviour introduces leftover byte-array state on type change. Thus, only during a type change, the byte-array is deleted.

**Unit-tests:** This commit introduces unit tests that verify the correct state of the variables on type change.

**Limitations Accepted:** The issue could not be reproduced with a unit test. However, this is accepted since the fix follows a common theme for value update across all the project and is not expected to produce a regression. Moreover, the mere reproduction of the problem using private calls doesn't give any extra value.

**Co-authored-by**: tasso94, petros.savvidis
**Related-to:** https://github.com/camunda/camunda-bpm-platform/issues/4324, https://jira.camunda.com/browse/SUPPORT-21494