### PR TITLE
chore: switch to Sonatype Central Portal deployment

### DIFF
--- a/.ci/daily/Jenkinsfile
+++ b/.ci/daily/Jenkinsfile
@@ -168,7 +168,7 @@ pipeline {
                   jdkVersion: 'jdk-17-latest',
                   withPodSpec: true)
                 script {
-                  str = 's@:camunda-nexus:.*\\\$@:central:https://oss.sonatype.org/content/repositories/snapshots@g'
+                  str = 's@:camunda-nexus:.*\\\$@:central:https://central.sonatype.com/repository/maven-snapshots/@g'
                   sh(label: 'Change staging from Nexus to Maven Central snapshots', script: 'sed -i ' + str + ' staging/deferred/.index')
                 }
                

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-bpm-release-parent</artifactId>
-    <version>2.3.0</version>
+    <version>2.5.0</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath />
   </parent>
@@ -262,7 +262,7 @@
     </profile>
 
     <profile>
-      <id>sonatype-oss-release</id>
+      <id>central-sonatype-publish</id>
       <modules>
         <module>spring-boot-starter</module>
         <module>quarkus-extension</module>

--- a/test-utils/assert/pom.xml
+++ b/test-utils/assert/pom.xml
@@ -57,7 +57,7 @@
     </profile>
 
     <profile>
-      <id>sonatype-oss-release</id>
+      <id>central-sonatype-publish</id>
       <modules>
         <module>core</module>
       </modules>

--- a/webapps/assembly-jakarta/pom.xml
+++ b/webapps/assembly-jakarta/pom.xml
@@ -445,7 +445,7 @@
 
   <profiles>
     <profile>
-      <id>sonatype-oss-release</id>
+      <id>central-sonatype-publish</id>
       <properties>
         <!-- skip building the frontend-sources zip artifact
         when releasing the community edition (alpha/minor releases) -->

--- a/webapps/assembly/pom.xml
+++ b/webapps/assembly/pom.xml
@@ -188,7 +188,7 @@
 
   <profiles>
     <profile>
-      <id>sonatype-oss-release</id>
+      <id>central-sonatype-publish</id>
       <properties>
         <!-- skip building the frontend-sources zip artifact
         when releasing the community edition (alpha/minor releases) -->


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/833.

