### PR TITLE
chore(engine): revert unnecessary changes for migrator

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricActivityInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricActivityInstanceQueryImpl.java
@@ -54,7 +54,6 @@ public class HistoricActivityInstanceQueryImpl extends AbstractQuery<HistoricAct
   protected ActivityInstanceState activityInstanceState;
   protected String[] tenantIds;
   protected boolean isTenantIdSet;
-  protected String activityInstanceIdAfter;
 
   public HistoricActivityInstanceQueryImpl() {
   }
@@ -77,15 +76,6 @@ public class HistoricActivityInstanceQueryImpl extends AbstractQuery<HistoricAct
     return commandContext
       .getHistoricActivityInstanceManager()
       .findHistoricActivityInstancesByQueryCriteria(this, page);
-  }
-
-  public HistoricActivityInstanceQueryImpl idAfter(String id) {
-    this.activityInstanceIdAfter = id;
-    return this;
-  }
-
-  public String getIdAfter() {
-    return activityInstanceIdAfter;
   }
 
   public HistoricActivityInstanceQueryImpl processInstanceId(String processInstanceId) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricIncidentQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricIncidentQueryImpl.java
@@ -59,22 +59,12 @@ public class HistoricIncidentQueryImpl extends AbstractVariableQueryImpl<Histori
   protected String[] tenantIds;
   protected boolean isTenantIdSet;
   protected String[] jobDefinitionIds;
-  protected String incidentIdAfter;
 
   public HistoricIncidentQueryImpl() {
   }
 
   public HistoricIncidentQueryImpl(CommandExecutor commandExecutor) {
     super(commandExecutor);
-  }
-
-  public HistoricIncidentQuery idAfter(String id) {
-    this.incidentIdAfter = id;
-    return this;
-  }
-
-  public String getIncidentIdAfter() {
-    return incidentIdAfter;
   }
 
   public HistoricIncidentQuery incidentId(String incidentId) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -99,7 +99,6 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   protected Set<String> state = new HashSet<>();
 
   protected String caseInstanceId;
-  protected String processInstanceIdAfter;
 
   protected List<HistoricProcessInstanceQueryImpl> queries = new ArrayList<>(Collections.singletonList(this));
   protected boolean isOrQueryActive = false;
@@ -111,16 +110,6 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
 
   public HistoricProcessInstanceQueryImpl(CommandExecutor commandExecutor) {
     super(commandExecutor);
-  }
-
-
-  public HistoricProcessInstanceQueryImpl idAfter(String id) {
-    this.processInstanceIdAfter = id;
-    return this;
-  }
-
-  public String getIdAfter() {
-    return processInstanceIdAfter;
   }
 
   public HistoricProcessInstanceQueryImpl processInstanceId(String processInstanceId) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -105,8 +105,6 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
   protected Date startedAfter;
   protected Date startedBefore;
 
-  protected String taskIdAfter;
-
   protected List<HistoricTaskInstanceQueryImpl> queries = new ArrayList<>(Arrays.asList(this));
   protected boolean isOrQueryActive = false;
 
@@ -135,14 +133,6 @@ public class HistoricTaskInstanceQueryImpl extends AbstractQuery<HistoricTaskIns
       .findHistoricTaskInstancesByQueryCriteria(this, page);
   }
 
