### PR TITLE
Implement filteration by rootProcessInstanceId for Process Instances and History Process instances endpoints #2582

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/history-process-instance.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/history-process-instance.ftl
@@ -108,6 +108,11 @@
     "desc": "Restrict the query to all process instances that are top level process instances."
   },
 
+  "rootProcessInstanceId": {
+    "type": "string",
+    "desc": "Filter by root process instance id."
+  },
+
   "finished": {
     "type": "boolean",
     "desc": "Only include finished process instances. This flag includes all process instances

--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/process-instance-query-params.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/process-instance-query-params.ftl
@@ -141,6 +141,11 @@
       defaultValue = 'false'
       desc = "Restrict the query to all process instances that are top level process instances."/>
 
+  <@lib.parameter name = "rootProcessInstanceId"
+      location = "query"
+      type = "string"
+      desc = "Filter by root process instance id."/>
+
   <@lib.parameter name = "leafProcessInstances"
       location = "query"
       type = "boolean"

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricProcessInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/history/HistoricProcessInstanceQueryDto.java
@@ -74,6 +74,7 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
   private String processInstanceId;
   private Set<String> processInstanceIds;
   private List<String> processInstanceIdNotIn;
+  private String rootProcessInstanceId;
   private String processDefinitionId;
   private String processDefinitionKey;
   private List<String> processDefinitionKeys;
@@ -150,6 +151,15 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
   @CamundaQueryParam(value = "processInstanceIdNotIn", converter = StringListConverter.class)
   public void setProcessInstanceIdNotIn(List<String> processInstanceIdNotIn) {
     this.processInstanceIdNotIn = processInstanceIdNotIn;
+  }
+
+  public String getRootProcessInstanceId() {
+    return rootProcessInstanceId;
+  }
+
+  @CamundaQueryParam("rootProcessInstanceId")
+  public void setRootProcessInstanceId(String rootProcessInstanceId) {
+    this.rootProcessInstanceId = rootProcessInstanceId;
   }
 
   public String getProcessDefinitionId() {
@@ -427,6 +437,9 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
     }
     if (processInstanceIdNotIn != null && !processInstanceIdNotIn.isEmpty()) {
       query.processInstanceIdNotIn(processInstanceIdNotIn.toArray(new String[0]));
+    }
+    if (rootProcessInstanceId != null) {
+      query.rootProcessInstanceId(rootProcessInstanceId);
     }
     if (processDefinitionId != null) {
       query.processDefinitionId(processDefinitionId);

--- a/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/runtime/ProcessInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/camunda/bpm/engine/rest/dto/runtime/ProcessInstanceQueryDto.java
@@ -75,6 +75,7 @@ public class ProcessInstanceQueryDto extends AbstractQueryDto<ProcessInstanceQue
   private Set<String> processInstanceIds;
   private Boolean withIncident;
   private String incidentId;
+  private String rootProcessInstanceId;
   private String incidentType;
   private String incidentMessage;
   private String incidentMessageLike;
@@ -285,6 +286,15 @@ public class ProcessInstanceQueryDto extends AbstractQueryDto<ProcessInstanceQue
     this.incidentId = incidentId;
   }
 
+  public String getRootProcessInstanceId() {
+    return rootProcessInstanceId;
+  }
+
+  @CamundaQueryParam("rootProcessInstanceId")
+  public void setRootProcessInstanceId(String rootProcessInstanceId) {
+    this.rootProcessInstanceId = rootProcessInstanceId;
+  }
+
   public String getIncidentType() {
     return incidentType;
   }
@@ -441,6 +451,9 @@ public class ProcessInstanceQueryDto extends AbstractQueryDto<ProcessInstanceQue
     }
     if (incidentId != null) {
       query.incidentId(incidentId);
+    }
+    if (rootProcessInstanceId != null) {
+      query.rootProcessInstanceId(rootProcessInstanceId);
     }
     if (incidentType != null) {
       query.incidentType(incidentType);

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ProcessInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/ProcessInstanceRestServiceQueryTest.java
@@ -242,6 +242,7 @@ public class ProcessInstanceRestServiceQueryTest extends
     verify(mockedQuery).incidentMessage(queryParameters.get("incidentMessage"));
     verify(mockedQuery).incidentMessageLike(queryParameters.get("incidentMessageLike"));
     verify(mockedQuery).incidentType(queryParameters.get("incidentType"));
+    verify(mockedQuery).rootProcessInstanceId(queryParameters.get("rootProcessInstanceId"));
     verify(mockedQuery).list();
   }
 
@@ -264,6 +265,7 @@ public class ProcessInstanceRestServiceQueryTest extends
     parameters.put("incidentMessageLike", "incMessageLike");
     parameters.put("incidentType", "incType");
     parameters.put("caseInstanceId", "aCaseInstanceId");
+    parameters.put("rootProcessInstanceId", "aRootProcessInstanceId");
 
     return parameters;
   }