This PR upgrades the `camunda-bpm-release-parent` POM to version 2.5.0 and switches to the new `central-sonatype-publish` profile. This is part of our [migration](https://github.com/camunda/camunda-release-parent/blob/infra-833-prepare-migration/README.md) to the new Sonatype Central Portal.

Sonatype is deprecating the legacy OSSRH Staging API, and the migration affects all Camunda namespaces (io.camunda, org.camunda). Publishing via OSSRH will no longer be possible once the namespaces are migrated.

To ensure a smooth transition for the monorepo, I have surfaced changes in terms of plugin execution, and test deployment of an (empty) test submodule to a test namespace.

<details>
  <summary>TEST Submodule POM</summary>

```xml

<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

  <modelVersion>4.0.0</modelVersion>

  <parent>
    <groupId>org.camunda.bpm</groupId>
    <artifactId>camunda-parent</artifactId>
    <relativePath>../parent</relativePath>
    <version>7.24.0-SNAPSHOT</version>
  </parent>

  <groupId>io.github.clementnero.maven-poc-833.camunda.camunda-bpm-platform</groupId>
  <artifactId>infra-833-test</artifactId>
  <version>7.23.0-SNAPSHOT</version>
  <packaging>pom</packaging>

  <name>Infra 833 Test</name>

  <properties>
    <!-- Camund Nexus / Artifactory  -->
    <skip.camunda.release>false</skip.camunda.release>
    <nexus.release.repository>https://artifacts.camunda.com/artifactory/camunda-internal</nexus.release.repository>
    <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/camunda-internal-snapshots</nexus.snapshot.repository>
    <!-- Maven Central -->
    <skip.central.release>false</skip.central.release>
    <deploymentName>https://github.com/camunda/camunda-bpm-platform - Infra 833 Test</deploymentName>
  </properties>
</project>
```
</details>


### Plugins

To prevent any unexpected issue with plugin executions, I compared the effective <plugins> and <pluginManagement> sections using versions 3.9.1 and 4.0.0 of the parent POM to quickly surface any odd config changes that might affect behavior.

<details>
  <summary>Effective-plugins when using <strong>camunda-bpm-release-parent.2.3.0</strong> POM</summary>

```xml
mvnw help:effective-pom -Psonatype-oss-release
```
[effective-plugins.camunda-bpm-release-parent.2.3.0.xml.gz](https://github.com/user-attachments/files/20755037/effective-plugins.camunda-bpm-release-parent.2.3.0.xml.gz)
</details> 

<details>
  <summary>Effective-plugins when using <strong>camunda-release-parent.2.5.0</strong> POM</summary>

```xml
mvnw help:effective-pom -Pcentral-sonatype-publish
```
[effective-plugins.camunda-bpm-release-parent.2.5.0.xml.gz](https://github.com/user-attachments/files/20755041/effective-plugins.camunda-bpm-release-parent.2.5.0.xml.gz)


</details> 

Effective changes:

TL;DR ✅ 
- The `central-sonatype-publish` profile is now the default and is appended to the value of `arguments` property of the `maven-release-plugin` (actually not used by Connectors).
- A new `id:central-deploy` execution of the `central-publishing-maven-plugin` is configured, replacing the previous `id:central-deploy` execution from the `nexus-staging-maven-plugin`.

```diff
@@ -11,10 +11,18 @@
         <groupId>org.codehaus.cargo</groupId>
         <artifactId>cargo-maven3-plugin</artifactId>
         <version>1.10.16</version>
       </plugin>
       <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
+        <configuration>
+          <waitMaxTime>3600</waitMaxTime>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
         <version>2.8</version>
       </plugin>
       <plugin>
@@ -190,10 +198,14 @@
             </manifest>
           </archive>
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.4.1</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>2.16</version>
         <executions>
           <execution>
             <goals>
@@ -255,11 +267,11 @@
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.3</version>
         <configuration>
           <mavenExecutorId>forked-path</mavenExecutorId>
           <useReleaseProfile>false</useReleaseProfile>
-          <arguments>${arguments} -Psonatype-oss-release</arguments>
+          <arguments>${arguments} -Pcentral-sonatype-publish</arguments>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <version>2.6</version>
@@ -387,13 +399,44 @@
                 <file>/Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/dependencies.txt</file>
                 <type>txt</type>
                 <classifier>third-party-bom</classifier>
               </artifact>
             </artifacts>
+          </configuration>
+        </execution>
+      </executions>
+    </plugin>
+    <plugin>
+      <groupId>org.sonatype.central</groupId>
+      <artifactId>central-publishing-maven-plugin</artifactId>
+      <version>0.7.0</version>
+      <extensions>true</extensions>
+      <executions>
+        <execution>
+          <id>central-deploy</id>
+          <phase>deploy</phase>
+          <goals>
+            <goal>publish</goal>
+          </goals>
+          <configuration>
+            <autoPublish>false</autoPublish>
+            <deploymentName>https://github.com/camunda/camunda-bpm-platform - Infra 833 Test</deploymentName>
+            <failOnBuildFailure>true</failOnBuildFailure>
+            <publishingServerId>central</publishingServerId>
+            <skipPublishing>false</skipPublishing>
+            <waitMaxTime>3600</waitMaxTime>
           </configuration>
         </execution>
       </executions>
+      <configuration>
+        <autoPublish>false</autoPublish>
+        <deploymentName>https://github.com/camunda/camunda-bpm-platform - Infra 833 Test</deploymentName>
+        <failOnBuildFailure>true</failOnBuildFailure>
+        <publishingServerId>central</publishingServerId>
+        <skipPublishing>false</skipPublishing>
+        <waitMaxTime>3600</waitMaxTime>
+      </configuration>
     </plugin>
     <plugin>
       <groupId>org.codehaus.mojo</groupId>
       <artifactId>license-maven-plugin</artifactId>
       <version>1.14</version>
@@ -633,27 +676,10 @@
           <configuration>
             <detectBuildFailures>true</detectBuildFailures>
             <serverId>camunda-nexus</serverId>
             <nexusUrl>https://artifacts.camunda.com/artifactory</nexusUrl>
             <skipStaging>true</skipStaging>
-            <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
-            <stagingProgressTimeoutMinutes>60</stagingProgressTimeoutMinutes>
-          </configuration>
-        </execution>
-        <execution>
-          <id>central-deploy</id>
-          <phase>deploy</phase>
-          <goals>
-            <goal>deploy</goal>
-          </goals>
-          <configuration>
-            <detectBuildFailures>true</detectBuildFailures>
-            <keepStagingRepositoryOnFailure>true</keepStagingRepositoryOnFailure>
-            <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
-            <serverId>central</serverId>
-            <nexusUrl>https://oss.sonatype.org</nexusUrl>
-            <skipStaging>false</skipStaging>
             <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
             <stagingProgressTimeoutMinutes>60</stagingProgressTimeoutMinutes>
           </configuration>
         </execution>
       </executions>
```

### Deployment

To ensure artifact deployment continues to work, I performed one locally using `release:prepare` and `release:perform` plugin goals (maven-release-plugin).

For this, I used a minimal empty test submodulemodule inheriting the project’s (parent) POMs but changed the groupId to a test namespace (io.github.clementnero).

<details>
  <summary>Deployment logs</summary>

```log
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Not installing Nexus Staging features:
[INFO]  * Preexisting staging related goal bindings found in 1 modules.
[INFO] 
[INFO] --< io.github.clementnero.maven-poc-833.camunda.camunda-bpm-platform:infra-833-test >--
[INFO] Building Infra 833 Test 7.23.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- clean:2.6:clean (default-clean) @ infra-833-test ---
[INFO] Deleting /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target
[INFO] 
[INFO] --< io.github.clementnero.maven-poc-833.camunda.camunda-bpm-platform:infra-833-test >--
[INFO] Building Infra 833 Test 7.23.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- release:2.5.3:prepare (default-cli) @ infra-833-test ---
[INFO] Verifying that there are no local modifications...
[INFO]   ignoring changes on: **/pom.xml.releaseBackup, **/pom.xml.next, **/pom.xml.tag, **/pom.xml.branch, **/release.properties, **/pom.xml.backup
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test && git rev-parse --show-toplevel
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test && git status --porcelain .
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test
[WARNING] Ignoring unrecognized line: ?? infra-833-test/release.properties
[INFO] Ignoring SNAPSHOT depenedencies and plugins ...
[INFO] Transforming 'Infra 833 Test'...
[INFO] Not generating release POMs
[INFO] Executing goals 'clean verify'...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test && /opt/homebrew/Cellar/maven/3.9.9/libexec/bin/mvn -s /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/release-settings5260080056835046746.xml clean verify --no-plugin-updates --batch-mode '-Dgpg.passphrase=c9@2WmUDC8GqNj(y9Ogv' -Pcentral-sonatype-publish
    [WARNING] Command line option -npu is deprecated and will be removed in future Maven versions.
    [INFO] Scanning for projects...
    [INFO] Inspecting build with total of 1 modules
    [INFO] Not installing Central Publishing features. Preexisting publish related goal bindings found in 1 modules.
    [INFO] Inspecting build with total of 1 modules...
    [INFO] Not installing Nexus Staging features:
    [INFO]  * Preexisting staging related goal bindings found in 1 modules.
    [INFO] 
    [INFO] --< io.github.clementnero.maven-poc-833.camunda.camunda-bpm-platform:infra-833-test >--
    [INFO] Building Infra 833 Test 7.23.0
    [INFO]   from pom.xml
    [INFO] --------------------------------[ pom ]---------------------------------
    [INFO] 
    [INFO] --- clean:2.6:clean (default-clean) @ infra-833-test ---
    [INFO] 
    [INFO] --- source:2.3:jar-no-fork (attach-sources) @ infra-833-test ---
    [INFO] 
    [INFO] --- source:2.3:test-jar-no-fork (attach-test-sources) @ infra-833-test ---
    [INFO] 
    [INFO] --- javadoc:3.0.1:jar (attach-javadocs) @ infra-833-test ---
    [INFO] Not executing Javadoc as the project is not a Java classpath-capable package
    [INFO] 
    [INFO] --- dependency:2.8:list (list-deps) @ infra-833-test ---
    [INFO] Skipping plugin execution
    [INFO] 
    [INFO] --- antrun:1.8:run (reformat-dependencies) @ infra-833-test ---
    [INFO] Skipping Antrun execution
    [INFO] 
    [INFO] --- build-helper:1.9.1:attach-artifact (attach-deps) @ infra-833-test ---
    [INFO] Skip attaching artifacts
    [INFO] 
    [INFO] --- gpg:1.6:sign (sign-artifacts) @ infra-833-test ---
    [INFO] ------------------------------------------------------------------------
    [INFO] BUILD SUCCESS
    [INFO] ------------------------------------------------------------------------
    [INFO] Total time:  1.595 s
    [INFO] Finished at: 2025-06-16T12:22:26+02:00
    [INFO] ------------------------------------------------------------------------
[INFO] Checking in modified POMs...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test && git add -- pom.xml
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test && git rev-parse --show-toplevel
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test && git status --porcelain .
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test
[WARNING] Ignoring unrecognized line: ?? infra-833-test/pom.xml.releaseBackup
[WARNING] Ignoring unrecognized line: ?? infra-833-test/release.properties
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test && git commit --verbose -F /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/maven-scm-209125271.commit pom.xml
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test
[INFO] Tagging release with the label infra-833-test-7.23.0...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test && git tag -F /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/maven-scm-1719645228.commit infra-833-test-7.23.0
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test && git ls-files
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test
[INFO] Transforming 'Infra 833 Test'...
[INFO] Not removing release POMs
[INFO] Checking in modified POMs...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test && git add -- pom.xml
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test && git rev-parse --show-toplevel
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test && git status --porcelain .
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test
[WARNING] Ignoring unrecognized line: ?? infra-833-test/pom.xml.releaseBackup
[WARNING] Ignoring unrecognized line: ?? infra-833-test/release.properties
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test && git commit --verbose -F /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/maven-scm-1903442687.commit pom.xml
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test
[INFO] Release preparation complete.
[INFO] 
[INFO] --- release:2.5.3:perform (default-cli) @ infra-833-test ---
[INFO] Performing a LOCAL checkout from scm:git:file:///Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test
[INFO] Checking out the project to perform the release ...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target && git clone --branch infra-833-test-7.23.0 file:///Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target
[INFO] Performing a LOCAL checkout from scm:git:file:///Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform
[INFO] Checking out the project to perform the release ...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target && git clone --branch infra-833-test-7.23.0 file:///Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target
[INFO] Executing: /bin/sh -c cd /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/ && git ls-remote file:///Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform
[INFO] Working directory: /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout && git fetch file:///Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout && git checkout infra-833-test-7.23.0
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout && git ls-files
[INFO] Working directory: /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout
[INFO] Invoking perform goals in directory /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test
[INFO] Executing goals 'deploy'...
[INFO] Executing: /bin/sh -c cd /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test && /opt/homebrew/Cellar/maven/3.9.9/libexec/bin/mvn -s /var/folders/zw/_30vxb_s0_qdhnsndcxf_nf00000gn/T/release-settings1063616427756781536.xml deploy --no-plugin-updates --batch-mode '-Dgpg.passphrase=c9@2WmUDC8GqNj(y9Ogv' -Pcentral-sonatype-publish -f pom.xml
    [WARNING] Command line option -npu is deprecated and will be removed in future Maven versions.
    [INFO] Scanning for projects...
    [INFO] Inspecting build with total of 1 modules
    [INFO] Not installing Central Publishing features. Preexisting publish related goal bindings found in 1 modules.
    [INFO] Inspecting build with total of 1 modules...
    [INFO] Not installing Nexus Staging features:
    [INFO]  * Preexisting staging related goal bindings found in 1 modules.
    [INFO] 
    [INFO] --< io.github.clementnero.maven-poc-833.camunda.camunda-bpm-platform:infra-833-test >--
    [INFO] Building Infra 833 Test 7.23.0
    [INFO]   from pom.xml
    [INFO] --------------------------------[ pom ]---------------------------------
    [INFO] 
    [INFO] --- source:2.3:jar-no-fork (attach-sources) @ infra-833-test ---
    [INFO] 
    [INFO] --- source:2.3:test-jar-no-fork (attach-test-sources) @ infra-833-test ---
    [INFO] 
    [INFO] --- javadoc:3.0.1:jar (attach-javadocs) @ infra-833-test ---
    [INFO] Not executing Javadoc as the project is not a Java classpath-capable package
    [INFO] 
    [INFO] --- dependency:2.8:list (list-deps) @ infra-833-test ---
    [INFO] Skipping plugin execution
    [INFO] 
    [INFO] --- antrun:1.8:run (reformat-dependencies) @ infra-833-test ---
    [INFO] Skipping Antrun execution
    [INFO] 
    [INFO] --- build-helper:1.9.1:attach-artifact (attach-deps) @ infra-833-test ---
    [INFO] Skip attaching artifacts
    [INFO] 
    [INFO] --- gpg:1.6:sign (sign-artifacts) @ infra-833-test ---
    [INFO] 
    [INFO] --- install:3.1.2:install (default-install) @ infra-833-test ---
    [INFO] Installing /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/pom.xml to /Users/clement.nero/.m2/repository/io/github/clementnero/maven-poc-833/camunda/camunda-bpm-platform/infra-833-test/7.23.0/infra-833-test-7.23.0.pom
    [INFO] Installing /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/target/infra-833-test-7.23.0.pom.asc to /Users/clement.nero/.m2/repository/io/github/clementnero/maven-poc-833/camunda/camunda-bpm-platform/infra-833-test/7.23.0/infra-833-test-7.23.0.pom.asc
    [INFO] 
    [INFO] --- deploy:2.8.2:deploy (default-deploy) @ infra-833-test ---
    [INFO] Skipping artifact deployment
    [INFO] 
    [INFO] --- nexus-staging:1.6.13:deploy (default-deploy) @ infra-833-test ---
    [INFO] Performing deferred deploys (gathering into "/Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/target/nexus-staging/deferred")...
    [INFO] Installing /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/pom.xml to /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/target/nexus-staging/deferred/io/github/clementnero/maven-poc-833/camunda/camunda-bpm-platform/infra-833-test/7.23.0/infra-833-test-7.23.0.pom
    [INFO] Installing /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/target/infra-833-test-7.23.0.pom.asc to /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/target/nexus-staging/deferred/io/github/clementnero/maven-poc-833/camunda/camunda-bpm-platform/infra-833-test/7.23.0/infra-833-test-7.23.0.pom.asc
    [INFO] Deploying remotely...
    [INFO] Bulk deploying locally gathered artifacts from directory: 
    [INFO]  * Bulk deploying locally gathered snapshot artifacts
    [INFO] Uploading to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/camunda-bpm-platform/infra-833-test/7.23.0/infra-833-test-7.23.0.pom.asc
    [INFO] Uploaded to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/camunda-bpm-platform/infra-833-test/7.23.0/infra-833-test-7.23.0.pom.asc (659 B at 932 B/s)
    [INFO] Downloading from camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/camunda-bpm-platform/infra-833-test/maven-metadata.xml
    [INFO] Uploading to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/camunda-bpm-platform/infra-833-test/maven-metadata.xml
    [INFO] Uploaded to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/camunda-bpm-platform/infra-833-test/maven-metadata.xml (360 B at 1.0 kB/s)
    [INFO] Uploading to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/camunda-bpm-platform/infra-833-test/7.23.0/infra-833-test-7.23.0.pom
    [INFO] Uploaded to camunda-nexus: https://artifacts.camunda.com/artifactory/camunda-internal/io/github/clementnero/maven-poc-833/camunda/camunda-bpm-platform/infra-833-test/7.23.0/infra-833-test-7.23.0.pom (2.7 kB at 4.5 kB/s)
    [INFO]  * Bulk deploy of locally gathered snapshot artifacts finished.
    [INFO] Remote deploy finished with success.
    [INFO] 
    [INFO] --- central-publishing:0.7.0:publish (central-deploy) @ infra-833-test ---
    [INFO] Using Central baseUrl: https://central.sonatype.com
    [INFO] Using credentials from server id central in settings.xml
    [INFO] Using Usertoken auth, with namecode: g0xTmVDT
    [INFO] Staging 2 files
    [INFO] Staging /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/pom.xml
    [INFO] Installing /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/pom.xml to /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/target/central-staging/io/github/clementnero/maven-poc-833/camunda/camunda-bpm-platform/infra-833-test/7.23.0/infra-833-test-7.23.0.pom
    [INFO] Staging /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/target/infra-833-test-7.23.0.pom.asc
    [INFO] Installing /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/target/infra-833-test-7.23.0.pom.asc to /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/target/central-staging/io/github/clementnero/maven-poc-833/camunda/camunda-bpm-platform/infra-833-test/7.23.0/infra-833-test-7.23.0.pom.asc
    [INFO] Pre Bundling - deleted /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/target/central-staging/io/github/clementnero/maven-poc-833/camunda/camunda-bpm-platform/infra-833-test/maven-metadata-central-staging.xml
    [INFO] Generate checksums for dir: io/github/clementnero/maven-poc-833/camunda/camunda-bpm-platform/infra-833-test/7.23.0
    [INFO] Going to create /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/target/central-publishing/central-bundle.zip by bundling content at /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/target/central-staging
    [INFO] Created bundle successfully /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/target/central-staging/central-bundle.zip
    [INFO] Going to upload /Users/clement.nero/camunda/833/io-org.camunda/camunda-7/camunda-bpm-platform/infra-833-test/target/checkout/infra-833-test/target/central-publishing/central-bundle.zip
    [INFO] Uploaded bundle successfully, deployment name: https://github.com/camunda/camunda-bpm-platform - Infra 833 Test, deploymentId: 0ac0fdc5-08c5-4861-b8cb-627365c8a83e. Deployment will require manual publishing
    [INFO] Waiting until Deployment 0ac0fdc5-08c5-4861-b8cb-627365c8a83e is validated
    [INFO] Deployment 0ac0fdc5-08c5-4861-b8cb-627365c8a83e has been validated. To finish publishing visit https://central.sonatype.com/publishing/deployments
    [INFO] ------------------------------------------------------------------------
    [INFO] BUILD SUCCESS
    [INFO] ------------------------------------------------------------------------
    [INFO] Total time:  10.432 s
    [INFO] Finished at: 2025-06-16T12:22:46+02:00
    [INFO] ------------------------------------------------------------------------
[INFO] Cleaning up after release...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  26.247 s
[INFO] Finished at: 2025-06-16T12:22:46+02:00
[INFO] ------------------------------------------------------------------------
```
</details>

Results:
- Artifactory: https://artifacts.camunda.com/ui/repos/tree/General/camunda-internal/io/github/clementnero/maven-poc-833/camunda/camunda-bpm-platform/infra-833-test/7.23.0
- Central Portal
    <img width="1596" alt="image" src="https://github.com/user-attachments/assets/38fd1e03-db51-4fac-979d-a5be6cbca61f" />
    
 EDIT: the job deploying to Maven Central uses Maven >3.8 and jdk17