### PR TITLE
chore(deps): bump `json-smart` to 2.5.2

### DIFF
--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -375,6 +375,18 @@
         <artifactId>mssqlserver</artifactId>
         <version>${version.testcontainers}</version>
       </dependency>
+
+      <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart</artifactId>
+        <version>${version.json-smart}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.jayway.jsonpath</groupId>
+        <artifactId>json-path</artifactId>
+        <version>${version.json-path}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -31,7 +31,7 @@
     <version.icu.icu4j>71.1</version.icu.icu4j>
     <!-- json-smart and accessors-smart are runtime dependencies of json-path -->
     <version.json-path>2.9.0</version.json-path>
-    <version.json-smart>2.5.0</version.json-smart>
+    <version.json-smart>2.5.2</version.json-smart>
     <version.accessors-smart>2.5.0</version.accessors-smart>
     <version.gson>2.8.9</version.gson>
     <version.openjpa>2.4.3</version.openjpa>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -32,7 +32,7 @@
     <!-- json-smart and accessors-smart are runtime dependencies of json-path -->
     <version.json-path>2.9.0</version.json-path>
     <version.json-smart>2.5.2</version.json-smart>
-    <version.accessors-smart>2.5.0</version.accessors-smart>
+    <version.accessors-smart>2.5.2</version.accessors-smart>
     <version.gson>2.8.9</version.gson>
     <version.openjpa>2.4.3</version.openjpa>
     <version.hibernate>5.6.5.Final</version.hibernate>

--- a/spin/pom.xml
+++ b/spin/pom.xml
@@ -112,6 +112,12 @@
       </dependency>
 
       <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart</artifactId>
+        <version>${version.json-smart}</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.jayway.jsonpath</groupId>
         <artifactId>json-path</artifactId>
         <version>${version.json-path}</version>


### PR DESCRIPTION
related to camunda/camunda-bpm-platform#5119