### PR TITLE
Removing obsolete dependency, org.json:json, that is no longer used in the project

### DIFF
--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -167,11 +167,6 @@
         <version>${version.graal.js}</version>
       </dependency>
       <dependency>
-        <groupId>org.json</groupId>
-        <artifactId>json</artifactId>
-        <version>20070829</version>
-      </dependency>
-      <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-library</artifactId>
         <scope>test</scope>


### PR DESCRIPTION
As per online discussion with Github users @venetrius and @tasso94 involved with this camunda project, removing an dependency that is no longer used in the project