### PR TITLE
chore(relase): add 724 instance migration project

### DIFF
--- a/qa/test-db-instance-migration/test-fixture-724/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-724/pom.xml
@@ -16,23 +16,20 @@
   <name>camunda BPM - QA - upgrade - instance migration - test fixture - 7.24.0</name>
 
   <properties>
-    <!-- delete when 7.24 is released -->
-    <camunda.version.current>${project.version}</camunda.version.current>
-    <camunda.version.previous>7.23.0</camunda.version.previous>
+    <camunda.version.previous>7.24.0</camunda.version.previous>
   </properties>
 
-  <!-- uncomment when 7.24 is released -->
-  <!--   <dependencyManagement> -->
-  <!--     <dependencies> -->
-  <!--       <dependency> -->
-  <!--         <groupId>org.camunda.bpm</groupId> -->
-  <!--         <artifactId>camunda-bom</artifactId> -->
-  <!--         <version>7.24.0</version> -->
-  <!--         <scope>import</scope> -->
-  <!--         <type>pom</type> -->
-  <!--       </dependency> -->
-  <!--     </dependencies> -->
-  <!--   </dependencyManagement> -->
+     <dependencyManagement>
+       <dependencies>
+         <dependency>
+           <groupId>org.camunda.bpm</groupId>
+           <artifactId>camunda-bom</artifactId>
+           <version>7.24.0</version>
+           <scope>import</scope>
+           <type>pom</type>
+         </dependency>
+       </dependencies>
+     </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -110,9 +107,7 @@
                     <artifactItem>
                       <groupId>org.camunda.bpm.distro</groupId>
                       <artifactId>camunda-sql-scripts</artifactId>
-                      <!-- Replace after 7.24.0 release -->
-                      <version>${camunda.version.current}</version>
-                      <!--<version>7.24.0</version>-->
+                      <version>7.24.0</version>
                       <type>test-jar</type>
                       <outputDirectory>${project.build.directory}/scripts-current</outputDirectory>
                       <overWrite>true</overWrite>
@@ -122,8 +117,7 @@
               </execution>
             </executions>
           </plugin>
-          <!-- uncomment when 7.24 is released -->
-          <!--<plugin>
+          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
             <configuration>
@@ -144,7 +138,7 @@
                 </configuration>
               </execution>
             </executions>
-          </plugin>-->
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
related to #5097

[Release guide reference](https://confluence.camunda.com/spaces/AP/pages/110233098/Performing+a+Minor+Release#PerformingaMinorRelease-Addnewversiontothebrokenboards:~:text=Add%20instance%20migration,instance%20migration%20pom)

May not actually be needed according to [slack convo](https://camunda.slack.com/archives/C036ZURJFMX/p1760340019572669)
