### PR TITLE
deps(wildfly): upgrade to wildfly 35

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -406,7 +406,8 @@ pipeline {
                 cambpmRunMaven('qa/',
                   'clean install -Pwildfly,h2,webapps-integration',
                   runtimeStash: true,
-                  archiveStash: true)
+                  archiveStash: true,
+                  jdkVersion: 'jdk-17-latest')
               },
               postFailure: {
                 cambpmPublishTestResult()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -404,7 +404,7 @@ pipeline {
               agentLabel: 'chrome_112',
               runSteps: {
                 cambpmRunMaven('qa/',
-                  'clean install -Pwildfly,h2,webapps-integration',
+                  "clean install -Pwildfly,h2,webapps-integration -pl '!integration-tests-engine-jakarta'",
                   runtimeStash: true,
                   archiveStash: true,
                   jdkVersion: 'jdk-17-latest')

--- a/distro/wildfly/assembly/src/wildfly/standalone-full.xml
+++ b/distro/wildfly/assembly/src/wildfly/standalone-full.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<server xmlns="urn:jboss:domain:20.0">
+<server xmlns="urn:jboss:domain:community:20.0">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.connector"/>
@@ -131,15 +131,15 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
         <subsystem xmlns="urn:jboss:domain:core-management:1.0"/>
-        <subsystem xmlns="urn:jboss:domain:datasources:7.1">
+        <subsystem xmlns="urn:jboss:domain:datasources:7.2">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true" statistics-enabled="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}">
-                    <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                    <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=${wildfly.h2.compatibility.mode:REGULAR}</connection-url>
                     <driver>h2</driver>
                     <security user-name="sa" password="sa"/>
                 </datasource>
                 <datasource jndi-name="java:jboss/datasources/ProcessEngine" pool-name="ProcessEngine" enabled="true" use-java-context="true" jta="true" use-ccm="true">
-                    <connection-url>jdbc:h2:./camunda-h2-dbs/process-engine;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                    <connection-url>jdbc:h2:./camunda-h2-dbs/process-engine;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=${wildfly.h2.compatibility.mode:REGULAR}</connection-url>
                     <driver>h2</driver>
                     <transaction-isolation>TRANSACTION_READ_COMMITTED</transaction-isolation>
                     <security user-name="sa" password="sa"/>
@@ -418,7 +418,7 @@
         <subsystem xmlns="urn:jboss:domain:io:4.0" default-worker="default">
             <worker name="default"/>
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:jaxrs:3.0"/>
+        <subsystem xmlns="urn:jboss:domain:jaxrs:4.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:6.0">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
             <bean-validation enabled="true"/>

--- a/distro/wildfly/assembly/src/wildfly/standalone.xml
+++ b/distro/wildfly/assembly/src/wildfly/standalone.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<server xmlns="urn:jboss:domain:20.0">
+<server xmlns="urn:jboss:domain:community:20.0">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.connector"/>
@@ -129,15 +129,15 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
         <subsystem xmlns="urn:jboss:domain:core-management:1.0"/>
-        <subsystem xmlns="urn:jboss:domain:datasources:7.1">
+        <subsystem xmlns="urn:jboss:domain:datasources:7.2">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true" statistics-enabled="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}">
-                    <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                    <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=${wildfly.h2.compatibility.mode:REGULAR}</connection-url>
                     <driver>h2</driver>
                     <security user-name="sa" password="sa"/>
                 </datasource>
                 <datasource jndi-name="java:jboss/datasources/ProcessEngine" pool-name="ProcessEngine" enabled="true" use-java-context="true" jta="true" use-ccm="true">
-                    <connection-url>jdbc:h2:./camunda-h2-dbs/process-engine;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                    <connection-url>jdbc:h2:./camunda-h2-dbs/process-engine;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=${wildfly.h2.compatibility.mode:REGULAR}</connection-url>
                     <driver>h2</driver>
                     <transaction-isolation>TRANSACTION_READ_COMMITTED</transaction-isolation>
                     <security user-name="sa" password="sa"/>
@@ -406,7 +406,7 @@
         <subsystem xmlns="urn:jboss:domain:io:4.0" default-worker="default">
             <worker name="default"/>
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:jaxrs:3.0"/>
+        <subsystem xmlns="urn:jboss:domain:jaxrs:4.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:6.0">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
             <bean-validation enabled="true"/>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -57,8 +57,8 @@
     <version.bouncycastle>1.47</version.bouncycastle>
 
     <!-- application servers -->
-    <version.wildfly>35.0.0.Beta1</version.wildfly>
-    <version.wildfly.core>27.0.0.Beta5</version.wildfly.core>
+    <version.wildfly>35.0.0.Final</version.wildfly>
+    <version.wildfly.core>27.0.0.Final</version.wildfly.core>
 
     <version.wildfly26>26.0.1.Final</version.wildfly26>
     <version.wildfly26.core>18.0.4.Final</version.wildfly26.core>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -239,7 +239,7 @@
         <plugin>
           <groupId>org.codehaus.cargo</groupId>
           <artifactId>cargo-maven3-plugin</artifactId>
-          <version>1.10.9</version>
+          <version>1.10.16</version>
         </plugin>
         <plugin>
           <groupId>net.kennychua</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -57,8 +57,8 @@
     <version.bouncycastle>1.47</version.bouncycastle>
 
     <!-- application servers -->
-    <version.wildfly>33.0.1.Final</version.wildfly>
-    <version.wildfly.core>25.0.1.Final</version.wildfly.core>
+    <version.wildfly>35.0.0.Beta1</version.wildfly>
+    <version.wildfly.core>27.0.0.Beta5</version.wildfly.core>
 
     <version.wildfly26>26.0.1.Final</version.wildfly26>
     <version.wildfly26.core>18.0.4.Final</version.wildfly26.core>

--- a/qa/integration-tests-webapps/pom.xml
+++ b/qa/integration-tests-webapps/pom.xml
@@ -19,7 +19,7 @@
     <!-- Fixed for WildFly 26 -->
     <cargo.wildfly26.container.id>wildfly26x</cargo.wildfly26.container.id>
     <!-- Needs to be adjusted with every WildFly update -->
-    <cargo.wildfly.container.id>wildfly29x</cargo.wildfly.container.id>
+    <cargo.wildfly.container.id>wildfly35x</cargo.wildfly.container.id>
 
     <redirect.test.output>true</redirect.test.output>
 

--- a/qa/wildfly-runtime/src/main/wildfly/domain/configuration/domain.xml
+++ b/qa/wildfly-runtime/src/main/wildfly/domain/configuration/domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<domain xmlns="urn:jboss:domain:20.0">
+<domain xmlns="urn:jboss:domain:community:20.0">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
@@ -107,15 +107,15 @@
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
             <subsystem xmlns="urn:jboss:domain:core-management:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:datasources:7.1">
+            <subsystem xmlns="urn:jboss:domain:datasources:7.2">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true" statistics-enabled="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}">
-                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=${wildfly.h2.compatibility.mode:REGULAR}</connection-url>
                         <driver>h2</driver>
                         <security user-name="sa" password="sa"/>
                     </datasource>
                     <datasource jndi-name="java:jboss/datasources/ProcessEngine" pool-name="ProcessEngineDS" enabled="true" use-java-context="true">
