### PR TITLE
Fix get historic process instance api orquery for mutiple statues and withIncidents combined with orQuery

### DIFF
--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricProcessInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricProcessInstanceRestServiceInteractionTest.java
@@ -44,6 +44,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.HashSet;
 import javax.ws.rs.core.Response.Status;
 import org.camunda.bpm.engine.AuthorizationException;
 import org.camunda.bpm.engine.BadUserRequestException;
@@ -551,11 +552,7 @@ public class HistoricProcessInstanceRestServiceInteractionTest extends AbstractR
     // given
     HistoricProcessInstanceQueryImpl mockedQuery = mock(HistoricProcessInstanceQueryImpl.class);
     when(historyServiceMock.createHistoricProcessInstanceQuery()).thenReturn(mockedQuery);
-
-    String payload = "{ \"orQueries\": [{" +
-        "\"processDefinitionKey\": \"aKey\", " +
-        "\"processInstanceBusinessKey\": \"aBusinessKey\"}] }";
-
+    String payload = "{\"orQueries\": [{ \"processDefinitionKey\": \"aKey\", \"processInstanceBusinessKey\": \"aBusinessKey\", \"completed\": true ,\"active\": true}]}";
     // when
     given()
       .contentType(POST_JSON_CONTENT_TYPE)
@@ -574,6 +571,7 @@ public class HistoricProcessInstanceRestServiceInteractionTest extends AbstractR
     // then
     assertThat(argument.getValue().getProcessDefinitionKey()).isEqualTo("aKey");
     assertThat(argument.getValue().getBusinessKey()).isEqualTo("aBusinessKey");
+    assertThat(argument.getValue().getState()).isEqualTo(new HashSet<>(Arrays.asList("COMPLETED", "ACTIVE")));
   }
 
   protected void verifyBatchJson(String batchJson) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -20,7 +20,7 @@ import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotContainsEmpty
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotContainsNull;
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotEmpty;
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
-import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureNull;
+import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureEmpty;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -91,7 +91,7 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   protected boolean isTenantIdSet;
   protected String[] executedActivityIds;
   protected String[] activeActivityIds;
-  protected String state;
+  protected Set<String> state = new HashSet<>();
 
   protected String caseInstanceId;
 
@@ -599,7 +599,7 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
     return incidentStatus;
   }
 
-  public String getState() {
+  public Set<String> getState() {
     return state;
   }
 
@@ -772,36 +772,46 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
 
   @Override
   public HistoricProcessInstanceQuery active() {
-    ensureNull(BadUserRequestException.class, "Already querying for historic process instance with another state", state, state);
-    state = HistoricProcessInstance.STATE_ACTIVE;
+    if(!isOrQueryActive) {
+      ensureEmpty(BadUserRequestException.class, "Already querying for historic process instance with another state", state);
+    }
+    state.add(HistoricProcessInstance.STATE_ACTIVE);
     return this;
   }
 
   @Override
   public HistoricProcessInstanceQuery suspended() {
-    ensureNull(BadUserRequestException.class, "Already querying for historic process instance with another state", state, state);
-    state = HistoricProcessInstance.STATE_SUSPENDED;
+    if(!isOrQueryActive) {
+      ensureEmpty(BadUserRequestException.class, "Already querying for historic process instance with another state", state);
+    }
+    state.add(HistoricProcessInstance.STATE_SUSPENDED);
     return this;
   }
 
   @Override
   public HistoricProcessInstanceQuery completed() {
-    ensureNull(BadUserRequestException.class, "Already querying for historic process instance with another state", state, state);
-    state = HistoricProcessInstance.STATE_COMPLETED;
+    if(!isOrQueryActive) {
+      ensureEmpty(BadUserRequestException.class, "Already querying for historic process instance with another state", state);
+    }
+    state.add(HistoricProcessInstance.STATE_COMPLETED);
     return this;
   }
 
   @Override
   public HistoricProcessInstanceQuery externallyTerminated() {
-    ensureNull(BadUserRequestException.class, "Already querying for historic process instance with another state", state, state);
-    state = HistoricProcessInstance.STATE_EXTERNALLY_TERMINATED;
+    if(!isOrQueryActive) {
+      ensureEmpty(BadUserRequestException.class, "Already querying for historic process instance with another state", state);
+    }
+    state.add(HistoricProcessInstance.STATE_EXTERNALLY_TERMINATED);
     return this;
   }
 
   @Override
   public HistoricProcessInstanceQuery internallyTerminated() {
-    ensureNull(BadUserRequestException.class, "Already querying for historic process instance with another state", state, state);
-    state = HistoricProcessInstance.STATE_INTERNALLY_TERMINATED;
+    if(!isOrQueryActive) {
+      ensureEmpty(BadUserRequestException.class, "Already querying for historic process instance with another state", state);
+    }
+    state.add(HistoricProcessInstance.STATE_INTERNALLY_TERMINATED);
     return this;
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/util/EnsureUtil.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/util/EnsureUtil.java
@@ -128,6 +128,14 @@ public final class EnsureUtil {
   }
 
   @SuppressWarnings("rawtypes")
+  public static void ensureEmpty(Class<? extends ProcessEngineException> exceptionClass, String message, Collection collection) {
+    if (collection != null && !collection.isEmpty()) {
+      String variableName = collection.iterator().next().toString();
+      throw generateException(exceptionClass, message, variableName, "is not empty");
+    }
+  }
+
+  @SuppressWarnings("rawtypes")
   public static void ensureNotEmpty(String variableName, Map map) {
     ensureNotEmpty("", variableName, map);
   }

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
@@ -405,12 +405,12 @@
     <bind name="JOIN_TYPE" value="'inner join'" />
 
     <foreach collection="queries" item="query">
-      <if test="query.isOrQueryActive">
-        <bind name="JOIN_TYPE" value="'left join'" />
-      </if>
 
       <if test="query != null &amp;&amp; (query.withIncidents || query.withRootIncidents || query.incidentStatus != null || query.incidentMessage != null || query.incidentMessageLike != null || query.incidentType != null)">
         <bind name="INC_JOIN" value="true" />
+        <if test="query.isOrQueryActive">
+          <bind name="JOIN_TYPE" value="'left join'" />
+        </if>
       </if>
 
       <if test="query != null &amp;&amp; (query.executedActivityIds != null and query.executedActivityIds.length > 0) || (query.activeActivityIds != null and query.activeActivityIds.length > 0)">
@@ -519,8 +519,15 @@
                 </foreach>
               )
             </if>
-            <if test="query.state != null">
-              ${queryType} SELF.STATE_ = #{query.state}
+
+            <if test="query.state != null and !query.state.isEmpty()">
+              ${queryType} (
+              SELF.STATE_ IS NOT NULL
+              AND SELF.STATE_ IN
+              <foreach item="state" index="index" collection="query.state" open="(" separator="," close=")">
+                #{state}
+              </foreach>
+              )
             </if>
 
 

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricProcessInstanceQueryOrTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/HistoricProcessInstanceQueryOrTest.java
@@ -919,6 +919,7 @@ public class HistoricProcessInstanceQueryOrTest {
 
   @Test
   @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
   public void shouldReturnHistoricProcInstWithVarValue1OrVarValue21() {
     // given
     Map<String, Object> vars = new HashMap<String, Object>();
@@ -971,6 +972,7 @@ public class HistoricProcessInstanceQueryOrTest {
 
   @Test
   @Deployment(resources={"org/camunda/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
   public void shouldReturnHistoricProcInstWithVarValue1OrVarValue23() {
     // given
     Map<String, Object> vars = new HashMap<String, Object>();


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/3182