### PR TITLE
fix(engine): candidateGroupLike is NULL when used with or

### DIFF
--- a/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
+++ b/engine/src/main/resources/org/camunda/bpm/engine/impl/mapping/entity/Task.xml
@@ -613,7 +613,7 @@
                     or
                   </if>
                   <if test="query.candidateGroupLike != null">
-                    I.GROUP_ID_ LIKE #{candidateGroupLike}
+                    I.GROUP_ID_ LIKE #{query.candidateGroupLike}
                   </if>
                   )
                 </if>

--- a/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/camunda/bpm/engine/test/api/task/TaskQueryTest.java
@@ -770,6 +770,58 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     assertThrows(ProcessEngineException.class, query::singleResult);
   }
 
+    @Test
+    public void testQueryByCandidateGroupLikeInsideAnOr() {
+        // management group is candidate for 3 tasks, one of them is already assigned
+        TaskQuery query = taskService.createTaskQuery().or().taskCandidateGroupLike("management").taskId("non-existing").endOr();
+        assertEquals(2, query.count());
+        assertEquals(2, query.list().size());
+        assertThrows(ProcessEngineException.class, query::singleResult);
+
+        // test with "shortened" group name for like query
+        query = taskService.createTaskQuery().or().taskCandidateGroupLike("mana%").taskId("non-existing").endOr();
+        assertEquals(2, query.count());
+        assertEquals(2, query.list().size());
+        assertThrows(ProcessEngineException.class, query::singleResult);
+
+        // test with "shortened" group name for like query (different part)
+        query = taskService.createTaskQuery().or().taskCandidateGroupLike("%ment").taskId("non-existing").endOr();
+        assertEquals(2, query.count());
+        assertEquals(2, query.list().size());
+        assertThrows(ProcessEngineException.class, query::singleResult);
+
+        // test management candidates group with assigned tasks included
+        query = taskService.createTaskQuery().or().taskCandidateGroupLike("management").includeAssignedTasks().taskId("non-existing").endOr();
+        assertEquals(3, query.count());
+        assertEquals(3, query.list().size());
+        assertThrows(ProcessEngineException.class, query::singleResult);
+
+        // test with "shortened" group name for like query (assigned tasks included)
+        query = taskService.createTaskQuery().or().taskCandidateGroupLike("mana%").includeAssignedTasks().taskId("non-existing").endOr();
+        assertEquals(3, query.count());
+        assertEquals(3, query.list().size());
+        assertThrows(ProcessEngineException.class, query::singleResult);
+
+        // test with "shortened" group name for like query (different part, assigned tasks included)
+        query = taskService.createTaskQuery().or().taskCandidateGroupLike("%ment").includeAssignedTasks().taskId("non-existing").endOr();
+        assertEquals(3, query.count());
+        assertEquals(3, query.list().size());
+        assertThrows(ProcessEngineException.class, query::singleResult);
+
+        // test query that matches tasks with the "management" the "accountancy" candidate groups
+        // accountancy group is candidate for 3 tasks, one of them is already assigned
+        query = taskService.createTaskQuery().or().taskCandidateGroupLike("%an%").taskId("non-existing").endOr();
+        assertEquals(4, query.count());
+        assertEquals(4, query.list().size());
+        assertThrows(ProcessEngineException.class, query::singleResult);
+
+        // test query that matches tasks with the "management" the "accountancy" candidate groups (assigned tasks included)
+        query = taskService.createTaskQuery().or().taskCandidateGroupLike("%an%").includeAssignedTasks().taskId("non-existing").endOr();
+        assertEquals(5, query.count());
+        assertEquals(5, query.list().size());
+        assertThrows(ProcessEngineException.class, query::singleResult);
+    }
+
   @Test
   public void testQueryWithCandidateGroups() {
     // test withCandidateGroups


### PR DESCRIPTION
- fixes Task.xml

related to https://github.com/camunda/camunda-bpm-platform/issues/5362