-                        <connection-url>jdbc:h2:mem:processengine;DB_CLOSE_DELAY=-1</connection-url>
+                        <connection-url>jdbc:h2:mem:processengine;DB_CLOSE_DELAY=-1;MODE=${wildfly.h2.compatibility.mode:REGULAR}</connection-url>
                         <driver>h2</driver>
                         <security user-name="sa" password="sa"/>
                     </datasource>
@@ -359,7 +359,7 @@
             <subsystem xmlns="urn:jboss:domain:io:4.0" default-worker="default">
                 <worker name="default"/>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jaxrs:3.0"/>
+            <subsystem xmlns="urn:jboss:domain:jaxrs:4.0"/>
             <subsystem xmlns="urn:jboss:domain:jca:6.0">
                 <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
                 <bean-validation enabled="true"/>
@@ -546,10 +546,10 @@
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
             <subsystem xmlns="urn:jboss:domain:core-management:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:datasources:7.1">
+            <subsystem xmlns="urn:jboss:domain:datasources:7.2">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true" statistics-enabled="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}">
-                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=${wildfly.h2.compatibility.mode:REGULAR}</connection-url>
                         <driver>h2</driver>
                         <security user-name="sa" password="sa"/>
                     </datasource>
@@ -772,7 +772,7 @@
                         <expiration interval="0"/>
                     </replicated-cache>
                 </cache-container>
-                <cache-container name="web" default-cache="dist" marshaller="PROTOSTREAM" modules="org.wildfly.clustering.web.infinispan">
+                <cache-container name="web" default-cache="dist" marshaller="PROTOSTREAM" modules="org.wildfly.clustering.session.infinispan.embedded">
                     <transport lock-timeout="60000"/>
                     <replicated-cache name="sso">
                         <locking isolation="REPEATABLE_READ"/>
@@ -810,7 +810,7 @@
             <subsystem xmlns="urn:jboss:domain:io:4.0" default-worker="default">
                 <worker name="default"/>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jaxrs:3.0"/>
