### PR TITLE
fix(ci): skip starter-security module for jdk11 stages

### DIFF
--- a/.ci/config/stage-types.yaml
+++ b/.ci/config/stage-types.yaml
@@ -159,7 +159,7 @@ platform-jdk-openjdk-jdk-11-latest:
           !spring-boot-starter/starter-qa/integration-test-webapp,!spring-boot-starter/starter-qa/integration-test-webapp/invoice-example,
           !spring-boot-starter/starter-qa/integration-test-webapp/runtime,
           !distro/run,!distro/run/assembly,!distro/run/core,!distro/run/distro,!distro/run/modules,!distro/run/modules/example,
-          !distro/run/modules/rest,!distro/run/modules/webapps,!distro/run/qa,!distro/run/qa/integration-tests,
+          !distro/run/modules/rest,!distro/run/modules/webapps,!distro/run/modules/oauth2,!distro/run/qa,!distro/run/qa/integration-tests,
           !distro/run/qa/runtime,!distro/run/qa/example-plugin''
     -Pdistro,distro-ce,distro-wildfly'
   stash:
@@ -196,7 +196,7 @@ platform-jdk-jdk-11-latest:
           !spring-boot-starter/starter-qa/integration-test-webapp,!spring-boot-starter/starter-qa/integration-test-webapp/invoice-example,
           !spring-boot-starter/starter-qa/integration-test-webapp/runtime,
           !distro/run,!distro/run/assembly,!distro/run/core,!distro/run/distro,!distro/run/modules,!distro/run/modules/example,
-          !distro/run/modules/rest,!distro/run/modules/webapps,!distro/run/qa,!distro/run/qa/integration-tests,
+          !distro/run/modules/rest,!distro/run/modules/webapps,!distro/run/modules/oauth2,!distro/run/qa,!distro/run/qa/integration-tests,
           !distro/run/qa/runtime,!distro/run/qa/example-plugin''
     -Pdistro,distro-ce,distro-wildfly'
   stash:

--- a/.ci/config/stage-types.yaml
+++ b/.ci/config/stage-types.yaml
@@ -150,7 +150,7 @@ platform-jdk-openjdk-jdk-11-latest:
   directory: '.'
   command: 'install source:jar source:test-jar
     -pl ''!spring-boot-starter,!spring-boot-starter/starter,!spring-boot-starter/starter-client/spring,!spring-boot-starter/starter-client/spring-boot,
-          !spring-boot-starter/starter-qa,!spring-boot-starter/starter-rest,!spring-boot-starter/starter-test,!spring-boot-starter/starter-webapp,
+          !spring-boot-starter/starter-qa,!spring-boot-starter/starter-rest,!spring-boot-starter/starter-test,!spring-boot-starter/starter-webapp,!spring-boot-starter/starter-security,
           !spring-boot-starter/starter-webapp-core,
           !spring-boot-starter/starter-qa/integration-test-liquibase,!spring-boot-starter/starter-qa/integration-test-plugins,
           !spring-boot-starter/starter-qa/integration-test-plugins/spin,!spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-all,
@@ -187,7 +187,7 @@ platform-jdk-jdk-11-latest:
   directory: '.'
   command: 'install source:jar source:test-jar
     -pl ''!spring-boot-starter,!spring-boot-starter/starter,!spring-boot-starter/starter-client/spring,!spring-boot-starter/starter-client/spring-boot,
-          !spring-boot-starter/starter-qa,!spring-boot-starter/starter-rest,!spring-boot-starter/starter-test,!spring-boot-starter/starter-webapp,
+          !spring-boot-starter/starter-qa,!spring-boot-starter/starter-rest,!spring-boot-starter/starter-test,!spring-boot-starter/starter-webapp,!spring-boot-starter/starter-security,
           !spring-boot-starter/starter-webapp-core,
           !spring-boot-starter/starter-qa/integration-test-liquibase,!spring-boot-starter/starter-qa/integration-test-plugins,
           !spring-boot-starter/starter-qa/integration-test-plugins/spin,!spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-all,


### PR DESCRIPTION
related to https://github.com/camunda/camunda-bpm-platform/issues/4451