### PR TITLE
refactor(engine-rest): Ensure Proper Exception Code Assignment in ExceptionHandlerHelper

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/ExceptionHandlerHelper.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/exception/ExceptionHandlerHelper.java
@@ -52,8 +52,6 @@ public class ExceptionHandlerHelper {
     Response.Status responseStatus = getStatus(throwable);
     ExceptionDto exceptionDto = fromException(throwable);
 
-    provideExceptionCode(throwable, exceptionDto);
-
     return Response
         .status(responseStatus)
         .entity(exceptionDto)
@@ -85,17 +83,21 @@ public class ExceptionHandlerHelper {
   }
 
   public ExceptionDto fromException(Throwable e) {
+    ExceptionDto exceptionDto;
     if (e instanceof MigratingProcessInstanceValidationException) {
-      return MigratingProcessInstanceValidationExceptionDto.from((MigratingProcessInstanceValidationException)e);
+      exceptionDto = MigratingProcessInstanceValidationExceptionDto.from((MigratingProcessInstanceValidationException)e);
     } else if (e instanceof MigrationPlanValidationException) {
-      return MigrationPlanValidationExceptionDto.from((MigrationPlanValidationException)e);
+      exceptionDto = MigrationPlanValidationExceptionDto.from((MigrationPlanValidationException)e);
     } else if (e instanceof AuthorizationException) {
-      return AuthorizationExceptionDto.fromException((AuthorizationException)e);
+      exceptionDto = AuthorizationExceptionDto.fromException((AuthorizationException)e);
     } else if (e instanceof ParseException){
-      return ParseExceptionDto.fromException((ParseException) e);
+      exceptionDto = ParseExceptionDto.fromException((ParseException) e);
     } else {
-      return ExceptionDto.fromException(e);
+      exceptionDto = ExceptionDto.fromException(e);
     }
+    provideExceptionCode(e, exceptionDto);
+
+    return exceptionDto;
   }
 
   public Response.Status getStatus(Throwable exception) {


### PR DESCRIPTION
### Background

While implementing custom exception handling for my Camunda REST API, I used the `ExceptionHandlerHelper` class from the `engine-rest` module to ensure that the behavior of error handling is consistent with the built-in Camunda REST API error handling. The custom exception handler code is as follows:

```java
@ControllerAdvice
public class CustomExceptionHandler extends ResponseEntityExceptionHandler {

    protected static final ExceptionLogger LOGGER = ExceptionLogger.REST_LOGGER;
    private static final ExceptionHandlerHelper DELEGATE = ExceptionHandlerHelper.getInstance();

    @ExceptionHandler
    public ResponseEntity<Object> handleAnyException(Throwable ex, NativeWebRequest request) {
         ExceptionDto exceptionDto = DELEGATE.fromException(ex);
         return handleExceptionInternal((Exception) ex, exceptionDto, buildHeaders(ex), HttpStatusCode.valueOf(DELEGATE.getStatus(ex).getStatusCode()), request);
    }

    @Nullable
    @Override
    protected ResponseEntity<Object> handleExceptionInternal(
            Exception ex,
            @Nullable Object body,
            HttpHeaders headers,
            HttpStatusCode statusCode,
            WebRequest request
    ) {
        LOGGER.log(ex);
        if (body == null) {
            return super.handleExceptionInternal(ex, DELEGATE.fromException(ex), headers, statusCode, request);
        }
        return super.handleExceptionInternal(ex, body, headers, statusCode, request);
    }

    private HttpHeaders buildHeaders(Throwable err) {
        // ...
    }

}
```

However, the `code` field value in the response body (`ExceptionDto`) was always `null`, resulting in outputs like the following:

```json
{
    "type": "AuthorizationException",
    "message": "The user with id 'tom' does not have 'CREATE' permission on resource 'Deployment'.",
    "code": null,
    "userId": "tom",
    "resourceName": "Deployment",
    "resourceId": null,
    "permissionName": "CREATE",
    "missingAuthorizations": [
        {
            "permissionName": "CREATE",
            "resourceName": "Deployment",
            "resourceId": null
        }
    ]
}
```

### Changes Overview

This PR resolves an issue where the `code` field in `ExceptionDto` was always `null`. The following adjustments were made:

1. **Refactored `fromException` Method**: Ensured the `provideExceptionCode` method is called for all exception types, correctly assigning the exception code.
2. **Removed Redundant Code**: Eliminated the redundant `provideExceptionCode` call in the `getResponse` method to avoid unnecessary processing.


Related to https://github.com/camunda/camunda-bpm-platform/issues/4824