-  public HistoricTaskInstanceQueryImpl idAfter(String id) {
-    this.taskIdAfter = id;
-    return this;
-  }
-
-  public String getTaskIdAfter() {
-    return taskIdAfter;
-  }
 
   public HistoricTaskInstanceQueryImpl processInstanceId(String processInstanceId) {
     this.processInstanceId = processInstanceId;

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessDefinitionQueryImpl.java
@@ -90,8 +90,6 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
   protected String versionTag;
   protected String versionTagLike;
 
-  protected String processDefinitionIdAfter;
-
   protected boolean isStartableInTasklist = false;
   protected boolean isNotStartableInTasklist = false;
   protected boolean startablePermissionCheck = false;
@@ -109,15 +107,6 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
   public ProcessDefinitionQuery processDefinitionId(String processDefinitionId) {
     this.id = processDefinitionId;
     return this;
-  }
-
-  public ProcessDefinitionQueryImpl idAfter(String processDefinitionId) {
-    this.processDefinitionIdAfter = processDefinitionId;
-    return this;
-  }
-
-  public String getProcessDefinitionIdAfter() {
-    return processDefinitionIdAfter;
   }
 
   public ProcessDefinitionQuery processDefinitionIdIn(String... ids) {

--- a/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/impl/ProcessInstanceQueryImpl.java
@@ -71,7 +71,6 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
   protected String[] activityIds;
   protected boolean isRootProcessInstances;
   protected boolean isLeafProcessInstances;
-  protected String idAfter;
 
   protected boolean isTenantIdSet = false;
   protected String[] tenantIds;
@@ -182,11 +181,6 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
   public ProcessInstanceQuery subCaseInstanceId(String subCaseInstanceId) {
     ensureNotNull("subCaseInstanceId", subCaseInstanceId);
     this.subCaseInstanceId = subCaseInstanceId;
-    return this;
-  }
-
-  public ProcessInstanceQuery idAfter(String id) {
-    idAfter = id;
     return this;
   }
 
@@ -506,10 +500,6 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
 
   public String[] getTenantIds() {
     return tenantIds;
-  }
-
-  public String getIdAfter() {
-    return idAfter;
   }
 
   @Override

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Execution.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Execution.xml
@@ -280,9 +280,6 @@
         <trim suffixOverrides="and">
           RES.PARENT_ID_ is null and
           <trim prefix="(" prefixOverrides="or|and" suffix=")">
-            <if test="query.idAfter != null">
-              ${queryType} RES.ID_ > #{idAfter}
-            </if>
             <if test="query.processDefinitionId != null">
               ${queryType} P.ID_ = #{query.processDefinitionId}
             </if>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricActivityInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricActivityInstance.xml
@@ -375,9 +375,6 @@
       <if test="activityInstanceId != null">
         and RES.ID_ = #{activityInstanceId}
       </if>
-      <if test="activityInstanceIdAfter != null">
-        RES.ID_ > #{activityInstanceIdAfter}
-      </if>
       <if test="executionId != null">
         and RES.EXECUTION_ID_ = #{executionId}
       </if>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricIncident.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricIncident.xml
@@ -433,9 +433,6 @@
       <if test="id != null">
         RES.ID_ = #{id}
       </if>
-      <if test="incidentIdAfter != null">
-        RES.ID_ > #{incidentIdAfter}
-      </if>
       <if test="incidentType != null">
         and RES.INCIDENT_TYPE_ = #{incidentType}
       </if>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
@@ -462,9 +462,6 @@
         <trim suffixOverrides="and">
           1 = 1 and
           <trim prefixOverrides="or|and">
-            <if test="query.processInstanceIdAfter != null">
-              ${queryType} SELF.PROC_INST_ID_ > #{query.processInstanceIdAfter}
-            </if>
             <if test="query.processInstanceId != null">
               ${queryType} SELF.PROC_INST_ID_ = #{query.processInstanceId}
             </if>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/HistoricTaskInstance.xml
@@ -470,9 +470,6 @@
             <if test="query.taskId != null">
               ${queryType} RES.ID_ = #{query.taskId}
             </if>
-            <if test="query.taskIdAfter != null">
-              ${queryType} RES.ID_ > #{query.taskIdAfter}
-            </if>
             <if test="query.processDefinitionId != null">
               ${queryType} RES.PROC_DEF_ID_ = #{query.processDefinitionId}
             </if>

--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ProcessDefinition.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/ProcessDefinition.xml
@@ -254,9 +254,6 @@
       <if test="id != null">
         RES.ID_ = #{id}
       </if>
-      <if test="processDefinitionIdAfter != null">
-        RES.ID_ > #{processDefinitionIdAfter}
-      </if>
       <if test="ids != null &amp;&amp; ids.length > 0">
         and RES.ID_ in
         <foreach item="item" index="index" collection="ids"


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/5234

### Notes

- From https://github.com/camunda/camunda-bpm-platform/pull/5135, only kept changes related to `Activity Instance` and `Variable Instance` and related tests.
- Reverted everything else.
- All migrator tests are green locally with these changes.