@@ -917,7 +919,42 @@ public class ProcessInstanceRestServiceQueryTest extends
     verify(mockedQuery).incidentMessage(queryParameters.get("incidentMessage"));
     verify(mockedQuery).incidentMessageLike(queryParameters.get("incidentMessageLike"));
     verify(mockedQuery).incidentType(queryParameters.get("incidentType"));
+    verify(mockedQuery).rootProcessInstanceId(queryParameters.get("rootProcessInstanceId"));
     verify(mockedQuery).list();
+  }
+
+  @Test
+  public void testGetProcessInstancesForRootProcessInstanceId() {
+    Response response = given().queryParam("rootProcessInstanceId", MockProvider.EXAMPLE_ROOT_PROCESS_INSTANCE_ID)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .then()
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .contentType(ContentType.JSON)
+        .when()
+        .get(PROCESS_INSTANCE_QUERY_URL);
+
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> instances = from(content).getList("");
+    assertThat(instances).size().isGreaterThan(0);
+
+    String returnedProcessInstanceId = from(content).getString("[0].id");
+    String returnedProcessDefinitionId = from(content).getString("[0].definitionId");
+    String returnedProcessInstanceBusinessKey = from(content).getString("[0].businessKey");
+    String returnedCaseInstanceId = from(content).getString("[0].caseInstanceId");
+    Boolean returnedIsEnded = from(content).getBoolean("[0].ended");
+    Boolean returnedIsSuspended = from(content).getBoolean("[0].suspended");
+    String returnedTenantId = from(content).getString("[0].tenantId");
+
+    Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID, returnedProcessInstanceId);
+    Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, returnedProcessDefinitionId);
+    Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY, returnedProcessInstanceBusinessKey);
+    Assert.assertEquals(MockProvider.EXAMPLE_CASE_INSTANCE_ID, returnedCaseInstanceId);
+    Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_ENDED, returnedIsEnded);
+    Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED, returnedIsSuspended);
+    Assert.assertEquals(MockProvider.EXAMPLE_TENANT_ID, returnedTenantId);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/helper/MockProvider.java
@@ -247,6 +247,7 @@ public abstract class MockProvider {
   public static final String EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY = "aKey";
   public static final String EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY_LIKE = "aKeyLike";
   public static final String EXAMPLE_PROCESS_INSTANCE_ID = "aProcInstId";
+  public static final String EXAMPLE_ROOT_PROCESS_INSTANCE_ID = "aRootProcessInstanceId";
   public static final String EXAMPLE_ROOT_HISTORIC_PROCESS_INSTANCE_ID = "aRootProcInstId";
   public static final String ANOTHER_EXAMPLE_PROCESS_INSTANCE_ID = "anotherId";
   public static final boolean EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED = false;

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricProcessInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricProcessInstanceRestServiceQueryTest.java
@@ -456,6 +456,70 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
   }
 
   @Test