+            <subsystem xmlns="urn:jboss:domain:jaxrs:4.0"/>
             <subsystem xmlns="urn:jboss:domain:jca:6.0">
                 <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
                 <bean-validation enabled="true"/>
@@ -1012,10 +1012,10 @@
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
             <subsystem xmlns="urn:jboss:domain:core-management:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:datasources:7.1">
+            <subsystem xmlns="urn:jboss:domain:datasources:7.2">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true" statistics-enabled="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}">
-                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=${wildfly.h2.compatibility.mode:REGULAR}</connection-url>
                         <driver>h2</driver>
                         <security user-name="sa" password="sa"/>
                     </datasource>
@@ -1269,7 +1269,7 @@
             <subsystem xmlns="urn:jboss:domain:io:4.0" default-worker="default">
                 <worker name="default"/>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jaxrs:3.0"/>
+            <subsystem xmlns="urn:jboss:domain:jaxrs:4.0"/>
             <subsystem xmlns="urn:jboss:domain:jca:6.0">
                 <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
                 <bean-validation enabled="true"/>
@@ -1447,10 +1447,10 @@
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
             <subsystem xmlns="urn:jboss:domain:core-management:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:datasources:7.1">
+            <subsystem xmlns="urn:jboss:domain:datasources:7.2">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true" statistics-enabled="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}">
-                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=${wildfly.h2.compatibility.mode:REGULAR}</connection-url>
                         <driver>h2</driver>
                         <security user-name="sa" password="sa"/>
                     </datasource>
@@ -1683,7 +1683,7 @@
                         <expiration interval="0"/>
                     </replicated-cache>
                 </cache-container>
-                <cache-container name="web" default-cache="dist" marshaller="PROTOSTREAM" modules="org.wildfly.clustering.web.infinispan">
+                <cache-container name="web" default-cache="dist" marshaller="PROTOSTREAM" modules="org.wildfly.clustering.session.infinispan.embedded">
                     <transport lock-timeout="60000"/>
                     <replicated-cache name="sso">
                         <locking isolation="REPEATABLE_READ"/>
@@ -1721,7 +1721,7 @@
             <subsystem xmlns="urn:jboss:domain:io:4.0" default-worker="default">
                 <worker name="default"/>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jaxrs:3.0"/>
+            <subsystem xmlns="urn:jboss:domain:jaxrs:4.0"/>
             <subsystem xmlns="urn:jboss:domain:jca:6.0">
                 <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
                 <bean-validation enabled="true"/>
@@ -2300,6 +2300,7 @@
             <excluded-extensions>
                 <extension module="org.wildfly.extension.clustering.ejb"/>
                 <extension module="org.wildfly.extension.elytron-oidc-client"/>
+                <extension module="org.wildfly.extension.jakarta.data"/>
                 <extension module="org.wildfly.extension.opentelemetry"/>
                 <extension module="org.wildfly.extension.micrometer"/>
                 <extension module="org.wildfly.extension.microprofile.lra-participant"/>
@@ -2313,6 +2314,7 @@
             <excluded-extensions>
                 <extension module="org.wildfly.extension.clustering.ejb"/>
                 <extension module="org.wildfly.extension.elytron-oidc-client"/>
+                <extension module="org.wildfly.extension.jakarta.data"/>
                 <extension module="org.wildfly.extension.opentelemetry"/>
                 <extension module="org.wildfly.extension.micrometer"/>
                 <extension module="org.wildfly.extension.microprofile.lra-participant"/>
@@ -2325,6 +2327,7 @@
             <host-release id="WildFly25.0"/>
             <excluded-extensions>
                 <extension module="org.wildfly.extension.clustering.ejb"/>
+                <extension module="org.wildfly.extension.jakarta.data"/>
                 <extension module="org.wildfly.extension.micrometer"/>
                 <extension module="org.wildfly.extension.microprofile.lra-participant"/>
                 <extension module="org.wildfly.extension.microprofile.lra-coordinator"/>
@@ -2336,6 +2339,7 @@
             <host-release id="WildFly26.0"/>
             <excluded-extensions>
                 <extension module="org.wildfly.extension.clustering.ejb"/>
+                <extension module="org.wildfly.extension.jakarta.data"/>
                 <extension module="org.wildfly.extension.micrometer"/>
                 <extension module="org.wildfly.extension.microprofile.lra-participant"/>
                 <extension module="org.wildfly.extension.microprofile.lra-coordinator"/>
@@ -2346,6 +2350,7 @@
         <host-exclude name="WildFly27.0">
             <host-release id="WildFly27.0"/>
             <excluded-extensions>
