### PR TITLE
openapi(tasks): include task state in response specification

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/history/HistoricTaskInstanceDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/history/HistoricTaskInstanceDto.ftl
@@ -167,7 +167,13 @@
       type = "string"
       desc = "The process instance id of the root process instance that initiated the process
               containing this task."
-      last = true
+  />
+
+  <@lib.property
+    name = "taskState"
+    type = "string"
+    desc = "The task's state."
+    last = true
   />
 
 </@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/task/TaskDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/task/TaskDto.ftl
@@ -129,8 +129,13 @@
     <@lib.property
         name = "tenantId"
         type = "string"
-        last = true
         desc = "If not `null`, the tenant id of the task." />
+
+    <@lib.property
+        name = "taskState"
+        type = "string"
+        desc = "The task's state."
+        last = true />
 
 </@lib.dto>
 </#macro>


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/4683

Hints for review:

Adds taskState in the response schema of:

- Task 
	- Get List
	- Get List (POST)
	- Get
- Historic Task Instance 
	- Get Tasks (Historic)
	- Get Tasks (Historic) (POST) 

Examples already have it.