### PR TITLE
fix(engine): Print correct value of processDefinitionId in toString() for HistoricDetailVariableInstanceUpdateEntity and HistoricVariableUpdateEventEntity

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/history/event/HistoricVariableUpdateEventEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/history/event/HistoricVariableUpdateEventEntity.java
@@ -136,7 +136,7 @@ public class HistoricVariableUpdateEventEntity extends HistoricDetailEventEntity
            + ", eventType=" + eventType
            + ", executionId=" + executionId
            + ", id=" + id
-           + ", processDefinitionId=" + processInstanceId
+           + ", processDefinitionId=" + processDefinitionId
            + ", processInstanceId=" + processInstanceId
            + ", taskId=" + taskId
            + ", timestamp=" + timestamp

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricDetailVariableInstanceUpdateEntity.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/persistence/entity/HistoricDetailVariableInstanceUpdateEntity.java
@@ -144,7 +144,7 @@ public class HistoricDetailVariableInstanceUpdateEntity extends HistoricVariable
            + ", eventType=" + eventType
            + ", executionId=" + executionId
            + ", id=" + id
-           + ", processDefinitionId=" + processInstanceId
+           + ", processDefinitionId=" + processDefinitionId
            + ", processInstanceId=" + processInstanceId
            + ", taskId=" + taskId
            + ", timestamp=" + timestamp


### PR DESCRIPTION
Related to #4927