### PR TITLE
chore(spring-boot/rest): expose `FetchAndLockHandler` configurations

### DIFF
--- a/spring-boot-starter/starter-rest/pom.xml
+++ b/spring-boot-starter/starter-rest/pom.xml
@@ -14,7 +14,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.camunda.bpm.springboot</groupId>
       <artifactId>camunda-bpm-spring-boot-starter</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/spring-boot-starter/starter-rest/src/main/java/org/camunda/bpm/spring/boot/starter/rest/CamundaBpmRestInitializer.java
+++ b/spring-boot-starter/starter-rest/src/main/java/org/camunda/bpm/spring/boot/starter/rest/CamundaBpmRestInitializer.java
@@ -18,6 +18,7 @@ package org.camunda.bpm.spring.boot.starter.rest;
 
 import org.camunda.bpm.engine.rest.filter.CacheControlFilter;
 import org.camunda.bpm.engine.rest.filter.EmptyBodyFilter;
+import org.camunda.bpm.spring.boot.starter.property.CamundaBpmProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.web.servlet.JerseyApplicationPath;
@@ -27,7 +28,7 @@ import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterRegistration;
 import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletException;
+
 import java.util.EnumSet;
 import java.util.Map;
 
@@ -46,13 +47,18 @@ public class CamundaBpmRestInitializer implements ServletContextInitializer {
 
   private JerseyApplicationPath applicationPath;
 
-  public CamundaBpmRestInitializer(JerseyApplicationPath applicationPath) {
+  private final CamundaBpmProperties properties;
+
+  public CamundaBpmRestInitializer(JerseyApplicationPath applicationPath, CamundaBpmProperties properties) {
     this.applicationPath = applicationPath;
+    this.properties = properties;
   }
 
   @Override
-  public void onStartup(ServletContext servletContext) throws ServletException {
+  public void onStartup(ServletContext servletContext) {
     this.servletContext = servletContext;
+
+    properties.getRestApi().getFetchAndLock().getInitParams().forEach(servletContext::setInitParameter);
 
     String restApiPathPattern = applicationPath.getUrlMapping();
 
@@ -81,4 +87,5 @@ public class CamundaBpmRestInitializer implements ServletContextInitializer {
 
     return filterRegistration;
   }
+
 }

--- a/spring-boot-starter/starter-rest/src/main/java/org/camunda/bpm/spring/boot/starter/rest/CamundaBpmRestJerseyAutoConfiguration.java
+++ b/spring-boot-starter/starter-rest/src/main/java/org/camunda/bpm/spring/boot/starter/rest/CamundaBpmRestJerseyAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.camunda.bpm.spring.boot.starter.rest;
 
 import org.camunda.bpm.engine.rest.impl.FetchAndLockContextListener;
 import org.camunda.bpm.spring.boot.starter.CamundaBpmAutoConfiguration;
+import org.camunda.bpm.spring.boot.starter.property.CamundaBpmProperties;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -41,7 +42,7 @@ public class CamundaBpmRestJerseyAutoConfiguration {
   }
 
   @Bean
-  public CamundaBpmRestInitializer camundaBpmRestInitializer(JerseyApplicationPath applicationPath) {
-    return new CamundaBpmRestInitializer(applicationPath);
+  public CamundaBpmRestInitializer camundaBpmRestInitializer(JerseyApplicationPath applicationPath, CamundaBpmProperties props) {
+    return new CamundaBpmRestInitializer(applicationPath, props);
   }
 }

--- a/spring-boot-starter/starter-rest/src/test/java/org/camunda/bpm/spring/boot/starter/rest/config/fetchandlock/FetchAndLockHandlerConfigureQueueCapacityIT.java
+++ b/spring-boot-starter/starter-rest/src/test/java/org/camunda/bpm/spring/boot/starter/rest/config/fetchandlock/FetchAndLockHandlerConfigureQueueCapacityIT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.rest.config.fetchandlock;
+
+import jakarta.servlet.ServletContext;
+import org.camunda.bpm.spring.boot.starter.rest.test.TestRestApplication;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { TestRestApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {"camunda.bpm.rest-api.fetch-and-lock.queue-capacity=333"})
+public class FetchAndLockHandlerConfigureQueueCapacityIT {
+
+    @Autowired
+    protected ServletContext servletContext;
+
+    @Test
+    public void shouldReturnConfiguredQueueCapacity() {
+        // when
+        String queueCapacity = servletContext.getInitParameter("fetch-and-lock-queue-capacity");
+
+        // then
+        assertThat(queueCapacity).isEqualTo("333");
+    }
+}

--- a/spring-boot-starter/starter-rest/src/test/java/org/camunda/bpm/spring/boot/starter/rest/config/fetchandlock/FetchAndLockHandlerConfigureUniqueWorkerRequestFalseIT.java
+++ b/spring-boot-starter/starter-rest/src/test/java/org/camunda/bpm/spring/boot/starter/rest/config/fetchandlock/FetchAndLockHandlerConfigureUniqueWorkerRequestFalseIT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.rest.config.fetchandlock;
+
+import jakarta.servlet.ServletContext;
+import org.camunda.bpm.spring.boot.starter.rest.test.TestRestApplication;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { TestRestApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {"camunda.bpm.rest-api.fetch-and-lock.unique-worker-request=false"})
+public class FetchAndLockHandlerConfigureUniqueWorkerRequestFalseIT {
+
+    @Autowired
+    protected ServletContext servletContext;
+
+    @Test
+    public void shouldReturnConfiguredUniqueWorkerRequest() {
+        // when
+        String uniqueWorkerRequest = servletContext.getInitParameter("fetch-and-lock-unique-worker-request");
+
+        // then
+        assertThat(uniqueWorkerRequest).isNull();
+    }
+
+}

--- a/spring-boot-starter/starter-rest/src/test/java/org/camunda/bpm/spring/boot/starter/rest/config/fetchandlock/FetchAndLockHandlerConfigureUniqueWorkerRequestTrueIT.java
+++ b/spring-boot-starter/starter-rest/src/test/java/org/camunda/bpm/spring/boot/starter/rest/config/fetchandlock/FetchAndLockHandlerConfigureUniqueWorkerRequestTrueIT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.rest.config.fetchandlock;
+
+import jakarta.servlet.ServletContext;
+import org.camunda.bpm.spring.boot.starter.rest.test.TestRestApplication;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { TestRestApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {"camunda.bpm.rest-api.fetch-and-lock.unique-worker-request=true"})
+public class FetchAndLockHandlerConfigureUniqueWorkerRequestTrueIT {
+
+    @Autowired
+    protected ServletContext servletContext;
+
+    @Test
+    public void shouldReturnConfiguredUniqueWorkerRequest() {
+        // when
+        String uniqueWorkerRequest = servletContext.getInitParameter("fetch-and-lock-unique-worker-request");
+
+        // then
+        assertThat(uniqueWorkerRequest).isEqualTo("true");
+    }
+
+}

--- a/spring-boot-starter/starter-rest/src/test/java/org/camunda/bpm/spring/boot/starter/rest/config/fetchandlock/FetchAndLockHandlerDefaultConfigIT.java
+++ b/spring-boot-starter/starter-rest/src/test/java/org/camunda/bpm/spring/boot/starter/rest/config/fetchandlock/FetchAndLockHandlerDefaultConfigIT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.rest.config.fetchandlock;
+
+import jakarta.servlet.ServletContext;
+import org.camunda.bpm.spring.boot.starter.rest.test.TestRestApplication;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { TestRestApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class FetchAndLockHandlerDefaultConfigIT {
+
+    @Autowired
+    protected ServletContext servletContext;
+
+    @Test
+    public void shouldReturnDefaultValues() {
+        // when
+        String queueCapacity = servletContext.getInitParameter("fetch-and-lock-queue-capacity");
+        String uniqueWorkerRequest = servletContext.getInitParameter("fetch-and-lock-unique-worker-request");
+
+        // then
+        assertThat(queueCapacity).isNull();
+        assertThat(uniqueWorkerRequest).isNull();
+    }
+
+}

--- a/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/CamundaBpmProperties.java
+++ b/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/CamundaBpmProperties.java
@@ -141,6 +141,12 @@ public class CamundaBpmProperties {
   @NestedConfigurationProperty
   private WebappProperty webapp = new WebappProperty();
 
+  /**
+   * REST API configuration
+   */
+  @NestedConfigurationProperty
+  private RestApiProperty restApi = new RestApiProperty();
+
   @NestedConfigurationProperty
   private AuthorizationProperty authorization = new AuthorizationProperty();
 
@@ -249,6 +255,14 @@ public class CamundaBpmProperties {
     this.webapp = webapp;
   }
 
+  public RestApiProperty getRestApi() {
+    return restApi;
+  }
+
+  public void setRestApi(RestApiProperty restApi) {
+    this.restApi = restApi;
+  }
+
   public AuthorizationProperty getAuthorization() {
     return authorization;
   }
@@ -346,6 +360,7 @@ public class CamundaBpmProperties {
       .add("database=" + database)
       .add("jobExecution=" + jobExecution)
       .add("webapp=" + webapp)
+      .add("restApi=" + restApi)
       .add("authorization=" + authorization)
       .add("genericProperties=" + genericProperties)
       .add("adminUser=" + adminUser)

--- a/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/FetchAndLockProperties.java
+++ b/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/FetchAndLockProperties.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.property;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringJoiner;
+
+import static org.camunda.bpm.spring.boot.starter.property.CamundaBpmProperties.joinOn;
+
+public class FetchAndLockProperties {
+
+  protected boolean uniqueWorkerRequest = false;
+  protected Integer queueCapacity = 200;
+
+  public Map<String, String> getInitParams() {
+    Map<String, String> initParams = new HashMap<>();
+
+    if (uniqueWorkerRequest) { // default is false
+      initParams.put("fetch-and-lock-unique-worker-request", String.valueOf(true));
+    }
+
+    if (queueCapacity != 200) {
+      initParams.put("fetch-and-lock-queue-capacity", Integer.toString(queueCapacity));
+    }
+
+    return initParams;
+  }
+
+
+  public boolean isUniqueWorkerRequest() {
+    return uniqueWorkerRequest;
+  }
+
+  public void setUniqueWorkerRequest(boolean uniqueWorkerRequest) {
+    this.uniqueWorkerRequest = uniqueWorkerRequest;
+  }
+
+  public Integer getQueueCapacity() {
+    return queueCapacity;
+  }
+
+  public void setQueueCapacity(Integer queueCapacity) {
+    this.queueCapacity = queueCapacity;
+  }
+
+  @Override
+  public String toString() {
+    StringJoiner joinedString = joinOn(this.getClass())
+
+            .add("uniqueWorkerRequest=" + uniqueWorkerRequest)
+            .add("queueCapacity=" + queueCapacity);
+
+    return joinedString.toString();
+  }
+
+}

--- a/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/RestApiProperty.java
+++ b/spring-boot-starter/starter/src/main/java/org/camunda/bpm/spring/boot/starter/property/RestApiProperty.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.property;
+
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+import static org.camunda.bpm.spring.boot.starter.property.CamundaBpmProperties.joinOn;
+
+public class RestApiProperty {
+
+  @NestedConfigurationProperty
+  protected FetchAndLockProperties fetchAndLock = new FetchAndLockProperties();
+
+  public FetchAndLockProperties getFetchAndLock() {
+    return fetchAndLock;
+  }
+
+  public void setFetchAndLock(FetchAndLockProperties fetchAndLock) {
+    this.fetchAndLock = fetchAndLock;
+  }
+
+  @Override
+  public String toString() {
+    return joinOn(this.getClass())
+      .add("fetchAndLock='" + fetchAndLock + '\'')
+      .toString();
+  }
+
+}

--- a/spring-boot-starter/starter/src/test/java/org/camunda/bpm/spring/boot/starter/property/ParsePropertiesHelper.java
+++ b/spring-boot-starter/starter/src/test/java/org/camunda/bpm/spring/boot/starter/property/ParsePropertiesHelper.java
@@ -37,12 +37,14 @@ public abstract class ParsePropertiesHelper {
 
   protected MetricsProperty metrics;
   protected WebappProperty webapp;
+  protected RestApiProperty restApiProperty;
   protected JobExecutionProperty jobExecution;
 
   @PostConstruct
   public void init() {
     metrics = properties.getMetrics();
     webapp = properties.getWebapp();
+    restApiProperty = properties.getRestApi();
     jobExecution = properties.getJobExecution();
   }
 }

--- a/spring-boot-starter/starter/src/test/java/org/camunda/bpm/spring/boot/starter/property/RestApiPropertyDefaultsTest.java
+++ b/spring-boot-starter/starter/src/test/java/org/camunda/bpm/spring/boot/starter/property/RestApiPropertyDefaultsTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.property;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RestApiPropertyDefaultsTest extends ParsePropertiesHelper {
+
+  @Test
+  public void shouldConfigureFetchAndLockProperties() {
+    // then
+    assertThat(restApiProperty.getFetchAndLock().isUniqueWorkerRequest()).isFalse();
+    assertThat(restApiProperty.getFetchAndLock().getQueueCapacity()).isEqualTo(200);
+  }
+
+}

--- a/spring-boot-starter/starter/src/test/java/org/camunda/bpm/spring/boot/starter/property/RestApiPropertyTest.java
+++ b/spring-boot-starter/starter/src/test/java/org/camunda/bpm/spring/boot/starter/property/RestApiPropertyTest.java
@@ -19,8 +19,6 @@ package org.camunda.bpm.spring.boot.starter.property;
 import org.junit.Test;
 import org.springframework.test.context.TestPropertySource;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 

--- a/spring-boot-starter/starter/src/test/java/org/camunda/bpm/spring/boot/starter/property/RestApiPropertyTest.java
+++ b/spring-boot-starter/starter/src/test/java/org/camunda/bpm/spring/boot/starter/property/RestApiPropertyTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.spring.boot.starter.property;
+
+import org.junit.Test;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@TestPropertySource(properties = {
+        "camunda.bpm.rest-api.fetch-and-lock.unique-worker-request=true",
+        "camunda.bpm.rest-api.fetch-and-lock.queue-capacity=333"
+})
+public class RestApiPropertyTest extends ParsePropertiesHelper {
+
+  @Test
+  public void shouldConfigureFetchAndLockProperties() {
+    // then
+    assertThat(restApiProperty.getFetchAndLock().isUniqueWorkerRequest()).isTrue();
+    assertThat(restApiProperty.getFetchAndLock().getQueueCapacity()).isEqualTo(333);
+  }
+
+}


### PR DESCRIPTION
Exposes the following configurations:
* `camunda.bpm.rest-api.fetch-and-lock.queue-capacity`
* `camunda.bpm.rest-api.fetch-and-lock.unique-worker-request`

related to camunda/camunda-bpm-platform#5140