### PR TITLE
chore(deps): bump quarkus to 3.20.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -18,7 +18,7 @@
   </description>
 
   <properties>
-    <version.quarkus> 3.19.2</version.quarkus>
+    <version.quarkus>3.20.0.CR1</version.quarkus>
     <version.spring.framework>5.3.39</version.spring.framework>
     <version.spring.framework6>6.2.4</version.spring.framework6>
     <version.spring-boot>3.4.3</version.spring-boot>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -18,7 +18,7 @@
   </description>
 
   <properties>
-    <version.quarkus>3.20.0.CR1</version.quarkus>
+    <version.quarkus>3.20.0</version.quarkus>
     <version.spring.framework>5.3.39</version.spring.framework>
     <version.spring.framework6>6.2.4</version.spring.framework6>
     <version.spring-boot>3.4.3</version.spring-boot>


### PR DESCRIPTION
related to #4870

License check for 3.20 done [here](https://docs.google.com/spreadsheets/d/1EDSQm4OMJWiYg9hmHZmsCq0dWTy8SpGYSolWnozjagQ/edit?gid=1870671348#gid=1870671348)
- except for`jna`, none of the licenses changed
- for `jna`, one of jna's licenses is on the Go list 