### PR TITLE
fix(webapp): Handle null authentication as unauthorized

### DIFF
--- a/webapps/assembly/src/main/java/org/camunda/bpm/webapp/impl/security/auth/UserAuthenticationResource.java
+++ b/webapps/assembly/src/main/java/org/camunda/bpm/webapp/impl/security/auth/UserAuthenticationResource.java
@@ -99,6 +99,12 @@ public class UserAuthenticationResource {
     }
 
     UserAuthentication authentication = AuthenticationUtil.createAuthentication(processEngine, username);
+    if (authentication == null) {
+      if(isWebappsAuthenticationLoggingEnabled(processEngine)) {
+        LOGGER.infoWebappFailedLogin(username, "not authorized");
+      }
+      return unauthorized();
+    }
 
     ServletContext servletContext = request.getServletContext();
     Date cacheValidationTime = ServletContextUtil.getAuthCacheValidationTime(servletContext);

--- a/webapps/assembly/src/test/java/org/camunda/bpm/webapp/impl/security/auth/UserAuthenticationResourceTest.java
+++ b/webapps/assembly/src/test/java/org/camunda/bpm/webapp/impl/security/auth/UserAuthenticationResourceTest.java
@@ -17,7 +17,6 @@
 package org.camunda.bpm.webapp.impl.security.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mockStatic;
 
 import java.util.Date;
@@ -206,24 +205,22 @@ public class UserAuthenticationResourceTest {
   }
 
   @Test
-  public void assertNullAuthenticationThrowsNPE() {
+  public void shouldReturnUnauthorizedOnNullAuthentication() {
     // given
     User jonny = identityService.newUser("jonny");
     jonny.setPassword("jonnyspassword");
     identityService.saveUser(jonny);
+    UserAuthenticationResource authResource = new UserAuthenticationResource();
+    authResource.request = new MockHttpServletRequest();
 
     try (MockedStatic<AuthenticationUtil> authenticationUtilMock = mockStatic(AuthenticationUtil.class)) {
       authenticationUtilMock.when(() -> AuthenticationUtil.createAuthentication("webapps-test-engine", "jonny")).thenReturn(null);
 
       // when
-      UserAuthenticationResource authResource = new UserAuthenticationResource();
-      authResource.request = new MockHttpServletRequest();
-      assertThatThrownBy(() -> authResource.doLogin("webapps-test-engine", "tasklist", "jonny", "jonnyspassword"))
-          // then
-          .isInstanceOf(NullPointerException.class);
+      Response response = authResource.doLogin("webapps-test-engine", "tasklist", "jonny", "jonnyspassword");
 
-      // we should get a forbidden return code
-      // Assert.assertEquals(Status.FORBIDDEN.getStatusCode(), response.getStatus());
+      // then
+      Assert.assertEquals(Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
     }
   }
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/3739