### PR TITLE
test(sql): Test fix for incorrect running instances count in process …

### DIFF
--- a/webapps/assembly/src/main/resources/org/camunda/bpm/cockpit/plugin/base/queries/processDefinition.xml
+++ b/webapps/assembly/src/main/resources/org/camunda/bpm/cockpit/plugin/base/queries/processDefinition.xml
@@ -101,7 +101,6 @@
                   (
                     select
                         I.PROC_DEF_ID_
-                      , I.INCIDENT_TYPE_
                       , count(I.ID_) as INCIDENT_COUNT_
                     from
                         ${prefix}ACT_RU_INCIDENT I
@@ -111,7 +110,7 @@
                       <include refid="org.camunda.bpm.engine.impl.persistence.entity.TenantEntity.queryTenantCheckWithPrefix" />
                     </where>
                     group by
-                        I.PROC_DEF_ID_, I.INCIDENT_TYPE_
+                        I.PROC_DEF_ID_
                   ) INC
               on
                   PROCDEF.ID_ = INC.PROC_DEF_ID_


### PR DESCRIPTION
**Context**: The query `selectPDStatistics` calculates the total processInstances wrong.
**Used-by**: `ProcessDefinitionRestService#getStatisticsCount`

**Why**: The group by `incidentType` part of the query should not be used for counting the total process instances.

**Tests**: The commit adds a test which expects the correct statistics returned when process instances related to incidents with different types are used.

**Related-to**: https://jira.camunda.com/browse/SUPPORT-24279
https://github.com/camunda/camunda-bpm-platform/issues/4756