### PR TITLE
Updated file pattern regex

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/container/impl/deployment/AbstractParseBpmPlatformXmlStep.java
+++ b/engine/src/main/java/org/camunda/bpm/container/impl/deployment/AbstractParseBpmPlatformXmlStep.java
@@ -136,7 +136,8 @@ public abstract class AbstractParseBpmPlatformXmlStep extends DeploymentOperatio
       return null;
     }
 
-    Pattern filePattern = Pattern.compile("^(/|[A-z]://?|[A-z]:\\\\).*[/|\\\\]bpm-platform\\.xml$", Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+    Pattern filePattern = Pattern.compile("^(/|[A-Za-z]://?|[A-Za-z]:\\\\).*[/|\\\\]bpm-platform\\.xml$",
+            Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
     Matcher fileMatcher = filePattern.matcher(url);
     if (fileMatcher.matches()) {
       File configurationLocation = new File(url);


### PR DESCRIPTION
Updated regex to handle overly permissive regular expression range which was found in CodeQL

Testing locally:

nstall Maven >3.9, Java 17

Create a file in the root directory of the repository (do not commit this file), settings.xml. This will direct Maven to pull dependencies from the upstream project's repository, which is required to build and test the project.
```
<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/SETTINGS/1.0.0"
          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
    <profiles>
        <profile>
            <id>camunda-bpm</id>
            <repositories>
                <repository>
                    <id>camunda-bpm-nexus</id>
                    <name>camunda-bpm-nexus</name>
                    <releases>
                        <enabled>true</enabled>
                    </releases>
                    <snapshots>
                        <enabled>true</enabled>
                    </snapshots>
                    <url>https://artifacts.camunda.com/artifactory/public/</url>
                </repository>
            </repositories>
        </profile>
    </profiles>
    <activeProfiles>
        <activeProfile>camunda-bpm</activeProfile>
    </activeProfiles>
</settings>
```
The following command will run unit tests for the affected submodule, using the Maven settings file you just created:
mvn --settings settings.xml -Daether.connector.https.securityMode=insecure -f engine/pom.xml clean test 