+  public void testGetHistoryProcessInstancesForRootProcessInstanceId() {
+    Response response = given().queryParam("rootProcessInstanceId",
+            MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_ROOT_PROCESS_INSTANCE_ID)
+        .header("accept", MediaType.APPLICATION_JSON)
+        .then()
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .contentType(ContentType.JSON)
+        .when()
+        .get(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
+
+    verify(mockedQuery).list();
+
+    String content = response.asString();
+    List<String> instances = from(content).getList("");
+    assertThat(instances).size().isGreaterThan(0);
+
+    String returnedProcessInstanceId = from(content).getString("[0].id");
+    String returnedProcessInstanceBusinessKey = from(content).getString("[0].businessKey");
+    String returnedProcessDefinitionId = from(content).getString("[0].processDefinitionId");
+    String returnedProcessDefinitionKey = from(content).getString("[0].processDefinitionKey");
+    String returnedProcessDefinitionName = from(content).getString("[0].processDefinitionName");
+    int returnedProcessDefinitionVersion = from(content).getInt("[0].processDefinitionVersion");
+    String returnedStartTime = from(content).getString("[0].startTime");
+    String returnedEndTime = from(content).getString("[0].endTime");
+    String returnedRemovalTime = from(content).getString("[0].removalTime");
+    long returnedDurationInMillis = from(content).getLong("[0].durationInMillis");
+    String returnedStartUserId = from(content).getString("[0].startUserId");
+    String returnedStartActivityId = from(content).getString("[0].startActivityId");
+    String returnedDeleteReason = from(content).getString("[0].deleteReason");
+    String returnedRootProcessInstanceId = from(content).getString("[0].rootProcessInstanceId");
+    String returnedSuperProcessInstanceId = from(content).getString("[0].superProcessInstanceId");
+    String returnedSuperCaseInstanceId = from(content).getString("[0].superCaseInstanceId");
+    String returnedCaseInstanceId = from(content).getString("[0].caseInstanceId");
+    String returnedTenantId = from(content).getString("[0].tenantId");
+    String returnedState = from(content).getString("[0].state");
+    String restartedProcessInstanceId = from(content).getString("[0].restartedProcessInstanceId");
+
+    Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID, returnedProcessInstanceId);
+    Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY, returnedProcessInstanceBusinessKey);
+    Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, returnedProcessDefinitionId);
+    Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_DEFINITION_KEY, returnedProcessDefinitionKey);
+    Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_DEFINITION_NAME, returnedProcessDefinitionName);
+    Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_DEFINITION_VERSION, returnedProcessDefinitionVersion);
+    Assert.assertEquals(MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_START_TIME, returnedStartTime);
+    Assert.assertEquals(MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_END_TIME, returnedEndTime);
+    Assert.assertEquals(MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_REMOVAL_TIME, returnedRemovalTime);
+    Assert.assertEquals(MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_DURATION_MILLIS, returnedDurationInMillis);
+    Assert.assertEquals(MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_START_USER_ID, returnedStartUserId);
+    Assert.assertEquals(MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_START_ACTIVITY_ID, returnedStartActivityId);
+    Assert.assertEquals(MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_DELETE_REASON, returnedDeleteReason);
+    Assert.assertEquals(MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_ROOT_PROCESS_INSTANCE_ID,
+        returnedRootProcessInstanceId);
+    Assert.assertEquals(MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_SUPER_PROCESS_INSTANCE_ID,
+        returnedSuperProcessInstanceId);
+    Assert.assertEquals(MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_SUPER_CASE_INSTANCE_ID,
+        returnedSuperCaseInstanceId);
+    Assert.assertEquals(MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_CASE_INSTANCE_ID, returnedCaseInstanceId);
+    Assert.assertEquals(MockProvider.EXAMPLE_TENANT_ID, returnedTenantId);
+    Assert.assertEquals(MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_STATE, returnedState);
+    Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID, restartedProcessInstanceId);
+  }
+
+  @Test
   public void testAdditionalParametersExcludingProcesses() {
     Map<String, String> stringQueryParameters = getCompleteStringQueryParameters();
 
@@ -504,6 +568,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     parameters.put("caseInstanceId", MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_CASE_INSTANCE_ID);
     parameters.put("state", MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_STATE);
     parameters.put("incidentType", MockProvider.EXAMPLE_INCIDENT_TYPE);
+    parameters.put("rootProcessInstanceId", MockProvider.EXAMPLE_HISTORIC_PROCESS_INSTANCE_ROOT_PROCESS_INSTANCE_ID);
 
     return parameters;
   }
@@ -525,6 +590,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     verify(mockedQuery).subCaseInstanceId(stringQueryParameters.get("subCaseInstanceId"));
     verify(mockedQuery).caseInstanceId(stringQueryParameters.get("caseInstanceId"));
     verify(mockedQuery).incidentType(stringQueryParameters.get("incidentType"));
+    verify(mockedQuery).rootProcessInstanceId(stringQueryParameters.get("rootProcessInstanceId"));
 
     verify(mockedQuery).list();
   }
@@ -1614,14 +1680,14 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     variableJson.put("name", "varName");
     variableJson.put("value", "varValue");
     variableJson.put("operator", "eq");
-    
+
     List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
     variables.add(variableJson);
-    
+
     Map<String, Object> json = new HashMap<String, Object>();
     json.put("variables", variables);
     json.put("variableValuesIgnoreCase", true);
-    
+
     given()
     .contentType(POST_JSON_CONTENT_TYPE)
     .body(json)
@@ -1630,7 +1696,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     .statusCode(Status.OK.getStatusCode())
     .when()
     .post(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
-    
+
     verify(mockedQuery).matchVariableValuesIgnoreCase();
     verify(mockedQuery).variableValueEquals("varName", "varValue");
   }
@@ -1641,14 +1707,14 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     variableJson.put("name", "varName");
     variableJson.put("value", "varValue");
     variableJson.put("operator", "neq");
-    
+
     List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
     variables.add(variableJson);
-    
+
     Map<String, Object> json = new HashMap<String, Object>();
     json.put("variables", variables);
     json.put("variableValuesIgnoreCase", true);
-    
+
     given()
     .contentType(POST_JSON_CONTENT_TYPE)
     .body(json)
@@ -1657,7 +1723,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     .statusCode(Status.OK.getStatusCode())
     .when()
     .post(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
-    
+
     verify(mockedQuery).matchVariableValuesIgnoreCase();
     verify(mockedQuery).variableValueNotEquals("varName", "varValue");
   }
@@ -1668,14 +1734,14 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     variableJson.put("name", "varName");
     variableJson.put("value", "varValue");
     variableJson.put("operator", "like");
-    
+
     List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
     variables.add(variableJson);
-    
+
     Map<String, Object> json = new HashMap<String, Object>();
     json.put("variables", variables);
     json.put("variableValuesIgnoreCase", true);
-    
+
     given()
     .contentType(POST_JSON_CONTENT_TYPE)
     .body(json)
