### PR TITLE
Fix duplicate declaration of maven-dependency-plugin

### DIFF
--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -181,12 +181,6 @@
                   <excludes>configuration/default.yml,configuration/production.yml</excludes>
                 </configuration>
               </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
               <execution>
                 <id>copy-plugin</id>
                 <goals>


### PR DESCRIPTION
Remove duplicate definition of maven-dependency-plugin, rather just use the list of executions.


This was causing build using Maven 4.0.0-rc4 to fail.