+                <extension module="org.wildfly.extension.jakarta.data"/>
                 <extension module="org.wildfly.extension.micrometer"/>
                 <extension module="org.wildfly.extension.microprofile.lra-participant"/>
                 <extension module="org.wildfly.extension.microprofile.lra-coordinator"/>
@@ -2356,25 +2361,47 @@
         <host-exclude name="WildFly28.0">
             <host-release id="WildFly28.0"/>
             <excluded-extensions>
+                <extension module="org.wildfly.extension.jakarta.data"/>
                 <extension module="org.wildfly.extension.mvc-krazo"/>
             </excluded-extensions>
         </host-exclude>
         <host-exclude name="WildFly29.0">
             <host-release id="WildFly29.0"/>
             <excluded-extensions>
+                <extension module="org.wildfly.extension.jakarta.data"/>
                 <extension module="org.wildfly.extension.mvc-krazo"/>
             </excluded-extensions>
         </host-exclude>
         <host-exclude name="WildFly30.0">
             <host-release id="WildFly30.0"/>
             <excluded-extensions>
+                <extension module="org.wildfly.extension.jakarta.data"/>
                 <extension module="org.wildfly.extension.mvc-krazo"/>
             </excluded-extensions>
         </host-exclude>
         <host-exclude name="WildFly31.0">
             <host-release id="WildFly31.0"/>
             <excluded-extensions>
+                <extension module="org.wildfly.extension.jakarta.data"/>
                 <extension module="org.wildfly.extension.mvc-krazo"/>
+            </excluded-extensions>
+        </host-exclude>
+        <host-exclude name="WildFly32.0">
+            <host-release id="WildFly32.0"/>
+            <excluded-extensions>
+                <extension module="org.wildfly.extension.jakarta.data"/>
+            </excluded-extensions>
+        </host-exclude>
+        <host-exclude name="WildFly33.0">
+            <host-release id="WildFly33.0"/>
+            <excluded-extensions>
+                <extension module="org.wildfly.extension.jakarta.data"/>
+            </excluded-extensions>
+        </host-exclude>
+        <host-exclude name="WildFly34.0">
+            <host-api-version major-version="27" minor-version="0"/>
+            <excluded-extensions>
+                <extension module="org.wildfly.extension.jakarta.data"/>
             </excluded-extensions>
         </host-exclude>
     </host-excludes>

--- a/qa/wildfly-runtime/src/main/wildfly/domain/configuration/host.xml
+++ b/qa/wildfly-runtime/src/main/wildfly/domain/configuration/host.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<host xmlns="urn:jboss:domain:20.0" name="primary">
+<host xmlns="urn:jboss:domain:community:20.0" name="primary">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/qa/wildfly-runtime/src/main/wildfly/standalone/configuration/standalone.xml
+++ b/qa/wildfly-runtime/src/main/wildfly/standalone/configuration/standalone.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<server xmlns="urn:jboss:domain:20.0">
+<server xmlns="urn:jboss:domain:community:20.0">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.connector"/>
@@ -129,7 +129,7 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>
         <subsystem xmlns="urn:jboss:domain:core-management:1.0"/>
-        <subsystem xmlns="urn:jboss:domain:datasources:7.1">
+        <subsystem xmlns="urn:jboss:domain:datasources:7.2">
             <datasources>
                 <drivers>
                     <!-- all drivers needed in QA are listed here -->
@@ -400,7 +400,7 @@
         <subsystem xmlns="urn:jboss:domain:io:4.0" default-worker="default">
             <worker name="default"/>
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:jaxrs:3.0"/>
+        <subsystem xmlns="urn:jboss:domain:jaxrs:4.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:6.0">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
             <bean-validation enabled="true"/>


### PR DESCRIPTION
related to https://github.com/camunda/camunda-bpm-platform/issues/4655

### Description
Adds support for wildfly 35

Keeping track of license check in [this doc](https://docs.google.com/document/d/1s8_6fLdjl3j0B5WQEav2orGcwz4uUs-MIuah4YqBtxs/edit?tab=t.0)

- [x] License check doc [here](https://docs.google.com/document/d/1s8_6fLdjl3j0B5WQEav2orGcwz4uUs-MIuah4YqBtxs/edit?tab=t.0) (ignore checkboxes in license bot list)
- [x] Manual testing of CE Wildfly 35
- [x] Manual testing of EE Wildfly 35
- [x] Manual testing of EE Jboss 8
- [x] CI green

For manual testing setup, [this](https://docs.camunda.org/manual/develop/installation/full/jboss/manual/#setup) guide was used.
Follow up: https://github.com/camunda/team-automation-platform/issues/282