### PR TITLE
fix(git): update templates to remove tasklists

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,9 +36,11 @@ assignees:
 - [ ] Step X
 -->
 
-```[tasklist]
 ### Pull Requests
-```
+
+<!--
+- PR links here
+-->
 
 ### Dev2QA handover
 - [ ] Does this ticket need a QA test and the testing goals are not clear from the description? Add a [Dev2QA handover comment](https://confluence.camunda.com/display/AP/Handover+Dev+-%3E+Testing)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -30,9 +30,11 @@ assignees: ''
 - [ ] Step X
 -->
 
-```[tasklist]
 ### Pull Requests
-```
+
+<!--
+- PR links here
+-->
 
 ### Dev2QA handover
 - [ ] Does this ticket need a QA test and the testing goals are not clear from the description? Add a [Dev2QA handover comment](https://confluence.camunda.com/display/AP/Handover+Dev+-%3E+Testing)

--- a/.github/ISSUE_TEMPLATE/subtask.md
+++ b/.github/ISSUE_TEMPLATE/subtask.md
@@ -24,6 +24,8 @@ assignees: ''
 - [ ] Step X
 -->
 
-```[tasklist]
 ### Pull Requests
-```
+
+<!--
+- PR links here
+-->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -24,9 +24,11 @@ assignees: ''
 - [ ] Step X
 -->
 
-```[tasklist]
 ### Pull Requests
-```
+
+<!--
+- PR links here
+-->
 
 ### Dev2QA handover
 - [ ] Does this ticket need a QA test and the testing goals are not clear from the description? Add a [Dev2QA handover comment](https://confluence.camunda.com/display/AP/Handover+Dev+-%3E+Testing)


### PR DESCRIPTION
Related to https://github.com/camunda/team-automation-platform/issues/344

Removes deprecated tasklists from git issue templates