### PR TITLE
fix(asyncInstanceModification): respect ancestor during startBefore/after cmd execution

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AbstractInstantiationCmd.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cmd/AbstractInstantiationCmd.java
@@ -86,6 +86,14 @@ public abstract class AbstractInstantiationCmd extends AbstractProcessInstanceMo
     return variablesLocal;
   }
 
+  public String getAncestorActivityInstanceId() {
+    return ancestorActivityInstanceId;
+  }
+
+  public void setAncestorActivityInstanceId(String ancestorActivityInstanceId) {
+    this.ancestorActivityInstanceId = ancestorActivityInstanceId;
+  }
+
   public Void execute(final CommandContext commandContext) {
     ExecutionEntity processInstance = commandContext.getExecutionManager().findExecutionById(processInstanceId);
 
@@ -325,7 +333,6 @@ public abstract class AbstractInstantiationCmd extends AbstractProcessInstanceMo
       throw new ProcessEngineException("Cannot instantiate element " + targetElement);
     }
   }
-
 
   protected void instantiateConcurrent(ExecutionEntity ancestorScopeExecution, List<PvmActivity> parentFlowScopes, CoreModelElement targetElement) {
     if (PvmTransition.class.isAssignableFrom(targetElement.getClass())) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/json/ModificationCmdJsonConverter.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/json/ModificationCmdJsonConverter.java
@@ -16,6 +16,7 @@
  */
 package org.camunda.bpm.engine.impl.json;
 
+import com.google.gson.JsonObject;
 import org.camunda.bpm.engine.impl.cmd.AbstractProcessInstanceModificationCommand;
 import org.camunda.bpm.engine.impl.cmd.ActivityAfterInstantiationCmd;
 import org.camunda.bpm.engine.impl.cmd.ActivityBeforeInstantiationCmd;
@@ -24,7 +25,6 @@ import org.camunda.bpm.engine.impl.cmd.ActivityInstanceCancellationCmd;
 import org.camunda.bpm.engine.impl.cmd.TransitionInstanceCancellationCmd;
 import org.camunda.bpm.engine.impl.cmd.TransitionInstantiationCmd;
 import org.camunda.bpm.engine.impl.util.JsonUtil;
-import com.google.gson.JsonObject;
 
 public class ModificationCmdJsonConverter extends JsonObjectConverter<AbstractProcessInstanceModificationCommand> {
 
@@ -38,6 +38,7 @@ public class ModificationCmdJsonConverter extends JsonObjectConverter<AbstractPr
   public static final String CANCEL_ACTIVITY_INSTANCES = "cancelActivityInstances";
   public static final String PROCESS_INSTANCE = "processInstances";
   public static final String CANCEL_TRANSITION_INSTANCES = "cancelTransitionInstances";
+  public static final String ANCESTOR_ACTIVITY_INSTANCE_ID = "ancestorActivityInstanceId";
 
   @Override
   public JsonObject toJsonObject(AbstractProcessInstanceModificationCommand command) {
@@ -45,23 +46,25 @@ public class ModificationCmdJsonConverter extends JsonObjectConverter<AbstractPr
 
     if (command instanceof ActivityAfterInstantiationCmd) {
       JsonUtil.addField(json, START_AFTER, ((ActivityAfterInstantiationCmd) command).getTargetElementId());
-    }
-    else if (command instanceof ActivityBeforeInstantiationCmd) {
+      JsonUtil.addField(json, ANCESTOR_ACTIVITY_INSTANCE_ID,
+          ((ActivityAfterInstantiationCmd) command).getAncestorActivityInstanceId());
+    } else if (command instanceof ActivityBeforeInstantiationCmd) {
       JsonUtil.addField(json, START_BEFORE, ((ActivityBeforeInstantiationCmd) command).getTargetElementId());
-    }
-    else if (command instanceof TransitionInstantiationCmd) {
+      JsonUtil.addField(json, ANCESTOR_ACTIVITY_INSTANCE_ID,
+          ((ActivityBeforeInstantiationCmd) command).getAncestorActivityInstanceId());
+    } else if (command instanceof TransitionInstantiationCmd) {
       JsonUtil.addField(json, START_TRANSITION, ((TransitionInstantiationCmd) command).getTargetElementId());
-    }
-    else if (command instanceof ActivityCancellationCmd) {
+    } else if (command instanceof ActivityCancellationCmd) {
       JsonUtil.addField(json, CANCEL_ALL, ((ActivityCancellationCmd) command).getActivityId());
-      JsonUtil.addField(json, CANCEL_CURRENT, ((ActivityCancellationCmd) command).isCancelCurrentActiveActivityInstances());
-    }
-    else if (command instanceof ActivityInstanceCancellationCmd) {
-      JsonUtil.addField(json, CANCEL_ACTIVITY_INSTANCES, ((ActivityInstanceCancellationCmd) command).getActivityInstanceId());
+      JsonUtil.addField(json, CANCEL_CURRENT,
+          ((ActivityCancellationCmd) command).isCancelCurrentActiveActivityInstances());
+    } else if (command instanceof ActivityInstanceCancellationCmd) {
+      JsonUtil.addField(json, CANCEL_ACTIVITY_INSTANCES,
+          ((ActivityInstanceCancellationCmd) command).getActivityInstanceId());
       JsonUtil.addField(json, PROCESS_INSTANCE, ((ActivityInstanceCancellationCmd) command).getProcessInstanceId());
-    }
-    else if (command instanceof TransitionInstanceCancellationCmd) {
-      JsonUtil.addField(json, CANCEL_TRANSITION_INSTANCES, ((TransitionInstanceCancellationCmd) command).getTransitionInstanceId());
+    } else if (command instanceof TransitionInstanceCancellationCmd) {
+      JsonUtil.addField(json, CANCEL_TRANSITION_INSTANCES,
+          ((TransitionInstanceCancellationCmd) command).getTransitionInstanceId());
       JsonUtil.addField(json, PROCESS_INSTANCE, ((TransitionInstanceCancellationCmd) command).getProcessInstanceId());
     }
 
@@ -75,23 +78,28 @@ public class ModificationCmdJsonConverter extends JsonObjectConverter<AbstractPr
 
     if (json.has(START_BEFORE)) {
       cmd = new ActivityBeforeInstantiationCmd(JsonUtil.getString(json, START_BEFORE));
-    }
-    else if (json.has(START_AFTER)) {
+      if (json.has(ANCESTOR_ACTIVITY_INSTANCE_ID)) {
+        ((ActivityBeforeInstantiationCmd) cmd).setAncestorActivityInstanceId(
+            JsonUtil.getString(json, ANCESTOR_ACTIVITY_INSTANCE_ID));
+      }
+    } else if (json.has(START_AFTER)) {
       cmd = new ActivityAfterInstantiationCmd(JsonUtil.getString(json, START_AFTER));
-    }
-    else if (json.has(START_TRANSITION)) {
+      if (json.has(ANCESTOR_ACTIVITY_INSTANCE_ID)) {
+        ((ActivityAfterInstantiationCmd) cmd).setAncestorActivityInstanceId(
+            JsonUtil.getString(json, ANCESTOR_ACTIVITY_INSTANCE_ID));
+      }
+    } else if (json.has(START_TRANSITION)) {
       cmd = new TransitionInstantiationCmd(JsonUtil.getString(json, START_TRANSITION));
-    }
-    else if (json.has(CANCEL_ALL)) {
+    } else if (json.has(CANCEL_ALL)) {
       cmd = new ActivityCancellationCmd(JsonUtil.getString(json, CANCEL_ALL));
       boolean cancelCurrentActiveActivityInstances = JsonUtil.getBoolean(json, CANCEL_CURRENT);
       ((ActivityCancellationCmd) cmd).setCancelCurrentActiveActivityInstances(cancelCurrentActiveActivityInstances);
-    }
-    else if (json.has(CANCEL_ACTIVITY_INSTANCES)) {
-      cmd = new ActivityInstanceCancellationCmd(JsonUtil.getString(json, PROCESS_INSTANCE), JsonUtil.getString(json, CANCEL_ACTIVITY_INSTANCES));
-    }
-    else if (json.has(CANCEL_TRANSITION_INSTANCES)) {
-      cmd = new TransitionInstanceCancellationCmd(JsonUtil.getString(json, PROCESS_INSTANCE), JsonUtil.getString(json, CANCEL_TRANSITION_INSTANCES));
+    } else if (json.has(CANCEL_ACTIVITY_INSTANCES)) {
+      cmd = new ActivityInstanceCancellationCmd(JsonUtil.getString(json, PROCESS_INSTANCE),
+          JsonUtil.getString(json, CANCEL_ACTIVITY_INSTANCES));
+    } else if (json.has(CANCEL_TRANSITION_INSTANCES)) {
+      cmd = new TransitionInstanceCancellationCmd(JsonUtil.getString(json, PROCESS_INSTANCE),
+          JsonUtil.getString(json, CANCEL_TRANSITION_INSTANCES));
     }
 
     return cmd;

--- a/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/ProcessInstanceModificationTest.loop.bpmn
+++ b/engine/src/test/resources/org/camunda/bpm/engine/test/api/runtime/ProcessInstanceModificationTest.loop.bpmn
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0jxg5tl" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.17.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.21.0">
+  <bpmn:process id="loopProcess" name="loopProcess" isExecutable="true" camunda:historyTimeToLive="730">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_10b3t9t</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="loop" name="loop">
+      <bpmn:incoming>Flow_10b3t9t</bpmn:incoming>
+      <bpmn:outgoing>Flow_13ek3ki</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics camunda:collection="${ids}" camunda:elementVariable="id" />
+      <bpmn:serviceTask id="task" name="task" camunda:type="external" camunda:topic="not-existent">
+        <bpmn:incoming>Flow_1qch4x2</bpmn:incoming>
+        <bpmn:outgoing>Flow_0tvbudp</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:startEvent id="Event_0dibapb">
+        <bpmn:outgoing>Flow_1qch4x2</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:endEvent id="Event_1j2rxfp">
+        <bpmn:incoming>Flow_0tvbudp</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_1qch4x2" sourceRef="Event_0dibapb" targetRef="task" />
+      <bpmn:sequenceFlow id="Flow_0tvbudp" sourceRef="task" targetRef="Event_1j2rxfp" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_13ek3ki" sourceRef="loop" targetRef="Event_1c73epl" />
+    <bpmn:endEvent id="Event_1c73epl">
+      <bpmn:incoming>Flow_13ek3ki</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_10b3t9t" sourceRef="StartEvent_1" targetRef="loop" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="test">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="139" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_122fqfd_di" bpmnElement="loop" isExpanded="true">
+        <dc:Bounds x="330" y="82" width="450" height="158" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_089ksdn" bpmnElement="task">
+        <dc:Bounds x="510" y="122" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0dibapb_di" bpmnElement="Event_0dibapb">
+        <dc:Bounds x="352" y="144" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1j2rxfp_di" bpmnElement="Event_1j2rxfp">
+        <dc:Bounds x="722" y="144" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1qch4x2_di" bpmnElement="Flow_1qch4x2">
+        <di:waypoint x="388" y="162" />
+        <di:waypoint x="510" y="162" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0tvbudp_di" bpmnElement="Flow_0tvbudp">
+        <di:waypoint x="610" y="162" />
+        <di:waypoint x="722" y="162" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1c73epl_di" bpmnElement="Event_1c73epl">
+        <dc:Bounds x="922" y="143" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_13ek3ki_di" bpmnElement="Flow_13ek3ki">
+        <di:waypoint x="780" y="161" />
+        <di:waypoint x="922" y="161" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10b3t9t_di" bpmnElement="Flow_10b3t9t">
+        <di:waypoint x="188" y="157" />
+        <di:waypoint x="330" y="157" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
related to #4507

[Suggesting](https://github.com/camunda/camunda-bpm-platform/pull/4829#discussion_r1867865183) a follow up to investigate whether a similar fix is required for TransitionInstantiationCmd (and implement if so)