### PR TITLE
chore(optimize): exclude standalone tasks from optimize queries

### DIFF
--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
@@ -738,6 +738,7 @@
       <if test="parameter.finishedAfter == null and parameter.finishedAt == null">
         and RES.END_TIME_ is not null
       </if>
+      and TASK_DEF_KEY_ is not null
     </where>
 
     ORDER BY RES.END_TIME_ ASC
@@ -758,6 +759,7 @@
         and RES.START_TIME_ = #{parameter.startedAt}
       </if>
       and RES.END_TIME_ is null
+      and TASK_DEF_KEY_ is not null
     </where>
 
     ORDER BY RES.START_TIME_ ASC


### PR DESCRIPTION
related to [OPT#4735](https://github.com/camunda/camunda-bpm-platform/issues/4735)

Excludes standallone usertasks from optimize exports. 