@@ -1684,7 +1750,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     .statusCode(Status.OK.getStatusCode())
     .when()
     .post(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
-    
+
     verify(mockedQuery).matchVariableValuesIgnoreCase();
     verify(mockedQuery).variableValueLike("varName", "varValue");
   }
@@ -1696,14 +1762,14 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     variableJson.put("name", "varName");
     variableJson.put("value", "varValue");
     variableJson.put("operator", "eq");
-    
+
     List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
     variables.add(variableJson);
-    
+
     Map<String, Object> json = new HashMap<String, Object>();
     json.put("variables", variables);
     json.put("variableNamesIgnoreCase", true);
-    
+
     given()
     .contentType(POST_JSON_CONTENT_TYPE)
     .body(json)
@@ -1712,7 +1778,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     .statusCode(Status.OK.getStatusCode())
     .when()
     .post(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
-    
+
     verify(mockedQuery).matchVariableNamesIgnoreCase();
     verify(mockedQuery).variableValueEquals("varName", "varValue");
   }
@@ -1723,14 +1789,14 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     variableJson.put("name", "varName");
     variableJson.put("value", "varValue");
     variableJson.put("operator", "neq");
-    
+
     List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
     variables.add(variableJson);
-    
+
     Map<String, Object> json = new HashMap<String, Object>();
     json.put("variables", variables);
     json.put("variableNamesIgnoreCase", true);
-    
+
     given()
     .contentType(POST_JSON_CONTENT_TYPE)
     .body(json)
@@ -1739,7 +1805,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     .statusCode(Status.OK.getStatusCode())
     .when()
     .post(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
-    
+
     verify(mockedQuery).matchVariableNamesIgnoreCase();
     verify(mockedQuery).variableValueNotEquals("varName", "varValue");
   }

--- a/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricProcessInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/camunda/bpm/engine/rest/history/HistoricProcessInstanceRestServiceQueryTest.java
@@ -1680,14 +1680,14 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     variableJson.put("name", "varName");
     variableJson.put("value", "varValue");
     variableJson.put("operator", "eq");
-
+    
     List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
     variables.add(variableJson);
-
+    
     Map<String, Object> json = new HashMap<String, Object>();
     json.put("variables", variables);
     json.put("variableValuesIgnoreCase", true);
-
+    
     given()
     .contentType(POST_JSON_CONTENT_TYPE)
     .body(json)
@@ -1696,7 +1696,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     .statusCode(Status.OK.getStatusCode())
     .when()
     .post(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
-
+    
     verify(mockedQuery).matchVariableValuesIgnoreCase();
     verify(mockedQuery).variableValueEquals("varName", "varValue");
   }
@@ -1707,14 +1707,14 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     variableJson.put("name", "varName");
     variableJson.put("value", "varValue");
     variableJson.put("operator", "neq");
-
+    
     List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
     variables.add(variableJson);
-
+    
     Map<String, Object> json = new HashMap<String, Object>();
     json.put("variables", variables);
     json.put("variableValuesIgnoreCase", true);
-
+    
     given()
     .contentType(POST_JSON_CONTENT_TYPE)
     .body(json)
@@ -1723,7 +1723,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     .statusCode(Status.OK.getStatusCode())
     .when()
     .post(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
-
+    
     verify(mockedQuery).matchVariableValuesIgnoreCase();
     verify(mockedQuery).variableValueNotEquals("varName", "varValue");
   }
@@ -1734,14 +1734,14 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     variableJson.put("name", "varName");
     variableJson.put("value", "varValue");
     variableJson.put("operator", "like");
-
+    
     List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
     variables.add(variableJson);
-
+    
     Map<String, Object> json = new HashMap<String, Object>();
     json.put("variables", variables);
     json.put("variableValuesIgnoreCase", true);
-
+    
     given()
     .contentType(POST_JSON_CONTENT_TYPE)
     .body(json)
@@ -1750,7 +1750,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     .statusCode(Status.OK.getStatusCode())
     .when()
     .post(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
-
+    
     verify(mockedQuery).matchVariableValuesIgnoreCase();
     verify(mockedQuery).variableValueLike("varName", "varValue");
   }
@@ -1762,14 +1762,14 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     variableJson.put("name", "varName");
     variableJson.put("value", "varValue");
     variableJson.put("operator", "eq");
-
+    
     List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
     variables.add(variableJson);
-
+    
     Map<String, Object> json = new HashMap<String, Object>();
     json.put("variables", variables);
     json.put("variableNamesIgnoreCase", true);
-
+    
     given()
     .contentType(POST_JSON_CONTENT_TYPE)
     .body(json)
@@ -1778,7 +1778,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     .statusCode(Status.OK.getStatusCode())
     .when()
     .post(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
-
+    
     verify(mockedQuery).matchVariableNamesIgnoreCase();
     verify(mockedQuery).variableValueEquals("varName", "varValue");
   }
