### PR TITLE
🔧(feat): add filter to isolate job executor between Blue and Green env

### DIFF
--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
@@ -211,6 +211,10 @@
         )
       </if>
 
+      <if test="parameter.tenantId != null or parameter.tenantId != empty">
+          and RES.TENANT_ID_ = #{parameter.tenantId}
+      </if>
+
       <if test="parameter.jobPriorityMin != null">
         and RES.PRIORITY_ &gt;= #{parameter.jobPriorityMin}
       </if>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
@@ -181,6 +181,7 @@
     ${limitBefore}
     select RES.ID_,
       RES.REV_,
+      RES.TENANT_ID_,
       RES.DUEDATE_,
     <if test="parameter.applyExclusiveOverProcessHierarchies">
       RES.ROOT_PROC_INST_ID_,

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Job.xml
@@ -212,7 +212,7 @@
         )
       </if>
 
-      <if test="parameter.tenantId != null or parameter.tenantId != empty">
+      <if test="parameter.tenantId != null">
           and RES.TENANT_ID_ = #{parameter.tenantId}
       </if>
 


### PR DESCRIPTION
- Implemented a filter to ensure that the job executor of one environment does not retrieve jobs from the other.  
- When the Blue environment is active, the job executor ignores jobs from the Green environment.  
- When the Green environment is active, the job executor ignores jobs from the Blue environment.  
- Used `tenantId` as a unique identifier to validate and enforce the restriction.

Related to: https://github.com/camunda/camunda-bpm-platform/issues/5051