### PR TITLE
fix(openApi): add missing schema declarations

### DIFF
--- a/engine-rest/engine-rest-openapi/README.md
+++ b/engine-rest/engine-rest-openapi/README.md
@@ -2,7 +2,7 @@ REST API - OpenAPI documentation generation
 ========
 
 This project generates a single openapi.json containing the OpeanAPI documentation of the Engine Rest API.
-Aligned with OpeanAPI specification version [3.0.2](https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.2.md).
+Aligned with OpenAPI specification version [3.0.2](https://github.com/OAI/OpenAPI-Specification/blob/3.0.2/versions/3.0.2.md).
 
 # Table of Contents
 1. [Build and phases](#build-and-phases)

--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/utils.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/utils.ftl
@@ -255,6 +255,7 @@
 <#macro response code desc
         flatType=""
         dto=""
+        contentDesc=""
         array=false
         additionalProperties=false
         mediaType="application/json"
@@ -270,6 +271,7 @@
                 array = array
                 additionalProperties = additionalProperties
                 mediaType = mediaType
+                contentDesc = contentDesc
                 binary = binary
                 examples = examples />
           },
@@ -296,6 +298,7 @@
                   array = type["array"]
                   additionalProperties = type["additionalProperties"]
                   mediaType = type["mediaType"]
+                  contentDesc = type["contentDesc"]
                   binary = type["binary"]
                   examples = type["examples"] /><#sep>,
             </#list>
@@ -314,6 +317,7 @@
         array=false
         additionalProperties=false
         mediaType="application/json"
+        contentDesc=""
         binary = false
         examples=[] >
            <#if mediaType == "application/xhtml+xml" | (mediaType == "application/json" & !array & flatType == "string") | binary>
@@ -326,6 +330,11 @@
            <#else>
              "${mediaType}": {
                "schema": {
+
+               <#if mediaType == "text/plain" && contentDesc?has_content>
+                   "type" : "string",
+                   "description" : "${contentDesc}"
+               </#if>
 
                  <#if array>
                    "type" : "array",

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/errorDetails/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/{id}/errorDetails/get.ftl
@@ -21,27 +21,21 @@
 
   "responses" : {
 
-    "200": {
-      "description": "Request successful.",
-      "content": {
-        "text/plain": {
-          "schema": {
-            "type": "string",
-            "description": "The error details for the external task."
-          },
-          "examples": {
-            "example-1": {
-              "value": "org.apache.ibatis.jdbc.RuntimeSqlException: org.apache.ibatis.jdbc.RuntimeSqlException: test cause
-                  at org.camunda.bpm.engine.test.api.externaltask.ExternalTaskServiceTest.testHandleFailureWithErrorDetails(ExternalTaskServiceTest.java:1424)
-                  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
-                  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
-                  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
-                "
-            }
-          }
-        }
-      }
-    },
+    <@lib.response
+    code = "200"
+    mediaType= "text/plain"
+    desc = "Request successful."
+    contentDesc = "The error details for the external task."
+    examples = ['"example-1": {
+                       "summary": "GET `external-task/someId/errorDetails`",
+                       "description": "GET `external-task/someId/errorDetails`",
+                       "value": "org.apache.ibatis.jdbc.RuntimeSqlException: org.apache.ibatis.jdbc.RuntimeSqlException: test cause
+                                      at org.camunda.bpm.engine.test.api.externaltask.ExternalTaskServiceTest.testHandleFailureWithErrorDetails(ExternalTaskServiceTest.java:1424)
+                                      at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+                                      at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+                                      at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+                                      ..."
+                     }']/>
 
 
   <@lib.response

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/history/external-task-log/{id}/error-details/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/history/external-task-log/{id}/error-details/get.ftl
@@ -28,6 +28,7 @@
         code = "200"
         mediaType= "text/plain"
         desc = "Request successful."
+        contentDesc = "Returns the error details of the historic external task log with the given ID."
         examples = ['"example-1": {
                        "summary": "GET `history/external-task-log/someId/error-details`",
                        "description": "GET `history/external-task-log/someId/error-details`",

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/history/job-log/{id}/stacktrace/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/history/job-log/{id}/stacktrace/get.ftl
@@ -28,6 +28,7 @@
         code = "200"
         mediaType= "text/plain"
         desc = "Request successful."
+        contentDesc = "Returns the stacktrace of the exception for the historic job with the given ID."
         examples = ['"example-1": {
                        "summary": "response",
                        "description": "GET `history/job-log/someId/stacktrace`

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/job/{id}/stacktrace/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/job/{id}/stacktrace/get.ftl
@@ -27,6 +27,7 @@
         code = "200"
         mediaType= "text/plain"
         desc = "Request successful."
+        contentDesc = "Returns the stacktrace of the exception for the job with the given ID."
         examples = ['"example-1": {
                        "description": "GET `/job/aJobId/stacktrace`",
                        "value": "java.lang.RuntimeException: A exception message!


### PR DESCRIPTION
related to #3298

Adds missing schema declarations for:

- `/job/aJobId/stacktrace`
- `history/job-log/someId/stacktrace`

I noticed that there was no attribute for the response macro to add this declaration for string responses, instead of defaulting to the "manual" approach I adjusted the macro to add a `contenctDesc` field as that seemed cleaner to me - let me know if there is a reason not to have this added there though and we can instead rewrite the above without using the macros.

While I was there I also noticed it was missing for `history/external-task-log/someId/error-details` so this adds it for that too. Also adjusts the equivalent in `external-task/someId/errorDetails` just for consistency.