@@ -1789,14 +1789,14 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     variableJson.put("name", "varName");
     variableJson.put("value", "varValue");
     variableJson.put("operator", "neq");
-
+    
     List<Map<String, Object>> variables = new ArrayList<Map<String, Object>>();
     variables.add(variableJson);
-
+    
     Map<String, Object> json = new HashMap<String, Object>();
     json.put("variables", variables);
     json.put("variableNamesIgnoreCase", true);
-
+    
     given()
     .contentType(POST_JSON_CONTENT_TYPE)
     .body(json)
@@ -1805,7 +1805,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     .statusCode(Status.OK.getStatusCode())
     .when()
     .post(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
-
+    
     verify(mockedQuery).matchVariableNamesIgnoreCase();
     verify(mockedQuery).variableValueNotEquals("varName", "varValue");
   }

--- a/engine/src/main/java/org/camunda/bpm/engine/history/HistoricProcessInstanceQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/history/HistoricProcessInstanceQuery.java
@@ -55,6 +55,11 @@ public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInsta
   HistoricProcessInstanceQuery processInstanceIdNotIn(String... processInstanceIdNotIn);
 
   /**
+   * Only select historic process instances for the given root process instance id
+   */
+  HistoricProcessInstanceQuery rootProcessInstanceId(String rootProcessInstanceId);
+
+  /**
    * Only select historic process instances for the given process definition
    */
   HistoricProcessInstanceQuery processDefinitionId(String processDefinitionId);

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -55,6 +55,7 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
 
   private static final long serialVersionUID = 1L;
   protected String processInstanceId;
+  protected String rootProcessInstanceId;
   protected String processDefinitionId;
   protected String processDefinitionName;
   protected String processDefinitionNameLike;
@@ -128,6 +129,12 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
     return this;
   }
 
+  public HistoricProcessInstanceQuery rootProcessInstanceId(String rootProcessInstanceId) {
+    ensureNotNull("Root process instance id", rootProcessInstanceId);
+    this.rootProcessInstanceId = rootProcessInstanceId;
+    return this;
+  }
+
   public HistoricProcessInstanceQueryImpl processDefinitionId(String processDefinitionId) {
     this.processDefinitionId = processDefinitionId;
     return this;
@@ -189,7 +196,7 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
     this.withRootIncidents = true;
     return this;
   }
