### PR TITLE
fix(modules): oauth2 module should be available for ce and ee

### DIFF
--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -87,6 +87,7 @@
       <modules>
         <module>modules</module>
         <module>modules/rest</module>
+        <module>modules/oauth2</module>
         <module>modules/example</module>
         <module>core</module>
         <module>assembly</module>
@@ -100,7 +101,6 @@
       </activation>
       <modules>
         <module>modules/webapps</module>
-        <module>modules/oauth2</module>
         <module>distro</module>
         <module>qa</module>
       </modules>


### PR DESCRIPTION
Moving the `modules/oauth2` from `distro-ce` to `distro` since it should be available in both builds ce and ee.


https://github.com/camunda/camunda-bpm-platform/issues/4451

fixes failure in [7.22-TEST-RELEASE-build-camunda-bpm-EE-tags](https://release.cambpm.camunda.cloud/job/7.22/job/7.22-TEST-RELEASE-build-camunda-bpm-EE-tags/)
Profiles used in release:

- ce - `-Pdistro,distro-ce,distro-wildfly,distro-webjar,release-community`
- ee - `-Pdistro,distro-wildfly,distro-webjar,distro-starter`