### PR TITLE
Fix camunda-spin-bom import in camunda-only-bom #4605

### DIFF
--- a/bom/camunda-only-bom/pom.xml
+++ b/bom/camunda-only-bom/pom.xml
@@ -232,6 +232,8 @@
         <groupId>org.camunda.connect</groupId>
         <artifactId>camunda-connect-bom</artifactId>
         <version>${project.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
 
       <!-- dmn engine dependencies

--- a/bom/camunda-only-bom/pom.xml
+++ b/bom/camunda-only-bom/pom.xml
@@ -213,30 +213,8 @@
         <groupId>org.camunda.spin</groupId>
         <artifactId>camunda-spin-bom</artifactId>
         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.camunda.spin</groupId>
-        <artifactId>camunda-spin-dataformat-all</artifactId>
-        <version>${project.version}</version>
-        <!-- Excluding dependencies that are shaded in camunda-spin-dataformat-all -->
-        <exclusions>
-          <exclusion>
-            <groupId>org.camunda.spin</groupId>
-            <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.camunda.spin</groupId>
-            <artifactId>camunda-spin-dataformat-xml-dom</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-          </exclusion>
-        </exclusions>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.camunda.commons</groupId>

--- a/bom/camunda-only-bom/pom.xml
+++ b/bom/camunda-only-bom/pom.xml
@@ -220,6 +220,8 @@
         <groupId>org.camunda.commons</groupId>
         <artifactId>camunda-commons-bom</artifactId>
         <version>${project.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.camunda.template-engines</groupId>

--- a/clients/java/client/pom.xml
+++ b/clients/java/client/pom.xml
@@ -108,7 +108,6 @@
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-all</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/clients/java/client/pom.xml
+++ b/clients/java/client/pom.xml
@@ -53,13 +53,11 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-logging</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-typed-values</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/commons/bom/pom.xml
+++ b/commons/bom/pom.xml
@@ -1,11 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <!-- HEADS-UP: Do not use camunda-parent as parent,
+  it would introduce a cyclic dependency to this bom -->
   <parent>
     <groupId>org.camunda.bpm</groupId>
-    <artifactId>camunda-parent</artifactId>
-    <relativePath>../../parent</relativePath>
+    <artifactId>camunda-root</artifactId>
     <version>7.22.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <groupId>org.camunda.commons</groupId>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -1,13 +1,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <!-- camunda BPM parent release pom -->
   <parent>
-    <groupId>org.camunda.commons</groupId>
-    <artifactId>camunda-commons-bom</artifactId>
+    <groupId>org.camunda.bpm</groupId>
+    <artifactId>camunda-parent</artifactId>
+    <relativePath>../parent</relativePath>
     <version>7.22.0-SNAPSHOT</version>
-    <relativePath>bom</relativePath>
   </parent>
 
+  <groupId>org.camunda.commons</groupId>
   <artifactId>camunda-commons-root</artifactId>
   <name>camunda Commons - Root Pom</name>
   <inceptionYear>2014</inceptionYear>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -1,7 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <!-- camunda BPM parent release pom -->
   <parent>
     <groupId>org.camunda.bpm</groupId>
     <artifactId>camunda-parent</artifactId>

--- a/commons/typed-values/pom.xml
+++ b/commons/typed-values/pom.xml
@@ -35,7 +35,6 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-utils</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/connect/bom/pom.xml
+++ b/connect/bom/pom.xml
@@ -1,11 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <!-- HEADS-UP: Do not use camunda-parent as parent,
+  it would introduce a cyclic dependency to this bom -->
   <parent>
     <groupId>org.camunda.bpm</groupId>
-    <artifactId>camunda-parent</artifactId>
-    <relativePath>../../parent</relativePath>
+    <artifactId>camunda-root</artifactId>
     <version>7.22.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <groupId>org.camunda.connect</groupId>

--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -1,13 +1,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <!-- camunda BPM parent release pom -->
   <parent>
-    <groupId>org.camunda.connect</groupId>
-    <artifactId>camunda-connect-bom</artifactId>
+    <groupId>org.camunda.bpm</groupId>
+    <artifactId>camunda-parent</artifactId>
+    <relativePath>../parent</relativePath>
     <version>7.22.0-SNAPSHOT</version>
-    <relativePath>bom</relativePath>
   </parent>
 
+  <groupId>org.camunda.connect</groupId>
   <artifactId>camunda-connect-root</artifactId>
   <name>Camunda Platform - connect - root</name>
   <inceptionYear>2014</inceptionYear>
@@ -34,14 +36,6 @@
 
   <dependencyManagement>
     <dependencies>
-
-      <dependency>
-        <groupId>org.camunda.commons</groupId>
-        <artifactId>camunda-commons-bom</artifactId>
-        <version>${project.version}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
 
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>

--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -1,7 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <!-- camunda BPM parent release pom -->
   <parent>
     <groupId>org.camunda.bpm</groupId>
     <artifactId>camunda-parent</artifactId>

--- a/distro/run/core/pom.xml
+++ b/distro/run/core/pom.xml
@@ -42,7 +42,6 @@
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-all</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/distro/tomcat/assembly/pom.xml
+++ b/distro/tomcat/assembly/pom.xml
@@ -126,7 +126,6 @@
     <dependency>
       <groupId>org.camunda.connect</groupId>
       <artifactId>camunda-connect-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -138,7 +137,6 @@
     <dependency>
       <groupId>org.camunda.connect</groupId>
       <artifactId>camunda-connect-connectors-all</artifactId>
-      <version>${project.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.camunda.connect</groupId>

--- a/distro/tomcat/assembly/pom.xml
+++ b/distro/tomcat/assembly/pom.xml
@@ -110,7 +110,6 @@
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -122,7 +121,6 @@
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-all</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -70,13 +70,11 @@
     <dependency>
       <groupId>org.camunda.connect</groupId>
       <artifactId>camunda-connect-http-client</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.camunda.connect</groupId>
       <artifactId>camunda-connect-soap-http-client</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <!-- script engine dependencies -->

--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -55,13 +55,11 @@
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-xml-dom-jakarta</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/distro/wildfly26/modules/pom.xml
+++ b/distro/wildfly26/modules/pom.xml
@@ -70,13 +70,11 @@
     <dependency>
       <groupId>org.camunda.connect</groupId>
       <artifactId>camunda-connect-http-client</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.camunda.connect</groupId>
       <artifactId>camunda-connect-soap-http-client</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <!-- script engine dependencies -->

--- a/distro/wildfly26/modules/pom.xml
+++ b/distro/wildfly26/modules/pom.xml
@@ -55,13 +55,11 @@
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-xml-dom</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/engine-dmn/engine/pom.xml
+++ b/engine-dmn/engine/pom.xml
@@ -20,13 +20,11 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-utils</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-typed-values</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/engine-dmn/feel-api/pom.xml
+++ b/engine-dmn/feel-api/pom.xml
@@ -17,7 +17,6 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-typed-values</artifactId>
-      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/engine-dmn/feel-juel/pom.xml
+++ b/engine-dmn/feel-juel/pom.xml
@@ -23,13 +23,11 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-logging</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-typed-values</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/engine-plugins/connect-plugin/pom.xml
+++ b/engine-plugins/connect-plugin/pom.xml
@@ -16,20 +16,17 @@
     <dependency>
       <groupId>org.camunda.connect</groupId>
       <artifactId>camunda-connect-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.camunda.connect</groupId>
       <artifactId>camunda-connect-http-client</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.camunda.connect</groupId>
       <artifactId>camunda-connect-soap-http-client</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/engine-plugins/identity-ldap/pom.xml
+++ b/engine-plugins/identity-ldap/pom.xml
@@ -21,7 +21,6 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-logging</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <!-- LDAP Libraries to start test server -->

--- a/engine-plugins/pom.xml
+++ b/engine-plugins/pom.xml
@@ -64,7 +64,6 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-testing</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/engine-plugins/spin-plugin/pom.xml
+++ b/engine-plugins/spin-plugin/pom.xml
@@ -16,7 +16,6 @@
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -36,14 +35,12 @@
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-xml-dom</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/engine-plugins/spin-plugin/pom.xml
+++ b/engine-plugins/spin-plugin/pom.xml
@@ -125,7 +125,6 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-testing</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/engine-rest/engine-rest-jakarta/pom.xml
+++ b/engine-rest/engine-rest-jakarta/pom.xml
@@ -116,7 +116,6 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-logging</artifactId>
-      <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -194,7 +193,6 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-testing</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -86,7 +86,6 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-logging</artifactId>
-      <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -218,7 +217,6 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-testing</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -774,7 +774,6 @@
         <dependency>
           <groupId>org.camunda.spin</groupId>
           <artifactId>camunda-spin-dataformat-all</artifactId>
-          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>org.camunda.bpm</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -779,7 +779,6 @@
         <dependency>
           <groupId>org.camunda.connect</groupId>
           <artifactId>camunda-connect-connectors-all</artifactId>
-          <version>${project.version}</version>
           <exclusions>
             <exclusion>
               <groupId>org.camunda.connect</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -89,13 +89,11 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-logging</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-typed-values</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -246,7 +244,6 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-testing</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/qa/integration-tests-engine-jakarta/pom.xml
+++ b/qa/integration-tests-engine-jakarta/pom.xml
@@ -250,7 +250,6 @@
     <dependency>
       <groupId>org.camunda.connect</groupId>
       <artifactId>camunda-connect-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <!-- explicit Spring dependencies for applications

--- a/qa/integration-tests-engine-jakarta/pom.xml
+++ b/qa/integration-tests-engine-jakarta/pom.xml
@@ -215,13 +215,11 @@
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -198,7 +198,6 @@
     <dependency>
       <groupId>org.camunda.connect</groupId>
       <artifactId>camunda-connect-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <!-- explicit Spring dependencies for applications

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -163,13 +163,11 @@
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/qa/integration-tests-webapps/pom.xml
+++ b/qa/integration-tests-webapps/pom.xml
@@ -177,7 +177,6 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-logging</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/qa/test-db-instance-migration/test-fixture-722/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-722/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/qa/test-db-instance-migration/test-migration/pom.xml
+++ b/qa/test-db-instance-migration/test-migration/pom.xml
@@ -21,7 +21,6 @@
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.camunda.bpm</groupId>

--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -241,7 +241,6 @@
         <dependency>
           <groupId>org.camunda.commons</groupId>
           <artifactId>camunda-commons-testing</artifactId>
-          <version>${project.version}</version>
           <scope>test</scope>
         </dependency>
 

--- a/qa/tomcat9-runtime/pom.xml
+++ b/qa/tomcat9-runtime/pom.xml
@@ -134,7 +134,6 @@
         <dependency>
           <groupId>org.camunda.spin</groupId>
           <artifactId>camunda-spin-core</artifactId>
-          <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -145,7 +144,6 @@
         <dependency>
           <groupId>org.camunda.spin</groupId>
           <artifactId>camunda-spin-dataformat-all</artifactId>
-          <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/qa/tomcat9-runtime/pom.xml
+++ b/qa/tomcat9-runtime/pom.xml
@@ -149,7 +149,6 @@
         <dependency>
           <groupId>org.camunda.connect</groupId>
           <artifactId>camunda-connect-core</artifactId>
-          <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -170,7 +169,6 @@
               <artifactId>camunda-connect-soap-http-client</artifactId>
             </exclusion>
           </exclusions>
-          <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/spin/bom/pom.xml
+++ b/spin/bom/pom.xml
@@ -1,21 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.camunda.bpm</groupId>
-    <artifactId>camunda-parent</artifactId>
-    <relativePath>../../parent</relativePath>
-    <version>7.22.0-SNAPSHOT</version>
-  </parent>
-
   <groupId>org.camunda.spin</groupId>
   <artifactId>camunda-spin-bom</artifactId>
   <name>camunda spin - bom</name>
+  <version>7.22.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-
-  <properties>
-    <plugin.version.javadoc>3.3.1</plugin.version.javadoc>
-  </properties>
 
   <dependencyManagement>
     <dependencies>
@@ -37,6 +27,25 @@
         <groupId>org.camunda.spin</groupId>
         <artifactId>camunda-spin-dataformat-all</artifactId>
         <version>${project.version}</version>
+        <!-- Excluding dependencies that are shaded in camunda-spin-dataformat-all -->
+        <exclusions>
+          <exclusion>
+            <groupId>org.camunda.spin</groupId>
+            <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.camunda.spin</groupId>
+            <artifactId>camunda-spin-dataformat-xml-dom</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -58,22 +67,6 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>${plugin.version.javadoc}</version>
-          <configuration combine.children="append">
-            <doclint>none</doclint>
-            <detectJavaApiLink>false</detectJavaApiLink>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 
   <scm>
     <url>https://github.com/camunda/camunda-bpm-platform</url>

--- a/spin/bom/pom.xml
+++ b/spin/bom/pom.xml
@@ -1,6 +1,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <!-- HEADS-UP: Do not use camunda-parent as parent,
+  it would introduce a cyclic dependency to this bom -->
+  <parent>
+    <groupId>org.camunda.bpm</groupId>
+    <artifactId>camunda-root</artifactId>
+    <version>7.22.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
   <groupId>org.camunda.spin</groupId>
   <artifactId>camunda-spin-bom</artifactId>
   <name>camunda spin - bom</name>

--- a/spin/pom.xml
+++ b/spin/pom.xml
@@ -3,12 +3,13 @@
 
   <!-- camunda BPM parent release pom -->
   <parent>
-    <groupId>org.camunda.spin</groupId>
-    <artifactId>camunda-spin-bom</artifactId>
+    <groupId>org.camunda.bpm</groupId>
+    <artifactId>camunda-parent</artifactId>
+    <relativePath>../parent</relativePath>
     <version>7.22.0-SNAPSHOT</version>
-    <relativePath>bom</relativePath>
   </parent>
 
+  <groupId>org.camunda.spin</groupId>
   <artifactId>camunda-spin-root</artifactId>
   <name>camunda Spin - root</name>
   <inceptionYear>2014</inceptionYear>
@@ -27,6 +28,7 @@
     <powermock.version>2.0.9</powermock.version>
     <mockito.version>3.3.3</mockito.version>
     <spin.version.old>1.23.0</spin.version.old>
+    <plugin.version.javadoc>3.3.1</plugin.version.javadoc>
 
     <license.includeTransitiveDependencies>false</license.includeTransitiveDependencies>
     <additionalparam>-Xdoclint:none</additionalparam>
@@ -130,6 +132,15 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${plugin.version.javadoc}</version>
+          <configuration combine.children="append">
+            <doclint>none</doclint>
+            <detectJavaApiLink>false</detectJavaApiLink>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>

--- a/spin/pom.xml
+++ b/spin/pom.xml
@@ -45,14 +45,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.camunda.commons</groupId>
-        <artifactId>camunda-commons-bom</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
         <version>${version.jackson}</version>

--- a/spin/pom.xml
+++ b/spin/pom.xml
@@ -1,7 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <!-- camunda BPM parent release pom -->
   <parent>
     <groupId>org.camunda.bpm</groupId>
     <artifactId>camunda-parent</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-all/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-all/pom.xml
@@ -29,7 +29,6 @@
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-all</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-json-jackson/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-json-jackson/pom.xml
@@ -32,7 +32,6 @@
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/spring-boot-starter/starter/pom.xml
+++ b/spring-boot-starter/starter/pom.xml
@@ -120,7 +120,6 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-testing</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/spring-boot-starter/starter/pom.xml
+++ b/spring-boot-starter/starter/pom.xml
@@ -55,7 +55,6 @@
     <dependency>
       <groupId>org.camunda.spin</groupId>
       <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
       <optional>true</optional>
     </dependency>
 

--- a/webapps/assembly-jakarta/pom.xml
+++ b/webapps/assembly-jakarta/pom.xml
@@ -490,12 +490,10 @@
         <dependency>
           <groupId>org.camunda.spin</groupId>
           <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
-          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>org.camunda.spin</groupId>
           <artifactId>camunda-spin-dataformat-xml-dom-jakarta</artifactId>
-          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>org.camunda.bpm</groupId>

--- a/webapps/assembly/pom.xml
+++ b/webapps/assembly/pom.xml
@@ -232,12 +232,10 @@
         <dependency>
           <groupId>org.camunda.spin</groupId>
           <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
-          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>org.camunda.spin</groupId>
           <artifactId>camunda-spin-dataformat-xml-dom</artifactId>
-          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>org.camunda.bpm</groupId>

--- a/webapps/pom.xml
+++ b/webapps/pom.xml
@@ -66,7 +66,6 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-logging</artifactId>
-      <version>${project.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -80,7 +79,6 @@
     <dependency>
       <groupId>org.camunda.commons</groupId>
       <artifactId>camunda-commons-testing</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
# Fix camunda-spin-bom import in camunda-only-bom #4605

Fixes #4605

It was necessary to remove the parent from `camunda-spin-bom` , because it would introduce a cyclic import of the `camunda-bom` which would in turn import `camunda-spin-bom` .... `camunda-spin-bom` currently is without parent. Should it be necessary I would suggest to use `camunda-bpm-release-parent`.