### PR TITLE
feat: Extend `ValidationResults` to allow write results until a max size

### DIFF
--- a/model-api/xml-model/src/main/java/org/camunda/bpm/model/xml/impl/validation/ModelValidationResultsImpl.java
+++ b/model-api/xml-model/src/main/java/org/camunda/bpm/model/xml/impl/validation/ModelValidationResultsImpl.java
@@ -17,6 +17,7 @@
 package org.camunda.bpm.model.xml.impl.validation;
 
 import java.io.StringWriter;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -42,6 +43,15 @@ public class ModelValidationResultsImpl implements ValidationResults {
     this.collectedResults = collectedResults;
     this.errorCount = errorCount;
     this.warningCount = warningCount;
+  }
+
+  public ModelValidationResultsImpl(ValidationResults... validationResults) {
+    collectedResults = new HashMap<>();
+    for (var entry : validationResults) {
+      collectedResults.putAll(entry.getResults());
+      errorCount += entry.getErrorCount();
+      warningCount += entry.getWarinigCount();
+    }
   }
 
   @Override
@@ -106,7 +116,7 @@ public class ModelValidationResultsImpl implements ValidationResults {
     if (lastItemToPrint && currentSize <= maxSize) {
       return true;
     }
-    
+
     int suffixLength = suffixWithNumberOfRemainingResults(printedCount).length();
     return currentSize + suffixLength <= maxSize;
   }

