### PR TITLE
feat(restAPI): add withJobsRetrying to rest and openAPI

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/history-process-instance.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/history-process-instance.ftl
@@ -113,6 +113,12 @@
     "desc": "Only include unfinished process instances. Value may only be `true`, as `false` is the default behavior."
   },
 
+  "withJobsRetrying": {
+    "type": "boolean",
+    "desc": "Only include process instances which are associated with jobs that have encountered exceptions and still
+     have retries left. Value may only be `true`, as `false` is the default behavior."
+  },
+
   "withIncidents": {
     "type": "boolean",
     "desc": "Only include process instances which have an incident. Value may only be `true`, as `false` is the default behavior."

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricProcessInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricProcessInstanceQueryDto.java
@@ -85,6 +85,7 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
   private Boolean rootProcessInstances;
   private Boolean finished;
   private Boolean unfinished;
+  private Boolean withJobsRetrying;
   private Boolean withIncidents;
   private Boolean withRootIncidents;
   private String incidentType;
@@ -207,6 +208,11 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
   @CamundaQueryParam(value = "unfinished", converter = BooleanConverter.class)
   public void setUnfinished(Boolean unfinished) {
     this.unfinished = unfinished;
+  }
+
+  @CamundaQueryParam(value = "withJobsRetrying", converter = BooleanConverter.class)
+  public void setWithJobsRetrying(Boolean withJobsRetrying) {
+    this.withJobsRetrying = withJobsRetrying;
   }
 
   @CamundaQueryParam(value = "withIncidents", converter = BooleanConverter.class)
@@ -448,6 +454,9 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
     }
     if (unfinished != null && unfinished) {
       query.unfinished();
+    }
+    if (withJobsRetrying != null && withJobsRetrying) {
+      query.withJobsRetrying();
     }
     if (withIncidents != null && withIncidents) {
       query.withIncidents();

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricProcessInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricProcessInstanceRestServiceQueryTest.java
@@ -794,6 +794,40 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
   }
 
   @Test
+  public void testQueryWithJobsRetrying() {
+    given()
+      .queryParam("withJobsRetrying", true)
+      .then()
+      .expect()
+      .statusCode(Status.OK.getStatusCode())
+      .when()
+      .get(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
+
+    InOrder inOrder = inOrder(mockedQuery);
+    inOrder.verify(mockedQuery).withJobsRetrying();
+    inOrder.verify(mockedQuery).list();
+  }
+
+  @Test
+  public void testQueryWithJobsRetryingAsPost() {
+    Map<String, Boolean> body = new HashMap<String, Boolean>();
+    body.put("withJobsRetrying", true);
+
+    given()
+      .contentType(POST_JSON_CONTENT_TYPE)
+      .body(body)
+      .then()
+      .expect()
+      .statusCode(Status.OK.getStatusCode())
+      .when()
+      .post(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
+
+    InOrder inOrder = inOrder(mockedQuery);
+    inOrder.verify(mockedQuery).withJobsRetrying();
+    inOrder.verify(mockedQuery).list();
+  }
+
+  @Test
   public void testQueryWithIncidents() {
     given()
       .queryParam("withIncidents", true)


### PR DESCRIPTION
related to https://github.com/camunda/camunda-bpm-platform/issues/4905

Adds the `withJobsRetrying` query parameter to openAPI definition as well as `HistoricProcessInstanceQueryDto` for use by cockpit instance search. See ticket for more details.