### PR TITLE
fix(spin) time zone unit tests fail when run it in non CET timezone in spin module

### DIFF
--- a/spin/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/XmlTestUtil.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/XmlTestUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.spin.xml;
+
+public class XmlTestUtil {
+  /**
+   * Example input <ns2:date>2015-04-04T00:00:00+02:00</ns2:date> -> <ns2:date>2015-04-04</ns2:date>
+   *
+   * @param input a string containing timezone offset
+   * @return same as input string without the timezone offset
+   */
+  public static String removeTimeZone(String input) {
+    int indexOfTimezone = input.indexOf("T00:00:00");
+    if (indexOfTimezone != -1) {
+      int indexOfClosingBracket = input.indexOf("<", indexOfTimezone);
+      if (indexOfClosingBracket != -1) {
+        input = input.substring(0, indexOfTimezone) + input.substring(indexOfClosingBracket);
+      }
+    }
+    return input;
+  }
+}

--- a/spin/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/XmlTestUtil.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/XmlTestUtil.java
@@ -24,13 +24,23 @@ public class XmlTestUtil {
    * @return same as input string without the timezone offset
    */
   public static String removeTimeZone(String input) {
-    int indexOfTimezone = input.indexOf("T00:00:00");
-    if (indexOfTimezone != -1) {
-      int indexOfClosingBracket = input.indexOf("<", indexOfTimezone);
-      if (indexOfClosingBracket != -1) {
-        input = input.substring(0, indexOfTimezone) + input.substring(indexOfClosingBracket);
-      }
+    if (input == null) {
+      return null;
     }
-    return input;
+
+    final String TIMEZONE = "T00:00:00";
+    final String CLOSING_BRACKET = "<";
+
+    int indexOfTimezone = input.indexOf(TIMEZONE);
+    if (indexOfTimezone == -1) {
+      return input;
+    }
+
+    int indexOfClosingBracket = input.indexOf(CLOSING_BRACKET, indexOfTimezone);
+    if (indexOfClosingBracket == -1) {
+      return input;
+    }
+
+    return input.substring(0, indexOfTimezone) + input.substring(indexOfClosingBracket);
   }
 }

--- a/spin/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/dom/XmlDomMapJavaToXmlScriptTest.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/dom/XmlDomMapJavaToXmlScriptTest.java
@@ -22,6 +22,7 @@ import static org.camunda.spin.xml.XmlTestConstants.createExampleOrder;
 
 import org.camunda.spin.impl.test.Script;
 import org.camunda.spin.impl.test.ScriptTest;
+import org.camunda.spin.xml.XmlTestUtil;
 import org.camunda.spin.xml.mapping.Order;
 import org.junit.Test;
 
@@ -36,7 +37,11 @@ public abstract class XmlDomMapJavaToXmlScriptTest extends ScriptTest{
     script.execute();
     String xml = script.getVariable("xml");
 
-    assertThat(xml).isXmlEqualTo(EXAMPLE_VALIDATION_XML);
+    //In EXAMPLE_VALIDATION_XML, expected date is hardcoded in CET timezone, ignoring it so that it passes when ran in
+    //different timezone
+    String exampleValidationXmlWoTimezone = XmlTestUtil.removeTimeZone(EXAMPLE_VALIDATION_XML);
+    xml = XmlTestUtil.removeTimeZone(xml);
+    assertThat(xml).isXmlEqualTo(exampleValidationXmlWoTimezone);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/spin/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/dom/XmlDomMapJavaToXmlTest.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/camunda/spin/xml/dom/XmlDomMapJavaToXmlTest.java
@@ -22,6 +22,7 @@ import static org.camunda.spin.Spin.XML;
 import static org.camunda.spin.xml.XmlTestConstants.EXAMPLE_VALIDATION_XML;
 import static org.camunda.spin.xml.XmlTestConstants.createExampleOrder;
 
+import org.camunda.spin.xml.XmlTestUtil;
 import org.camunda.spin.xml.mapping.NonXmlRootElementType;
 import org.camunda.spin.xml.mapping.Order;
 import org.junit.Test;
@@ -32,8 +33,11 @@ public class XmlDomMapJavaToXmlTest {
   public void shouldMapJavaToXml() {
     Order order = createExampleOrder();
     String orderAsString = XML(order).toString();
-
-    assertThat(orderAsString).isXmlEqualTo(EXAMPLE_VALIDATION_XML);
+    //In EXAMPLE_VALIDATION_XML, expected date is hardcoded in CET timezone, ignoring it so that it passes when ran in
+    //different timezone
+    String exampleValidationXmlWoTimezone = XmlTestUtil.removeTimeZone(EXAMPLE_VALIDATION_XML);
+    orderAsString = XmlTestUtil.removeTimeZone(orderAsString);
+    assertThat(orderAsString).isXmlEqualTo(exampleValidationXmlWoTimezone);
   }
 
   @Test


### PR DESCRIPTION
Related to: https://github.com/camunda/camunda-bpm-platform/issues/4606