--- a/model-api/xml-model/src/main/java/org/camunda/bpm/model/xml/impl/validation/ModelValidationResultsImpl.java
+++ b/model-api/xml-model/src/main/java/org/camunda/bpm/model/xml/impl/validation/ModelValidationResultsImpl.java
@@ -100,9 +100,10 @@ public class ModelValidationResultsImpl implements ValidationResults {
         // Size and Length are not necessarily the same, depending on the encoding of the string.
         int currentSize = writer.getBuffer().toString().getBytes().length;
         int currentLength = writer.getBuffer().length();
-        if (!canAccommodateResult(maxSize, currentSize, printedCount)) {
+        if (!canAccommodateResult(maxSize, currentSize, printedCount, formatter)) {
           writer.getBuffer().setLength(previousLength);
-          writer.append(suffixWithNumberOfRemainingResults(printedCount));
+          int remaining = errorCount + warningCount - printedCount;
+          formatter.formatSuffixWithOmittedResultsCount(writer, remaining);
           return;
         }
         printedCount++;
@@ -111,19 +112,15 @@ public class ModelValidationResultsImpl implements ValidationResults {
     }
   }
 
-  private boolean canAccommodateResult(int maxSize, int currentSize, int printedCount) {
-    boolean lastItemToPrint = printedCount == errorCount + warningCount - 1;
-    if (lastItemToPrint && currentSize <= maxSize) {
+  private boolean canAccommodateResult(
+      int maxSize, int currentSize, int printedCount, ValidationResultFormatter formatter) {
+    boolean isLastItemToPrint = printedCount == errorCount + warningCount - 1;
+    if (isLastItemToPrint && currentSize <= maxSize) {
       return true;
     }
-
-    int suffixLength = suffixWithNumberOfRemainingResults(printedCount).length();
-    return currentSize + suffixLength <= maxSize;
-  }
-
-  private String suffixWithNumberOfRemainingResults(int printedCount) {
     int remaining = errorCount + warningCount - printedCount;
-    return String.format(" and %d more errors and/or warnings", remaining);
+    int suffixLength = formatter.getFormattedSuffixWithOmittedResultsSize(remaining);
+    return currentSize + suffixLength <= maxSize;
   }
 
   @Override

--- a/model-api/xml-model/src/main/java/org/camunda/bpm/model/xml/validation/ValidationResultFormatter.java
+++ b/model-api/xml-model/src/main/java/org/camunda/bpm/model/xml/validation/ValidationResultFormatter.java
@@ -21,8 +21,8 @@ import java.io.StringWriter;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 
 /**
- * SPI which can be implemented to print out a summary of a validation result.
- * See {@link ValidationResults#write(StringWriter, ValidationResultFormatter)}
+ * SPI which can be implemented to print out a summary of a validation result. See {@link
+ * ValidationResults#write(StringWriter, ValidationResultFormatter)}
  *
  * @author Daniel Meyer
  * @since 7.6
@@ -45,4 +45,25 @@ public interface ValidationResultFormatter {
    */
   void formatResult(StringWriter writer, ValidationResult result);
 
+  /**
+   * formats a suffix with the count of omitted errors/warnings, to be used when writing with a
+   * maximum output size limit. See {@link ValidationResults#write(StringWriter,
+   * ValidationResultFormatter, int)}
+   *
+   * @param writer the writer
+   * @param count the count of results omitted from the writer output
+   */
+  default void formatSuffixWithOmittedResultsCount(StringWriter writer, int count) {
+    // Do NOTHING by default
+  }
+
+  /**
+   * returns the size of the formatted suffix (donating the count of omitted results) in bytes
+   *
+   * @param count the count of results to be omitted from the writer output
+   * @return the size of the formatted suffix in bytes
+   */
+  default int getFormattedSuffixWithOmittedResultsSize(int count) {
+    return 0;
+  }
 }

--- a/model-api/xml-model/src/main/java/org/camunda/bpm/model/xml/validation/ValidationResults.java
+++ b/model-api/xml-model/src/main/java/org/camunda/bpm/model/xml/validation/ValidationResults.java
@@ -56,8 +56,17 @@ public interface ValidationResults {
    * Utility method to print out a summary of the validation results.
    *
    * @param writer a {@link StringWriter} to which the result should be printed
-   * @param printer formatter for printing elements and validation results
+   * @param formatter formatter for printing elements and validation results
    */
-  void write(StringWriter writer, ValidationResultFormatter printer);
+  void write(StringWriter writer, ValidationResultFormatter formatter);
+
+  /**
+   * Utility method to print out a summary of the validation results.
+   *
+   * @param writer a {@link StringWriter} to which the result should be printed
+   * @param formatter formatter for printing elements and validation results
+   * @param maxSize the maximum size (in bytes) that is allowed to be written to the writer
+   */
+  void write(StringWriter writer, ValidationResultFormatter formatter, int maxSize);
 
 }

--- a/model-api/xml-model/src/test/java/org/camunda/bpm/model/xml/validation/ModelValidationTest.java
+++ b/model-api/xml-model/src/test/java/org/camunda/bpm/model/xml/validation/ModelValidationTest.java
@@ -122,7 +122,7 @@ public class ModelValidationTest {
         .hasLineCount(5)
         .describedAs(
             "shall contain only one error/warning and mention the count of the missing ones")
-        .endsWith(" and 5 more errors and/or warnings");
+        .endsWith(String.format(TestResultFormatter.OMITTED_RESULTS_SUFFIX_FORMAT, 5));
   }
 
   @Test

--- a/model-api/xml-model/src/test/java/org/camunda/bpm/model/xml/validation/ModelValidationTest.java
+++ b/model-api/xml-model/src/test/java/org/camunda/bpm/model/xml/validation/ModelValidationTest.java
@@ -20,13 +20,9 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-
 import org.camunda.bpm.model.xml.ModelInstance;
 import org.camunda.bpm.model.xml.impl.validation.ModelValidationResultsImpl;
-import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.camunda.bpm.model.xml.testmodel.TestModelParser;
 import org.camunda.bpm.model.xml.testmodel.instance.Bird;
 import org.junit.Before;
@@ -50,9 +46,7 @@ public class ModelValidationTest {
 
   @Test
   public void shouldValidateWithEmptyList() {
-    List<ModelElementValidator<?>> validators = new ArrayList<ModelElementValidator<?>>();
-
-    ValidationResults results = modelInstance.validate(validators);
+    ValidationResults results = modelInstance.validate(List.of());
 
     assertThat(results).isNotNull();
     assertThat(results.hasErrors()).isFalse();
@@ -60,9 +54,7 @@ public class ModelValidationTest {
 
   @Test
   public void shouldCollectWarnings() {
-    List<ModelElementValidator<?>> validators = new ArrayList<ModelElementValidator<?>>();
-
-    validators.add(new IsAdultWarner());
+    List<ModelElementValidator<?>> validators = List.of(new IsAdultWarner());
 
     ValidationResults results = modelInstance.validate(validators);
 
@@ -74,9 +66,7 @@ public class ModelValidationTest {
 
   @Test
   public void shouldCollectErrors() {
-    List<ModelElementValidator<?>> validators = new ArrayList<ModelElementValidator<?>>();
-
-    validators.add(new IllegalBirdValidator("tweety"));
+    List<ModelElementValidator<?>> validators = List.of(new IllegalBirdValidator("tweety"));
 
     ValidationResults results = modelInstance.validate(validators);
 
@@ -88,9 +78,7 @@ public class ModelValidationTest {
 
   @Test
   public void shouldWriteResults() {
-    List<ModelElementValidator<?>> validators = new ArrayList<ModelElementValidator<?>>();
-
-    validators.add(new IllegalBirdValidator("tweety"));
+    List<ModelElementValidator<?>> validators = List.of(new IllegalBirdValidator("tweety"));
 
     ValidationResults results = modelInstance.validate(validators);
 
@@ -132,7 +120,7 @@ public class ModelValidationTest {
 
     // has 7 warnings
     var results1 = modelInstance.validate(List.of(new IsAdultWarner()));
-    //has 1 error
+    // has 1 error
     var results2 = modelInstance.validate(List.of(new IllegalBirdValidator("tweety")));
     var stringWriter = new StringWriter();
 
@@ -152,17 +140,15 @@ public class ModelValidationTest {
 
   @Test
   public void shouldReturnResults() {
-    List<ModelElementValidator<?>> validators = new ArrayList<ModelElementValidator<?>>();
-
-    validators.add(new IllegalBirdValidator("tweety"));
-    validators.add(new IsAdultWarner());
+    List<ModelElementValidator<?>> validators =
+        List.of(new IllegalBirdValidator("tweety"), new IsAdultWarner());
 
     ValidationResults results = modelInstance.validate(validators);
 
     assertThat(results.getErrorCount()).isEqualTo(1);
     assertThat(results.getWarinigCount()).isEqualTo(7);
 
-    Map<ModelElementInstance, List<ValidationResult>> resultsByElement = results.getResults();
+    var resultsByElement = results.getResults();
     assertThat(resultsByElement.size()).isEqualTo(7);
 
     for (var resultEntry : resultsByElement.entrySet()) {

--- a/model-api/xml-model/src/test/java/org/camunda/bpm/model/xml/validation/TestResultFormatter.java
+++ b/model-api/xml-model/src/test/java/org/camunda/bpm/model/xml/validation/TestResultFormatter.java
@@ -24,19 +24,19 @@ import org.camunda.bpm.model.xml.testmodel.instance.FlyingAnimal;
 
 /**
  * @author Daniel Meyer
- *
  */
 @SuppressWarnings("resource")
 public class TestResultFormatter implements ValidationResultFormatter {
+
+  public static final String OMITTED_RESULTS_SUFFIX_FORMAT = "and %d more errors and/or warnings";
 
   @Override
   public void formatElement(StringWriter writer, ModelElementInstance element) {
     Formatter formatter = new Formatter(writer);
 
-    if(element instanceof FlyingAnimal) {
-      formatter.format("%s\n", ((FlyingAnimal)element).getId());
-    }
-    else {
+    if (element instanceof FlyingAnimal) {
+      formatter.format("%s\n", ((FlyingAnimal) element).getId());
+    } else {
       formatter.format("%s\n", element.getElementType().getTypeName());
     }
 
@@ -46,8 +46,17 @@ public class TestResultFormatter implements ValidationResultFormatter {
   @Override
   public void formatResult(StringWriter writer, ValidationResult result) {
     new Formatter(writer)
-      .format("\t%s (%d): %s\n", result.getType(), result.getCode(), result.getMessage())
-      .flush();
+        .format("\t%s (%d): %s\n", result.getType(), result.getCode(), result.getMessage())
+        .flush();
   }
 
+  @Override
+  public void formatSuffixWithOmittedResultsCount(StringWriter writer, int count) {
+    new Formatter(writer).format(OMITTED_RESULTS_SUFFIX_FORMAT, count).flush();
+  }
+
+  @Override
+  public int getFormattedSuffixWithOmittedResultsSize(int count) {
+    return String.format(OMITTED_RESULTS_SUFFIX_FORMAT, count).getBytes().length;
+  }
 }


### PR DESCRIPTION
## Description

### Update
- Added two new methods to the ValidationResultFormatter:
  - one to format and print the suffix
  - and another to return the expected size of this suffix
- Created empty default implementation for both methods not to break backwards-compatibility
- Updated the `write` implementation to use the new formatter methods
- Implemented the new methods in the TestResultFormatter and updated the test

--- 

Extend ValidationResults to allow write results until a max size

- Added a new `ValidationResults.write` method that accepts a `maxSize`

  - keeps writing results to the writer as usual while comparing the size of the writer to the maxSize after every append
  - keeps track of the length of the writer after every append
  - if the size of the writer exceeds the max size, it resets the writer to the previous length and appends a suffix with the number of remaining results.
- Added a new constructor to aggregate a list of ValidationResults into one
  
  Zeebe uses two different validators, one for design-time validations, and one for run-time validations
  
  Currently, it calls `write` on the two validation results separately. But since we need to limit the size of the printed results, it would be easier to have a way to combine both results in one, and call `write` only once for both.

## Related issues

closes: #4443
related to: https://github.com/camunda/camunda/issues/11284