### PR TITLE
feat(core) Add update and delete command Java/Rest APIs

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/process-instance/{id}/comment/delete.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/process-instance/{id}/comment/delete.ftl
@@ -1,0 +1,49 @@
+<#macro endpoint_macro docsUrl="">
+  {
+    <@lib.endpointInfo
+        id = "deleteProcessInstanceComments"
+        tag = "Process Instance Comment"
+        summary = "Delete ProcessInstance Comments"
+        desc = "Deletes all comments of a processIntance by processInstance id." />
+
+  "parameters": [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the process instance for which all comments are to be deleted."/>
+
+  ],
+  "responses": {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful." />
+
+    <@lib.response
+        code = "401"
+        dto = "ExceptionDto"
+        desc = "The authenticated user is unauthorized to delete this resource. See the
+                        [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                        for the error response format."/>
+
+    <@lib.response
+        code = "403"
+        dto = "AuthorizationExceptionDto"
+        desc = "The history of the engine is disabled. See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                        for the error response format." />
+
+    <@lib.response
+        code = "500"
+        dto = "ExceptionDto"
+        last = true
+        desc = "Comments of a process instance could not be deleted successfully.
+                            See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                            for the error response format." />
+
+   }
+  }
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/process-instance/{id}/comment/put.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/process-instance/{id}/comment/put.ftl
@@ -1,0 +1,73 @@
+<#macro endpoint_macro docsUrl="">
+  {
+
+    <@lib.endpointInfo
+        id = "updateProcessInstanceComment"
+        tag = "Process Instance Comment"
+        summary = "Update"
+        desc = "Updates a Comment." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id associated of a process instance of a comment to be updated."/>
+
+  ],
+
+    <@lib.requestBody
+        mediaType = "application/json"
+        dto = "CommentDto"
+        requestDesc = "**Note:** Only the `id` and `message` properties will be used. Every other
+          property passed to this endpoint will be ignored."
+        examples = ['"example-1": {
+                             "summary": "PUT /process-instance/aProcessInstanceId/comment",
+                             "value": {
+                                "id": "75bc161a-12da-11e4-7d3a-f4ccdc10a445",
+                                "message": "a process instance comment"
+                             }
+                           }'] />
+
+  "responses" : {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful."  />
+
+    <@lib.response
+        code = "400"
+        dto = "ExceptionDto"
+        desc = "Returned if some of the query parameters are invalid, for example if
+                    the value of `commentId` parameter is supplied as null. See the
+                    [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                    for the error response format." />
+
+    <@lib.response
+        code = "401"
+        dto = "ExceptionDto"
+        desc = "The authenticated user is unauthorized to update this resource. See the
+                    [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                    for the error response format." />
+
+    <@lib.response
+        code = "403"
+        dto = "AuthorizationExceptionDto"
+        desc = "The history of the engine is disabled. See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                    for the error response format." />
+
+    <@lib.response
+        code = "500"
+        dto = "ExceptionDto"
+        last = true
+        desc = "The comment of a process instance could not be updated successfully.
+                    See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                    for the error response format." />
+
+   }
+  }
+
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/process-instance/{id}/comment/{commentId}/delete.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/process-instance/{id}/comment/{commentId}/delete.ftl
@@ -1,0 +1,59 @@
+<#macro endpoint_macro docsUrl="">
+  {
+
+    <@lib.endpointInfo
+        id = "deleteProcessInstanceComment"
+        tag = "Process Instance Comment"
+        summary = "Delete"
+        desc = "Removes a comment from a process instance by id." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        desc = "The id of the processInstance." />
+
+    <@lib.parameter
+        name = "commentId"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the comment to be removed." />
+
+  ],
+
+  "responses" : {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful." />
+
+    <@lib.response
+        code = "401"
+        dto = "ExceptionDto"
+        desc = "The authenticated user is unauthorized to delete this resource. See the
+                        [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                        for the error response format." />
+
+    <@lib.response
+        code = "403"
+        dto = "AuthorizationExceptionDto"
+        desc = "The history of the engine is disabled. See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                    for the error response format." />
+
+    <@lib.response
+        code = "500"
+        dto = "ExceptionDto"
+        last = true
+        desc = "The comment of a process instance could not be deleted successfully.
+                    See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                    for the error response format." />
+
+    }
+  }
+
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/comment/delete.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/comment/delete.ftl
@@ -1,0 +1,49 @@
+<#macro endpoint_macro docsUrl="">
+  {
+    <@lib.endpointInfo
+        id = "deleteTaskComments"
+        tag = "Task Comment"
+        summary = "Delete Task Comments"
+        desc = "Deletes all comments of a task by task id." />
+
+  "parameters": [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the task for which all comments are to be deleted."/>
+
+  ],
+  "responses": {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful." />
+
+    <@lib.response
+        code = "401"
+        dto = "ExceptionDto"
+        desc = "The authenticated user is unauthorized to delete this resource. See the
+                        [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                        for the error response format."
+    />
+
+    <@lib.response
+        code = "403"
+        dto = "AuthorizationExceptionDto"
+        desc = "The history of the engine is disabled. See the [Introduction](/reference/rest/overview/#error-handling)
+                        for the error response format." />
+
+    <@lib.response
+        code = "500"
+        dto = "ExceptionDto"
+        last = true
+        desc = "Comments of a task could not be deleted successfully.
+                                See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                                for the error response format." />
+    }
+  }
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/comment/put.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/comment/put.ftl
@@ -1,0 +1,64 @@
+<#macro endpoint_macro docsUrl="">
+  {
+
+    <@lib.endpointInfo
+        id = "updateTaskComment"
+        tag = "Task Comment"
+        summary = "Update"
+        desc = "Updates a Comment." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id associated of a task of a comment to be updated."/>
+
+  ],
+
+    <@lib.requestBody
+        mediaType = "application/json"
+        dto = "CommentDto"
+        requestDesc = "**Note:** Only the `id` and `message` properties will be used. Every other
+          property passed to this endpoint will be ignored."
+        examples = ['"example-1": {
+                             "summary": "PUT /task/aTaskId/comment",
+                             "value": {
+                                "id": "86cd272a-23ea-22e5-8e4a-e5bded20a556",
+                                "message": "a task comment"
+                             }
+                           }'] />
+
+  "responses" : {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful."  />
+
+    <@lib.response
+        code = "401"
+        dto = "ExceptionDto"
+        desc = "The authenticated user is unauthorized to update this resource. See the
+                        [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                        for the error response format."/>
+
+    <@lib.response
+        code = "403"
+        dto = "AuthorizationExceptionDto"
+        desc = "The history of the engine is disabled. See the [Introduction](/reference/rest/overview/#error-handling)
+                        for the error response format." />
+
+    <@lib.response
+        code = "500"
+        dto = "ExceptionDto"
+        last = true
+        desc = "The comment of a task could not be updated successfully.
+                                See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                                for the error response format." />
+   }
+  }
+
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/comment/{commentId}/delete.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/comment/{commentId}/delete.ftl
@@ -1,0 +1,59 @@
+<#macro endpoint_macro docsUrl="">
+  {
+
+    <@lib.endpointInfo
+        id = "deleteTaskComment"
+        tag = "Task Comment"
+        summary = "Delete"
+        desc = "Removes a comment from a task by id." />
+
+  "parameters" : [
+
+    <@lib.parameter
+        name = "id"
+        location = "path"
+        type = "string"
+        required = true
+        desc = "The id of the task." />
+
+    <@lib.parameter
+        name = "commentId"
+        location = "path"
+        type = "string"
+        required = true
+        last = true
+        desc = "The id of the comment to be removed." />
+
+  ],
+
+  "responses" : {
+
+    <@lib.response
+        code = "204"
+        desc = "Request successful." />
+
+    <@lib.response
+        code = "401"
+        dto = "ExceptionDto"
+        desc = "The authenticated user is unauthorized to delete this resource. See the
+                    [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                    for the error response format."/>
+
+    <@lib.response
+        code = "403"
+        dto = "AuthorizationExceptionDto"
+        desc = "The history of the engine is disabled. See the [Introduction](/reference/rest/overview/#error-handling)
+                    for the error response format." />
+
+    <@lib.response
+        code = "500"
+        dto = "ExceptionDto"
+        last = true
+        desc = "The comment of a task could not be deleted successfully.
+                    See the [Introduction](${docsUrl}/reference/rest/overview/#error-handling)
+                    for the error response format." />
+
+    }
+  }
+
+</#macro>

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/runtime/ProcessInstanceCommentResource.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/runtime/ProcessInstanceCommentResource.java
@@ -17,11 +17,14 @@
 package org.camunda.bpm.engine.rest.sub.runtime;
 
 import java.util.List;
-
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-
 import org.camunda.bpm.engine.rest.dto.task.CommentDto;
 
 public interface ProcessInstanceCommentResource {
@@ -30,4 +33,15 @@ public interface ProcessInstanceCommentResource {
   @Produces(MediaType.APPLICATION_JSON)
   List<CommentDto> getComments();
 
+  @DELETE
+  @Path("/{commentId}")
+  @Produces(MediaType.APPLICATION_JSON)
+  void deleteComment(@PathParam("commentId") String commentId);
+
+  @PUT
+  @Consumes(MediaType.APPLICATION_JSON)
+  void updateComment(CommentDto comment);
+
+  @DELETE
+  void deleteComments();
 }

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/runtime/impl/ProcessInstanceCommentResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/runtime/impl/ProcessInstanceCommentResourceImpl.java
@@ -19,11 +19,14 @@ package org.camunda.bpm.engine.rest.sub.runtime.impl;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import javax.ws.rs.core.Response.Status;
-
+import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.IdentityService;
 import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.ProcessEngineException;
+import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.exception.NotValidException;
+import org.camunda.bpm.engine.exception.NullValueException;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.identity.Authentication;
@@ -57,6 +60,70 @@ public class ProcessInstanceCommentResourceImpl implements ProcessInstanceCommen
     }
 
     return comments;
+  }
+
+  /**
+   * Deletes a comment by a given commentId
+   */
+  @Override
+  public void deleteComment(String commentId) {
+    ensureHistoryEnabled(Status.FORBIDDEN);
+    ensureProcessInstanceExists(Status.NOT_FOUND);
+
+    TaskService taskService = engine.getTaskService();
+    try {
+      taskService.deleteProcessInstanceComment(processInstanceId, commentId);
+    } catch (NotValidException e) {
+      throw new InvalidRequestException(Status.NOT_FOUND,
+          "Deletion is not possible. No comment exists for processInstanceId '" + processInstanceId
+              + "' and comment id '" + commentId + "'.");
+    }
+  }
+
+  /**
+   * Updates message for a given processInstance ID and commentId
+   */
+  public void updateComment(CommentDto comment) {
+    ensureHistoryEnabled(Status.FORBIDDEN);
+    ensureProcessInstanceExists(Status.NOT_FOUND);
+
+    TaskService taskService = engine.getTaskService();
+    try {
+      taskService.updateProcessInstanceComment(processInstanceId, comment.getId(), comment.getMessage());
+    } catch (NotValidException e) {
+      throw new InvalidRequestException(Status.NOT_FOUND,
+          "Update is not possible. No comment exists for process instance id '" + processInstanceId
+              + "' and comment id '" + comment.getId() + "'.");
+    } catch (AuthorizationException e) {
+      throw e;
+    } catch (NullValueException e) {
+      throw new InvalidRequestException(Status.BAD_REQUEST, e.getMessage());
+    } catch (ProcessEngineException e) {
+      throw new InvalidRequestException(Status.BAD_REQUEST, e, "Not enough parameters submitted");
+    }
+  }
+
+  /**
+   * Deletes all comments by a given processInstanceId
+   */
+  @Override
+  public void deleteComments() {
+    ensureHistoryEnabled(Status.FORBIDDEN);
+    ensureProcessInstanceExists(Status.NOT_FOUND);
+    TaskService taskService = engine.getTaskService();
+
+    try {
+      taskService.deleteProcessInstanceComments(processInstanceId);
+    } catch (NotValidException e) {
+      throw new InvalidRequestException(Status.NOT_FOUND,
+          "Deletion of comments not possible for processInstance id '" + processInstanceId + "'.");
+    }
+  }
+
+  private void ensureHistoryEnabled(Status status) {
+    if (!isHistoryEnabled()) {
+      throw new InvalidRequestException(status, "History is not enabled");
+    }
   }
 
   private boolean isHistoryEnabled() {

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/task/TaskCommentResource.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/sub/task/TaskCommentResource.java
@@ -16,13 +16,19 @@
  */
 package org.camunda.bpm.engine.rest.sub.task;
 
-import org.camunda.bpm.engine.rest.dto.task.CommentDto;
-
-import javax.ws.rs.*;
+import java.util.List;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
-import java.util.List;
+import org.camunda.bpm.engine.rest.dto.task.CommentDto;
 
 public interface TaskCommentResource {
 
@@ -40,5 +46,17 @@ public interface TaskCommentResource {
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   CommentDto createComment(@Context UriInfo uriInfo, CommentDto comment);
+
+  @DELETE
+  @Path("/{commentId}")
+  @Produces(MediaType.APPLICATION_JSON)
+  void deleteComment(@PathParam("commentId") String commentId);
+
+  @PUT
+  @Consumes(MediaType.APPLICATION_JSON)
+  void updateComment(CommentDto comment);
+
+  @DELETE
+  void deleteComments();
 
 }

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/TaskRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/TaskRestServiceInteractionTest.java
@@ -65,6 +65,9 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
+import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -76,11 +79,9 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
-
 import org.assertj.core.api.Assertions;
 import org.camunda.bpm.ProcessApplicationService;
 import org.camunda.bpm.application.ProcessApplicationInfo;
@@ -95,6 +96,7 @@ import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.exception.NotFoundException;
 import org.camunda.bpm.engine.exception.NotValidException;
+import org.camunda.bpm.engine.exception.NullValueException;
 import org.camunda.bpm.engine.form.TaskFormData;
 import org.camunda.bpm.engine.history.HistoricTaskInstance;
 import org.camunda.bpm.engine.history.HistoricTaskInstanceQuery;
@@ -142,10 +144,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-
-import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
-import io.restassured.response.Response;
 
 public class TaskRestServiceInteractionTest extends
     AbstractRestServiceTest {
@@ -3724,6 +3722,315 @@ public class TaskRestServiceInteractionTest extends
       .body("message", equalTo("aMessage"))
       .when()
       .post(HANDLE_BPMN_ESCALATION_URL);
+  }
+
+  @Test
+  public void testDeleteTaskCommentThrowsAuthorizationException() {
+    String message = "expected exception";
+    doThrow(new AuthorizationException(message)).when(taskServiceMock)
+        .deleteTaskComment(MockProvider.EXAMPLE_TASK_ID, EXAMPLE_TASK_COMMENT_ID);
+
+    given().pathParam("id", MockProvider.EXAMPLE_TASK_ID)
+        .pathParam("commentId", EXAMPLE_TASK_COMMENT_ID)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .then()
+        .expect()
+        .statusCode(Status.FORBIDDEN.getStatusCode())
+        .when()
+        .delete(SINGLE_TASK_SINGLE_COMMENT_URL);
+  }
+
+  @Test
+  public void testDeleteTaskComment() {
+    given().pathParam("id", MockProvider.EXAMPLE_TASK_ID)
+        .pathParam("commentId", EXAMPLE_TASK_COMMENT_ID)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .then()
+        .expect()
+        .statusCode(Status.NO_CONTENT.getStatusCode())
+        .when()
+        .delete(SINGLE_TASK_SINGLE_COMMENT_URL);
+  }
+
+  @Test
+  public void testDeleteTaskCommentWithHistoryDisabled() {
+    mockHistoryDisabled();
+
+    given().pathParam("id", MockProvider.EXAMPLE_TASK_ID)
+        .pathParam("commentId", EXAMPLE_TASK_COMMENT_ID)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .then()
+        .expect()
+        .statusCode(Status.FORBIDDEN.getStatusCode())
+        .body(containsString("History is not enabled"))
+        .when()
+        .delete(SINGLE_TASK_SINGLE_COMMENT_URL);
+  }
+
+  @Test
+  public void testDeleteTaskCommentForNonExistingCommentId() {
+    doThrow(new NotValidException()).when(taskServiceMock).deleteTaskComment(EXAMPLE_TASK_ID, NON_EXISTING_ID);
+
+    given().pathParam("id", EXAMPLE_TASK_ID)
+        .pathParam("commentId", NON_EXISTING_ID)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .then()
+        .expect()
+        .statusCode(Status.NOT_FOUND.getStatusCode())
+        .contentType(ContentType.JSON)
+        .body(containsString(
+            "Deletion is not possible. No comment exists for task id '" + EXAMPLE_TASK_ID + "' and comment id '"
+                + NON_EXISTING_ID + "'."))
+        .when()
+        .delete(SINGLE_TASK_SINGLE_COMMENT_URL);
+  }
+
+  @Test
+  public void testDeleteTaskCommentForNonExistingCommentIdWithHistoryDisabled() {
+    mockHistoryDisabled();
+
+    given().pathParam("id", EXAMPLE_TASK_ID)
+        .pathParam("commentId", NON_EXISTING_ID)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .then()
+        .expect()
+        .statusCode(Status.FORBIDDEN.getStatusCode())
+        .body(containsString("History is not enabled"))
+        .when()
+        .delete(SINGLE_TASK_SINGLE_COMMENT_URL);
+  }
+
+  @Test
+  public void testDeleteTaskCommentForNonExistingTask() {
+    when(historicTaskInstanceQueryMock.taskId(NON_EXISTING_ID)).thenReturn(historicTaskInstanceQueryMock);
+    when(historicTaskInstanceQueryMock.singleResult()).thenReturn(null);
+
+    given().pathParam("id", NON_EXISTING_ID)
+        .pathParam("commentId", EXAMPLE_TASK_COMMENT_ID)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .then()
+        .expect()
+        .statusCode(Status.NOT_FOUND.getStatusCode())
+        .body(containsString("No task found for task id " + NON_EXISTING_ID))
+        .when()
+        .delete(SINGLE_TASK_SINGLE_COMMENT_URL);
+  }
+
+  @Test
+  public void testDeleteTaskCommentForNonExistingTaskWithHistoryDisabled() {
+    mockHistoryDisabled();
+
+    given().pathParam("id", NON_EXISTING_ID)
+        .pathParam("commentId", EXAMPLE_TASK_COMMENT_ID)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .then()
+        .expect()
+        .statusCode(Status.FORBIDDEN.getStatusCode())
+        .body(containsString("History is not enabled"))
+        .when()
+        .delete(SINGLE_TASK_SINGLE_COMMENT_URL);
+  }
+
+  @Test
+  public void testDeleteTaskCommentsThrowsAuthorizationException() {
+    String message = "expected exception";
+    doThrow(new AuthorizationException(message)).when(taskServiceMock).deleteTaskComments(MockProvider.EXAMPLE_TASK_ID);
+
+    given().pathParam("id", MockProvider.EXAMPLE_TASK_ID)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .then()
+        .expect()
+        .statusCode(Status.FORBIDDEN.getStatusCode())
+        .when()
+        .delete(SINGLE_TASK_COMMENTS_URL);
+  }
+
+  @Test
+  public void testDeleteTaskComments() {
+    given().pathParam("id", MockProvider.EXAMPLE_TASK_ID)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .then()
+        .expect()
+        .statusCode(Status.NO_CONTENT.getStatusCode())
+        .when()
+        .delete(SINGLE_TASK_COMMENTS_URL);
+  }
+
+  @Test
+  public void testDeleteTaskCommentsWithHistoryDisabled() {
+    mockHistoryDisabled();
+
+    given().pathParam("id", MockProvider.EXAMPLE_TASK_ID)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .then()
+        .expect()
+        .statusCode(Status.FORBIDDEN.getStatusCode())
+        .body(containsString("History is not enabled"))
+        .when()
+        .delete(SINGLE_TASK_COMMENTS_URL);
+  }
+
+  @Test
+  public void testDeleteTaskCommentsForNonExistingTask() {
+    when(historicTaskInstanceQueryMock.taskId(NON_EXISTING_ID)).thenReturn(historicTaskInstanceQueryMock);
+    when(historicTaskInstanceQueryMock.singleResult()).thenReturn(null);
+
+    given().pathParam("id", NON_EXISTING_ID)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .then()
+        .expect()
+        .statusCode(Status.NOT_FOUND.getStatusCode())
+        .body(containsString("No task found for task id " + NON_EXISTING_ID))
+        .when()
+        .delete(SINGLE_TASK_COMMENTS_URL);
+  }
+
+  @Test
+  public void testDeleteTaskCommentsForNonExistingTaskWithHistoryDisabled() {
+    mockHistoryDisabled();
+
+    given().pathParam("id", NON_EXISTING_ID)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .then()
+        .expect()
+        .statusCode(Status.FORBIDDEN.getStatusCode())
+        .body(containsString("History is not enabled"))
+        .when()
+        .delete(SINGLE_TASK_COMMENTS_URL);
+  }
+
+  @Test
+  public void testUpdateTaskComment() {
+    Map<String, Object> json = new HashMap<>();
+
+    json.put("id", EXAMPLE_TASK_COMMENT_ID);
+    json.put("message", EXAMPLE_TASK_COMMENT_FULL_MESSAGE);
+
+    given().pathParam("id", EXAMPLE_TASK_ID)
+        .body(json)
+        .contentType(ContentType.JSON)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .expect()
+        .statusCode(Status.NO_CONTENT.getStatusCode())
+        .when()
+        .put(SINGLE_TASK_COMMENTS_URL);
+
+    verify(taskServiceMock).updateTaskComment(EXAMPLE_TASK_ID, EXAMPLE_TASK_COMMENT_ID,
+        EXAMPLE_TASK_COMMENT_FULL_MESSAGE);
+  }
+
+  @Test
+  public void testUpdateTaskCommentCommentIdNull() {
+    String message = "expected exception";
+    doThrow(new NullValueException(message)).when(taskServiceMock)
+        .updateTaskComment(EXAMPLE_TASK_ID, null, EXAMPLE_TASK_COMMENT_FULL_MESSAGE);
+
+    Map<String, Object> json = new HashMap<>();
+
+    json.put("id", null);
+    json.put("message", EXAMPLE_TASK_COMMENT_FULL_MESSAGE);
+
+    given().pathParam("id", EXAMPLE_TASK_ID)
+        .body(json)
+        .contentType(ContentType.JSON)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .expect()
+        .statusCode(Status.BAD_REQUEST.getStatusCode())
+        .when()
+        .put(SINGLE_TASK_COMMENTS_URL);
+  }
+
+  @Test
+  public void testUpdateTaskCommentMessageIdNull() {
+    String message = "expected exception";
+    doThrow(new NullValueException(message)).when(taskServiceMock)
+        .updateTaskComment(EXAMPLE_TASK_ID, EXAMPLE_TASK_COMMENT_ID, null);
+
+    Map<String, Object> json = new HashMap<>();
+
+    json.put("id", EXAMPLE_TASK_COMMENT_ID);
+    json.put("message", null);
+
+    given().pathParam("id", EXAMPLE_TASK_ID)
+        .body(json)
+        .contentType(ContentType.JSON)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .expect()
+        .statusCode(Status.BAD_REQUEST.getStatusCode())
+        .when()
+        .put(SINGLE_TASK_COMMENTS_URL);
+  }
+
+  @Test
+  public void testUpdateTaskCommentExtraProperties() {
+    Map<String, Object> json = new HashMap<>();
+
+    //Only id and message are used
+    json.put("id", EXAMPLE_TASK_COMMENT_ID);
+    json.put("userId", "anyUserId");
+    json.put("time", withTimezone("2014-01-01T00:00:00"));
+    json.put("message", EXAMPLE_TASK_COMMENT_FULL_MESSAGE);
+    json.put("removalTime", withTimezone("2014-05-01T00:00:00"));
+    json.put("rootProcessInstanceId", EXAMPLE_TASK_COMMENT_ROOT_PROCESS_INSTANCE_ID);
+    json.put("processInstanceId", MockProvider.EXAMPLE_PROCESS_INSTANCE_ID);
+
+    given().pathParam("id", EXAMPLE_TASK_ID)
+        .body(json)
+        .contentType(ContentType.JSON)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .expect()
+        .statusCode(Status.NO_CONTENT.getStatusCode())
+        .when()
+        .put(SINGLE_TASK_COMMENTS_URL);
+
+    verify(taskServiceMock).updateTaskComment(EXAMPLE_TASK_ID, EXAMPLE_TASK_COMMENT_ID,
+        EXAMPLE_TASK_COMMENT_FULL_MESSAGE);
+  }
+
+  @Test
+  public void testUpdateTaskCommentTaskIdNotFound() {
+    when(historicTaskInstanceQueryMock.taskId(NON_EXISTING_ID)).thenReturn(historicTaskInstanceQueryMock);
+    when(historicTaskInstanceQueryMock.singleResult()).thenReturn(null);
+
+    Map<String, Object> json = new HashMap<>();
+
+    json.put("id", EXAMPLE_TASK_COMMENT_ID);
+    json.put("message", EXAMPLE_TASK_COMMENT_FULL_MESSAGE);
+
+    given().pathParam("id", NON_EXISTING_ID)
+        .body(json)
+        .contentType(ContentType.JSON)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .expect()
+        .statusCode(Status.NOT_FOUND.getStatusCode())
+        .contentType(ContentType.JSON)
+        .body("type", equalTo(InvalidRequestException.class.getSimpleName()))
+        .body(containsString("No task found for task id " + NON_EXISTING_ID))
+        .when()
+        .put(SINGLE_TASK_COMMENTS_URL);
+  }
+
+  @Test
+  public void testUpdateTaskCommentThrowsAuthorizationException() {
+    String message = "expected exception";
+    doThrow(new AuthorizationException(message)).when(taskServiceMock)
+        .updateTaskComment(EXAMPLE_TASK_ID, EXAMPLE_TASK_COMMENT_ID, EXAMPLE_TASK_COMMENT_FULL_MESSAGE);
+    when(historicTaskInstanceQueryMock.taskId(EXAMPLE_TASK_ID)).thenReturn(historicTaskInstanceQueryMock);
+
+    Map<String, Object> json = new HashMap<>();
+    json.put("id", EXAMPLE_TASK_COMMENT_ID);
+    json.put("message", EXAMPLE_TASK_COMMENT_FULL_MESSAGE);
+
+    given().pathParam("id", EXAMPLE_TASK_ID)
+        .body(json)
+        .contentType(ContentType.JSON)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .expect()
+        .statusCode(Status.FORBIDDEN.getStatusCode())
+        .contentType(ContentType.JSON)
+        .when()
+        .put(SINGLE_TASK_COMMENTS_URL);
+
   }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
@@ -201,6 +201,11 @@ public abstract class MockProvider {
   public static final String EXAMPLE_TASK_COMMENT_TIME = withTimezone("2014-04-24T14:10:44");
   public static final String EXAMPLE_TASK_COMMENT_ROOT_PROCESS_INSTANCE_ID = "aRootProcInstId";
 
+  //process instance comment
+  public static final String EXAMPLE_PROCESS_INSTANCE_COMMENT_ID = "aProcessInstanceCommentId";
+  public static final String EXAMPLE_PROCESS_INSTANCE_COMMENT_FULL_MESSAGE = "aProcessInstanceCommentFullMessage";
+
+
   // task attachment
   public static final String EXAMPLE_TASK_ATTACHMENT_ID = "aTaskAttachmentId";
   public static final String EXAMPLE_TASK_ATTACHMENT_NAME = "aTaskAttachmentName";

--- a/engine/src/main/java/org/camunda/bpm/engine/EntityTypes.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/EntityTypes.java
@@ -57,4 +57,5 @@ public class EntityTypes {
   public static final String OPERATION_LOG = "OperationLog";
   public static final String INCIDENT = "Incident";
   public static final String SYSTEM = "System";
+  public static final String COMMENT = "Comment";
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/TaskService.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/TaskService.java
@@ -1107,6 +1107,36 @@ public interface TaskService {
   /** Creates a comment to a task and/or process instance and returns the comment. */
   Comment createComment(String taskId, String processInstanceId, String message);
 
+  /**
+   * Deletes a comment by a given taskId and comment ID
+   */
+  void deleteTaskComment(String taskId, String commentId);
+
+  /**
+   * Deletes a comment by a given processInstanceId and comment ID
+   */
+  void deleteProcessInstanceComment(String processInstanceId, String commentId);
+
+  /**
+   * Deletes comments by a given task ID
+   */
+  void deleteTaskComments(String taskId);
+
+  /**
+   * Deletes comments by a given processInstance ID
+   */
+  void deleteProcessInstanceComments(String processInstanceId);
+
+  /**
+   * Updates comment on a given task ID
+   */
+  void updateTaskComment(String taskId, String commentId, String message);
+
+  /**
+   * Updates comment on a given processInstance ID
+   */
+  void updateProcessInstanceComment(String processInstanceId, String commentId, String message);
+
   /** The comments related to the given task. */
   List<Comment> getTaskComments(String taskId);
 

--- a/engine/src/main/java/org/camunda/bpm/engine/history/UserOperationLogEntry.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/history/UserOperationLogEntry.java
@@ -122,6 +122,9 @@ public interface UserOperationLogEntry {
   String OPERATION_TYPE_SET_VARIABLE = "SetVariable";
   String OPERATION_TYPE_SET_VARIABLES = "SetVariables";
 
+  String OPERATION_TYPE_UPDATE_COMMENT = "UpdateComment";
+  String OPERATION_TYPE_DELETE_COMMENT = "DeleteComment";
+
   String OPERATION_TYPE_REMOVE_VARIABLE = "RemoveVariable";
   String OPERATION_TYPE_MODIFY_VARIABLE = "ModifyVariable";
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/TaskServiceImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/TaskServiceImpl.java
@@ -40,7 +40,11 @@ import org.camunda.bpm.engine.impl.cmd.CreateTaskCmd;
 import org.camunda.bpm.engine.impl.cmd.DelegateTaskCmd;
 import org.camunda.bpm.engine.impl.cmd.DeleteAttachmentCmd;
 import org.camunda.bpm.engine.impl.cmd.DeleteGroupIdentityLinkCmd;
+import org.camunda.bpm.engine.impl.cmd.DeleteProcessInstanceCommentCmd;
+import org.camunda.bpm.engine.impl.cmd.DeleteProcessInstanceCommentsCmd;
 import org.camunda.bpm.engine.impl.cmd.DeleteTaskCmd;
+import org.camunda.bpm.engine.impl.cmd.DeleteTaskCommentCmd;
+import org.camunda.bpm.engine.impl.cmd.DeleteTaskCommentsCmd;
 import org.camunda.bpm.engine.impl.cmd.DeleteUserIdentityLinkCmd;
 import org.camunda.bpm.engine.impl.cmd.GetAttachmentCmd;
 import org.camunda.bpm.engine.impl.cmd.GetAttachmentContentCmd;
@@ -71,6 +75,8 @@ import org.camunda.bpm.engine.impl.cmd.SetTaskNameCmd;
 import org.camunda.bpm.engine.impl.cmd.SetTaskOwnerCmd;
 import org.camunda.bpm.engine.impl.cmd.SetTaskPriorityCmd;
 import org.camunda.bpm.engine.impl.cmd.SetTaskVariablesCmd;
+import org.camunda.bpm.engine.impl.cmd.UpdateProcessInstanceCommentCmd;
+import org.camunda.bpm.engine.impl.cmd.UpdateTaskCommentCmd;
 import org.camunda.bpm.engine.impl.util.ExceptionUtil;
 import org.camunda.bpm.engine.task.Attachment;
 import org.camunda.bpm.engine.task.Comment;
@@ -378,6 +384,30 @@ public class TaskServiceImpl extends ServiceImpl implements TaskService {
 
   public Comment createComment(String taskId, String processInstance, String message) {
     return commandExecutor.execute(new AddCommentCmd(taskId, processInstance, message));
+  }
+
+  public void deleteTaskComment(String taskId, String commentId) {
+    commandExecutor.execute(new DeleteTaskCommentCmd(taskId, commentId));
+  }
+
+  public void deleteProcessInstanceComment(String processInstanceId, String commentId) {
+    commandExecutor.execute(new DeleteProcessInstanceCommentCmd(processInstanceId, commentId));
+  }
+
+  public void deleteTaskComments(String taskId) {
+    commandExecutor.execute(new DeleteTaskCommentsCmd(taskId));
+  }
+
+  public void deleteProcessInstanceComments(String processInstanceId) {
+    commandExecutor.execute(new DeleteProcessInstanceCommentsCmd(processInstanceId));
+  }
+
+  public void updateTaskComment(String taskId, String commentId, String message) {
+    commandExecutor.execute(new UpdateTaskCommentCmd(taskId, commentId, message));
+  }
+
+  public void updateProcessInstanceComment(String processInstanceId, String commentId, String message) {
+    commandExecutor.execute(new UpdateProcessInstanceCommentCmd(processInstanceId, commentId, message));
   }
 
   public List<Comment> getTaskComments(String taskId) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/CommandChecker.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/CommandChecker.java
@@ -272,6 +272,11 @@ public interface CommandChecker {
   void checkDeleteTask(TaskEntity task);
 
   /**
+   * Check if it is allowed to update a task
+   */
+  void checkUpdateTask(TaskEntity task);
+
+  /**
    * Checks if it is allowed to read the given decision definition.
    */
   void checkReadDecisionDefinition(DecisionDefinitionEntity decisionDefinition);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/auth/AuthorizationCommandChecker.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/auth/AuthorizationCommandChecker.java
@@ -16,6 +16,36 @@
  */
 package org.camunda.bpm.engine.impl.cfg.auth;
 
+import static org.camunda.bpm.engine.authorization.Authorization.ANY;
+import static org.camunda.bpm.engine.authorization.Permissions.CREATE;
+import static org.camunda.bpm.engine.authorization.Permissions.CREATE_INSTANCE;
+import static org.camunda.bpm.engine.authorization.Permissions.DELETE;
+import static org.camunda.bpm.engine.authorization.Permissions.DELETE_HISTORY;
+import static org.camunda.bpm.engine.authorization.Permissions.DELETE_INSTANCE;
+import static org.camunda.bpm.engine.authorization.Permissions.READ;
+import static org.camunda.bpm.engine.authorization.Permissions.READ_HISTORY;
+import static org.camunda.bpm.engine.authorization.Permissions.READ_INSTANCE;
+import static org.camunda.bpm.engine.authorization.Permissions.READ_TASK;
+import static org.camunda.bpm.engine.authorization.Permissions.TASK_ASSIGN;
+import static org.camunda.bpm.engine.authorization.Permissions.TASK_WORK;
+import static org.camunda.bpm.engine.authorization.Permissions.UPDATE;
+import static org.camunda.bpm.engine.authorization.Permissions.UPDATE_INSTANCE;
+import static org.camunda.bpm.engine.authorization.Permissions.UPDATE_TASK;
+import static org.camunda.bpm.engine.authorization.Resources.BATCH;
+import static org.camunda.bpm.engine.authorization.Resources.DECISION_DEFINITION;
+import static org.camunda.bpm.engine.authorization.Resources.DECISION_REQUIREMENTS_DEFINITION;
+import static org.camunda.bpm.engine.authorization.Resources.DEPLOYMENT;
+import static org.camunda.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
+import static org.camunda.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
+import static org.camunda.bpm.engine.authorization.Resources.TASK;
+
+import org.camunda.bpm.engine.authorization.Permission;
+import org.camunda.bpm.engine.authorization.ProcessDefinitionPermissions;
+import org.camunda.bpm.engine.authorization.ProcessInstancePermissions;
+import org.camunda.bpm.engine.authorization.Resources;
+import org.camunda.bpm.engine.authorization.SystemPermissions;
+import org.camunda.bpm.engine.authorization.TaskPermissions;
+import org.camunda.bpm.engine.authorization.UserOperationLogCategoryPermissions;
 import org.camunda.bpm.engine.history.HistoricCaseInstance;
 import org.camunda.bpm.engine.history.HistoricDecisionInstance;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
@@ -29,23 +59,19 @@ import org.camunda.bpm.engine.impl.db.PermissionCheckBuilder;
 import org.camunda.bpm.engine.impl.dmn.entity.repository.DecisionDefinitionEntity;
 import org.camunda.bpm.engine.impl.dmn.entity.repository.DecisionRequirementsDefinitionEntity;
 import org.camunda.bpm.engine.impl.history.event.HistoricExternalTaskLogEntity;
-import org.camunda.bpm.engine.impl.persistence.entity.*;
+import org.camunda.bpm.engine.impl.persistence.entity.AuthorizationManager;
+import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricJobLogEventEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricProcessInstanceEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricTaskInstanceEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.camunda.bpm.engine.repository.CaseDefinition;
 import org.camunda.bpm.engine.repository.DecisionDefinition;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.camunda.bpm.engine.runtime.CaseExecution;
-
-import static org.camunda.bpm.engine.authorization.Authorization.ANY;
-import static org.camunda.bpm.engine.authorization.Permissions.*;
-import static org.camunda.bpm.engine.authorization.Resources.*;
-
-import org.camunda.bpm.engine.authorization.Permission;
-import org.camunda.bpm.engine.authorization.ProcessDefinitionPermissions;
-import org.camunda.bpm.engine.authorization.ProcessInstancePermissions;
-import org.camunda.bpm.engine.authorization.Resources;
-import org.camunda.bpm.engine.authorization.SystemPermissions;
-import org.camunda.bpm.engine.authorization.TaskPermissions;
-import org.camunda.bpm.engine.authorization.UserOperationLogCategoryPermissions;
 
 /**
  * {@link CommandChecker} that uses the {@link AuthorizationManager} to perform
@@ -734,6 +760,10 @@ public class AuthorizationCommandChecker implements CommandChecker {
     if (executionId == null && caseExecutionId == null) {
       getAuthorizationManager().checkAuthorization(DELETE, TASK, taskId);
     }
+  }
+
+  public void checkUpdateTask(TaskEntity task) {
+    getAuthorizationManager().checkAuthorization(UPDATE, TASK, task.getId());
   }
 
   public void checkUserOperationLog(UserOperationLogEntry entry,

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/multitenancy/TenantCommandChecker.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/multitenancy/TenantCommandChecker.java
@@ -30,7 +30,16 @@ import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.dmn.entity.repository.DecisionDefinitionEntity;
 import org.camunda.bpm.engine.impl.dmn.entity.repository.DecisionRequirementsDefinitionEntity;
 import org.camunda.bpm.engine.impl.history.event.HistoricExternalTaskLogEntity;
-import org.camunda.bpm.engine.impl.persistence.entity.*;
+import org.camunda.bpm.engine.impl.persistence.entity.DeploymentEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricJobLogEventEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricProcessInstanceEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricTaskInstanceEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.TenantManager;
 import org.camunda.bpm.engine.repository.CaseDefinition;
 import org.camunda.bpm.engine.repository.DecisionDefinition;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
@@ -328,6 +337,12 @@ public class TenantCommandChecker implements CommandChecker {
   public void checkDeleteTask(TaskEntity task) {
     if (task != null && !getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
       throw LOG.exceptionCommandWithUnauthorizedTenant("delete the task '"+ task.getId() + "'");
+    }
+  }
+
+  public void checkUpdateTask(TaskEntity task) {
+    if (task != null && !getTenantManager().isAuthenticatedTenant(task.getTenantId())) {
+      throw LOG.exceptionCommandWithUnauthorizedTenant("update the task '" + task.getId() + "'");
     }
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AddCommentCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AddCommentCmd.java
@@ -16,9 +16,11 @@
  */
 package org.camunda.bpm.engine.impl.cmd;
 
+import static org.camunda.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_START;
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
+
 import java.io.Serializable;
 import java.util.Date;
-
 import org.camunda.bpm.engine.ProcessEngineException;
 import org.camunda.bpm.engine.impl.context.Context;
 import org.camunda.bpm.engine.impl.history.event.HistoricProcessInstanceEventEntity;
@@ -30,9 +32,6 @@ import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.camunda.bpm.engine.task.Comment;
 import org.camunda.bpm.engine.task.Event;
-
-import static org.camunda.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_START;
-import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 
 /**
@@ -78,10 +77,7 @@ public class AddCommentCmd implements Command<Comment>, Serializable {
       provideRemovalTime(comment);
     }
 
-    String eventMessage = message.replaceAll("\\s+", " ");
-    if (eventMessage.length() > 163) {
-      eventMessage = eventMessage.substring(0, 160) + "...";
-    }
+    String eventMessage = comment.toEventMessage(message);
     comment.setMessage(eventMessage);
 
     comment.setFullMessage(message);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteProcessInstanceCommentCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteProcessInstanceCommentCmd.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.cmd;
+
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
+
+import java.io.Serializable;
+import org.camunda.bpm.engine.history.UserOperationLogEntry;
+import org.camunda.bpm.engine.impl.cfg.CommandChecker;
+import org.camunda.bpm.engine.impl.interceptor.Command;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.persistence.entity.CommentEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.PropertyChange;
+import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
+
+/**
+ * Command to delete a comment by a given commentId and processInstanceId.
+ */
+public class DeleteProcessInstanceCommentCmd implements Command<Object>, Serializable {
+
+  private static final long serialVersionUID = 1L;
+  protected String commentId;
+  protected String processInstanceId;
+
+  public DeleteProcessInstanceCommentCmd(String processInstanceId, String commentId) {
+    this.processInstanceId = processInstanceId;
+    this.commentId = commentId;
+  }
+
+  public Object execute(CommandContext commandContext) {
+    ensureNotNull("commentId", commentId);
+
+    CommentEntity comment = commandContext.getCommentManager()
+        .findCommentByProcessInstanceIdAndCommentId(processInstanceId, commentId);
+
+    if (comment != null) {
+      TaskEntity task = getTask(comment, commandContext);
+      checkUpdateProcessInstance(processInstanceId, commandContext);
+      commandContext.getDbEntityManager().delete(comment);
+
+      PropertyChange propertyChange = new PropertyChange("comment", null, comment.getMessage());
+      commandContext.getOperationLogManager()
+          .logCommentOperation(UserOperationLogEntry.OPERATION_TYPE_DELETE_COMMENT, task, propertyChange);
+      task.triggerUpdateEvent();
+    }
+
+    return null;
+  }
+
+  private TaskEntity getTask(CommentEntity comment, CommandContext commandContext) {
+    String taskId = comment.getTaskId();
+    TaskEntity task = commandContext.getTaskManager().findTaskById(taskId);
+    ensureNotNull("Task not found for taskId: " + taskId + " CommentId: " + commentId, "comment", comment);
+    return task;
+  }
+
+  protected void checkUpdateProcessInstance(String processInstanceId, CommandContext commandContext) {
+    for (CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+      checker.checkUpdateProcessInstanceById(processInstanceId);
+    }
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteProcessInstanceCommentCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteProcessInstanceCommentCmd.java
@@ -28,6 +28,8 @@ import org.camunda.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
 
 /**
+ * see https://github.com/camunda/camunda-bpm-platform/issues/2551
+ *
  * Command to delete a comment by a given commentId and processInstanceId.
  */
 public class DeleteProcessInstanceCommentCmd implements Command<Object>, Serializable {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteProcessInstanceCommentsCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteProcessInstanceCommentsCmd.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.cmd;
+
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import org.camunda.bpm.engine.history.UserOperationLogEntry;
+import org.camunda.bpm.engine.impl.cfg.CommandChecker;
+import org.camunda.bpm.engine.impl.interceptor.Command;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.PropertyChange;
+import org.camunda.bpm.engine.task.Comment;
+
+/**
+ * Command to delete comments by a given processInstance ID.
+ */
+public class DeleteProcessInstanceCommentsCmd implements Command<Object>, Serializable {
+
+  private static final long serialVersionUID = 1L;
+  protected String processInstanceId;
+
+  public DeleteProcessInstanceCommentsCmd(String processInstanceId) {
+    this.processInstanceId = processInstanceId;
+  }
+
+  public Object execute(CommandContext commandContext) {
+    ensureNotNull("processInstanceId", processInstanceId);
+    ExecutionEntity processInstance = commandContext.getExecutionManager().findExecutionById(processInstanceId);
+    ensureNotNull("No processInstance exists with processInstanceId: " + processInstanceId, "processInstance: ",
+        processInstance);
+
+    List<Comment> comments = commandContext.getCommentManager().findCommentsByProcessInstanceId(processInstanceId);
+    if (!comments.isEmpty()) {
+      checkUpdateProcessInstance(processInstanceId, commandContext);
+      commandContext.getCommentManager()
+          .deleteCommentsByProcessInstanceIds(Collections.singletonList(processInstanceId));
+      PropertyChange propertyChange = new PropertyChange("comment", null, null);
+      commandContext.getOperationLogManager()
+          .logCommentOperation(UserOperationLogEntry.OPERATION_TYPE_DELETE_COMMENT, processInstance, propertyChange);
+    }
+    return null;
+  }
+
+  protected void checkUpdateProcessInstance(String processInstanceId, CommandContext commandContext) {
+    for (CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+      checker.checkUpdateProcessInstanceById(processInstanceId);
+    }
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteProcessInstanceCommentsCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteProcessInstanceCommentsCmd.java
@@ -30,6 +30,8 @@ import org.camunda.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.camunda.bpm.engine.task.Comment;
 
 /**
+ * see https://github.com/camunda/camunda-bpm-platform/issues/2551
+ *
  * Command to delete comments by a given processInstance ID.
  */
 public class DeleteProcessInstanceCommentsCmd implements Command<Object>, Serializable {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteTaskCommentCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteTaskCommentCmd.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.cmd;
+
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
+
+import java.io.Serializable;
+import org.camunda.bpm.engine.history.UserOperationLogEntry;
+import org.camunda.bpm.engine.impl.cfg.CommandChecker;
+import org.camunda.bpm.engine.impl.interceptor.Command;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.persistence.entity.CommentEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.PropertyChange;
+import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
+
+/**
+ * Command to delete a comment by a given commentId and taskId.
+ */
+public class DeleteTaskCommentCmd implements Command<Object>, Serializable {
+
+  private static final long serialVersionUID = 1L;
+  protected String commentId;
+  protected String taskId;
+
+  public DeleteTaskCommentCmd(String taskId, String commentId) {
+    this.taskId = taskId;
+    this.commentId = commentId;
+  }
+
+  public Object execute(CommandContext commandContext) {
+    ensureNotNull("commentId", commentId);
+
+    CommentEntity comment = commandContext.getCommentManager().findCommentByTaskIdAndCommentId(taskId, commentId);
+    if (comment != null) {
+      TaskEntity task = getTask(comment, commandContext);
+
+      checkUpdateTask(task, commandContext);
+      commandContext.getDbEntityManager().delete(comment);
+
+      PropertyChange propertyChange = new PropertyChange("comment", null, comment.getMessage());
+      commandContext.getOperationLogManager()
+          .logCommentOperation(UserOperationLogEntry.OPERATION_TYPE_DELETE_COMMENT, task, propertyChange);
+      task.triggerUpdateEvent();
+    }
+    return null;
+  }
+
+  private TaskEntity getTask(CommentEntity comment, CommandContext commandContext) {
+    String taskId = comment.getTaskId();
+    TaskEntity task = commandContext.getTaskManager().findTaskById(taskId);
+    ensureNotNull("Task not found for taskId: " + taskId + " CommentId: " + commentId, "comment", comment);
+    return task;
+  }
+
+  protected void checkUpdateTask(TaskEntity task, CommandContext commandContext) {
+    for (CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+      checker.checkUpdateTask(task);
+    }
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteTaskCommentCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteTaskCommentCmd.java
@@ -28,6 +28,8 @@ import org.camunda.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
 
 /**
+ * see https://github.com/camunda/camunda-bpm-platform/issues/2551
+ *
  * Command to delete a comment by a given commentId and taskId.
  */
 public class DeleteTaskCommentCmd implements Command<Object>, Serializable {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteTaskCommentsCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteTaskCommentsCmd.java
@@ -29,6 +29,8 @@ import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.camunda.bpm.engine.task.Comment;
 
 /**
+ * see https://github.com/camunda/camunda-bpm-platform/issues/2551
+ *
  * Command to delete comments by a given task ID.
  */
 public class DeleteTaskCommentsCmd implements Command<Void>, Serializable {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteTaskCommentsCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/DeleteTaskCommentsCmd.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.cmd;
+
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
+
+import java.io.Serializable;
+import java.util.List;
+import org.camunda.bpm.engine.history.UserOperationLogEntry;
+import org.camunda.bpm.engine.impl.cfg.CommandChecker;
+import org.camunda.bpm.engine.impl.interceptor.Command;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.persistence.entity.PropertyChange;
+import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
+import org.camunda.bpm.engine.task.Comment;
+
+/**
+ * Command to delete comments by a given task ID.
+ */
+public class DeleteTaskCommentsCmd implements Command<Void>, Serializable {
+
+  private static final long serialVersionUID = 1L;
+  protected String taskId;
+
+  public DeleteTaskCommentsCmd(String taskId) {
+    this.taskId = taskId;
+  }
+
+  public Void execute(CommandContext commandContext) {
+    ensureNotNull("taskId", taskId);
+    TaskEntity task = commandContext.getTaskManager().findTaskById(taskId);
+    ensureNotNull("No task exists with taskId: " + taskId, "task", task);
+    List<Comment> comments = commandContext.getCommentManager().findCommentsByTaskId(taskId);
+    if (!comments.isEmpty()) {
+      checkUpdateTask(task, commandContext);
+      commandContext.getCommentManager().deleteCommentsByTaskId(taskId);
+      PropertyChange propertyChange = new PropertyChange("comment", null, null);
+      commandContext.getOperationLogManager()
+          .logCommentOperation(UserOperationLogEntry.OPERATION_TYPE_DELETE_COMMENT, task, propertyChange);
+      task.triggerUpdateEvent();
+    }
+    return null;
+  }
+
+  protected void checkUpdateTask(TaskEntity task, CommandContext commandContext) {
+    for (CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+      checker.checkUpdateTask(task);
+    }
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/UpdateProcessInstanceCommentCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/UpdateProcessInstanceCommentCmd.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.cmd;
+
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
+
+import java.io.Serializable;
+import org.camunda.bpm.engine.history.UserOperationLogEntry;
+import org.camunda.bpm.engine.impl.cfg.CommandChecker;
+import org.camunda.bpm.engine.impl.interceptor.Command;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.persistence.entity.CommentEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.PropertyChange;
+import org.camunda.bpm.engine.impl.util.ClockUtil;
+
+/**
+ * Command to update a comment by a given processInstance ID.
+ */
+public class UpdateProcessInstanceCommentCmd implements Command<Object>, Serializable {
+
+  private static final long serialVersionUID = 1L;
+  protected String commentId;
+  protected String message;
+  protected String processInstanceId;
+
+  public UpdateProcessInstanceCommentCmd(String processInstanceId, String commentId, String message) {
+    this.processInstanceId = processInstanceId;
+    this.commentId = commentId;
+    this.message = message;
+  }
+
+  public Object execute(CommandContext commandContext) {
+    ensureNotNull("commentId", commentId);
+    ensureNotNull("processInstanceId", processInstanceId);
+    ensureNotNull("message", message);
+
+    CommentEntity comment = commandContext.getCommentManager()
+        .findCommentByProcessInstanceIdAndCommentId(processInstanceId, commentId);
+    ensureNotNull("No comment exists with commentId: " + commentId + " and processInstanceId: " + processInstanceId,
+        "comment", comment);
+
+    ExecutionEntity processInstance = commandContext.getExecutionManager().findExecutionById(processInstanceId);
+    ensureNotNull("No processInstance exists with processInstanceId: " + processInstanceId, "processInstance",
+        processInstance);
+
+    checkUpdateProcessInstance(processInstanceId, commandContext);
+    updateComment(commandContext, comment, message);
+
+    PropertyChange propertyChange = new PropertyChange("comment", comment.getMessage(), message);
+    commandContext.getOperationLogManager()
+        .logCommentOperation(UserOperationLogEntry.OPERATION_TYPE_UPDATE_COMMENT, processInstance, propertyChange);
+
+    return null;
+  }
+
+  protected void checkUpdateProcessInstance(String processInstanceId, CommandContext commandContext) {
+    for (CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+      checker.checkUpdateProcessInstanceById(processInstanceId);
+    }
+  }
+
+  private void updateComment(CommandContext commandContext, CommentEntity comment, String message) {
+    String eventMessage = comment.toEventMessage(message);
+    String userId = commandContext.getAuthenticatedUserId();
+
+    comment.setMessage(eventMessage);
+    comment.setFullMessage(message);
+    comment.setTime(ClockUtil.getCurrentTime());
+    comment.setAction(UserOperationLogEntry.OPERATION_TYPE_UPDATE_COMMENT);
+    comment.setUserId(userId);
+
+    commandContext.getCommentManager().updateCommentMessage(comment);
+  }
+
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/UpdateProcessInstanceCommentCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/UpdateProcessInstanceCommentCmd.java
@@ -29,6 +29,8 @@ import org.camunda.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 
 /**
+ * see https://github.com/camunda/camunda-bpm-platform/issues/2551
+ *
  * Command to update a comment by a given processInstance ID.
  */
 public class UpdateProcessInstanceCommentCmd implements Command<Object>, Serializable {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/UpdateTaskCommentCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/UpdateTaskCommentCmd.java
@@ -29,6 +29,8 @@ import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 
 /**
+ * see https://github.com/camunda/camunda-bpm-platform/issues/2551
+ *
  * Command to update a comment by a given task ID.
  */
 public class UpdateTaskCommentCmd implements Command<Object>, Serializable {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/UpdateTaskCommentCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/UpdateTaskCommentCmd.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.cmd;
+
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
+
+import java.io.Serializable;
+import org.camunda.bpm.engine.history.UserOperationLogEntry;
+import org.camunda.bpm.engine.impl.cfg.CommandChecker;
+import org.camunda.bpm.engine.impl.interceptor.Command;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.persistence.entity.CommentEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.PropertyChange;
+import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity;
+import org.camunda.bpm.engine.impl.util.ClockUtil;
+
+/**
+ * Command to update a comment by a given task ID.
+ */
+public class UpdateTaskCommentCmd implements Command<Object>, Serializable {
+
+  private static final long serialVersionUID = 1L;
+  protected String taskId;
+  protected String commentId;
+  protected String message;
+
+  public UpdateTaskCommentCmd(String taskId, String commentId, String message) {
+    this.taskId = taskId;
+    this.commentId = commentId;
+    this.message = message;
+  }
+
+  public Object execute(CommandContext commandContext) {
+    ensureNotNull("commentId", commentId);
+    ensureNotNull("taskId", taskId);
+    ensureNotNull("message", message);
+
+    CommentEntity comment = commandContext.getCommentManager().findCommentByTaskIdAndCommentId(taskId, commentId);
+    ensureNotNull("No comment exists with commentId: " + commentId + " and taskId: " + taskId, "comment", comment);
+    TaskEntity task = commandContext.getTaskManager().findTaskById(taskId);
+    ensureNotNull("No task exists with taskId: " + taskId, "task", task);
+
+    checkUpdateTask(task, commandContext);
+    updateComment(commandContext, comment);
+    PropertyChange propertyChange = new PropertyChange("comment", comment.getMessage(), message);
+    commandContext.getOperationLogManager()
+        .logCommentOperation(UserOperationLogEntry.OPERATION_TYPE_UPDATE_COMMENT, task, propertyChange);
+    task.triggerUpdateEvent();
+
+    return null;
+  }
+
+  private void updateComment(CommandContext commandContext, CommentEntity comment) {
+    String eventMessage = comment.toEventMessage(message);
+
+    String userId = commandContext.getAuthenticatedUserId();
+
+    comment.setMessage(eventMessage);
+    comment.setFullMessage(message);
+    comment.setTime(ClockUtil.getCurrentTime());
+    comment.setAction(UserOperationLogEntry.OPERATION_TYPE_UPDATE_COMMENT);
+    comment.setUserId(userId);
+
+    commandContext.getCommentManager().updateCommentMessage(comment);
+  }
+
+  protected void checkUpdateTask(TaskEntity task, CommandContext commandContext) {
+    for (CommandChecker checker : commandContext.getProcessEngineConfiguration().getCommandCheckers()) {
+      checker.checkUpdateTask(task);
+    }
+  }
+}

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/CommentEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/CommentEntity.java
@@ -201,6 +201,14 @@ public class CommentEntity implements Comment, Event, DbEntity, HistoricEntity, 
     this.removalTime = removalTime;
   }
 
+  public String toEventMessage(String message) {
+    String eventMessage = message.replaceAll("\\s+", " ");
+    if (eventMessage.length() > 163) {
+      eventMessage = eventMessage.substring(0, 160) + "...";
+    }
+    return eventMessage;
+  }
+
   @Override
   public String toString() {
     return this.getClass().getSimpleName()

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/CommentManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/CommentManager.java
@@ -108,6 +108,16 @@ public class CommentManager extends AbstractHistoricManager {
     return (CommentEntity) getDbEntityManager().selectOne("selectCommentByTaskIdAndCommentId", parameters);
   }
 
+  public CommentEntity findCommentByProcessInstanceIdAndCommentId(String processInstanceId, String commentId) {
+    checkHistoryEnabled();
+
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put("processInstanceId", processInstanceId);
+    parameters.put("id", commentId);
+
+    return (CommentEntity) getDbEntityManager().selectOne("selectCommentByProcessInstanceIdAndCommentId", parameters);
+  }
+
   public DbOperation addRemovalTimeToCommentsByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
     parameters.put("rootProcessInstanceId", rootProcessInstanceId);
@@ -140,6 +150,19 @@ public class CommentManager extends AbstractHistoricManager {
     return getDbEntityManager()
       .deletePreserveOrder(CommentEntity.class, "deleteCommentsByRemovalTime",
         new ListQueryParameterObject(parameters, 0, batchSize));
+  }
+
+  public void updateCommentMessage(CommentEntity entity) {
+    checkHistoryEnabled();
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("message", entity.getMessage());
+    parameters.put("fullMessageBytes", entity.getFullMessageBytes());
+    parameters.put("time", entity.getTime());
+    parameters.put("action", entity.getAction());
+    parameters.put("id", entity.getId());
+    parameters.put("userId", entity.getUserId());
+
+    getDbEntityManager().update(CommentEntity.class, "updateComment", parameters);
   }
 
 }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/UserOperationLogManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/UserOperationLogManager.java
@@ -493,6 +493,34 @@ public class UserOperationLogManager extends AbstractHistoricManager {
     }
   }
 
+  public void logCommentOperation(String operation, TaskEntity task, PropertyChange propertyChange) {
+    if (isUserOperationLogEnabled()) {
+      UserOperationLogContext context = new UserOperationLogContext();
+
+      UserOperationLogContextEntryBuilder entryBuilder = UserOperationLogContextEntryBuilder.entry(operation,
+              EntityTypes.COMMENT)
+          .category(UserOperationLogEntry.CATEGORY_TASK_WORKER)
+          .inContextOf(task, Collections.singletonList(propertyChange));
+      context.addEntry(entryBuilder.create());
+
+      fireUserOperationLog(context);
+    }
+  }
+
+  public void logCommentOperation(String operation, ExecutionEntity processInstance, PropertyChange propertyChange) {
+    if (isUserOperationLogEnabled()) {
+      UserOperationLogContext context = new UserOperationLogContext();
+
+      UserOperationLogContextEntryBuilder entryBuilder = UserOperationLogContextEntryBuilder.entry(operation,
+              EntityTypes.COMMENT)
+          .category(UserOperationLogEntry.CATEGORY_TASK_WORKER)
+          .inContextOf(processInstance, Collections.singletonList(propertyChange));
+      context.addEntry(entryBuilder.create());
+
+      fireUserOperationLog(context);
+    }
+  }
+
   public void logVariableOperation(String operation, String executionId, String taskId, PropertyChange propertyChange) {
     if(isUserOperationLogEnabled()) {
 

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Comment.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Comment.xml
@@ -20,9 +20,9 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.camunda.bpm.engine.impl.persistence.entity.CommentEntity">
-  
+
   <!-- COMMENT INSERT -->
-  
+
   <insert id="insertComment" parameterType="org.camunda.bpm.engine.impl.persistence.entity.CommentEntity">
     insert into ${prefix}ACT_HI_COMMENT (ID_, TYPE_, TIME_, USER_ID_, TASK_ID_, ROOT_PROC_INST_ID_, PROC_INST_ID_, ACTION_, MESSAGE_, FULL_MSG_, TENANT_ID_, REMOVAL_TIME_)
     values (
@@ -60,6 +60,17 @@
   </insert>
 
   <!-- UPDATE -->
+  <update id="updateComment" parameterType="java.util.Map">
+    update
+      ${prefix}ACT_HI_COMMENT
+    set MESSAGE_ = #{message ,jdbcType=VARCHAR},
+        FULL_MSG_= #{fullMessageBytes ,jdbcType=BLOB},
+        TIME_    = #{time ,jdbcType=TIMESTAMP},
+        ACTION_  = #{action ,jdbcType=VARCHAR},
+        USER_ID_ = #{userId ,jdbcType=VARCHAR}
+    where ID_ = #{id}
+  </update>
+
   <update id="updateCommentsByRootProcessInstanceId"
           parameterType="java.util.Map">
       update
@@ -213,13 +224,19 @@
 
   <!-- COMMENT DELETE -->
 
+  <delete id="deleteComment" parameterType="org.camunda.bpm.engine.impl.persistence.entity.CommentEntity">
+    delete
+    from ${prefix}ACT_HI_COMMENT
+    where ID_ = #{id}
+  </delete>
+
   <delete id="deleteCommentsByTaskId" parameterType="string">
-    delete from ${prefix}ACT_HI_COMMENT where TASK_ID_ = #{taskId} 
+    delete from ${prefix}ACT_HI_COMMENT where TASK_ID_ = #{taskId}
   </delete>
 
   <delete id="deleteCommentsByIds" parameterType="java.util.Map">
     delete from ${prefix}ACT_HI_COMMENT
-    where 
+    where
     <if test="taskProcessInstanceIds != null &amp;&amp; taskProcessInstanceIds.size > 0">
       TASK_ID_ in (
         select ID_
@@ -348,20 +365,25 @@
     <result property="tenantId" column="TENANT_ID_" jdbcType="VARCHAR" />
     <result property="removalTime" column="REMOVAL_TIME_" jdbcType="TIMESTAMP"/>
   </resultMap>
-  
+
   <!-- COMMENT SELECT -->
+  <select id="selectComment" parameterType="string" resultMap="commentResultMap">
+    select *
+    from ${prefix}ACT_HI_COMMENT
+    where ID_ = #{id}
+  </select>
 
   <select id="selectCommentsByTaskId" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject" resultMap="commentResultMap">
-    select * 
-    from ${prefix}ACT_HI_COMMENT 
+    select *
+    from ${prefix}ACT_HI_COMMENT
     where TASK_ID_ = #{parameter,jdbcType=VARCHAR}
       and TYPE_ = 'comment'
     order by TIME_ desc
   </select>
 
   <select id="selectCommentsByTaskId_postgres" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject" resultMap="commentResultMap_postgres">
-    select * 
-    from ${prefix}ACT_HI_COMMENT 
+    select *
+    from ${prefix}ACT_HI_COMMENT
     where TASK_ID_ = #{parameter,jdbcType=VARCHAR}
       and TYPE_ = 'comment'
     order by TIME_ desc
@@ -370,7 +392,7 @@
   <select id="selectEventsByTaskId" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject" resultMap="commentResultMap">
     <include refid="selectEventsByTaskIdSql"/>
   </select>
-  
+
   <select id="selectEventsByTaskId_postgres" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject" resultMap="commentResultMap_postgres">
     <include refid="selectEventsByTaskIdSql"/>
   </select>
@@ -427,29 +449,36 @@
   </sql>
 
   <select id="selectCommentsByProcessInstanceId" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject" resultMap="commentResultMap">
-    select * 
-    from ${prefix}ACT_HI_COMMENT 
+    select *
+    from ${prefix}ACT_HI_COMMENT
     where PROC_INST_ID_ = #{parameter,jdbcType=VARCHAR}
     order by TIME_ desc
   </select>
 
   <select id="selectCommentsByProcessInstanceId_postgres" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject" resultMap="commentResultMap_postgres">
-    select * 
-    from ${prefix}ACT_HI_COMMENT 
+    select *
+    from ${prefix}ACT_HI_COMMENT
     where PROC_INST_ID_ = #{parameter,jdbcType=BINARY}
     order by TIME_ desc
   </select>
 
   <select id="selectCommentByTaskIdAndCommentId" parameterType="map" resultMap="commentResultMap">
-    select * from ${prefix}ACT_HI_COMMENT 
+    select * from ${prefix}ACT_HI_COMMENT
     where TASK_ID_ = #{taskId,jdbcType=VARCHAR}
       and ID_ =  #{id,jdbcType=VARCHAR}
   </select>
 
   <select id="selectCommentByTaskIdAndCommentId_postgres" parameterType="map" resultMap="commentResultMap_postgres">
-    select * from ${prefix}ACT_HI_COMMENT 
+    select * from ${prefix}ACT_HI_COMMENT
     where TASK_ID_ = #{taskId,jdbcType=VARCHAR}
       and ID_ =  #{id,jdbcType=VARCHAR}
+  </select>
+
+  <select id="selectCommentByProcessInstanceIdAndCommentId" parameterType="map" resultMap="commentResultMap">
+    select *
+    from ${prefix}ACT_HI_COMMENT
+    where PROC_INST_ID_ = #{processInstanceId,jdbcType=VARCHAR}
+      and ID_ = #{id,jdbcType=VARCHAR}
   </select>
 
 </mapper>

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/AuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/AuthorizationTest.java
@@ -50,6 +50,7 @@ import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.camunda.bpm.engine.runtime.CaseInstance;
 import org.camunda.bpm.engine.runtime.Job;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.task.Comment;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.camunda.bpm.engine.variable.VariableMap;
@@ -69,6 +70,8 @@ public abstract class AuthorizationTest extends PluggableProcessEngineTest {
 
   protected static final String VARIABLE_NAME = "aVariableName";
   protected static final String VARIABLE_VALUE = "aVariableValue";
+  protected static final String TASK_ID = "myTask";
+
   protected List<String> deploymentIds = new ArrayList<>();
 
   @Before
@@ -285,6 +288,10 @@ public abstract class AuthorizationTest extends PluggableProcessEngineTest {
       taskService.deleteTask(taskId, cascade);
       return null;
     });
+  }
+
+  protected Comment createComment(String taskId, String processInstanceId, String message) {
+    return runWithoutAuthorization(() -> taskService.createComment(taskId, processInstanceId, message));
   }
 
   protected void addCandidateUser(final String taskId, final String user) {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/ProcessInstanceCommentAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/ProcessInstanceCommentAuthorizationTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.api.authorization;
+
+import static org.camunda.bpm.engine.authorization.Permissions.UPDATE;
+import static org.camunda.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+import java.util.List;
+import org.camunda.bpm.engine.AuthorizationException;
+import org.camunda.bpm.engine.task.Comment;
+import org.camunda.bpm.engine.test.Deployment;
+import org.junit.Test;
+
+public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
+  protected static final String ONE_TASK_PROCESS_KEY = "oneTaskProcess";
+
+  @Deployment(resources = "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
+  @Test
+  public void testDeleteProcessInstanceCommentWithoutAuthorization() {
+    // given
+    String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
+    createTask(TASK_ID);
+
+    Comment createdComment = createComment(TASK_ID, processInstanceId, "aComment");
+
+    try {
+      // when
+      taskService.deleteProcessInstanceComment(processInstanceId, createdComment.getId());
+      fail("Exception expected: It should not be possible to delete a task.");
+    } catch (AuthorizationException e) {
+      // then
+      testRule.assertTextPresent("The user with id 'test' does not have one of the following permissions: 'UPDATE'",
+          e.getMessage());
+    }
+
+    // triggers a db clean up
+    deleteTask(TASK_ID, true);
+  }
+
+  @Deployment(resources = "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
+  @Test
+  public void testDeleteProcessInstanceComment() {
+    // given
+    createTask(TASK_ID);
+    String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
+    Comment createdComment = taskService.createComment(TASK_ID, processInstanceId, "aComment");
+    createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
+
+    // when
+    taskService.deleteProcessInstanceComment(processInstanceId, createdComment.getId());
+
+    // then
+    List<Comment> deletedCommentLst = taskService.getProcessInstanceComments(processInstanceId);
+    assertEquals("The comments list should be empty", Collections.emptyList(), deletedCommentLst);
+
+    // triggers a db clean up
+    deleteTask(TASK_ID, true);
+  }
+
+  @Deployment(resources = "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
+  @Test
+  public void testDeleteProcessInstanceCommentsWithoutAuthorization() {
+    // given
+    createTask(TASK_ID);
+    String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
+    createComment(TASK_ID, processInstanceId, "aComment");
+
+    try {
+      // when
+      taskService.deleteProcessInstanceComments(processInstanceId);
+      fail("Exception expected: It should not be possible to delete a comment.");
+    } catch (AuthorizationException e) {
+      // then
+      testRule.assertTextPresent("The user with id 'test' does not have one of the following permissions: 'UPDATE'",
+          e.getMessage());
+    }
+
+    // triggers a db clean up
+    deleteTask(TASK_ID, true);
+  }
+
+  @Deployment(resources = "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
+  @Test
+  public void testDeleteProcessInstanceComments() {
+    // given
+    createTask(TASK_ID);
+    String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
+    taskService.createComment(TASK_ID, processInstanceId, "aCommentOne");
+    taskService.createComment(TASK_ID, processInstanceId, "aCommentTwo");
+
+    createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
+
+    // when
+    taskService.deleteProcessInstanceComments(processInstanceId);
+
+    // then
+    List<Comment> comments = taskService.getProcessInstanceComments(processInstanceId);
+    assertEquals("The comments list should be empty", Collections.emptyList(), comments);
+
+    // triggers a db clean up
+    deleteTask(TASK_ID, true);
+  }
+
+  @Deployment(resources = "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
+  @Test
+  public void testUpdateProcessInstanceCommentWithoutAuthorization() {
+    // given
+    createTask(TASK_ID);
+    String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
+    Comment createdComment = createComment(TASK_ID, processInstanceId, "originalComment");
+
+    try {
+      // when
+      taskService.updateProcessInstanceComment(processInstanceId, createdComment.getId(), "updateMessage");
+      fail("Exception expected: It should not be possible to delete a task.");
+    } catch (AuthorizationException e) {
+      // then
+      testRule.assertTextPresent("The user with id 'test' does not have one of the following permissions: 'UPDATE'",
+          e.getMessage());
+    }
+
+    deleteTask(TASK_ID, true);
+  }
+
+  @Deployment(resources = "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
+  @Test
+  public void testUpdateProcessInstanceComment() {
+    // given
+    String taskId = "myTask";
+    createTask(taskId);
+    String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
+
+    String commentMessage = "OriginalCommentMessage";
+    String updatedMessage = "UpdatedCommentMessage";
+    Comment comment = taskService.createComment(taskId, processInstanceId, commentMessage);
+    createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
+
+    // when
+    taskService.updateProcessInstanceComment(processInstanceId, comment.getId(), updatedMessage);
+
+    // then
+    List<Comment> comments = taskService.getProcessInstanceComments(processInstanceId);
+    assertFalse("The comments list should not be empty", comments.isEmpty());
+    assertEquals(updatedMessage, comments.get(0).getFullMessage());
+
+    // triggers a db clean up
+    deleteTask(taskId, true);
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/TaskCommentAuthorizationTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/authorization/TaskCommentAuthorizationTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.api.authorization;
+
+import static org.camunda.bpm.engine.authorization.Permissions.UPDATE;
+import static org.camunda.bpm.engine.authorization.Resources.TASK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+import java.util.List;
+import org.camunda.bpm.engine.AuthorizationException;
+import org.camunda.bpm.engine.task.Comment;
+import org.junit.Test;
+
+public class TaskCommentAuthorizationTest extends AuthorizationTest {
+
+  @Test
+  public void testDeleteTaskCommentWithoutAuthorization() {
+    // given
+    createTask(TASK_ID);
+    Comment createdComment = createComment(TASK_ID, null, "aComment");
+
+    try {
+      // when
+      taskService.deleteTaskComment(TASK_ID, createdComment.getId());
+      fail("Exception expected: It should not be possible to delete a comment.");
+    } catch (AuthorizationException e) {
+      // then
+      testRule.assertTextPresent(
+          "The user with id 'test' does not have 'UPDATE' permission on resource 'myTask' of type 'Task'",
+          e.getMessage());
+    }
+
+    // triggers a db clean up
+    deleteTask(TASK_ID, true);
+  }
+
+  @Test
+  public void testDeleteTaskComment() {
+    // given
+    createTask(TASK_ID);
+    Comment createdComment = taskService.createComment(TASK_ID, null, "aComment");
+    createGrantAuthorization(TASK, TASK_ID, userId, UPDATE);
+
+    // when
+    taskService.deleteTaskComment(TASK_ID, createdComment.getId());
+
+    // then
+    Comment shouldBeDeleletedComment = taskService.getTaskComment(TASK_ID, createdComment.getId());
+    assertNull(shouldBeDeleletedComment);
+
+    // triggers a db clean up
+    deleteTask(TASK_ID, true);
+  }
+
+  @Test
+  public void testDeleteTaskCommentsWithoutAuthorization() {
+    // given
+    createTask(TASK_ID);
+    createComment(TASK_ID, null, "aComment");
+
+    try {
+      // when
+      taskService.deleteTaskComments(TASK_ID);
+      fail("Exception expected: It should not be possible to delete a comment.");
+    } catch (AuthorizationException e) {
+      // then
+      testRule.assertTextPresent(
+          "The user with id 'test' does not have 'UPDATE' permission on resource 'myTask' of type 'Task'",
+          e.getMessage());
+    }
+
+    // triggers a db clean up
+    deleteTask(TASK_ID, true);
+  }
+
+  @Test
+  public void testDeleteTaskComments() {
+    // given
+    createTask(TASK_ID);
+    taskService.createComment(TASK_ID, null, "aCommentOne");
+    taskService.createComment(TASK_ID, null, "aCommentTwo");
+
+    createGrantAuthorization(TASK, TASK_ID, userId, UPDATE);
+
+    // when
+    taskService.deleteTaskComments(TASK_ID);
+
+    // then
+    List<Comment> comments = taskService.getTaskComments(TASK_ID);
+    assertEquals("The comments list should be empty", Collections.emptyList(), comments);
+
+    // triggers a db clean up
+    deleteTask(TASK_ID, true);
+  }
+
+  @Test
+  public void testUpdateTaskCommentWithoutAuthorization() {
+    // given
+    createTask(TASK_ID);
+    Comment createdComment = createComment(TASK_ID, null, "originalComment");
+
+    try {
+      // when
+      taskService.updateTaskComment(TASK_ID, createdComment.getId(), "updateMessage");
+      fail("Exception expected: It should not be possible to delete a comment.");
+    } catch (AuthorizationException e) {
+      // then
+      testRule.assertTextPresent(
+          "The user with id 'test' does not have 'UPDATE' permission on resource 'myTask' of type 'Task'",
+          e.getMessage());
+    }
+
+    // triggers a db clean up
+    deleteTask(TASK_ID, true);
+  }
+
+  @Test
+  public void testUpdateTaskComment() {
+    // given
+    createTask(TASK_ID);
+    String commentMessage = "OriginalCommentMessage";
+    String updatedMessage = "UpdatedCommentMessage";
+    Comment comment = taskService.createComment(TASK_ID, null, commentMessage);
+    createGrantAuthorization(TASK, TASK_ID, userId, UPDATE);
+
+    // when
+    taskService.updateTaskComment(TASK_ID, comment.getId(), updatedMessage);
+
+    // then
+    List<Comment> comments = taskService.getTaskComments(TASK_ID);
+    assertFalse("The comments list should not be empty", comments.isEmpty());
+    assertEquals(updatedMessage, comments.get(0).getFullMessage());
+
+    // triggers a db clean up
+    deleteTask(TASK_ID, true);
+  }
+
+}

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/encoding/ProcessEngineCharacterEncodingTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/encoding/ProcessEngineCharacterEncodingTest.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.task.Comment;
@@ -90,6 +89,10 @@ public class ProcessEngineCharacterEncodingTest {
     return task;
   }
 
+  protected Comment createNewComment(String taskId, String message) {
+    return taskService.createComment(taskId, null, message);
+  }
+
   @Test
   public void shouldPreserveArabicTaskCommentMessageWithCharset() {
     // given
@@ -118,4 +121,37 @@ public class ProcessEngineCharacterEncodingTest {
     assertThat(taskComments.get(0).getFullMessage()).isEqualTo(message);
   }
 
+  @Test
+  public void shouldPreserveArabicTaskUpdateCommentMessageWithCharset() {
+    // given
+    String taskId = newTask().getId();
+    Comment comment = createNewComment(taskId, "OriginalMessage");
+
+    // when
+    String updatedMessage = "این نمونه است";
+    taskService.updateTaskComment(taskId, comment.getId(), updatedMessage);
+
+    Comment updatedComment = taskService.getTaskComment(taskId, comment.getId());
+
+    // then
+    assertThat(updatedComment).isNotNull();
+    assertThat(updatedComment.getFullMessage()).isEqualTo(updatedMessage);
+  }
+
+  @Test
+  public void shouldPreserveLatinTaskUpdateCommentMessageWithCharset() {
+    // given
+    String taskId = newTask().getId();
+    Comment comment = createNewComment(taskId, "OriginalMessage");
+
+    // when
+    String updatedMessage = "This is an example";
+    taskService.updateTaskComment(taskId, comment.getId(), updatedMessage);
+
+    Comment updatedComment = taskService.getTaskComment(taskId, comment.getId());
+
+    // then
+    assertThat(updatedComment).isNotNull();
+    assertThat(updatedComment.getFullMessage()).isEqualTo(updatedMessage);
+  }
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskLastUpdatedTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskLastUpdatedTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Date;
 import java.util.List;
-
 import org.assertj.core.api.Assertions;
 import org.camunda.bpm.engine.OptimisticLockingException;
 import org.camunda.bpm.engine.RuntimeService;
@@ -30,6 +29,7 @@ import org.camunda.bpm.engine.impl.test.RequiredDatabase;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.task.Attachment;
+import org.camunda.bpm.engine.task.Comment;
 import org.camunda.bpm.engine.task.IdentityLinkType;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.Deployment;
@@ -414,4 +414,113 @@ public class TaskLastUpdatedTest {
     Assertions.assertThatThrownBy(() -> taskService.saveTask(task))
       .isInstanceOf(OptimisticLockingException.class);
   }
+
+  @Test
+  public void shouldSetLastUpdatedOnTaskDeleteComment() {
+    // given
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    Comment comment = taskService.createComment(task.getId(), processInstance.getId(), "message");
+
+    Date beforeUpdate = getBeforeCurrentTime();
+
+    // when
+    taskService.deleteTaskComment(task.getId(), comment.getId());
+
+    // then
+    Task taskResult = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    assertThat(taskResult).isNotNull();
+    assertThat(taskResult.getLastUpdated()).isAfter(beforeUpdate);
+  }
+
+  @Test
+  public void shouldSetLastUpdatedOnTaskDeleteComments() {
+    // given
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    taskService.createComment(task.getId(), processInstance.getId(), "message");
+
+    Date beforeUpdate = getBeforeCurrentTime();
+
+    // when
+    taskService.deleteTaskComments(task.getId());
+
+    // then
+    Task taskResult = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    assertThat(taskResult).isNotNull();
+    assertThat(taskResult.getLastUpdated()).isAfter(beforeUpdate);
+  }
+
+  @Test
+  public void shouldSetLastUpdatedOnTaskCommentUpdate() {
+    // given
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    Comment comment = taskService.createComment(task.getId(), processInstance.getId(), "aMessage");
+
+    Date beforeUpdate = getBeforeCurrentTime();
+
+    // when
+    taskService.updateTaskComment(task.getId(), comment.getId(), "updatedMessage");
+
+    // then
+    Task taskResult = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    assertThat(taskResult).isNotNull();
+    assertThat(taskResult.getLastUpdated()).isAfter(beforeUpdate);
+  }
+
+  @Test
+  public void shouldSetLastUpdatedOnProcessInstanceDeleteComment() {
+    // given
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    Comment comment = taskService.createComment(task.getId(), processInstance.getId(), "message");
+
+    Date beforeUpdate = getBeforeCurrentTime();
+
+    // when
+    taskService.deleteProcessInstanceComment(processInstance.getId(), comment.getId());
+
+    // then
+    Task taskResult = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    assertThat(taskResult).isNotNull();
+    assertThat(taskResult.getLastUpdated()).isAfter(beforeUpdate);
+  }
+
+  @Test
+  public void shouldSetLastUpdatedOnProcessInstanceDeleteComments() {
+    // given
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    taskService.createComment(task.getId(), processInstance.getId(), "message");
+
+    Date beforeUpdate = getBeforeCurrentTime();
+
+    // when
+    taskService.deleteProcessInstanceComments(processInstance.getId());
+
+    // then
+    Task taskResult = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    assertThat(taskResult).isNotNull();
+    assertThat(taskResult.getLastUpdated()).isAfter(beforeUpdate);
+  }
+
+  @Test
+  public void shouldSetLastUpdatedOnProcessInstanceCommentUpdate() {
+    // given
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    Comment comment = taskService.createComment(task.getId(), processInstance.getId(), "aMessage");
+
+    Date beforeUpdate = getBeforeCurrentTime();
+
+    // when
+    taskService.updateProcessInstanceComment(processInstance.getId(), comment.getId(), "updatedMessage");
+
+    // then
+    Task taskResult = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    assertThat(taskResult).isNotNull();
+    assertThat(taskResult.getLastUpdated()).isAfter(beforeUpdate);
+  }
+
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskServiceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskServiceTest.java
@@ -37,7 +37,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.camunda.bpm.engine.BadUserRequestException;
 import org.camunda.bpm.engine.CaseService;
 import org.camunda.bpm.engine.HistoryService;
@@ -80,7 +79,6 @@ import org.camunda.bpm.engine.test.RequiredHistoryLevel;
 import org.camunda.bpm.engine.test.util.ProcessEngineBootstrapRule;
 import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
 import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.camunda.bpm.engine.test.util.RemoveAfter;
 import org.camunda.bpm.engine.variable.VariableMap;
 import org.camunda.bpm.engine.variable.Variables;
 import org.camunda.bpm.engine.variable.type.ValueType;
@@ -280,6 +278,419 @@ public class TaskServiceTest {
 
     // Finally, delete task
     taskService.deleteTask(task.getId(), true);
+  }
+
+  @Test
+  public void testDeleteTaskCommentNullCommentId() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    String taskId = task.getId();
+    try {
+      taskService.deleteTaskComment(taskId, null);
+
+      fail("ProcessEngineException expected");
+    } catch (ProcessEngineException ae) {
+      testRule.assertTextPresent("commentId is null", ae.getMessage());
+    } finally {
+      taskService.deleteTask(task.getId(), true);
+    }
+  }
+
+  @Test
+  public void testDeleteTaskCommentNullTaskIdAndCommentId() {
+    try {
+      taskService.deleteTaskComment(null, null);
+      fail("ProcessEngineException expected");
+    } catch (ProcessEngineException ae) {
+      testRule.assertTextPresent("commentId is null", ae.getMessage());
+    }
+  }
+
+  @Test
+  public void testDeleteTaskCommentNotExistingCommentId() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    String taskId = task.getId();
+
+    // Deleting non-existing comment should be silently ignored
+    taskService.deleteTaskComment(taskId, "notExistingCommentId");
+
+    // Finally, delete task
+    taskService.deleteTask(taskId, true);
+  }
+
+  @Test
+  public void testDeleteTaskComment() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    String taskId = task.getId();
+
+    //create a task comment
+    Comment comment = taskService.createComment(taskId, "pid", "aMessage");
+    String commentId = comment.getId();
+
+    //delete a comment
+    taskService.deleteTaskComment(taskId, commentId);
+
+    //make sure the comment is not there.
+    Comment shouldBeDeleted = taskService.getTaskComment(taskId, commentId);
+    assertNull(shouldBeDeleted);
+
+    // Finally, delete task
+    taskService.deleteTask(taskId, true);
+  }
+
+  @Test
+  public void testDeleteTaskCommentsNullTaskId() {
+    try {
+      taskService.deleteTaskComments(null);
+      fail("ProcessEngineException expected");
+    } catch (ProcessEngineException ae) {
+      testRule.assertTextPresent("taskId is null", ae.getMessage());
+    }
+  }
+
+  @Test
+  public void testDeleteTaskCommentsNonExistingTaskId() {
+    try {
+      taskService.deleteTaskComments("nonExistingTaskId");
+      fail("ProcessEngineException expected");
+    } catch (ProcessEngineException ae) {
+      testRule.assertTextPresent("No task exists with taskId:", ae.getMessage());
+    }
+  }
+
+  @Test
+  public void testDeleteTaskCommentsNoComments() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    String taskId = task.getId();
+
+    // Deleting comments of a task that doesnt have any comments should silently ignored
+    taskService.deleteTaskComments(taskId);
+
+    // Finally, delete task
+    taskService.deleteTask(taskId, true);
+  }
+
+  @Test
+  public void testDeleteTaskComments() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    String taskId = task.getId();
+
+    //create a task comment
+    Comment comment = taskService.createComment(taskId, "pid", "aMessage");
+
+    //delete a comment
+    taskService.deleteTaskComments(taskId);
+
+    //make sure the comment is not there.
+    Comment shouldBeDeleted = taskService.getTaskComment(taskId, comment.getId());
+    assertNull(shouldBeDeleted);
+
+    // Finally, delete task
+    taskService.deleteTask(taskId, true);
+  }
+
+  @Test
+  public void testUpdateTaskCommentNullCommentId() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    String taskId = task.getId();
+    try {
+      taskService.updateTaskComment(taskId, null, "aMessage");
+
+      fail("ProcessEngineException expected");
+    } catch (ProcessEngineException ae) {
+      testRule.assertTextPresent("commentId is null", ae.getMessage());
+    } finally {
+      taskService.deleteTask(task.getId(), true);
+    }
+  }
+
+  @Test
+  public void testUpdateTaskCommentNullTaskId() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    String taskId = task.getId();
+    Comment comment = taskService.createComment(taskId, null, "originalMessage");
+
+    try {
+      taskService.updateTaskComment(null, comment.getId(), "updatedMessage");
+      fail("ProcessEngineException expected");
+    } catch (ProcessEngineException ae) {
+      testRule.assertTextPresent("taskId is null", ae.getMessage());
+    } finally {
+      taskService.deleteTask(taskId, true);
+    }
+  }
+
+  @Test
+  public void testUpdateTaskCommentNullMessage() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    String taskId = task.getId();
+    Comment comment = taskService.createComment(taskId, null, "originalMessage");
+
+    try {
+      taskService.updateTaskComment(taskId, comment.getId(), null);
+      fail("ProcessEngineException expected");
+    } catch (ProcessEngineException ae) {
+      testRule.assertTextPresent("message is null", ae.getMessage());
+    } finally {
+      taskService.deleteTask(task.getId(), true);
+    }
+  }
+
+  @Test
+  public void testUpdateTaskCommentNotExistingCommentId() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    String taskId = task.getId();
+    taskService.createComment(taskId, null, "originalMessage");
+    String nonExistingCommentId = "notExistingCommentId";
+
+    try {
+      taskService.updateTaskComment(taskId, nonExistingCommentId, "updatedMessage");
+      fail("ProcessEngineException expected");
+    } catch (ProcessEngineException ae) {
+      testRule.assertTextPresent("No comment exists with commentId: " + nonExistingCommentId + " and taskId: " + taskId,
+          ae.getMessage());
+    } finally {
+      taskService.deleteTask(task.getId(), true);
+    }
+  }
+
+  @Test
+  public void testUpdateTaskComment() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    String taskId = task.getId();
+    Comment comment = taskService.createComment(taskId, null, "originalMessage");
+    String updatedMessage = "updatedMessage";
+
+    taskService.updateTaskComment(taskId, comment.getId(), updatedMessage);
+
+    Comment actual = taskService.getTaskComment(taskId, comment.getId());
+
+    assertThat(actual).isNotNull();
+    assertEquals(updatedMessage, actual.getFullMessage());
+    // Finally, delete task
+    taskService.deleteTask(taskId, true);
+  }
+
+  @Test
+  public void testDeleteProcessInstanceCommentNullCommentId() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    String taskId = task.getId();
+    try {
+      taskService.deleteProcessInstanceComment(taskId, null);
+      fail("ProcessEngineException expected");
+    } catch (ProcessEngineException ae) {
+      testRule.assertTextPresent("commentId is null", ae.getMessage());
+    } finally {
+      taskService.deleteTask(taskId, true);
+    }
+  }
+
+  @Test
+  public void testDeleteProcessInstanceCommentNullTaskIdAndCommentId() {
+    try {
+      taskService.deleteProcessInstanceComment(null, null);
+      fail("ProcessEngineException expected");
+    } catch (ProcessEngineException ae) {
+      testRule.assertTextPresent("commentId is null", ae.getMessage());
+    }
+  }
+
+  @Deployment(resources = { "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml" })
+  @Test
+  public void testDeleteProcessInstanceCommentNotExistingCommentId() {
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+
+    // Deleting non-existing comment should be silently ignored
+    taskService.deleteProcessInstanceComment(processInstance.getId(), "notExistingCommentId");
+  }
+
+  @Deployment(resources = { "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml" })
+  @Test
+  public void testDeleteProcessInstanceComment() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    String taskId = task.getId();
+
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    String processInstanceId = processInstance.getId();
+
+    //create a task comment
+    Comment comment = taskService.createComment(taskId, processInstanceId, "aMessage");
+
+    //delete a comment
+    taskService.deleteProcessInstanceComment(processInstanceId, comment.getId());
+
+    //make sure the comment is not there.
+    List<Comment> shouldBeDeletedLst = taskService.getProcessInstanceComments(processInstanceId);
+    assertThat(shouldBeDeletedLst).isEmpty();
+
+    // Finally, delete task
+    taskService.deleteTask(taskId, true);
+  }
+
+  @Test
+  public void testDeleteProcessInstanceCommentsNullTaskId() {
+    try {
+      taskService.deleteProcessInstanceComments(null);
+      fail("ProcessEngineException expected");
+    } catch (ProcessEngineException ae) {
+      testRule.assertTextPresent("processInstanceId is null", ae.getMessage());
+    }
+  }
+
+  @Test
+  public void testDeleteProcessInstanceCommentsNonExistingTaskId() {
+    try {
+      taskService.deleteProcessInstanceComments("nonExistingTaskId");
+      fail("ProcessEngineException expected");
+    } catch (ProcessEngineException ae) {
+      testRule.assertTextPresent("No processInstance exists with processInstanceId:", ae.getMessage());
+    }
+  }
+
+  @Deployment(resources = { "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml" })
+  @Test
+  public void testDeleteProcessInstanceCommentsNoComments() {
+
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+
+    // Deleting comments of a task that doesn't have any comments should silently ignored
+    taskService.deleteProcessInstanceComments(processInstance.getId());
+  }
+
+  @Deployment(resources = { "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml" })
+  @Test
+  public void testDeleteProcessInstanceComments() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    String taskId = task.getId();
+
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    String processInstanceId = processInstance.getId();
+
+    //create a task comment
+    taskService.createComment(taskId, processInstanceId, "messageOne");
+    taskService.createComment(taskId, processInstanceId, "messageTwo");
+
+    //delete a comment
+    taskService.deleteProcessInstanceComments(processInstanceId);
+
+    //make sure the comment is not there.
+    List<Comment> shouldBeDeletedLst = taskService.getProcessInstanceComments(processInstanceId);
+    assertThat(shouldBeDeletedLst).isEmpty();
+
+    // Finally, delete task
+    taskService.deleteTask(taskId, true);
+  }
+
+  @Deployment(resources = { "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml" })
+  @Test
+  public void testUpdateProcessInstanceCommentNullCommentId() {
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    try {
+      taskService.updateProcessInstanceComment(processInstance.getId(), null, "aMessage");
+      fail("ProcessEngineException expected");
+    } catch (ProcessEngineException ae) {
+      testRule.assertTextPresent("commentId is null", ae.getMessage());
+    }
+  }
+
+  @Deployment(resources = { "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml" })
+  @Test
+  public void testUpdateProcessInstanceCommentNullProcessInstanceId() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    Comment comment = taskService.createComment(task.getId(), processInstance.getId(), "originalMessage");
+
+    try {
+      taskService.updateProcessInstanceComment(null, comment.getId(), "updatedMessage");
+      fail("ProcessEngineException expected");
+    } catch (ProcessEngineException ae) {
+      testRule.assertTextPresent("processInstanceId is null", ae.getMessage());
+    } finally {
+      taskService.deleteTask(task.getId(), true);
+    }
+  }
+
+  @Deployment(resources = { "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml" })
+  @Test
+  public void testUpdateProcessInstanceCommentNullMessage() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    String taskId = task.getId();
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    Comment comment = taskService.createComment(taskId, processInstance.getId(), "originalMessage");
+
+    try {
+      taskService.updateProcessInstanceComment(processInstance.getId(), comment.getId(), null);
+      fail("ProcessEngineException expected");
+    } catch (ProcessEngineException ae) {
+      testRule.assertTextPresent("message is null", ae.getMessage());
+    } finally {
+      taskService.deleteTask(task.getId(), true);
+    }
+  }
+
+  @Deployment(resources = { "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml" })
+  @Test
+  public void testUpdateProcessInstanceCommentNotExistingCommentId() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    String taskId = task.getId();
+
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    String processInstanceId = processInstance.getId();
+    taskService.createComment(taskId, processInstanceId, "originalMessage");
+
+    String nonExistingCommentId = "notExistingCommentId";
+    try {
+      taskService.updateProcessInstanceComment(processInstanceId, nonExistingCommentId, "updatedMessage");
+      fail("ProcessEngineException expected");
+    } catch (ProcessEngineException ae) {
+      testRule.assertTextPresent(
+          "No comment exists with commentId: " + nonExistingCommentId + " and processInstanceId: " + processInstanceId,
+          ae.getMessage());
+    } finally {
+      taskService.deleteTask(taskId, true);
+    }
+  }
+
+  @Deployment(resources = { "org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml" })
+  @Test
+  public void testUpdateProcessInstanceComment() {
+    Task task = taskService.newTask();
+    taskService.saveTask(task);
+    String taskId = task.getId();
+
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    String processInstanceId = processInstance.getId();
+
+    Comment comment = taskService.createComment(taskId, processInstanceId, "originalMessage");
+    String updatedMessage = "updatedMessage";
+
+    taskService.updateProcessInstanceComment(processInstanceId, comment.getId(), updatedMessage);
+
+    List<Comment> updateCommentLst = taskService.getProcessInstanceComments(processInstanceId);
+
+    assertThat(updateCommentLst).isNotEmpty();
+    assertThat(updateCommentLst).hasSize(1);
+
+    Comment actual = updateCommentLst.get(0);
+    assertEquals(updatedMessage, actual.getFullMessage());
+
+    // Finally, delete task
+    taskService.deleteTask(taskId, true);
   }
 
   @Test


### PR DESCRIPTION
- DELETE /task/{taskId}/comment/{commentId}
     deletes a comment of a given taskId and commentId
- DELETE /task/{taskId}/comment
     deletes all comments of a given taskId
- PUT /task/comment
      updates a comment
- DELETE /process-instance/{processInstanceId}/comment/{commentId}
      deletes a comment of a given processInstanceId and commentId
- DELETE /process-instance/{processInstanceId}/comment.
      deletes all comments of a given processInstanceId
- PUT /process-instance/comment
      updates a comment

related to: https://github.com/camunda/camunda-bpm-platform/issues/2551