### PR TITLE
chore(renovate): fix renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,19 +3,13 @@
   "extends": ["config:recommended"],
   "packageRules": [
     {
-      "packagePatterns": ["^org\.springframework\.boot"],
-      "groupName": "spring-boot-dependencies",
-      "enabled": true
-    },
-    {
-      "packagePatterns": ["^org\.springframework"],
-      "groupName": "spring-framework-dependencies",
-      "enabled": true
-    },
-    {
-      "packagePatterns": ["^org\.apache\.tomcat"],
-      "groupName": "tomcat-dependencies",
-      "enabled": true
+      "matchPackagePatterns": ["*"],
+      "excludePackagePatterns": [
+        "^org\.springframework\.boot",
+        "^org\.springframework",
+        "^org\.apache\.tomcat"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
The initial renovation configuration was dysfunctional, and it tried to update all third-party dependencies instead of only whitelisted ones.

Not sure if this will really do the trick. We probably need to try and error.

related to camunda/camunda-bpm-platform#5214