### PR TITLE
fix(xtac): initialize url resolver with null base url

### DIFF
--- a/clients/java/client/src/main/java/org/camunda/bpm/client/impl/ExternalTaskClientBuilderImpl.java
+++ b/clients/java/client/src/main/java/org/camunda/bpm/client/impl/ExternalTaskClientBuilderImpl.java
@@ -107,6 +107,7 @@ public class ExternalTaskClientBuilderImpl implements ExternalTaskClientBuilder 
     this.backoffStrategy = new ExponentialBackoffStrategy();
     this.isBackoffStrategyDisabled = false;
     this.httpClientBuilder = HttpClients.custom().useSystemProperties();
+    this.urlResolver = new PermanentUrlResolver(null);
   }
 
   public ExternalTaskClientBuilder baseUrl(String baseUrl) {

--- a/clients/java/client/src/test/java/org/camunda/bpm/client/impl/ExternalTaskClientBuilderImplTest.java
+++ b/clients/java/client/src/test/java/org/camunda/bpm/client/impl/ExternalTaskClientBuilderImplTest.java
@@ -17,6 +17,7 @@
 package org.camunda.bpm.client.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -24,7 +25,9 @@ import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.util.Timeout;
 import org.camunda.bpm.client.ExternalTaskClient;
+import org.camunda.bpm.client.ExternalTaskClientBuilder;
 import org.camunda.bpm.client.UrlResolver;
+import org.camunda.bpm.client.exception.ExternalTaskClientException;
 import org.camunda.bpm.engine.impl.util.ReflectUtil;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -89,6 +92,19 @@ public class ExternalTaskClientBuilderImplTest {
     public String getBaseUrl() {
       return baseUrl;
     }
+  }
+
+  @Test
+  public void testWithNullBaseUrl() {
+    // given
+    ExternalTaskClientBuilderImpl builder = new ExternalTaskClientBuilderImpl();
+
+    // when building with null base url then exception is thrown
+    assertThat(builder.getBaseUrl()).isNull();
+    assertThatThrownBy(builder::build)
+        .isInstanceOf(ExternalTaskClientException.class)
+        .hasMessageContaining("Base URL cannot be null or an empty string");
+
   }
 
 }

--- a/clients/java/client/src/test/java/org/camunda/bpm/client/impl/ExternalTaskClientBuilderImplTest.java
+++ b/clients/java/client/src/test/java/org/camunda/bpm/client/impl/ExternalTaskClientBuilderImplTest.java
@@ -17,7 +17,6 @@
 package org.camunda.bpm.client.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -25,9 +24,7 @@ import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.util.Timeout;
 import org.camunda.bpm.client.ExternalTaskClient;
-import org.camunda.bpm.client.ExternalTaskClientBuilder;
 import org.camunda.bpm.client.UrlResolver;
-import org.camunda.bpm.client.exception.ExternalTaskClientException;
 import org.camunda.bpm.engine.impl.util.ReflectUtil;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -95,16 +92,13 @@ public class ExternalTaskClientBuilderImplTest {
   }
 
   @Test
-  public void testWithNullBaseUrl() {
-    // given
+  public void testBuilderWithUnsetBaseUrl() {
+    // given unbuilt builder
     ExternalTaskClientBuilderImpl builder = new ExternalTaskClientBuilderImpl();
 
-    // when building with null base url then exception is thrown
+    // when getting base url and url resolver, then they are correctly initialized
     assertThat(builder.getBaseUrl()).isNull();
-    assertThatThrownBy(builder::build)
-        .isInstanceOf(ExternalTaskClientException.class)
-        .hasMessageContaining("Base URL cannot be null or an empty string");
-
+    assertThat(builder.urlResolver).isNotNull();
   }
 
 }


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/5112