### PR TITLE
check if opensaml or org.json is used

### DIFF
--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -137,11 +137,6 @@
         <version>1.1.1</version>
       </dependency>
       <dependency>
-        <groupId>org.opensaml</groupId>
-        <artifactId>opensaml</artifactId>
-        <version>1.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa</artifactId>
         <version>${version.openjpa}</version>
@@ -165,11 +160,6 @@
         <groupId>org.graalvm.js</groupId>
         <artifactId>js-scriptengine</artifactId>
         <version>${version.graal.js}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.json</groupId>
-        <artifactId>json</artifactId>
-        <version>20070829</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
These packages are part of the dependencyManagement block in `camunda-bpm-platform/internal-dependencies/pom.xml` but does not seem to have any usage. 

Related to: 
https://github.com/camunda/camunda-bpm-platform/issues/4378
https://github.com/camunda/camunda-bpm-platform/issues/4379