### PR TITLE
add missing properties createTime and extensionProperties to OpenAPI

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/utils.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/utils.ftl
@@ -128,7 +128,11 @@
 
         <#if additionalProperties>
           "additionalProperties": {
-            "$ref": "#/components/schemas/${dto}"
+            <#if dto="">
+              "type": "${itemType}"
+            <#else>
+              "$ref": "#/components/schemas/${dto}"
+            </#if>
           },
         </#if>
 

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/LockedExternalTaskDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/camunda/bpm/engine/rest/dto/runtime/externaltask/LockedExternalTaskDto.ftl
@@ -102,9 +102,22 @@
       type = "object"
       dto = "VariableValueDto"
       additionalProperties = true
-      last = true
       desc = "A JSON object containing a property for each of the requested variables. The key is the variable name,
               the value is a JSON object of serialized variable values with the following properties:" />
+
+  <@lib.property
+      name = "extensionProperties"
+      type = "object"
+      additionalProperties = true
+      desc = "A JSON object containing a property for each extension property. The key is the property name,
+              the value is the property value" />
+
+  <@lib.property
+      name = "createTime"
+      type = "string"
+      format = "date-time"
+      desc = "The date that the task was created."
+      last = true />
 
 </@lib.dto>
 

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/fetchAndLock/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/fetchAndLock/post.ftl
@@ -136,6 +136,9 @@
                                "value": "3456",
                                "valueInfo": {}
                              }
+                           },
+                           "extensionProperties": {
+                             "key": "value"
                            }
                          }
                        ]


### PR DESCRIPTION
Adding properties createTime and extensionProperties to the OpenAPI specification for LockedExternalTask. 
Generator needs to be adjusted to allow string type in the additionalProperties section.