### PR TITLE
chore(bpmn-assertions): fix typo in the variable names

### DIFF
--- a/test-utils/assert/core/src/main/java/org/camunda/bpm/engine/test/assertions/bpmn/ProcessInstanceAssert.java
+++ b/test-utils/assert/core/src/main/java/org/camunda/bpm/engine/test/assertions/bpmn/ProcessInstanceAssert.java
@@ -130,11 +130,11 @@ public class ProcessInstanceAssert extends AbstractProcessAssert<ProcessInstance
     ActivityInstance activityInstanceTree = runtimeService().getActivityInstance(actual.getId());
 
     // Collect all children recursively
-    Stream <ActivityInstance> flattendActivityInstances = collectAllDecendentActivities(activityInstanceTree);
+    Stream <ActivityInstance> flattendActivityInstances = collectAllDescendantActivities(activityInstanceTree);
 
-    Stream<String> decendentActivityIdStream = flattendActivityInstances
+    Stream<String> descendantActivityIdStream = flattendActivityInstances
         .flatMap(activityInstance -> getActivityIdAndCollectTransitions(activityInstance));
-    List<String> decendentActivityIds = decendentActivityIdStream.filter(
+    List<String> descendantActivityIds = descendantActivityIdStream.filter(
         // remove the root id from the list
         activityId -> !activityId.equals(activityInstanceTree.getActivityId())
     ).collect(Collectors.toList());
@@ -142,11 +142,11 @@ public class ProcessInstanceAssert extends AbstractProcessAssert<ProcessInstance
     final String message = "Expecting %s " +
       (isWaitingAt ? "to be waiting at " + (exactly ? "exactly " : "") + "%s, ": "NOT to be waiting at %s, ") +
       "but it is actually waiting at %s.";
-    ListAssert<String> assertion = Assertions.assertThat(decendentActivityIds)
+    ListAssert<String> assertion = Assertions.assertThat(descendantActivityIds)
       .overridingErrorMessage(message,
         toString(current),
         Lists.newArrayList(activityIds),
-        decendentActivityIds);
+        descendantActivityIds);
     if (exactly) {
       if (isWaitingAt) {
         assertion.containsOnly(activityIds);
@@ -164,11 +164,11 @@ public class ProcessInstanceAssert extends AbstractProcessAssert<ProcessInstance
     return this;
   }
 
-  private Stream<ActivityInstance> collectAllDecendentActivities(ActivityInstance root) {
+  private Stream<ActivityInstance> collectAllDescendantActivities(ActivityInstance root) {
     ActivityInstance[] childActivityInstances = root.getChildActivityInstances();
     return Stream.concat(
         Stream.of(root),
-        Arrays.stream(childActivityInstances).flatMap(child -> collectAllDecendentActivities(child))
+        Arrays.stream(childActivityInstances).flatMap(child -> collectAllDescendantActivities(child))
     );
   }
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/5382