### PR TITLE
remove(tests): remove telemetry configuration property 

### DIFF
--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -410,6 +410,8 @@
 
                 <exclude>**/ManagementServiceTableCountTest.java</exclude>
 
+                <!-- Can be removed in Camunda 7.23-->
+                <exclude>**/ConcurrentTelemetryConfigurationTest.java</exclude>
               </excludes>
               <testFailureIgnore>false</testFailureIgnore>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>

--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -410,7 +410,8 @@
 
                 <exclude>**/ManagementServiceTableCountTest.java</exclude>
 
-                <!-- Can be removed in Camunda 7.23-->
+                <!-- The test is not relevant in `old-engine` setup since the feature has been removed -->
+                <!-- See https://github.com/camunda/camunda-bpm-platform/pull/4544#discussion_r1728748399 -->
                 <exclude>**/ConcurrentTelemetryConfigurationTest.java</exclude>
               </excludes>
               <testFailureIgnore>false</testFailureIgnore>

--- a/quarkus-extension/README.md
+++ b/quarkus-extension/README.md
@@ -29,7 +29,6 @@ can look like the following:
 quarkus.camunda.cmmn-enabled=false
 quarkus.camunda.dmn-enabled=false
 quarkus.camunda.history=none
-quarkus.camunda.initialize-telemetry=false
 
 # job executor configuration
 quarkus.camunda.job-executor.thread-pool.max-pool-size=12

--- a/quarkus-extension/engine/deployment/src/test/resources/org/camunda/bpm/quarkus/engine/test/config/mixed-application.properties
+++ b/quarkus-extension/engine/deployment/src/test/resources/org/camunda/bpm/quarkus/engine/test/config/mixed-application.properties
@@ -2,7 +2,6 @@ quarkus.camunda.cmmn-enabled=false
 quarkus.camunda.dmn-enabled=false
 quarkus.camunda.history=none
 quarkus.camunda.enforce-history-time-to-live=false
-quarkus.camunda.initialize-telemetry=false
 
 quarkus.camunda.job-executor.thread-pool.max-pool-size=12
 quarkus.camunda.job-executor.thread-pool.queue-size=5

--- a/quarkus-extension/engine/deployment/src/test/resources/org/camunda/bpm/quarkus/engine/test/config/process-engine-config-application.properties
+++ b/quarkus-extension/engine/deployment/src/test/resources/org/camunda/bpm/quarkus/engine/test/config/process-engine-config-application.properties
@@ -2,6 +2,5 @@ quarkus.camunda.cmmn-enabled=false
 quarkus.camunda.dmn-enabled=false
 quarkus.camunda.history=none
 quarkus.camunda.enforce-history-time-to-live=false
-quarkus.camunda.initialize-telemetry=false
 
 quarkus.datasource.jdbc.url=jdbc:h2:mem:camunda;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE


### PR DESCRIPTION
+ exclude telemetry test in `old-engine` setup as telemetry feature is removed in newer versions; during rolling update users run old engine and data with new schema, so the test is not relevant for the scenario


fixes `quarkus-UNIT` in CE main and `old-engine` in CE daily/sidetrack

https://github.com/camunda/camunda-bpm-platform/issues/4483