### PR TITLE
chore(engine,parent): Bump GraalVM to 21.3.12

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -338,7 +338,7 @@ import org.camunda.bpm.engine.impl.runtime.DefaultCorrelationHandler;
 import org.camunda.bpm.engine.impl.runtime.DefaultDeserializationTypeValidator;
 import org.camunda.bpm.engine.impl.scripting.ScriptFactory;
 import org.camunda.bpm.engine.impl.scripting.engine.BeansResolverFactory;
-import org.camunda.bpm.engine.impl.scripting.engine.CustomScriptEngineManager;
+import org.camunda.bpm.engine.impl.scripting.engine.CamundaScriptEngineManager;
 import org.camunda.bpm.engine.impl.scripting.engine.DefaultScriptEngineResolver;
 import org.camunda.bpm.engine.impl.scripting.engine.ResolverFactory;
 import org.camunda.bpm.engine.impl.scripting.engine.ScriptBindingsFactory;
@@ -2642,7 +2642,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       resolverFactories.add(new BeansResolverFactory());
     }
     if (scriptEngineResolver == null) {
-      scriptEngineResolver = new DefaultScriptEngineResolver(new CustomScriptEngineManager());
+      scriptEngineResolver = new DefaultScriptEngineResolver(new CamundaScriptEngineManager());
     }
     if (scriptingEngines == null) {
       scriptingEngines = new ScriptingEngines(new ScriptBindingsFactory(resolverFactories), scriptEngineResolver);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -41,7 +41,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import javax.naming.InitialContext;
-import javax.script.ScriptEngineManager;
 import javax.sql.DataSource;
 import org.apache.ibatis.builder.xml.XMLConfigBuilder;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
@@ -339,6 +338,7 @@ import org.camunda.bpm.engine.impl.runtime.DefaultCorrelationHandler;
 import org.camunda.bpm.engine.impl.runtime.DefaultDeserializationTypeValidator;
 import org.camunda.bpm.engine.impl.scripting.ScriptFactory;
 import org.camunda.bpm.engine.impl.scripting.engine.BeansResolverFactory;
+import org.camunda.bpm.engine.impl.scripting.engine.CustomScriptEngineManager;
 import org.camunda.bpm.engine.impl.scripting.engine.DefaultScriptEngineResolver;
 import org.camunda.bpm.engine.impl.scripting.engine.ResolverFactory;
 import org.camunda.bpm.engine.impl.scripting.engine.ScriptBindingsFactory;
@@ -2642,7 +2642,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       resolverFactories.add(new BeansResolverFactory());
     }
     if (scriptEngineResolver == null) {
-      scriptEngineResolver = new DefaultScriptEngineResolver(new ScriptEngineManager());
+      scriptEngineResolver = new DefaultScriptEngineResolver(new CustomScriptEngineManager());
     }
     if (scriptingEngines == null) {
       scriptingEngines = new ScriptingEngines(new ScriptBindingsFactory(resolverFactories), scriptEngineResolver);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/engine/CamundaScriptEngineManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/engine/CamundaScriptEngineManager.java
@@ -61,6 +61,11 @@ public class CamundaScriptEngineManager extends ScriptEngineManager {
 
   }
 
+  /**
+   * Fetches the config logic of a given engine from the mappings and executes it in case it exists.
+   *
+   * @param engineName the given engine name
+   */
   protected void executeConfigurationBeforeEngineCreation(String engineName) {
     var config = engineNameToInitLogicMappings.get(engineName);
     if (config != null) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/engine/CamundaScriptEngineManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/engine/CamundaScriptEngineManager.java
@@ -33,13 +33,13 @@ import static org.camunda.bpm.engine.impl.scripting.engine.ScriptingEngines.GRAA
  * If custom logic is needed for a specific engine after the classpath detection, before the engine creation,
  * it can be added to the classes map.
  */
-public class CustomScriptEngineManager extends ScriptEngineManager {
+public class CamundaScriptEngineManager extends ScriptEngineManager {
 
   protected final Map<String, Runnable> engineNameToInitLogicMappings = Map.of(
       GRAAL_JS_SCRIPT_ENGINE_NAME, this::disableGraalVMInterpreterOnlyModeWarnings
   );
 
-  public CustomScriptEngineManager() {
+  public CamundaScriptEngineManager() {
     super(); // creates engine factories after classpath discovery
     applyConfigOnEnginesAfterClasspathDiscovery();
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/engine/CamundaScriptEngineManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/engine/CamundaScriptEngineManager.java
@@ -48,7 +48,7 @@ public class CamundaScriptEngineManager extends ScriptEngineManager {
     var engineNames = getEngineNamesFoundInClasspath();
 
     for (var engineName : engineNames) {
-      configureBeforeEngineCreation(engineName);
+      executeConfigurationBeforeEngineCreation(engineName);
     }
   }
 
@@ -61,7 +61,7 @@ public class CamundaScriptEngineManager extends ScriptEngineManager {
 
   }
 
-  protected void configureBeforeEngineCreation(String engineName) {
+  protected void executeConfigurationBeforeEngineCreation(String engineName) {
     var config = engineNameToInitLogicMappings.get(engineName);
     if (config != null) {
       config.run();

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/engine/CustomScriptEngineManager.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/scripting/engine/CustomScriptEngineManager.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.engine.impl.scripting.engine;
+
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptEngineManager;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.camunda.bpm.engine.impl.scripting.engine.ScriptingEngines.GRAAL_JS_SCRIPT_ENGINE_NAME;
+
+/**
+ * Custom Script Engine Manager that can execute custom logic:
+ * <p>
+ * a) after the discovery of the engines on the classpath; the respective engine factories are created
+ * b) before the engines are created.
+ *
+ * If custom logic is needed for a specific engine after the classpath detection, before the engine creation,
+ * it can be added to the classes map.
+ */
+public class CustomScriptEngineManager extends ScriptEngineManager {
+
+  protected final Map<String, Runnable> engineNameToInitLogicMappings = Map.of(
+      GRAAL_JS_SCRIPT_ENGINE_NAME, this::disableGraalVMInterpreterOnlyModeWarnings
+  );
+
+  public CustomScriptEngineManager() {
+    super(); // creates engine factories after classpath discovery
+    applyConfigOnEnginesAfterClasspathDiscovery();
+  }
+
+  protected void applyConfigOnEnginesAfterClasspathDiscovery() {
+    var engineNames = getEngineNamesFoundInClasspath();
+
+    for (var engineName : engineNames) {
+      configureBeforeEngineCreation(engineName);
+    }
+  }
+
+  protected List<String> getEngineNamesFoundInClasspath() {
+    var engineFactories = getEngineFactories();
+
+    return engineFactories.stream()
+        .map(ScriptEngineFactory::getEngineName)
+        .collect(Collectors.toList());
+
+  }
+
+  protected void configureBeforeEngineCreation(String engineName) {
+    var config = engineNameToInitLogicMappings.get(engineName);
+    if (config != null) {
+      config.run();
+    }
+  }
+
+  protected void disableGraalVMInterpreterOnlyModeWarnings() {
+    System.setProperty("polyglot.engine.WarnInterpreterOnly", "false");
+  }
+
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -27,8 +27,8 @@
     <!-- use minimum version of resteasy and jersey -->
     <version.jaxrs.api>2.0.1.Final</version.jaxrs.api>
     <version.groovy>4.0.22</version.groovy>
-    <version.graal.js>21.1.0</version.graal.js>
-    <version.icu.icu4j>68.2</version.icu.icu4j>
+    <version.graal.js>21.3.12</version.graal.js>
+    <version.icu.icu4j>71.1</version.icu.icu4j>
     <!-- json-smart and accessors-smart are runtime dependencies of json-path -->
     <version.json-path>2.9.0</version.json-path>
     <version.json-smart>2.5.0</version.json-smart>


### PR DESCRIPTION
**Notes**

- Bumps icu:icu4j to version 71.1

**Introduces**:

CustomScriptEngineManager - Class that allows to parameterise behaviour needed for a given JS engine: a) After the engines are detected from the classpath b) Before the engines are created

**GraalVM Warnings**

The commit sets the System property to disable the respective warnings introduced by bumping GraalVM to version 21.3.10.

- The system property is always set when a GraalJS script engine is found on the classpath
- The above applies by default to all distros

**Related-to**: https://github.com/camunda/camunda-bpm-platform/issues/4299