### PR TITLE
feat(engine): don't fail on change variables async when process instance does not exist 

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/batch/variables/BatchSetVariablesHandler.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/batch/variables/BatchSetVariablesHandler.java
@@ -51,7 +51,7 @@ public class BatchSetVariablesHandler extends AbstractBatchJobHandler<BatchConfi
 
     for (String processInstanceId : processInstanceIds) {
       commandContext.executeWithOperationLogPrevented(
-          new SetExecutionVariablesCmd(processInstanceId, variables, false, true));
+          new SetExecutionVariablesCmd(processInstanceId, variables, false, true, false));
     }
   }
 

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AbstractVariableCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AbstractVariableCmd.java
@@ -52,12 +52,12 @@ public abstract class AbstractVariableCmd implements Command<Void>, Serializable
 
     AbstractVariableScope scope = getEntity();
 
-    executeOperation(scope);
-
-    onSuccess(scope);
-
-    if(!preventLogUserOperation) {
-      logVariableOperation(scope);
+    if (scope != null) {
+      executeOperation(scope);
+      onSuccess(scope);
+      if(!preventLogUserOperation) {
+        logVariableOperation(scope);
+      }
     }
 
     return null;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SetExecutionVariablesCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/SetExecutionVariablesCmd.java
@@ -34,11 +34,22 @@ public class SetExecutionVariablesCmd extends AbstractSetVariableCmd {
 
   private static final long serialVersionUID = 1L;
 
+  protected boolean failIfNotExists = true;
+
   public SetExecutionVariablesCmd(String executionId,
                                   Map<String, ?> variables,
                                   boolean isLocal,
                                   boolean skipJavaSerializationFormatCheck) {
     super(executionId, variables, isLocal, skipJavaSerializationFormatCheck);
+  }
+
+  public SetExecutionVariablesCmd(String executionId,
+                                  Map<String, ?> variables,
+                                  boolean isLocal,
+                                  boolean skipJavaSerializationFormatCheck,
+                                  boolean failIfNotExists) {
+    this(executionId, variables, isLocal, skipJavaSerializationFormatCheck);
+    this.failIfNotExists = failIfNotExists;
   }
 
   public SetExecutionVariablesCmd(String executionId, Map<String, ? extends Object> variables, boolean isLocal) {
@@ -52,9 +63,13 @@ public class SetExecutionVariablesCmd extends AbstractSetVariableCmd {
       .getExecutionManager()
       .findExecutionById(entityId);
 
-    ensureNotNull("execution " + entityId + " doesn't exist", "execution", execution);
+    if (failIfNotExists) {
+      ensureNotNull("execution " + entityId + " doesn't exist", "execution", execution);
+    }
 
-    checkSetExecutionVariables(execution);
+    if(execution != null) {
+      checkSetExecutionVariables(execution);
+    }
 
     return execution;
   }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/RuntimeServiceTest.java
@@ -17,8 +17,10 @@
 package org.camunda.bpm.engine.test.api.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.camunda.bpm.engine.test.util.ActivityInstanceAssert.assertThat;
 import static org.camunda.bpm.engine.test.util.ActivityInstanceAssert.describeActivityInstanceTree;
+import static org.camunda.bpm.engine.test.util.ExecutableProcessUtil.USER_TASK_PROCESS;
 import static org.camunda.bpm.engine.variable.Variables.createVariables;
 import static org.camunda.bpm.engine.variable.Variables.objectValue;
 import static org.junit.Assert.assertEquals;
@@ -110,7 +112,6 @@ import org.junit.rules.RuleChain;
 public class RuntimeServiceTest {
 
   public static final String TESTING_INSTANCE_DELETION = "testing instance deletion";
-  public static final String A_STREAM = "aStream";
 
   @ClassRule
   public static ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule(configuration ->
@@ -1043,6 +1044,21 @@ public class RuntimeServiceTest {
     } catch (ProcessEngineException ae) {
       testRule.assertTextPresent("executionId is null", ae.getMessage());
     }
+  }
+
+
+  @Test
+  public void setVariablesSyncOnCompletedProcessInstance() {
+    // given completed process instance
+    testRule.deploy(USER_TASK_PROCESS);
+    String id = runtimeService.startProcessInstanceByKey("process").getId();
+    Task task = engineRule.getTaskService().createTaskQuery().processInstanceId(id).singleResult();
+    engineRule.getTaskService().complete(task.getId());
+
+    // when setting variables then exception is thrown
+    assertThatThrownBy(() -> runtimeService.setVariables(id, Variables.createVariables().putValue("foo", "bar")))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("execution " + id + " doesn't exist: execution is null");
   }
 
   private void checkHistoricVariableUpdateEntity(String variableName, String processInstanceId) {

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/SetVariablesBatchTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/SetVariablesBatchTest.java
@@ -19,6 +19,7 @@ package org.camunda.bpm.engine.test.api.runtime;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.camunda.bpm.engine.test.util.ExecutableProcessUtil.USER_TASK_PROCESS;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -40,11 +41,11 @@ import org.camunda.bpm.engine.exception.NullValueException;
 import org.camunda.bpm.engine.history.HistoricProcessInstanceQuery;
 import org.camunda.bpm.engine.history.UserOperationLogEntry;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
-import org.camunda.bpm.engine.management.JobDefinition;
 import org.camunda.bpm.engine.repository.Deployment;
 import org.camunda.bpm.engine.runtime.Job;
 import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
 import org.camunda.bpm.engine.runtime.VariableInstanceQuery;
+import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.RequiredHistoryLevel;
 import org.camunda.bpm.engine.test.dmn.businessruletask.TestPojo;
@@ -70,11 +71,11 @@ public class SetVariablesBatchTest {
 
   protected ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
   protected ProcessEngineTestRule engineTestRule = new ProcessEngineTestRule(engineRule);
-  protected BatchRule rule = new BatchRule(engineRule, engineTestRule);
+  protected BatchRule batchRule = new BatchRule(engineRule, engineTestRule);
   protected BatchHelper helper = new BatchHelper(engineRule);
 
   @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(engineTestRule).around(rule);
+  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(engineTestRule).around(batchRule);
 
   protected RuntimeService runtimeService;
   protected HistoryService historyService;
@@ -122,7 +123,7 @@ public class SetVariablesBatchTest {
           .containsExactly(tuple(null, "foo", "bar", batch.getId()));
 
     // when
-    rule.syncExec(batch);
+    batchRule.syncExec(batch);
 
     // then
     assertThat(query.list())
@@ -152,7 +153,7 @@ public class SetVariablesBatchTest {
           .containsExactly(tuple(null, "foo", "bar", batch.getId()));
 
     // when
-    rule.syncExec(batch);
+    batchRule.syncExec(batch);
 
     // then
     assertThat(query.list())
@@ -188,7 +189,7 @@ public class SetVariablesBatchTest {
           );
 
     // when
-    rule.syncExec(batch);
+    batchRule.syncExec(batch);
 
     // then
     assertThat(query.list())
@@ -223,7 +224,7 @@ public class SetVariablesBatchTest {
         .containsExactly(tuple(null, "foo", pojo, batch.getId()));
 
     // when
-    rule.syncExec(batch);
+    batchRule.syncExec(batch);
 
     // then
     assertThat(query.list())
@@ -260,7 +261,7 @@ public class SetVariablesBatchTest {
           );
 
     // when
-    rule.syncExec(batch);
+    batchRule.syncExec(batch);
 
     // then
     assertThat(query.list())
@@ -301,7 +302,7 @@ public class SetVariablesBatchTest {
           );
 
     // when
-    rule.syncExec(batch);
+    batchRule.syncExec(batch);
 
     // then
     assertThat(query.list())
@@ -332,7 +333,7 @@ public class SetVariablesBatchTest {
           .containsExactly(tuple(null, "foo", "bar", batch.getId()));
 
     // when
-    rule.syncExec(batch);
+    batchRule.syncExec(batch);
 
     // then
     assertThat(query.list())
@@ -372,7 +373,7 @@ public class SetVariablesBatchTest {
           .containsExactly(tuple(null, "foo", "bar", batch.getId()));
 
     // when
-    rule.syncExec(batch);
+    batchRule.syncExec(batch);
 
     // then
     assertThat(query.list())
@@ -402,7 +403,7 @@ public class SetVariablesBatchTest {
           .containsExactly(tuple(null, "foo", "bar", batch.getId()));
 
     // when
-    rule.syncExec(batch);
+    batchRule.syncExec(batch);
 
     // then
     assertThat(query.list())
@@ -433,7 +434,7 @@ public class SetVariablesBatchTest {
           .containsExactly(tuple(null, "foo", "bar", batch.getId()));
 
     // when
-    rule.syncExec(batch);
+    batchRule.syncExec(batch);
 
     // then
     assertThat(query.list())
@@ -539,10 +540,10 @@ public class SetVariablesBatchTest {
     // when
     Batch batch = runtimeService.setVariablesAsync(processInstanceIds, SINGLE_VARIABLE);
 
-    rule.executeSeedJobs(batch);
+    batchRule.executeSeedJobs(batch);
 
     // then
-    List<Job> executionJobs = rule.getExecutionJobs(batch);
+    List<Job> executionJobs = batchRule.getExecutionJobs(batch);
     assertThat(executionJobs)
         .extracting("deploymentId")
         .containsExactlyInAnyOrder(deploymentIdOne, deploymentIdTwo);
@@ -570,10 +571,10 @@ public class SetVariablesBatchTest {
     // when
     Batch batch = runtimeService.setVariablesAsync(runtimeQuery, SINGLE_VARIABLE);
 
-    rule.executeSeedJobs(batch);
+    batchRule.executeSeedJobs(batch);
 
     // then
-    List<Job> executionJobs = rule.getExecutionJobs(batch);
+    List<Job> executionJobs = batchRule.getExecutionJobs(batch);
     assertThat(executionJobs)
         .extracting("deploymentId")
         .containsExactlyInAnyOrder(deploymentIdOne, deploymentIdTwo);
@@ -602,10 +603,10 @@ public class SetVariablesBatchTest {
     // when
     Batch batch = runtimeService.setVariablesAsync(historyQuery, SINGLE_VARIABLE);
 
-    rule.executeSeedJobs(batch);
+    batchRule.executeSeedJobs(batch);
 
     // then
-    List<Job> executionJobs = rule.getExecutionJobs(batch);
+    List<Job> executionJobs = batchRule.getExecutionJobs(batch);
     assertThat(executionJobs)
         .extracting("deploymentId")
         .containsExactlyInAnyOrder(deploymentIdOne, deploymentIdTwo);
@@ -659,7 +660,7 @@ public class SetVariablesBatchTest {
     engineRule.getIdentityService()
         .setAuthenticatedUserId("demo");
 
-    rule.syncExec(batch);
+    batchRule.syncExec(batch);
 
     // then
     List<UserOperationLogEntry> logs = historyService.createUserOperationLogQuery()
@@ -682,10 +683,10 @@ public class SetVariablesBatchTest {
     // when
     Batch batch = runtimeService.setVariablesAsync(processInstanceIds, SINGLE_VARIABLE);
 
-    rule.executeSeedJobs(batch);
+    batchRule.executeSeedJobs(batch);
 
     // then
-    List<Job> executionJobs = rule.getExecutionJobs(batch);
+    List<Job> executionJobs = batchRule.getExecutionJobs(batch);
     assertThat(executionJobs)
         .extracting("processInstanceId")
         .containsExactlyInAnyOrder(processInstanceIdOne, processInstanceIdTwo);
@@ -707,10 +708,10 @@ public class SetVariablesBatchTest {
     // when
     Batch batch = runtimeService.setVariablesAsync(processInstanceIds, SINGLE_VARIABLE);
 
-    rule.executeSeedJobs(batch);
+    batchRule.executeSeedJobs(batch);
 
     // then
-    List<Job> executionJobs = rule.getExecutionJobs(batch);
+    List<Job> executionJobs = batchRule.getExecutionJobs(batch);
     assertThat(executionJobs)
         .extracting("processInstanceId")
         .containsOnlyNulls();
@@ -741,6 +742,76 @@ public class SetVariablesBatchTest {
 
     // clear
     managementService.deleteBatch(batch.getId(), true);
+  }
+
+  @Test
+  public void setVariablesAsyncOnCompletedProcessInstance() {
+    // given set variables on completed process instance
+    engineTestRule.deploy(USER_TASK_PROCESS);
+    String id = runtimeService.startProcessInstanceByKey(PROCESS_KEY).getId();
+    Batch batch = runtimeService.setVariablesAsync(List.of(id), SINGLE_VARIABLE);
+    Task task = engineRule.getTaskService().createTaskQuery().processInstanceId(id).singleResult();
+    engineRule.getTaskService().complete(task.getId());
+
+    // when executing batch then no exception is thrown
+    batchRule.syncExec(batch);
+  }
+
+  @Test
+  public void setVariablesAsyncOnCompletedProcessInstanceWithQuery() {
+    // given set variables on completed process instance
+    engineTestRule.deploy(USER_TASK_PROCESS);
+    String id = runtimeService.startProcessInstanceByKey(PROCESS_KEY).getId();
+    Batch batch = runtimeService.setVariablesAsync(runtimeService.createProcessInstanceQuery().processInstanceId(id), SINGLE_VARIABLE);
+    Task task = engineRule.getTaskService().createTaskQuery().processInstanceId(id).singleResult();
+    engineRule.getTaskService().complete(task.getId());
+
+    // when executing batch then no exception is thrown
+    batchRule.syncExec(batch);
+  }
+
+  @Test
+  public void setVariablesAsyncOnCompletedProcessInstanceWithHistoricQuery() {
+    // given set variables on completed process instance
+    engineTestRule.deploy(USER_TASK_PROCESS);
+    String id = runtimeService.startProcessInstanceByKey(PROCESS_KEY).getId();
+    Batch batch = runtimeService.setVariablesAsync(historyService.createHistoricProcessInstanceQuery().processInstanceId(id), SINGLE_VARIABLE);
+    Task task = engineRule.getTaskService().createTaskQuery().processInstanceId(id).singleResult();
+    engineRule.getTaskService().complete(task.getId());
+
+    // when executing batch then no exception is thrown
+    batchRule.syncExec(batch);
+  }
+
+  @Test
+  public void setVariablesSyncOnCompletedProcessInstance() {
+    // given completed process
+    engineTestRule.deploy(USER_TASK_PROCESS);
+    String id = runtimeService.startProcessInstanceByKey(PROCESS_KEY).getId();
+    Task task = engineRule.getTaskService().createTaskQuery().processInstanceId(id).singleResult();
+    engineRule.getTaskService().complete(task.getId());
+
+    // when setting variables then exception is thrown
+    assertThatThrownBy(() -> runtimeService.setVariables(id, SINGLE_VARIABLE))
+        .isInstanceOf(NullValueException.class);
+  }
+
+
+  @Test
+  public void setVariablesAsyncOnBatchWithOneCompletedInstance() {
+    // given set variables batch with one completed process instance
+    engineTestRule.deploy(USER_TASK_PROCESS);
+    String id1 = runtimeService.startProcessInstanceByKey(PROCESS_KEY).getId();
+    String id2 = runtimeService.startProcessInstanceByKey(PROCESS_KEY).getId();
+    Batch batch = runtimeService.setVariablesAsync(List.of(id1, id2), SINGLE_VARIABLE);
+    Task task = engineRule.getTaskService().createTaskQuery().processInstanceId(id1).singleResult();
+    engineRule.getTaskService().complete(task.getId());
+
+    // when executing the bacth
+    batchRule.syncExec(batch);
+
+    // then no exception is thrown and the variables are set for the existing process
+    assertThat(runtimeService.getVariables(id2).equals(SINGLE_VARIABLE));
   }
 
 }

--- a/engine/src/test/java/org/camunda/bpm/engine/test/history/JobEntityAndJobLogBatchIdTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/history/JobEntityAndJobLogBatchIdTest.java
@@ -17,6 +17,7 @@
 package org.camunda.bpm.engine.test.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.camunda.bpm.engine.test.util.ExecutableProcessUtil.USER_TASK_PROCESS;
 
 import java.util.List;
 import java.util.Map;
@@ -83,14 +84,6 @@ public class JobEntityAndJobLogBatchIdTest {
     externalTaskService = engineRule.getExternalTaskService();
   }
 
-  private BpmnModelInstance getUserTaskProcess() {
-    return Bpmn.createExecutableProcess("process")
-        .startEvent()
-        .userTask("task1")
-        .endEvent()
-        .done();
-  }
-
   private BpmnModelInstance getTwoUserTasksProcess() {
     return Bpmn.createExecutableProcess("process")
         .startEvent()
@@ -111,7 +104,7 @@ public class JobEntityAndJobLogBatchIdTest {
   @Test
   public void shouldSetBatchIdOnJobAndJobLog_SetHistoricBatchRemovalTime() {
     // given
-    testRule.deploy(getUserTaskProcess());
+    testRule.deploy(USER_TASK_PROCESS);
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
 
     // create historic Batch
@@ -159,7 +152,7 @@ public class JobEntityAndJobLogBatchIdTest {
   @Test
   public void shouldSetBatchIdOnJobAndJobLog_SetVariables() {
     // given
-    testRule.deploy(getUserTaskProcess());
+    testRule.deploy(USER_TASK_PROCESS);
     ProcessInstance process = runtimeService.startProcessInstanceByKey("process");
 
     Batch batch = runtimeService.setVariablesAsync(List.of(process.getId()), Variables.createVariables().putValue("foo", "bar"));
@@ -250,7 +243,7 @@ public class JobEntityAndJobLogBatchIdTest {
   @Test
   public void shouldSetBatchIdOnJobAndJobLog_DeleteProcessInstances() {
     // given
-    testRule.deploy(getUserTaskProcess());
+    testRule.deploy(USER_TASK_PROCESS);
     ProcessInstance process = runtimeService.startProcessInstanceByKey("process");
 
     Batch batch = runtimeService.deleteProcessInstancesAsync(List.of(process.getId()), null);
@@ -289,7 +282,7 @@ public class JobEntityAndJobLogBatchIdTest {
   @Test
   public void shouldSetBatchIdOnJobAndJobLog_Migration() {
     // given
-    ProcessDefinition sourceProcessDefinition = testRule.deployAndGetDefinition(getUserTaskProcess());
+    ProcessDefinition sourceProcessDefinition = testRule.deployAndGetDefinition(USER_TASK_PROCESS);
     ProcessInstance process = runtimeService.startProcessInstanceByKey("process");
     ProcessDefinition targetProcessDefinition = testRule.deployAndGetDefinition(getTwoUserTasksProcess());
 
@@ -351,7 +344,7 @@ public class JobEntityAndJobLogBatchIdTest {
   @Test
   public void shouldSetBatchIdOnJobAndJobLog_RestartProcessInstance() {
     // given
-    testRule.deploy(getUserTaskProcess());
+    testRule.deploy(USER_TASK_PROCESS);
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
     runtimeService.deleteProcessInstance(processInstance.getId(), null);
 
@@ -411,7 +404,7 @@ public class JobEntityAndJobLogBatchIdTest {
   @Test
   public void shouldSetBatchIdOnJobAndJobLog_UpdateProcessInstancesSuspendState() {
     // given
-    testRule.deploy(getUserTaskProcess());
+    testRule.deploy(USER_TASK_PROCESS);
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
 
     Batch batch = runtimeService.updateProcessInstanceSuspensionState()

--- a/engine/src/test/java/org/camunda/bpm/engine/test/util/ExecutableProcessUtil.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/util/ExecutableProcessUtil.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.test.util;
+
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+
+public class ExecutableProcessUtil {
+
+  public static final BpmnModelInstance USER_TASK_PROCESS = Bpmn.createExecutableProcess("process")
+      .startEvent()
+      .userTask("task1")
+      .endEvent()
+      .done();
+}


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/4795