-  
+
   public HistoricProcessInstanceQuery incidentIdIn(String... incidentIds) {
     ensureNotNull("incidentIds", (Object[]) incidentIds);
     this.incidentIds = incidentIds;
@@ -569,6 +576,10 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
 
   public String getProcessInstanceId() {
     return processInstanceId;
+  }
+
+  public String getRootProcessInstanceId() {
+    return rootProcessInstanceId;
   }
 
   public Set<String> getProcessInstanceIds() {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessInstanceQueryImpl.java
@@ -48,6 +48,7 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
 
   private static final long serialVersionUID = 1L;
   protected String processInstanceId;
+  protected String rootProcessInstanceId;
   protected String businessKey;
   protected String businessKeyLike;
   protected String processDefinitionId;
@@ -89,6 +90,12 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
   public ProcessInstanceQueryImpl processInstanceId(String processInstanceId) {
     ensureNotNull("Process instance id", processInstanceId);
     this.processInstanceId = processInstanceId;
+    return this;
+  }
+
+  public ProcessInstanceQueryImpl rootProcessInstanceId(String rootProcessInstanceId) {
+    ensureNotNull("Root process instance id", rootProcessInstanceId);
+    this.rootProcessInstanceId = rootProcessInstanceId;
     return this;
   }
 
@@ -368,6 +375,10 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
 
   public String getProcessInstanceId() {
     return processInstanceId;
+  }
+
+  public String getRootProcessInstanceId() {
+    return rootProcessInstanceId;
   }
 
   public Set<String> getProcessInstanceIds() {

--- a/engine/src/main/java/org/camunda/bpm/engine/runtime/ProcessInstanceQuery.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/runtime/ProcessInstanceQuery.java
@@ -43,6 +43,11 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
   ProcessInstanceQuery processInstanceIds(Set<String> processInstanceIds);
 
   /**
+   * Select process instances for the given root process instance id
+   */
+  ProcessInstanceQuery rootProcessInstanceId(String rootProcessInstanceId);
+
+  /**
    * Select process instances with the given business key
    */
   ProcessInstanceQuery processInstanceBusinessKey(String processInstanceBusinessKey);

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Execution.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Execution.xml
@@ -17,8 +17,8 @@
     limitations under the License.
 
 -->
-<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd"> 
+  
 <mapper namespace="org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity">
 
   <!-- EXECUTION INSERT -->
@@ -75,7 +75,7 @@
   </insert>
 
   <!-- EXECUTION UPDATE -->
-
+  
   <update id="updateExecution" parameterType="org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity">
     update ${prefix}ACT_RU_EXECUTION set
       REV_ = #{revisionNext, jdbcType=INTEGER},
@@ -97,7 +97,7 @@
     where ID_ = #{id, jdbcType=VARCHAR}
       and REV_ = #{revision, jdbcType=INTEGER}
   </update>
-
+  
   <update id="updateExecutionSuspensionStateByParameters" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject">
     update ${prefix}ACT_RU_EXECUTION set
       REV_ = 1 + REV_ ,
@@ -111,7 +111,7 @@
       </if>
       <if test="parameter.processDefinitionKey != null">
         and PROC_DEF_ID_ IN (
-        SELECT ID_
+          SELECT ID_ 
           FROM ${prefix}ACT_RE_PROCDEF PD
           WHERE PD.KEY_ = #{parameter.processDefinitionKey, jdbcType=VARCHAR}
           <if test="parameter.isTenantIdSet">
@@ -160,23 +160,23 @@
     <result property="tenantId" column="TENANT_ID_" jdbcType="VARCHAR"/>
     <result property="processDefinitionKey" column="PROC_DEF_KEY_" jdbcType="VARCHAR"/>  
   </resultMap>
-
+  
   <resultMap type="org.camunda.bpm.engine.impl.util.ImmutablePair" id="deploymentIdMapping">
     <id property="left" column="DEPLOYMENT_ID_" jdbcType="VARCHAR" />
     <id property="right" column="ID_" jdbcType="VARCHAR" />
   </resultMap>
-
+  
   <!-- EXECUTION SELECT -->
-
+  
   <select id="selectExecution" parameterType="string" resultMap="executionResultMap">
     select * from ${prefix}ACT_RU_EXECUTION where ID_ = #{id}
   </select>
-
+  
   <select id="selectExecutionsByParentExecutionId" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject" resultMap="executionResultMap">
     select * from ${prefix}ACT_RU_EXECUTION
     where PARENT_ID_ = #{parameter}
   </select>
-
+  
   <select id="selectExecutionsByProcessInstanceId" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject" resultMap="executionResultMap">
     select * from ${prefix}ACT_RU_EXECUTION
     where PROC_INST_ID_ = #{parameter}
@@ -187,7 +187,7 @@
     from ${prefix}ACT_RU_EXECUTION
     where PROC_DEF_ID_ = #{parameter} and PARENT_ID_ is null
   </select>
-
+  
   <select id="selectExecutionsByQueryCriteria" parameterType="org.camunda.bpm.engine.impl.ExecutionQueryImpl" resultMap="executionResultMap">
   	<include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.bindOrderBy"/>
     ${limitBefore}
@@ -198,13 +198,13 @@
     ${orderBy}
     ${limitAfter}
   </select>
-
+  
   <select id="selectExecutionCountByQueryCriteria" parameterType="org.camunda.bpm.engine.impl.ExecutionQueryImpl" resultType="long">
     ${countDistinctBeforeStart} RES.ID_ ${countDistinctBeforeEnd}
     <include refid="selectExecutionsByQueryCriteriaSql"/>
     ${countDistinctAfterEnd}
   </select>
-
+  
   <select id="selectProcessInstanceByQueryCriteria" parameterType="org.camunda.bpm.engine.impl.ProcessInstanceQueryImpl" resultMap="executionResultMap">
   	<include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.bindOrderBy"/>
     ${limitBefore}
@@ -215,7 +215,7 @@
     ${orderBy}
     ${limitAfter}
   </select>
-
+  
   <select id="selectProcessInstanceCountByQueryCriteria" parameterType="org.camunda.bpm.engine.impl.ProcessInstanceQueryImpl" resultType="long">
     ${countDistinctBeforeStart} RES.ID_ ${countDistinctBeforeEnd}
     <include refid="selectProcessInstanceByQueryCriteriaSql"/>
@@ -226,7 +226,7 @@
     select distinct RES.ID_
     <include refid="selectProcessInstanceByQueryCriteriaSql"/>
   </select>
-
+  
   <select id="selectProcessInstanceDeploymentIdMappingsByQueryCriteria" parameterType="org.camunda.bpm.engine.impl.ProcessInstanceQueryImpl" resultMap="deploymentIdMapping">
     select distinct P.DEPLOYMENT_ID_, RES.ID_
     <include refid="selectProcessInstanceByQueryCriteriaSql"/>
@@ -262,7 +262,7 @@
     inner join ${prefix}ACT_RE_PROCDEF P on RES.PROC_DEF_ID_ = P.ID_
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
-      <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause"/>
+      <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" /> 
       AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.ID_ ${authJoinSeparator} P.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
     </if>
 
@@ -561,7 +561,7 @@
     <if test="resultType == 'LIST_PAGE'">
         ${limitBeforeNativeQuery}
     </if>
-    ${sql}
+    ${sql} 
     <if test="resultType == 'LIST_PAGE'">
       ${limitAfter}
     </if>
@@ -569,6 +569,6 @@
 
   <select id="selectExecutionCountByNativeQuery" parameterType="java.util.Map" resultType="long">
     ${sql}
-  </select>
-
+  </select>  
+  
 </mapper>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Execution.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Execution.xml
@@ -17,8 +17,8 @@
     limitations under the License.
 
 -->
-<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd"> 
-  
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
 <mapper namespace="org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity">
 
   <!-- EXECUTION INSERT -->
@@ -75,7 +75,7 @@
   </insert>
 
   <!-- EXECUTION UPDATE -->
-  
+
   <update id="updateExecution" parameterType="org.camunda.bpm.engine.impl.persistence.entity.ExecutionEntity">
     update ${prefix}ACT_RU_EXECUTION set
       REV_ = #{revisionNext, jdbcType=INTEGER},
@@ -97,7 +97,7 @@
     where ID_ = #{id, jdbcType=VARCHAR}
       and REV_ = #{revision, jdbcType=INTEGER}
   </update>
-  
+
   <update id="updateExecutionSuspensionStateByParameters" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject">
     update ${prefix}ACT_RU_EXECUTION set
       REV_ = 1 + REV_ ,
@@ -111,7 +111,7 @@
       </if>
       <if test="parameter.processDefinitionKey != null">
         and PROC_DEF_ID_ IN (
-          SELECT ID_ 
+        SELECT ID_
           FROM ${prefix}ACT_RE_PROCDEF PD
           WHERE PD.KEY_ = #{parameter.processDefinitionKey, jdbcType=VARCHAR}
           <if test="parameter.isTenantIdSet">
@@ -160,23 +160,23 @@
     <result property="tenantId" column="TENANT_ID_" jdbcType="VARCHAR"/>
     <result property="processDefinitionKey" column="PROC_DEF_KEY_" jdbcType="VARCHAR"/>  
   </resultMap>
-  
+
   <resultMap type="org.camunda.bpm.engine.impl.util.ImmutablePair" id="deploymentIdMapping">
     <id property="left" column="DEPLOYMENT_ID_" jdbcType="VARCHAR" />
     <id property="right" column="ID_" jdbcType="VARCHAR" />
   </resultMap>
-  
+
   <!-- EXECUTION SELECT -->
-  
+
   <select id="selectExecution" parameterType="string" resultMap="executionResultMap">
     select * from ${prefix}ACT_RU_EXECUTION where ID_ = #{id}
   </select>
-  
+
   <select id="selectExecutionsByParentExecutionId" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject" resultMap="executionResultMap">
     select * from ${prefix}ACT_RU_EXECUTION
     where PARENT_ID_ = #{parameter}
   </select>
-  
+
   <select id="selectExecutionsByProcessInstanceId" parameterType="org.camunda.bpm.engine.impl.db.ListQueryParameterObject" resultMap="executionResultMap">
     select * from ${prefix}ACT_RU_EXECUTION
     where PROC_INST_ID_ = #{parameter}
@@ -187,7 +187,7 @@
     from ${prefix}ACT_RU_EXECUTION
     where PROC_DEF_ID_ = #{parameter} and PARENT_ID_ is null
   </select>
-  
+
   <select id="selectExecutionsByQueryCriteria" parameterType="org.camunda.bpm.engine.impl.ExecutionQueryImpl" resultMap="executionResultMap">
   	<include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.bindOrderBy"/>
     ${limitBefore}
@@ -198,13 +198,13 @@
     ${orderBy}
     ${limitAfter}
   </select>
-  
+
   <select id="selectExecutionCountByQueryCriteria" parameterType="org.camunda.bpm.engine.impl.ExecutionQueryImpl" resultType="long">
     ${countDistinctBeforeStart} RES.ID_ ${countDistinctBeforeEnd}
     <include refid="selectExecutionsByQueryCriteriaSql"/>
     ${countDistinctAfterEnd}
   </select>
-  
+
   <select id="selectProcessInstanceByQueryCriteria" parameterType="org.camunda.bpm.engine.impl.ProcessInstanceQueryImpl" resultMap="executionResultMap">
   	<include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.bindOrderBy"/>
     ${limitBefore}
@@ -215,7 +215,7 @@
     ${orderBy}
     ${limitAfter}
   </select>
-  
+
   <select id="selectProcessInstanceCountByQueryCriteria" parameterType="org.camunda.bpm.engine.impl.ProcessInstanceQueryImpl" resultType="long">
     ${countDistinctBeforeStart} RES.ID_ ${countDistinctBeforeEnd}
     <include refid="selectProcessInstanceByQueryCriteriaSql"/>
@@ -226,7 +226,7 @@
     select distinct RES.ID_
     <include refid="selectProcessInstanceByQueryCriteriaSql"/>
   </select>
-  
+
   <select id="selectProcessInstanceDeploymentIdMappingsByQueryCriteria" parameterType="org.camunda.bpm.engine.impl.ProcessInstanceQueryImpl" resultMap="deploymentIdMapping">
     select distinct P.DEPLOYMENT_ID_, RES.ID_
     <include refid="selectProcessInstanceByQueryCriteriaSql"/>
@@ -262,7 +262,7 @@
     inner join ${prefix}ACT_RE_PROCDEF P on RES.PROC_DEF_ID_ = P.ID_
 
     <if test="authCheck.shouldPerformAuthorizatioCheck &amp;&amp; !authCheck.revokeAuthorizationCheckEnabled &amp;&amp; authCheck.authUserId != null">
-      <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause" /> 
+      <include refid="org.camunda.bpm.engine.impl.persistence.entity.AuthorizationEntity.authCheckJoinWithoutOnClause"/>
       AUTH ON (AUTH.RESOURCE_ID_ ${authJoinStart} RES.ID_ ${authJoinSeparator} P.KEY_ ${authJoinSeparator} '*' ${authJoinEnd})
     </if>
 
@@ -305,6 +305,9 @@
             </if>
             <if test="query.processInstanceId != null">
               ${queryType} RES.PROC_INST_ID_ = #{query.processInstanceId}
+            </if>
+            <if test="query.rootProcessInstanceId != null">
+              ${queryType} RES.ROOT_PROC_INST_ID_ = #{query.rootProcessInstanceId}
             </if>
             <if test="query.processInstanceIds != null and !query.processInstanceIds.isEmpty()">
               ${queryType}
@@ -558,7 +561,7 @@
     <if test="resultType == 'LIST_PAGE'">
         ${limitBeforeNativeQuery}
     </if>
-    ${sql} 
+    ${sql}
     <if test="resultType == 'LIST_PAGE'">
       ${limitAfter}
     </if>
@@ -566,6 +569,6 @@
 
   <select id="selectExecutionCountByNativeQuery" parameterType="java.util.Map" resultType="long">
     ${sql}
-  </select>  
-  
+  </select>
+
 </mapper>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
@@ -465,6 +465,9 @@
             <if test="query.processInstanceId != null">
               ${queryType} SELF.PROC_INST_ID_ = #{query.processInstanceId}
             </if>
+            <if test="query.rootProcessInstanceId != null">
+              ${queryType} SELF.ROOT_PROC_INST_ID_ = #{query.rootProcessInstanceId}
+            </if>
             <if test="query.processInstanceIds != null and !query.processInstanceIds.isEmpty()">
               ${queryType}
               <bind name="listOfIds" value="query.processInstanceIds" />

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -62,6 +62,7 @@ import org.camunda.bpm.engine.test.api.runtime.migration.models.ProcessModels;
 import org.camunda.bpm.engine.test.util.ProcessEngineTestRule;
 import org.camunda.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.junit.Assert;
 import org.junit.Before;
@@ -2225,6 +2226,45 @@ public class ProcessInstanceQueryTest {
     List<ProcessInstance> list = query.list();
     assertEquals(1, list.size());
     assertEquals(processInstanceId, list.get(0).getId());
+  }
+
+  @Test
+  public void testQueryByRootProcessInstanceId() {
+    // given a parent process instance with a couple of subprocesses
+    BpmnModelInstance baseProcess = Bpmn.createExecutableProcess("baseProcess")
+        .startEvent("startRoot")
+        .callActivity()
+        .calledElement("levelOneProcess")
+        .endEvent("endRoot")
+        .done();
+
+    BpmnModelInstance levelOneProcess = Bpmn.createExecutableProcess("levelOneProcess")
+        .startEvent("startLevelOne")
+        .callActivity()
+        .calledElement("levelTwoProcess")
+        .endEvent("endLevelOne")
+        .done();
+
+    BpmnModelInstance levelTwoProcess = Bpmn.createExecutableProcess("levelTwoProcess")
+        .startEvent("startLevelTwo")
+        .userTask("Task1")
+        .endEvent("endLevelTwo")
+        .done();
+
+    testHelper.deploy(baseProcess, levelOneProcess, levelTwoProcess);
+    String rootProcessId = runtimeService.startProcessInstanceByKey("baseProcess").getId();
+    List<ProcessInstance> allProcessInstances = runtimeService.createProcessInstanceQuery().list();
+
+    // when
+    ProcessInstanceQuery processInstanceQuery = runtimeService.createProcessInstanceQuery()
+        .rootProcessInstanceId(rootProcessId);
+
+    // then
+    assertEquals(3, allProcessInstances.stream()
+        .filter(process -> process.getRootProcessInstanceId().equals(rootProcessId))
+        .count());
+    assertEquals(3, processInstanceQuery.count());
+    assertEquals(3, processInstanceQuery.list().size());
   }
 
   @Test


### PR DESCRIPTION
For the /process-instance & history/process-instance APIs, Have implemented the root-process-instance filters to get the Process instances related to the provided root-process-instance.

Git Issue: https://github.com/camunda/camunda-bpm-platform/issues/2582